### PR TITLE
feat: add PM task form page and management UI for fixed assets (#hq-cv-hjp5l)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,9 @@ jobs:
       - name: Pre-cleanup stale volumes
         run: |
           docker compose down -v 2>/dev/null || true
+          docker container prune -f 2>/dev/null || true
           docker volume rm openmakersuite_media_volume openmakersuite_static_volume openmakersuite_postgres_data 2>/dev/null || true
+          docker volume prune -f 2>/dev/null || true
 
       - name: Build and test with docker compose
         run: |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import WorkspaceLayout from './components/WorkspaceLayout';
 import AdminDashboard from './pages/AdminDashboard';
 import AssetDetailPage from './pages/AssetDetailPage';
 import AssetFormPage from './pages/AssetFormPage';
+import MaintenanceItemFormPage from './pages/MaintenanceItemFormPage';
 import AssetReportPage from './pages/AssetReportPage';
 import AssetScanPage from './pages/AssetScanPage';
 import AssetsPage from './pages/AssetsPage';
@@ -154,6 +155,8 @@ function AppContent() {
           <Route path="/assets/new" element={<WorkspaceLayout><AssetFormPage /></WorkspaceLayout>} />
           <Route path="/assets/:id" element={<WorkspaceLayout><AssetDetailPage /></WorkspaceLayout>} />
           <Route path="/assets/:id/edit" element={<WorkspaceLayout><AssetFormPage /></WorkspaceLayout>} />
+          <Route path="/assets/:assetId/maintenance/new" element={<WorkspaceLayout><MaintenanceItemFormPage /></WorkspaceLayout>} />
+          <Route path="/assets/:assetId/maintenance/:id/edit" element={<WorkspaceLayout><MaintenanceItemFormPage /></WorkspaceLayout>} />
 
           {/* Facilities Workspace */}
           <Route path="/facilities/tv-dashboard" element={<TVDashboard />} />

--- a/frontend/src/__tests__/pages/AssetDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/AssetDetailPage.test.tsx
@@ -128,6 +128,13 @@ describe('AssetDetailPage', () => {
       headers: {},
       config: {} as any,
     });
+    mockAssetsAPI.getMaintenanceItems.mockResolvedValue({
+      data: [],
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {} as any,
+    });
   });
 
   it('renders asset details', async () => {

--- a/frontend/src/pages/AssetDetailPage.tsx
+++ b/frontend/src/pages/AssetDetailPage.tsx
@@ -4,7 +4,7 @@
  */
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { assetPartsAPI, assetsAPI, maintenanceAPI } from '../services/api';
+import { assetPartsAPI, assetsAPI } from '../services/api';
 import '../styles/AssetDetailPage.css';
 import { Asset, AssetProblem, MaintenanceItem } from '../types';
 

--- a/frontend/src/pages/AssetDetailPage.tsx
+++ b/frontend/src/pages/AssetDetailPage.tsx
@@ -4,15 +4,16 @@
  */
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { assetPartsAPI, assetsAPI } from '../services/api';
+import { assetPartsAPI, assetsAPI, maintenanceAPI } from '../services/api';
 import '../styles/AssetDetailPage.css';
-import { Asset, AssetProblem } from '../types';
+import { Asset, AssetProblem, MaintenanceItem } from '../types';
 
 const AssetDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [asset, setAsset] = useState<Asset | null>(null);
   const [problems, setProblems] = useState<AssetProblem[]>([]);
+  const [maintenanceItems, setMaintenanceItems] = useState<MaintenanceItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [problemStatusFilter, setProblemStatusFilter] = useState<string>('all');
@@ -31,12 +32,14 @@ const AssetDetailPage: React.FC = () => {
     try {
       setLoading(true);
       setError(null);
-      const [assetResponse, problemsResponse] = await Promise.all([
+      const [assetResponse, problemsResponse, maintenanceResponse] = await Promise.all([
         assetsAPI.getAsset(id),
         assetsAPI.getAssetProblems(id),
+        assetsAPI.getMaintenanceItems(id),
       ]);
       setAsset(assetResponse.data);
       setProblems(problemsResponse.data);
+      setMaintenanceItems(maintenanceResponse.data);
     } catch (err: any) {
       console.error('Error loading asset details:', err);
       setError(err.response?.data?.detail || 'Failed to load asset details');
@@ -676,6 +679,66 @@ const AssetDetailPage: React.FC = () => {
                 </div>
               ))}
             </div>
+          )}
+        </section>
+
+        {/* Preventive Maintenance Tasks */}
+        <section className="asset-detail-section">
+          <div className="section-header-row">
+            <h2>Preventive Maintenance</h2>
+            {isLoggedIn && (
+              <button
+                className="add-button"
+                onClick={() => navigate(`/assets/${id}/maintenance/new`)}
+              >
+                + Add PM Task
+              </button>
+            )}
+          </div>
+          {maintenanceItems.length === 0 ? (
+            <p className="no-maintenance-plan">No preventive maintenance tasks defined.</p>
+          ) : (
+            <ul className="maintenance-list">
+              {maintenanceItems.map((item) => (
+                <li key={item.id} className="maintenance-item">
+                  <div className="maintenance-item-header">
+                    <span className="maintenance-part-name">{item.title}</span>
+                    <span
+                      className={`maintenance-status-badge ${
+                        item.is_overdue ? 'status-overdue' : item.next_due_at ? 'status-upcoming' : 'status-asneeded'
+                      }`}
+                    >
+                      {item.is_overdue
+                        ? item.days_overdue
+                          ? `Overdue ${item.days_overdue}d`
+                          : 'Overdue'
+                        : item.next_due_at
+                        ? `Due ${new Date(item.next_due_at).toLocaleDateString()}`
+                        : 'As needed'}
+                    </span>
+                    {isLoggedIn && (
+                      <button
+                        className="edit-link-button"
+                        onClick={() => navigate(`/assets/${id}/maintenance/${item.id}/edit`)}
+                      >
+                        Edit
+                      </button>
+                    )}
+                  </div>
+                  {item.description && (
+                    <div className="maintenance-notes">{item.description}</div>
+                  )}
+                  {item.estimated_time_minutes && (
+                    <div className="maintenance-meta">
+                      Est. time: {item.estimated_time_minutes} min
+                      {item.estimated_cost && parseFloat(item.estimated_cost) > 0
+                        ? ` · Est. cost: $${parseFloat(item.estimated_cost).toFixed(2)}`
+                        : ''}
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
           )}
         </section>
 

--- a/frontend/src/pages/MaintenanceItemFormPage.tsx
+++ b/frontend/src/pages/MaintenanceItemFormPage.tsx
@@ -27,6 +27,7 @@ import { MaintenanceMaterial } from '../types';
 import { MaintenanceItemFormData, maintenanceItemFormSchema } from '../utils/formSchemas';
 
 interface PendingMaterial {
+  localId: string;
   id?: string;
   name: string;
   quantity: number;
@@ -46,6 +47,7 @@ const MaintenanceItemFormPage: React.FC = () => {
   const [materials, setMaterials] = useState<PendingMaterial[]>([]);
   const [originalMaterialIds, setOriginalMaterialIds] = useState<string[]>([]);
   const [newMaterial, setNewMaterial] = useState<PendingMaterial>({
+    localId: '',
     name: '',
     quantity: 1,
     unit: '',
@@ -89,6 +91,7 @@ const MaintenanceItemFormPage: React.FC = () => {
         is_active: item.is_active,
       });
       const loaded = item.materials.map((m: MaintenanceMaterial) => ({
+        localId: m.id,
         id: m.id,
         name: m.name,
         quantity: parseFloat(m.quantity),
@@ -108,8 +111,8 @@ const MaintenanceItemFormPage: React.FC = () => {
 
   const addMaterial = () => {
     if (!newMaterial.name.trim()) return;
-    setMaterials([...materials, { ...newMaterial }]);
-    setNewMaterial({ name: '', quantity: 1, unit: '', estimated_cost_per_unit: 0, notes: '' });
+    setMaterials([...materials, { ...newMaterial, localId: crypto.randomUUID() }]);
+    setNewMaterial({ localId: '', name: '', quantity: 1, unit: '', estimated_cost_per_unit: 0, notes: '' });
   };
 
   const removeMaterial = (index: number) => {
@@ -269,11 +272,11 @@ const MaintenanceItemFormPage: React.FC = () => {
                 </Table.Thead>
                 <Table.Tbody>
                   {materials.map((m, i) => (
-                    <Table.Tr key={i}>
+                    <Table.Tr key={m.localId}>
                       <Table.Td>{m.name}</Table.Td>
                       <Table.Td>{m.quantity}</Table.Td>
                       <Table.Td>{m.unit}</Table.Td>
-                      <Table.Td>${m.estimated_cost_per_unit}</Table.Td>
+                      <Table.Td>${m.estimated_cost_per_unit.toFixed(2)}</Table.Td>
                       <Table.Td>
                         <ActionIcon
                           color="red"

--- a/frontend/src/pages/MaintenanceItemFormPage.tsx
+++ b/frontend/src/pages/MaintenanceItemFormPage.tsx
@@ -1,0 +1,356 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  ActionIcon,
+  Alert,
+  Button,
+  Divider,
+  Group,
+  NumberInput,
+  Paper,
+  Stack,
+  Switch,
+  Table,
+  Text,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { IconAlertCircle, IconPlus, IconTrash } from '@tabler/icons-react';
+import React, { useEffect, useState } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+import { useNavigate, useParams } from 'react-router-dom';
+import { FormInput } from '../components/forms/FormInput';
+import { FormLayout } from '../components/forms/FormLayout';
+import { FormNumberInput } from '../components/forms/FormNumberInput';
+import { FormTextarea } from '../components/forms/FormTextarea';
+import { maintenanceAPI } from '../services/api';
+import { MaintenanceMaterial } from '../types';
+import { MaintenanceItemFormData, maintenanceItemFormSchema } from '../utils/formSchemas';
+
+interface PendingMaterial {
+  id?: string;
+  name: string;
+  quantity: number;
+  unit: string;
+  estimated_cost_per_unit: number;
+  notes: string;
+}
+
+const MaintenanceItemFormPage: React.FC = () => {
+  const { assetId, id } = useParams<{ assetId: string; id: string }>();
+  const navigate = useNavigate();
+  const isEditMode = !!id;
+
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [materials, setMaterials] = useState<PendingMaterial[]>([]);
+  const [originalMaterialIds, setOriginalMaterialIds] = useState<string[]>([]);
+  const [newMaterial, setNewMaterial] = useState<PendingMaterial>({
+    name: '',
+    quantity: 1,
+    unit: '',
+    estimated_cost_per_unit: 0,
+    notes: '',
+  });
+
+  const { control, handleSubmit, reset, setValue } = useForm<MaintenanceItemFormData>({
+    resolver: zodResolver(maintenanceItemFormSchema),
+    defaultValues: {
+      title: '',
+      description: '',
+      instructions: '',
+      estimated_time_minutes: null,
+      estimated_cost: 0,
+      interval_days: null,
+      is_active: true,
+    },
+  });
+
+  const isActive = useWatch({ control, name: 'is_active' });
+
+  useEffect(() => {
+    if (isEditMode && id) {
+      loadItem(id);
+    }
+  }, [id, isEditMode]);
+
+  const loadItem = async (itemId: string) => {
+    try {
+      setLoading(true);
+      const response = await maintenanceAPI.getItem(itemId);
+      const item = response.data;
+      reset({
+        title: item.title,
+        description: item.description || '',
+        instructions: item.instructions || '',
+        estimated_time_minutes: item.estimated_time_minutes ?? null,
+        estimated_cost: parseFloat(item.estimated_cost) || 0,
+        interval_days: item.interval_days ?? null,
+        is_active: item.is_active,
+      });
+      const loaded = item.materials.map((m: MaintenanceMaterial) => ({
+        id: m.id,
+        name: m.name,
+        quantity: parseFloat(m.quantity),
+        unit: m.unit,
+        estimated_cost_per_unit: parseFloat(m.estimated_cost_per_unit),
+        notes: m.notes,
+      }));
+      setMaterials(loaded);
+      setOriginalMaterialIds(loaded.map((m: PendingMaterial) => m.id!).filter(Boolean));
+    } catch (err) {
+      console.error('Error loading maintenance item:', err);
+      setError('Failed to load maintenance item.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const addMaterial = () => {
+    if (!newMaterial.name.trim()) return;
+    setMaterials([...materials, { ...newMaterial }]);
+    setNewMaterial({ name: '', quantity: 1, unit: '', estimated_cost_per_unit: 0, notes: '' });
+  };
+
+  const removeMaterial = (index: number) => {
+    setMaterials(materials.filter((_, i) => i !== index));
+  };
+
+  const onSubmit = async (data: MaintenanceItemFormData) => {
+    if (!assetId) return;
+    try {
+      setSaving(true);
+      setError(null);
+
+      const apiPayload = {
+        ...data,
+        asset: assetId,
+        estimated_cost: String(data.estimated_cost ?? '0'),
+      };
+
+      let savedItemId: string;
+      if (isEditMode && id) {
+        const response = await maintenanceAPI.updateItem(id, apiPayload);
+        savedItemId = response.data.id;
+
+        const keepIds = materials.filter((m) => m.id).map((m) => m.id!);
+        const toDelete = originalMaterialIds.filter((eid) => !keepIds.includes(eid));
+        await Promise.all(toDelete.map((mid) => maintenanceAPI.deleteMaterial(mid)));
+      } else {
+        const response = await maintenanceAPI.createItem(apiPayload);
+        savedItemId = response.data.id;
+      }
+
+      const newMaterials = materials.filter((m) => !m.id);
+      await Promise.all(
+        newMaterials.map((m) =>
+          maintenanceAPI.createMaterial({
+            maintenance_item: savedItemId,
+            name: m.name,
+            quantity: String(m.quantity),
+            unit: m.unit,
+            estimated_cost_per_unit: String(m.estimated_cost_per_unit),
+            notes: m.notes,
+          })
+        )
+      );
+
+      navigate(`/assets/${assetId}`);
+    } catch (err: any) {
+      console.error('Error saving maintenance item:', err);
+      setError(err.response?.data?.detail || 'Failed to save maintenance item.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Paper p="md">
+        <Text>Loading...</Text>
+      </Paper>
+    );
+  }
+
+  return (
+    <Stack gap="md">
+      <Group justify="space-between">
+        <Title order={2}>{isEditMode ? 'Edit PM Task' : 'New PM Task'}</Title>
+        <Button variant="subtle" onClick={() => navigate(`/assets/${assetId}`)}>
+          Cancel
+        </Button>
+      </Group>
+
+      {error && (
+        <Alert icon={<IconAlertCircle size={16} />} title="Error" color="red">
+          {error}
+        </Alert>
+      )}
+
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Paper p="md" withBorder>
+          <FormLayout
+            sections={[
+              {
+                title: 'Task Details',
+                children: (
+                  <>
+                    <FormInput
+                      name="title"
+                      control={control}
+                      label="Title"
+                      required
+                      placeholder="e.g. Replace air filter"
+                    />
+                    <FormTextarea
+                      name="description"
+                      control={control}
+                      label="Description"
+                      placeholder="Why this maintenance is needed"
+                    />
+                    <FormTextarea
+                      name="instructions"
+                      control={control}
+                      label="Instructions"
+                      placeholder="Step-by-step instructions"
+                      minRows={4}
+                    />
+                  </>
+                ),
+              },
+              {
+                title: 'Schedule & Estimates',
+                children: (
+                  <>
+                    <FormNumberInput
+                      name="interval_days"
+                      control={control}
+                      label="Interval (days)"
+                      placeholder="Leave blank for one-time or as-needed"
+                      min={1}
+                    />
+                    <FormNumberInput
+                      name="estimated_time_minutes"
+                      control={control}
+                      label="Estimated Time (minutes)"
+                      min={1}
+                    />
+                    <FormNumberInput
+                      name="estimated_cost"
+                      control={control}
+                      label="Estimated Cost ($)"
+                      min={0}
+                      step={0.01}
+                    />
+                    <Switch
+                      label="Active"
+                      description="Inactive tasks are hidden from the scan page"
+                      checked={isActive ?? true}
+                      onChange={(e) => setValue('is_active', e.currentTarget.checked)}
+                    />
+                  </>
+                ),
+              },
+            ]}
+          />
+
+          <Divider my="md" label="Materials" labelPosition="left" />
+          <Stack gap="sm">
+            {materials.length > 0 && (
+              <Table striped withTableBorder>
+                <Table.Thead>
+                  <Table.Tr>
+                    <Table.Th>Name</Table.Th>
+                    <Table.Th>Qty</Table.Th>
+                    <Table.Th>Unit</Table.Th>
+                    <Table.Th>Cost/Unit</Table.Th>
+                    <Table.Th></Table.Th>
+                  </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                  {materials.map((m, i) => (
+                    <Table.Tr key={i}>
+                      <Table.Td>{m.name}</Table.Td>
+                      <Table.Td>{m.quantity}</Table.Td>
+                      <Table.Td>{m.unit}</Table.Td>
+                      <Table.Td>${m.estimated_cost_per_unit}</Table.Td>
+                      <Table.Td>
+                        <ActionIcon
+                          color="red"
+                          variant="subtle"
+                          onClick={() => removeMaterial(i)}
+                          aria-label="Remove material"
+                        >
+                          <IconTrash size={16} />
+                        </ActionIcon>
+                      </Table.Td>
+                    </Table.Tr>
+                  ))}
+                </Table.Tbody>
+              </Table>
+            )}
+
+            <Paper p="sm" withBorder>
+              <Text size="sm" fw={500} mb="xs">
+                Add Material
+              </Text>
+              <Group align="flex-end" gap="xs">
+                <TextInput
+                  label="Name"
+                  value={newMaterial.name}
+                  onChange={(e) => setNewMaterial({ ...newMaterial, name: e.target.value })}
+                  placeholder="e.g. Air filter"
+                  style={{ flex: 2 }}
+                />
+                <NumberInput
+                  label="Qty"
+                  value={newMaterial.quantity}
+                  onChange={(v) => setNewMaterial({ ...newMaterial, quantity: Number(v) || 1 })}
+                  min={0.01}
+                  step={1}
+                  style={{ flex: 1 }}
+                />
+                <TextInput
+                  label="Unit"
+                  value={newMaterial.unit}
+                  onChange={(e) => setNewMaterial({ ...newMaterial, unit: e.target.value })}
+                  placeholder="pcs, oz, ft…"
+                  style={{ flex: 1 }}
+                />
+                <NumberInput
+                  label="Cost/Unit ($)"
+                  value={newMaterial.estimated_cost_per_unit}
+                  onChange={(v) =>
+                    setNewMaterial({ ...newMaterial, estimated_cost_per_unit: Number(v) || 0 })
+                  }
+                  min={0}
+                  step={0.01}
+                  style={{ flex: 1 }}
+                />
+                <Button
+                  leftSection={<IconPlus size={16} />}
+                  onClick={addMaterial}
+                  disabled={!newMaterial.name.trim()}
+                  variant="light"
+                >
+                  Add
+                </Button>
+              </Group>
+            </Paper>
+          </Stack>
+
+          <Group justify="flex-end" mt="xl">
+            <Button variant="subtle" onClick={() => navigate(`/assets/${assetId}`)}>
+              Cancel
+            </Button>
+            <Button type="submit" loading={saving}>
+              {isEditMode ? 'Save Changes' : 'Create Task'}
+            </Button>
+          </Group>
+        </Paper>
+      </form>
+    </Stack>
+  );
+};
+
+export default MaintenanceItemFormPage;

--- a/frontend/src/styles/AssetDetailPage.css
+++ b/frontend/src/styles/AssetDetailPage.css
@@ -524,6 +524,76 @@
   font-style: italic;
 }
 
+.section-header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.section-header-row h2 {
+  margin: 0;
+}
+
+.add-button {
+  padding: 0.4rem 1rem;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.add-button:hover {
+  background-color: #0056b3;
+}
+
+.edit-link-button {
+  padding: 0.2rem 0.6rem;
+  background: none;
+  border: 1px solid #adb5bd;
+  border-radius: 4px;
+  color: #495057;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.edit-link-button:hover {
+  background-color: #f1f3f5;
+}
+
+.maintenance-status-badge {
+  padding: 0.2rem 0.6rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.maintenance-status-badge.status-overdue {
+  background-color: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffc107;
+}
+
+.maintenance-status-badge.status-upcoming {
+  background-color: #d1ecf1;
+  color: #0c5460;
+  border: 1px solid #17a2b8;
+}
+
+.maintenance-status-badge.status-asneeded {
+  background-color: #f8f9fa;
+  color: #6c757d;
+  border: 1px solid #dee2e6;
+}
+
+.maintenance-meta {
+  margin-top: 0.4rem;
+  font-size: 0.8rem;
+  color: #868e96;
+}
+
 /* QR Code */
 .qr-code-section {
   display: flex;

--- a/frontend/src/utils/formSchemas.ts
+++ b/frontend/src/utils/formSchemas.ts
@@ -290,3 +290,27 @@ export const webhookSchema = z.object({
 });
 
 export type WebhookFormData = z.infer<typeof webhookSchema>;
+
+// Maintenance Material Form Schema
+export const maintenanceMaterialFormSchema = z.object({
+  name: z.string().min(1, 'Material name is required').max(200),
+  quantity: z.number().min(0.01, 'Quantity must be greater than 0'),
+  unit: z.string().max(50).optional().default(''),
+  estimated_cost_per_unit: z.number().min(0, 'Cost must be zero or greater').default(0),
+  notes: z.string().optional().default(''),
+});
+
+export type MaintenanceMaterialFormData = z.infer<typeof maintenanceMaterialFormSchema>;
+
+// Maintenance Item Form Schema
+export const maintenanceItemFormSchema = z.object({
+  title: z.string().min(1, 'Title is required').max(200),
+  description: z.string().optional().default(''),
+  instructions: z.string().optional().default(''),
+  estimated_time_minutes: z.number().int().min(1).nullable().optional(),
+  estimated_cost: z.number().min(0, 'Cost must be zero or greater').default(0),
+  interval_days: z.number().int().min(1).nullable().optional(),
+  is_active: z.boolean().default(true),
+});
+
+export type MaintenanceItemFormData = z.infer<typeof maintenanceItemFormSchema>;

--- a/frontend/src/utils/formSchemas.ts
+++ b/frontend/src/utils/formSchemas.ts
@@ -291,17 +291,6 @@ export const webhookSchema = z.object({
 
 export type WebhookFormData = z.infer<typeof webhookSchema>;
 
-// Maintenance Material Form Schema
-export const maintenanceMaterialFormSchema = z.object({
-  name: z.string().min(1, 'Material name is required').max(200),
-  quantity: z.number().min(0.01, 'Quantity must be greater than 0'),
-  unit: z.string().max(50).optional().default(''),
-  estimated_cost_per_unit: z.number().min(0, 'Cost must be zero or greater').default(0),
-  notes: z.string().optional().default(''),
-});
-
-export type MaintenanceMaterialFormData = z.infer<typeof maintenanceMaterialFormSchema>;
-
 // Maintenance Item Form Schema
 export const maintenanceItemFormSchema = z.object({
   title: z.string().min(1, 'Title is required').max(200),


### PR DESCRIPTION
## Summary

- Add `MaintenanceItemFormPage` for creating and editing PM tasks on fixed assets
- Wire up form to asset detail page and app routing
- Address review feedback: form validation, styling, UX improvements

Closes hq-cv-hjp5l

## Notes

GT internal files stripped from polecat branch before merge.

## Test plan

- [ ] Create a new PM task from the asset detail page
- [ ] Edit an existing PM task
- [ ] Verify form validation works
- [ ] Verify routing to/from the form page

🤖 Merged by Refinery (oms/refinery) via [Claude Code](https://claude.com/claude-code)