### PR TITLE
Run migrations automatically when backend container starts

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -24,6 +24,9 @@ RUN pip install --upgrade pip && \
 # Copy project
 COPY . /app/
 
+# Ensure entrypoint script is executable
+RUN chmod +x /app/docker-entrypoint.sh
+
 # Create directories for static and media files
 RUN mkdir -p /app/staticfiles /app/media
 
@@ -34,6 +37,8 @@ RUN python manage.py collectstatic --noinput || true
 RUN useradd -m -u 1000 appuser && \
     chown -R appuser:appuser /app
 USER appuser
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 
 EXPOSE 8000
 

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "${SKIP_DB_MIGRATIONS}" != "1" ]; then
+  python manage.py migrate --noinput
+fi
+
+exec "$@"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -73,6 +73,7 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-makerspace}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-makerspace_inventory}
       - REDIS_URL=redis://redis:6379/0
       - CELERY_BROKER_URL=redis://redis:6379/0
+      - SKIP_DB_MIGRATIONS=1
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- add a shared docker entrypoint that runs Django migrations before starting the backend services
- update the production Dockerfile to install the entrypoint and execute it by default
- skip the automatic migrations in the Celery worker by setting `SKIP_DB_MIGRATIONS`

## Testing
- not run (infrastructure change)


------
https://chatgpt.com/codex/tasks/task_e_6909c50028dc832297392ce39229cfff