### PR TITLE
Adjust Brother asset label layout

### DIFF
--- a/backend/inventory/utils/label_generator.py
+++ b/backend/inventory/utils/label_generator.py
@@ -24,13 +24,14 @@ class BrotherLabelRenderer:
     """Render asset labels for Brother QL-820nwb printer (62mm labels)."""
 
     # Brother QL-820nwb uses 62mm wide labels
-    # Standard continuous label height is typically 100mm or 200mm
-    # We'll use 100mm (3.94 inches) for a good balance
+    # The DK-2251 roll is continuous, so we match the printable height to 62mm
+    # for a square label that trims right after the content.
     LABEL_WIDTH = 62 * mm  # 62mm = 2.44 inches
-    LABEL_HEIGHT = 100 * mm  # 100mm = 3.94 inches
+    LABEL_HEIGHT = 62 * mm  # Match the 62mm label roll height as well
 
     # Margins and spacing
-    MARGIN = 2 * mm
+    MARGIN = 4 * mm  # Provide extra breathing room for the title text
+    TOP_PADDING = 1.5 * mm
     QR_SIZE = 25 * mm  # QR code size
     TEXT_AREA_WIDTH = LABEL_WIDTH - (2 * MARGIN) - QR_SIZE - (2 * mm)
 
@@ -101,7 +102,7 @@ class BrotherLabelRenderer:
                 qr_image = ImageReader(asset.qr_code)
                 # Position QR code on the left
                 qr_x = self.MARGIN
-                qr_y = self.LABEL_HEIGHT - self.MARGIN - self.QR_SIZE
+                qr_y = self.LABEL_HEIGHT - self.MARGIN - self.TOP_PADDING - self.QR_SIZE
                 pdf_canvas.drawImage(
                     qr_image,
                     qr_x,
@@ -115,7 +116,7 @@ class BrotherLabelRenderer:
                 pdf_canvas.setFillColor(colors.grey)
                 pdf_canvas.rect(
                     self.MARGIN,
-                    self.LABEL_HEIGHT - self.MARGIN - self.QR_SIZE,
+                    self.LABEL_HEIGHT - self.MARGIN - self.TOP_PADDING - self.QR_SIZE,
                     self.QR_SIZE,
                     self.QR_SIZE,
                     fill=1,
@@ -123,7 +124,7 @@ class BrotherLabelRenderer:
 
         # Text area on the right side
         text_x = self.MARGIN + self.QR_SIZE + (2 * mm)
-        text_y = self.LABEL_HEIGHT - self.MARGIN
+        text_y = self.LABEL_HEIGHT - self.MARGIN - self.TOP_PADDING
 
         # Asset name (largest text)
         pdf_canvas.setFont("Helvetica-Bold", 10)


### PR DESCRIPTION
## Summary
- match the generated asset label height to the 62mm DK-2251 roll so labels end with the rendered content
- increase label margins and add top padding so the asset title and QR code sit comfortably within the printable area

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e67511f708322afce9247e7ec334a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Match label height to 62mm DK-2251 and add margin/top padding, updating QR and text positions accordingly.
> 
> - **Backend**:
>   - **Label layout (`backend/inventory/utils/label_generator.py`)**:
>     - Set `LABEL_HEIGHT` to `62mm` to match DK-2251; keep `LABEL_WIDTH` at `62mm`.
>     - Increase `MARGIN` to `4mm` and add `TOP_PADDING` (`1.5mm`).
>     - Reposition QR code and placeholder `rect` using new top padding.
>     - Adjust text baseline (`text_y`) to account for top padding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 419d04da4452420d219887afe1b4809bf1521ea7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->