### PR TITLE
Fix(#139): Cleaning up Locations tab

### DIFF
--- a/frontend/src/__tests__/services/api.test.ts
+++ b/frontend/src/__tests__/services/api.test.ts
@@ -54,6 +54,19 @@ describe('API Service', () => {
       expect(response.status).toBe(200);
     });
 
+    test('listLocations normalizes array responses', async () => {
+      const mockLocations = [
+        { id: 1, name: 'Main Workshop' },
+        { id: 2, name: 'Electronics Lab' },
+      ];
+
+      mock.onGet('/inventory/locations/').reply(200, mockLocations);
+
+      const response = await inventoryAPI.listLocations();
+
+      expect(response.data.results).toEqual(mockLocations);
+    });
+
     test('getLowStockItems fetches low stock items', async () => {
       const mockItems = [
         { id: '1', name: 'Low Stock Item', current_stock: 2 },

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -43,6 +43,16 @@ export const resolveApiBaseUrl = () => {
 
 const API_BASE_URL = resolveApiBaseUrl();
 
+const normalizeResults = <T>(data: { results?: T[] } | T[]): { results: T[] } => {
+  if (Array.isArray(data)) {
+    return { results: data };
+  }
+  if (data && Array.isArray(data.results)) {
+    return { results: data.results };
+  }
+  return { results: [] };
+};
+
 const api = axios.create({
   baseURL: API_BASE_URL,
   headers: {
@@ -247,7 +257,11 @@ export const inventoryAPI = {
     api.get<Checklist[]>(`/inventory/items/${id}/checklists/`),
 
   listLocations: () =>
-    api.get<{ results: Location[] }>('/inventory/locations/'),
+    api.get<{ results?: Location[] } | Location[]>('/inventory/locations/')
+      .then((response) => ({
+        ...response,
+        data: normalizeResults<Location>(response.data),
+      })),
 
   listCategories: () =>
     api.get<{ results: Category[] }>('/inventory/categories/'),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures consistent response shape for locations and adds coverage.
> 
> - Introduces `normalizeResults` helper to coerce array or paginated data into `{ results: T[] }`
> - Updates `inventoryAPI.listLocations` to handle both `{ results: Location[] }` and `Location[]`, returning normalized data
> - Adds unit test verifying `listLocations` normalizes array responses
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1655de97dd9c2e62c92d06976cd10909273f4b64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->