### PR TITLE
feat: preventive maintenance work orders, PDF forms, and PM dashboard (#oms-1qj)

### DIFF
--- a/backend/inventory/admin.py
+++ b/backend/inventory/admin.py
@@ -23,9 +23,14 @@ from .models import (
     MaintenanceItem,
     MaintenanceLog,
     MaintenanceMaterial,
+    MaintenanceTask,
     PriceHistory,
     Supplier,
     UsageLog,
+    WorkOrder,
+    WorkOrderMaterialUsage,
+    WorkOrderPhoto,
+    WorkOrderTaskCompletion,
 )
 
 
@@ -1340,6 +1345,13 @@ class MaintenanceMaterialInline(admin.TabularInline):
     fields = ["name", "quantity", "unit", "estimated_cost_per_unit", "notes"]
 
 
+class MaintenanceTaskInline(admin.TabularInline):
+    model = MaintenanceTask
+    extra = 1
+    fields = ["order", "title", "description", "is_required"]
+    ordering = ["order"]
+
+
 @admin.register(MaintenanceItem)
 class MaintenanceItemAdmin(admin.ModelAdmin):
     list_display = [
@@ -1353,7 +1365,7 @@ class MaintenanceItemAdmin(admin.ModelAdmin):
     list_filter = ["is_active", "asset__category"]
     search_fields = ["title", "description", "asset__name", "asset__asset_tag"]
     autocomplete_fields = ["asset"]
-    inlines = [MaintenanceMaterialInline]
+    inlines = [MaintenanceMaterialInline, MaintenanceTaskInline]
     readonly_fields = ["is_overdue", "days_overdue", "next_due_at", "created_at", "updated_at"]
     fieldsets = [
         (None, {"fields": ["asset", "title", "description", "is_active"]}),
@@ -1386,3 +1398,55 @@ class MaintenanceLogAdmin(admin.ModelAdmin):
     list_filter = ["completed_at"]
     search_fields = ["maintenance_item__title", "maintenance_item__asset__name", "notes"]
     readonly_fields = ["completed_at", "created_at"]
+
+
+@admin.register(MaintenanceTask)
+class MaintenanceTaskAdmin(admin.ModelAdmin):
+    list_display = ["maintenance_item", "order", "title", "is_required", "created_at"]
+    list_filter = ["is_required"]
+    search_fields = ["title", "maintenance_item__title", "maintenance_item__asset__name"]
+    ordering = ["maintenance_item", "order"]
+
+
+class WorkOrderTaskCompletionInline(admin.TabularInline):
+    model = WorkOrderTaskCompletion
+    extra = 0
+    fields = ["task_order", "task_title", "is_required", "is_completed", "completed_by", "completed_at", "notes"]
+    readonly_fields = ["task_order", "task_title", "is_required", "completed_at"]
+
+
+class WorkOrderMaterialUsageInline(admin.TabularInline):
+    model = WorkOrderMaterialUsage
+    extra = 0
+    fields = ["material_name", "quantity_planned", "unit", "was_used"]
+    readonly_fields = ["material_name", "quantity_planned", "unit"]
+
+
+class WorkOrderPhotoInline(admin.TabularInline):
+    model = WorkOrderPhoto
+    extra = 0
+    fields = ["image", "caption", "uploaded_by", "uploaded_at"]
+    readonly_fields = ["uploaded_at"]
+
+
+@admin.register(WorkOrder)
+class WorkOrderAdmin(admin.ModelAdmin):
+    list_display = [
+        "short_id",
+        "maintenance_item",
+        "status",
+        "due_date",
+        "assigned_to",
+        "completed_by_name",
+        "is_overdue",
+        "created_at",
+    ]
+    list_filter = ["status", "due_date"]
+    search_fields = [
+        "maintenance_item__title",
+        "maintenance_item__asset__name",
+        "completed_by_name",
+        "notes",
+    ]
+    readonly_fields = ["short_id", "is_overdue", "created_at", "updated_at"]
+    inlines = [WorkOrderTaskCompletionInline, WorkOrderMaterialUsageInline, WorkOrderPhotoInline]

--- a/backend/inventory/admin.py
+++ b/backend/inventory/admin.py
@@ -1411,7 +1411,15 @@ class MaintenanceTaskAdmin(admin.ModelAdmin):
 class WorkOrderTaskCompletionInline(admin.TabularInline):
     model = WorkOrderTaskCompletion
     extra = 0
-    fields = ["task_order", "task_title", "is_required", "is_completed", "completed_by", "completed_at", "notes"]
+    fields = [
+        "task_order",
+        "task_title",
+        "is_required",
+        "is_completed",
+        "completed_by",
+        "completed_at",
+        "notes",
+    ]
     readonly_fields = ["task_order", "task_title", "is_required", "completed_at"]
 
 

--- a/backend/inventory/migrations/0044_add_work_orders.py
+++ b/backend/inventory/migrations/0044_add_work_orders.py
@@ -1,0 +1,342 @@
+import uuid
+from decimal import Decimal
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0043_add_maintenance_models"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="MaintenanceTask",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4, editable=False, primary_key=True, serialize=False
+                    ),
+                ),
+                (
+                    "order",
+                    models.PositiveIntegerField(
+                        default=0,
+                        help_text="Display order (lower numbers appear first)",
+                    ),
+                ),
+                (
+                    "title",
+                    models.CharField(
+                        max_length=200, help_text="Short title for this step"
+                    ),
+                ),
+                (
+                    "description",
+                    models.TextField(
+                        blank=True,
+                        help_text="Detailed instructions for this step",
+                    ),
+                ),
+                (
+                    "is_required",
+                    models.BooleanField(
+                        default=True,
+                        help_text="Required steps must be completed before the work order can close",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "maintenance_item",
+                    models.ForeignKey(
+                        help_text="The maintenance task this step belongs to",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="tasks",
+                        to="inventory.maintenanceitem",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["order", "title"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="maintenancetask",
+            index=models.Index(
+                fields=["maintenance_item", "order"], name="mt_item_order_idx"
+            ),
+        ),
+        migrations.CreateModel(
+            name="WorkOrder",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4, editable=False, primary_key=True, serialize=False
+                    ),
+                ),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("open", "Open"),
+                            ("in_progress", "In Progress"),
+                            ("blocked", "Blocked"),
+                            ("completed", "Completed"),
+                        ],
+                        default="open",
+                        max_length=20,
+                        help_text="Current status of this work order",
+                    ),
+                ),
+                (
+                    "due_date",
+                    models.DateField(
+                        blank=True,
+                        null=True,
+                        help_text="Date by which this work order should be completed",
+                    ),
+                ),
+                (
+                    "completed_by_name",
+                    models.CharField(
+                        blank=True,
+                        max_length=200,
+                        help_text="Name of person who completed the work (for paper form tracking)",
+                    ),
+                ),
+                (
+                    "completed_at",
+                    models.DateTimeField(
+                        blank=True,
+                        null=True,
+                        help_text="When this work order was marked complete",
+                    ),
+                ),
+                (
+                    "notes",
+                    models.TextField(blank=True, help_text="Notes about this work order"),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "assigned_to",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="assigned_work_orders",
+                        to=settings.AUTH_USER_MODEL,
+                        help_text="User assigned to complete this work order",
+                    ),
+                ),
+                (
+                    "maintenance_item",
+                    models.ForeignKey(
+                        help_text="The maintenance task this work order is for",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="work_orders",
+                        to="inventory.maintenanceitem",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="workorder",
+            index=models.Index(
+                fields=["maintenance_item", "status"], name="wo_item_status_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="workorder",
+            index=models.Index(
+                fields=["due_date", "status"], name="wo_due_status_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="workorder",
+            index=models.Index(
+                fields=["status", "-created_at"], name="wo_status_created_idx"
+            ),
+        ),
+        migrations.CreateModel(
+            name="WorkOrderTaskCompletion",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4, editable=False, primary_key=True, serialize=False
+                    ),
+                ),
+                (
+                    "task_title",
+                    models.CharField(
+                        max_length=200,
+                        help_text="Denormalized task title (preserved if task is later deleted)",
+                    ),
+                ),
+                (
+                    "task_order",
+                    models.PositiveIntegerField(
+                        default=0,
+                        help_text="Display order (denormalized from task at creation time)",
+                    ),
+                ),
+                (
+                    "is_required",
+                    models.BooleanField(default=True, help_text="Whether this step is required"),
+                ),
+                ("is_completed", models.BooleanField(default=False)),
+                ("completed_at", models.DateTimeField(blank=True, null=True)),
+                ("notes", models.TextField(blank=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "completed_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="completed_work_order_tasks",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "task",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="completions",
+                        to="inventory.maintenancetask",
+                        help_text="The task step (null if task was deleted after WO creation)",
+                    ),
+                ),
+                (
+                    "work_order",
+                    models.ForeignKey(
+                        help_text="The work order this task completion belongs to",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="task_completions",
+                        to="inventory.workorder",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["task_order", "task_title"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="workordertaskcompletion",
+            index=models.Index(
+                fields=["work_order", "is_completed"], name="wotc_wo_completed_idx"
+            ),
+        ),
+        migrations.CreateModel(
+            name="WorkOrderMaterialUsage",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4, editable=False, primary_key=True, serialize=False
+                    ),
+                ),
+                (
+                    "material_name",
+                    models.CharField(
+                        max_length=200, help_text="Denormalized material name"
+                    ),
+                ),
+                (
+                    "quantity_planned",
+                    models.DecimalField(
+                        decimal_places=2,
+                        default=Decimal("1.00"),
+                        max_digits=10,
+                        help_text="Planned quantity from the maintenance item spec",
+                    ),
+                ),
+                ("unit", models.CharField(blank=True, max_length=50)),
+                (
+                    "was_used",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Whether this material was actually used",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "material",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="usage_records",
+                        to="inventory.maintenancematerial",
+                        help_text="The material specification (null if deleted after WO creation)",
+                    ),
+                ),
+                (
+                    "work_order",
+                    models.ForeignKey(
+                        help_text="The work order this material usage belongs to",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="material_usage",
+                        to="inventory.workorder",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["material_name"],
+            },
+        ),
+        migrations.CreateModel(
+            name="WorkOrderPhoto",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4, editable=False, primary_key=True, serialize=False
+                    ),
+                ),
+                (
+                    "image",
+                    models.ImageField(
+                        upload_to="work_order_photos/%Y/%m/",
+                        help_text="Photo of the asset or work performed",
+                    ),
+                ),
+                ("caption", models.CharField(blank=True, max_length=500)),
+                ("uploaded_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "uploaded_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="work_order_photos",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "work_order",
+                    models.ForeignKey(
+                        help_text="The work order this photo belongs to",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="photos",
+                        to="inventory.workorder",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-uploaded_at"],
+            },
+        ),
+    ]

--- a/backend/inventory/models.py
+++ b/backend/inventory/models.py
@@ -1717,6 +1717,271 @@ class MaintenanceLog(models.Model):
         return f"{self.maintenance_item.title} — completed by {completed_by} at {self.completed_at}"
 
 
+class MaintenanceTask(models.Model):
+    """
+    An ordered sub-task (line item) within a MaintenanceItem.
+
+    Allows a single maintenance item to have a numbered checklist of steps,
+    e.g., Task 1: "Disconnect Power", Task 2: "Lock Out Equipment".
+    These appear on both printed work order forms and the digital interface.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    maintenance_item = models.ForeignKey(
+        MaintenanceItem,
+        on_delete=models.CASCADE,
+        related_name="tasks",
+        help_text="The maintenance task this step belongs to",
+    )
+    order = models.PositiveIntegerField(
+        default=0,
+        help_text="Display order (lower numbers appear first)",
+    )
+    title = models.CharField(max_length=200, help_text="Short title for this step")
+    description = models.TextField(blank=True, help_text="Detailed instructions for this step")
+    is_required = models.BooleanField(
+        default=True,
+        help_text="Required steps must be completed before the work order can close",
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["order", "title"]
+        indexes = [
+            models.Index(fields=["maintenance_item", "order"], name="mt_item_order_idx"),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.maintenance_item.title} — Step {self.order}: {self.title}"
+
+
+class WorkOrder(models.Model):
+    """
+    A scheduled or generated work order for a preventive maintenance item.
+
+    Work orders can be printed as PDF forms for non-technical users or
+    completed digitally by technical users. Both paths feed back into the
+    maintenance history.
+    """
+
+    STATUS_OPEN = "open"
+    STATUS_IN_PROGRESS = "in_progress"
+    STATUS_BLOCKED = "blocked"
+    STATUS_COMPLETED = "completed"
+
+    STATUS_CHOICES = [
+        (STATUS_OPEN, "Open"),
+        (STATUS_IN_PROGRESS, "In Progress"),
+        (STATUS_BLOCKED, "Blocked"),
+        (STATUS_COMPLETED, "Completed"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    maintenance_item = models.ForeignKey(
+        MaintenanceItem,
+        on_delete=models.CASCADE,
+        related_name="work_orders",
+        help_text="The maintenance task this work order is for",
+    )
+    status = models.CharField(
+        max_length=20,
+        choices=STATUS_CHOICES,
+        default=STATUS_OPEN,
+        help_text="Current status of this work order",
+    )
+    due_date = models.DateField(
+        null=True,
+        blank=True,
+        help_text="Date by which this work order should be completed",
+    )
+    assigned_to = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="assigned_work_orders",
+        help_text="User assigned to complete this work order",
+    )
+    completed_by_name = models.CharField(
+        max_length=200,
+        blank=True,
+        help_text="Name of person who completed the work (for paper form tracking)",
+    )
+    completed_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text="When this work order was marked complete",
+    )
+    notes = models.TextField(blank=True, help_text="Notes about this work order")
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["maintenance_item", "status"], name="wo_item_status_idx"),
+            models.Index(fields=["due_date", "status"], name="wo_due_status_idx"),
+            models.Index(fields=["status", "-created_at"], name="wo_status_created_idx"),
+        ]
+
+    def __str__(self) -> str:
+        return f"WO-{str(self.id)[:8].upper()} — {self.maintenance_item.title} ({self.get_status_display()})"
+
+    @property
+    def is_overdue(self) -> bool:
+        """Return True if this open work order is past its due date."""
+        from django.utils import timezone
+
+        if self.status == self.STATUS_COMPLETED:
+            return False
+        if not self.due_date:
+            return False
+        return timezone.now().date() > self.due_date
+
+    @property
+    def short_id(self) -> str:
+        """Return a short human-readable identifier for this work order."""
+        return f"WO-{str(self.id)[:8].upper()}"
+
+
+class WorkOrderTaskCompletion(models.Model):
+    """
+    Tracks completion of an individual task step within a work order.
+
+    Created for each MaintenanceTask when a WorkOrder is generated,
+    allowing granular tracking of which steps have been completed.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    work_order = models.ForeignKey(
+        WorkOrder,
+        on_delete=models.CASCADE,
+        related_name="task_completions",
+        help_text="The work order this task completion belongs to",
+    )
+    task = models.ForeignKey(
+        MaintenanceTask,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="completions",
+        help_text="The task step (null if task was deleted after WO creation)",
+    )
+    task_title = models.CharField(
+        max_length=200,
+        help_text="Denormalized task title (preserved if task is later deleted)",
+    )
+    task_order = models.PositiveIntegerField(
+        default=0,
+        help_text="Display order (denormalized from task at creation time)",
+    )
+    is_required = models.BooleanField(
+        default=True,
+        help_text="Whether this step is required",
+    )
+    is_completed = models.BooleanField(default=False)
+    completed_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="completed_work_order_tasks",
+    )
+    completed_at = models.DateTimeField(null=True, blank=True)
+    notes = models.TextField(blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["task_order", "task_title"]
+        indexes = [
+            models.Index(fields=["work_order", "is_completed"], name="wotc_wo_completed_idx"),
+        ]
+
+    def __str__(self) -> str:
+        status = "✓" if self.is_completed else "○"
+        return f"{status} {self.task_title} (WO {self.work_order.short_id})"
+
+
+class WorkOrderMaterialUsage(models.Model):
+    """
+    Tracks which materials were actually used when completing a work order.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    work_order = models.ForeignKey(
+        WorkOrder,
+        on_delete=models.CASCADE,
+        related_name="material_usage",
+        help_text="The work order this material usage belongs to",
+    )
+    material = models.ForeignKey(
+        MaintenanceMaterial,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="usage_records",
+        help_text="The material specification (null if deleted after WO creation)",
+    )
+    material_name = models.CharField(
+        max_length=200,
+        help_text="Denormalized material name",
+    )
+    quantity_planned = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        default=Decimal("1.00"),
+        help_text="Planned quantity from the maintenance item spec",
+    )
+    unit = models.CharField(max_length=50, blank=True)
+    was_used = models.BooleanField(
+        default=False,
+        help_text="Whether this material was actually used",
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["material_name"]
+
+    def __str__(self) -> str:
+        status = "used" if self.was_used else "not used"
+        return f"{self.material_name} ({status}) — WO {self.work_order.short_id}"
+
+
+class WorkOrderPhoto(models.Model):
+    """
+    A photo attached to a work order by a technician.
+
+    Used for documenting wear, damage, or completed work.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    work_order = models.ForeignKey(
+        WorkOrder,
+        on_delete=models.CASCADE,
+        related_name="photos",
+        help_text="The work order this photo belongs to",
+    )
+    image = models.ImageField(
+        upload_to="work_order_photos/%Y/%m/",
+        help_text="Photo of the asset or work performed",
+    )
+    caption = models.CharField(max_length=500, blank=True)
+    uploaded_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="work_order_photos",
+    )
+    uploaded_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-uploaded_at"]
+
+    def __str__(self) -> str:
+        return f"Photo for WO {self.work_order.short_id} ({self.uploaded_at.date()})"
+
+
 class Fixture(models.Model):
     """
     Fixed assets that require periodic refilling (e.g., soap dispensers, paper towel holders).

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -1278,18 +1278,10 @@ class WorkOrderPhotoSerializer(serializers.ModelSerializer):
 class WorkOrderSerializer(serializers.ModelSerializer):
     """Full serializer for a work order, including nested completions and photos."""
 
-    maintenance_item_title = serializers.CharField(
-        source="maintenance_item.title", read_only=True
-    )
-    asset_name = serializers.CharField(
-        source="maintenance_item.asset.name", read_only=True
-    )
-    asset_tag = serializers.CharField(
-        source="maintenance_item.asset.asset_tag", read_only=True
-    )
-    asset_id = serializers.UUIDField(
-        source="maintenance_item.asset.id", read_only=True
-    )
+    maintenance_item_title = serializers.CharField(source="maintenance_item.title", read_only=True)
+    asset_name = serializers.CharField(source="maintenance_item.asset.name", read_only=True)
+    asset_tag = serializers.CharField(source="maintenance_item.asset.asset_tag", read_only=True)
+    asset_id = serializers.UUIDField(source="maintenance_item.asset.id", read_only=True)
     assigned_to_name = serializers.SerializerMethodField()
     short_id = serializers.ReadOnlyField()
     is_overdue = serializers.ReadOnlyField()
@@ -1340,18 +1332,10 @@ class WorkOrderSerializer(serializers.ModelSerializer):
 class WorkOrderListSerializer(serializers.ModelSerializer):
     """Lightweight serializer for work order list views."""
 
-    maintenance_item_title = serializers.CharField(
-        source="maintenance_item.title", read_only=True
-    )
-    asset_name = serializers.CharField(
-        source="maintenance_item.asset.name", read_only=True
-    )
-    asset_tag = serializers.CharField(
-        source="maintenance_item.asset.asset_tag", read_only=True
-    )
-    asset_id = serializers.UUIDField(
-        source="maintenance_item.asset.id", read_only=True
-    )
+    maintenance_item_title = serializers.CharField(source="maintenance_item.title", read_only=True)
+    asset_name = serializers.CharField(source="maintenance_item.asset.name", read_only=True)
+    asset_tag = serializers.CharField(source="maintenance_item.asset.asset_tag", read_only=True)
+    asset_id = serializers.UUIDField(source="maintenance_item.asset.id", read_only=True)
     short_id = serializers.ReadOnlyField()
     is_overdue = serializers.ReadOnlyField()
     task_completion_count = serializers.SerializerMethodField()

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -17,9 +17,14 @@ from .models import (
     MaintenanceItem,
     MaintenanceLog,
     MaintenanceMaterial,
+    MaintenanceTask,
     PriceHistory,
     Supplier,
     UsageLog,
+    WorkOrder,
+    WorkOrderMaterialUsage,
+    WorkOrderPhoto,
+    WorkOrderTaskCompletion,
 )
 
 
@@ -999,6 +1004,7 @@ class MaintenanceItemSerializer(serializers.ModelSerializer):
     asset_name = serializers.CharField(source="asset.name", read_only=True)
     asset_tag = serializers.CharField(source="asset.asset_tag", read_only=True)
     materials = MaintenanceMaterialSerializer(many=True, read_only=True)
+    tasks = MaintenanceTaskSerializer(many=True, read_only=True)
     is_overdue = serializers.ReadOnlyField()
     days_overdue = serializers.ReadOnlyField()
     next_due_at = serializers.ReadOnlyField()
@@ -1022,6 +1028,7 @@ class MaintenanceItemSerializer(serializers.ModelSerializer):
             "days_overdue",
             "next_due_at",
             "materials",
+            "tasks",
             "created_at",
             "updated_at",
         ]
@@ -1170,3 +1177,209 @@ class FixtureDetailSerializer(FixtureSerializer):
         if "recent_refill_requests" in data:
             data["recent_refill_requests"] = data["recent_refill_requests"][:10]
         return data
+
+
+class MaintenanceTaskSerializer(serializers.ModelSerializer):
+    """Serializer for ordered sub-task steps within a maintenance item."""
+
+    class Meta:
+        model = MaintenanceTask
+        fields = [
+            "id",
+            "maintenance_item",
+            "order",
+            "title",
+            "description",
+            "is_required",
+            "created_at",
+        ]
+        read_only_fields = ["created_at"]
+
+
+class WorkOrderTaskCompletionSerializer(serializers.ModelSerializer):
+    """Serializer for task completion records within a work order."""
+
+    completed_by_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = WorkOrderTaskCompletion
+        fields = [
+            "id",
+            "work_order",
+            "task",
+            "task_title",
+            "task_order",
+            "is_required",
+            "is_completed",
+            "completed_by",
+            "completed_by_name",
+            "completed_at",
+            "notes",
+            "created_at",
+        ]
+        read_only_fields = ["created_at", "completed_by_name", "task_title", "task_order"]
+
+    def get_completed_by_name(self, obj):
+        if obj.completed_by:
+            return obj.completed_by.get_full_name() or obj.completed_by.username
+        return None
+
+
+class WorkOrderMaterialUsageSerializer(serializers.ModelSerializer):
+    """Serializer for material usage tracking within a work order."""
+
+    class Meta:
+        model = WorkOrderMaterialUsage
+        fields = [
+            "id",
+            "work_order",
+            "material",
+            "material_name",
+            "quantity_planned",
+            "unit",
+            "was_used",
+            "created_at",
+        ]
+        read_only_fields = ["created_at", "material_name", "quantity_planned", "unit"]
+
+
+class WorkOrderPhotoSerializer(serializers.ModelSerializer):
+    """Serializer for photos attached to a work order."""
+
+    uploaded_by_name = serializers.SerializerMethodField()
+    image_url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = WorkOrderPhoto
+        fields = [
+            "id",
+            "work_order",
+            "image",
+            "image_url",
+            "caption",
+            "uploaded_by",
+            "uploaded_by_name",
+            "uploaded_at",
+        ]
+        read_only_fields = ["uploaded_at", "uploaded_by_name", "image_url"]
+
+    def get_uploaded_by_name(self, obj):
+        if obj.uploaded_by:
+            return obj.uploaded_by.get_full_name() or obj.uploaded_by.username
+        return None
+
+    def get_image_url(self, obj):
+        request = self.context.get("request")
+        if obj.image and request:
+            return request.build_absolute_uri(obj.image.url)
+        return None
+
+
+class WorkOrderSerializer(serializers.ModelSerializer):
+    """Full serializer for a work order, including nested completions and photos."""
+
+    maintenance_item_title = serializers.CharField(
+        source="maintenance_item.title", read_only=True
+    )
+    asset_name = serializers.CharField(
+        source="maintenance_item.asset.name", read_only=True
+    )
+    asset_tag = serializers.CharField(
+        source="maintenance_item.asset.asset_tag", read_only=True
+    )
+    asset_id = serializers.UUIDField(
+        source="maintenance_item.asset.id", read_only=True
+    )
+    assigned_to_name = serializers.SerializerMethodField()
+    short_id = serializers.ReadOnlyField()
+    is_overdue = serializers.ReadOnlyField()
+    task_completions = WorkOrderTaskCompletionSerializer(many=True, read_only=True)
+    material_usage = WorkOrderMaterialUsageSerializer(many=True, read_only=True)
+    photos = WorkOrderPhotoSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = WorkOrder
+        fields = [
+            "id",
+            "short_id",
+            "maintenance_item",
+            "maintenance_item_title",
+            "asset_name",
+            "asset_tag",
+            "asset_id",
+            "status",
+            "due_date",
+            "assigned_to",
+            "assigned_to_name",
+            "completed_by_name",
+            "completed_at",
+            "notes",
+            "is_overdue",
+            "task_completions",
+            "material_usage",
+            "photos",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = [
+            "short_id",
+            "is_overdue",
+            "created_at",
+            "updated_at",
+            "task_completions",
+            "material_usage",
+            "photos",
+        ]
+
+    def get_assigned_to_name(self, obj):
+        if obj.assigned_to:
+            return obj.assigned_to.get_full_name() or obj.assigned_to.username
+        return None
+
+
+class WorkOrderListSerializer(serializers.ModelSerializer):
+    """Lightweight serializer for work order list views."""
+
+    maintenance_item_title = serializers.CharField(
+        source="maintenance_item.title", read_only=True
+    )
+    asset_name = serializers.CharField(
+        source="maintenance_item.asset.name", read_only=True
+    )
+    asset_tag = serializers.CharField(
+        source="maintenance_item.asset.asset_tag", read_only=True
+    )
+    asset_id = serializers.UUIDField(
+        source="maintenance_item.asset.id", read_only=True
+    )
+    short_id = serializers.ReadOnlyField()
+    is_overdue = serializers.ReadOnlyField()
+    task_completion_count = serializers.SerializerMethodField()
+    task_total_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = WorkOrder
+        fields = [
+            "id",
+            "short_id",
+            "maintenance_item",
+            "maintenance_item_title",
+            "asset_name",
+            "asset_tag",
+            "asset_id",
+            "status",
+            "due_date",
+            "is_overdue",
+            "completed_by_name",
+            "completed_at",
+            "task_completion_count",
+            "task_total_count",
+            "created_at",
+            "updated_at",
+        ]
+
+    def get_task_completion_count(self, obj):
+        return obj.task_completions.filter(is_completed=True).count()
+
+    def get_task_total_count(self, obj):
+        return obj.task_completions.count()

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -998,6 +998,23 @@ class MaintenanceMaterialSerializer(serializers.ModelSerializer):
         read_only_fields = ["total_estimated_cost", "created_at"]
 
 
+class MaintenanceTaskSerializer(serializers.ModelSerializer):
+    """Serializer for ordered sub-task steps within a maintenance item."""
+
+    class Meta:
+        model = MaintenanceTask
+        fields = [
+            "id",
+            "maintenance_item",
+            "order",
+            "title",
+            "description",
+            "is_required",
+            "created_at",
+        ]
+        read_only_fields = ["created_at"]
+
+
 class MaintenanceItemSerializer(serializers.ModelSerializer):
     """Serializer for preventive maintenance tasks associated with an asset."""
 
@@ -1177,23 +1194,6 @@ class FixtureDetailSerializer(FixtureSerializer):
         if "recent_refill_requests" in data:
             data["recent_refill_requests"] = data["recent_refill_requests"][:10]
         return data
-
-
-class MaintenanceTaskSerializer(serializers.ModelSerializer):
-    """Serializer for ordered sub-task steps within a maintenance item."""
-
-    class Meta:
-        model = MaintenanceTask
-        fields = [
-            "id",
-            "maintenance_item",
-            "order",
-            "title",
-            "description",
-            "is_required",
-            "created_at",
-        ]
-        read_only_fields = ["created_at"]
 
 
 class WorkOrderTaskCompletionSerializer(serializers.ModelSerializer):

--- a/backend/inventory/urls.py
+++ b/backend/inventory/urls.py
@@ -20,9 +20,11 @@ from .views import (
     MaintenanceItemViewSet,
     MaintenanceLogViewSet,
     MaintenanceMaterialViewSet,
+    MaintenanceTaskViewSet,
     PriceHistoryViewSet,
     SupplierViewSet,
     UsageLogViewSet,
+    WorkOrderViewSet,
     lookup_by_code,
 )
 
@@ -41,6 +43,8 @@ router.register(r"fixture-refill-requests", FixtureRefillRequestViewSet)
 router.register(r"maintenance-items", MaintenanceItemViewSet)
 router.register(r"maintenance-materials", MaintenanceMaterialViewSet)
 router.register(r"maintenance-logs", MaintenanceLogViewSet)
+router.register(r"maintenance-tasks", MaintenanceTaskViewSet)
+router.register(r"work-orders", WorkOrderViewSet)
 router.register(r"reports/inventory", InventoryReportViewSet, basename="inventory-reports")
 router.register(r"reports/assets", AssetReportViewSet, basename="asset-reports")
 

--- a/backend/inventory/utils/work_order_pdf.py
+++ b/backend/inventory/utils/work_order_pdf.py
@@ -143,13 +143,9 @@ def generate_work_order_pdf(work_order: "WorkOrder", base_url: str = "") -> byte
 
     location_name = asset.location.name if asset.location else "—"
     manufacturer_name = (
-        asset.manufacturer.name
-        if asset.manufacturer
-        else (asset.manufacturer_name or "—")
+        asset.manufacturer.name if asset.manufacturer else (asset.manufacturer_name or "—")
     )
-    date_received = (
-        asset.date_received.strftime("%B %d, %Y") if asset.date_received else "—"
-    )
+    date_received = asset.date_received.strftime("%B %d, %Y") if asset.date_received else "—"
     amount_paid = f"${asset.amount_paid:.2f}" if asset.amount_paid else "—"
 
     asset_data = [
@@ -159,19 +155,23 @@ def generate_work_order_pdf(work_order: "WorkOrder", base_url: str = "") -> byte
         ["Category", asset.category.name if asset.category else "—", "Purchase Price", amount_paid],
     ]
     if work_order.due_date:
-        asset_data.append([
-            "Work Order Due",
-            work_order.due_date.strftime("%B %d, %Y"),
-            "WO Status",
-            work_order.get_status_display(),
-        ])
+        asset_data.append(
+            [
+                "Work Order Due",
+                work_order.due_date.strftime("%B %d, %Y"),
+                "WO Status",
+                work_order.get_status_display(),
+            ]
+        )
     else:
-        asset_data.append([
-            "Work Order Created",
-            work_order.created_at.strftime("%B %d, %Y"),
-            "WO Status",
-            work_order.get_status_display(),
-        ])
+        asset_data.append(
+            [
+                "Work Order Created",
+                work_order.created_at.strftime("%B %d, %Y"),
+                "WO Status",
+                work_order.get_status_display(),
+            ]
+        )
 
     asset_table = Table(
         asset_data,
@@ -257,9 +257,7 @@ def generate_work_order_pdf(work_order: "WorkOrder", base_url: str = "") -> byte
         story.append(Spacer(1, 8))
 
     # ── Task steps checklist ──────────────────────────────────────────────────
-    task_completions = list(
-        work_order.task_completions.order_by("task_order", "task_title")
-    )
+    task_completions = list(work_order.task_completions.order_by("task_order", "task_title"))
 
     if task_completions:
         story.append(Paragraph("Task Steps", subheading_style))
@@ -299,9 +297,7 @@ def generate_work_order_pdf(work_order: "WorkOrder", base_url: str = "") -> byte
             )
         )
         story.append(task_table)
-        story.append(
-            Paragraph("✱ = Required step", small_style)
-        )
+        story.append(Paragraph("✱ = Required step", small_style))
         story.append(Spacer(1, 8))
     elif item.instructions:
         # Fall back to instructions text if no structured tasks

--- a/backend/inventory/utils/work_order_pdf.py
+++ b/backend/inventory/utils/work_order_pdf.py
@@ -1,0 +1,369 @@
+"""
+PDF generation for preventive maintenance work orders.
+
+Generates a printable work order form that includes:
+- Asset summary (name, tag, location, purchase info)
+- QR code linking to the digital work order
+- Materials checklist
+- Task step checklist
+- Completion sign-off fields
+"""
+
+import io
+from typing import TYPE_CHECKING
+
+import qrcode
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    HRFlowable,
+    Image,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+if TYPE_CHECKING:
+    from inventory.models import WorkOrder
+
+
+def _make_qr_image(url: str, size_inches: float = 1.5) -> Image:
+    """Generate a QR code image from a URL."""
+    qr = qrcode.QRCode(
+        version=1,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=10,
+        border=2,
+    )
+    qr.add_data(url)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white")
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+
+    size = size_inches * inch
+    return Image(buf, width=size, height=size)
+
+
+def generate_work_order_pdf(work_order: "WorkOrder", base_url: str = "") -> bytes:
+    """
+    Generate a printable PDF work order.
+
+    Args:
+        work_order: The WorkOrder instance to generate a form for.
+        base_url: Base URL of the application (used for the QR code link).
+
+    Returns:
+        PDF content as bytes.
+    """
+    buf = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buf,
+        pagesize=letter,
+        rightMargin=0.5 * inch,
+        leftMargin=0.5 * inch,
+        topMargin=0.5 * inch,
+        bottomMargin=0.5 * inch,
+    )
+
+    styles = getSampleStyleSheet()
+    story = []
+
+    heading_style = ParagraphStyle(
+        "Heading",
+        parent=styles["Heading1"],
+        fontSize=16,
+        spaceAfter=4,
+    )
+    subheading_style = ParagraphStyle(
+        "SubHeading",
+        parent=styles["Heading2"],
+        fontSize=12,
+        spaceBefore=8,
+        spaceAfter=4,
+    )
+    normal_style = styles["Normal"]
+    small_style = ParagraphStyle(
+        "Small",
+        parent=styles["Normal"],
+        fontSize=9,
+        textColor=colors.HexColor("#444444"),
+    )
+    label_style = ParagraphStyle(
+        "Label",
+        parent=styles["Normal"],
+        fontSize=9,
+        fontName="Helvetica-Bold",
+    )
+
+    item = work_order.maintenance_item
+    asset = item.asset
+
+    # ── Header row: title + QR code ──────────────────────────────────────────
+    digital_url = f"{base_url}/maintenance/work-orders/{work_order.id}"
+    qr_image = _make_qr_image(digital_url, size_inches=1.4)
+
+    header_content = [
+        [
+            Paragraph(f"Work Order: {work_order.short_id}", heading_style),
+            qr_image,
+        ],
+        [
+            Paragraph(item.title, subheading_style),
+            Paragraph(
+                f"<font size='7' color='#666666'>Scan to open digital version</font>",
+                small_style,
+            ),
+        ],
+    ]
+    header_table = Table(
+        header_content,
+        colWidths=[5.5 * inch, 1.6 * inch],
+    )
+    header_table.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("ALIGN", (1, 0), (1, -1), "CENTER"),
+            ]
+        )
+    )
+    story.append(header_table)
+    story.append(HRFlowable(width="100%", thickness=1, color=colors.black))
+    story.append(Spacer(1, 6))
+
+    # ── Asset summary ─────────────────────────────────────────────────────────
+    story.append(Paragraph("Asset Information", subheading_style))
+
+    location_name = asset.location.name if asset.location else "—"
+    manufacturer_name = (
+        asset.manufacturer.name
+        if asset.manufacturer
+        else (asset.manufacturer_name or "—")
+    )
+    date_received = (
+        asset.date_received.strftime("%B %d, %Y") if asset.date_received else "—"
+    )
+    amount_paid = f"${asset.amount_paid:.2f}" if asset.amount_paid else "—"
+
+    asset_data = [
+        ["Asset Name", asset.name, "Asset Tag", asset.asset_tag or "—"],
+        ["Location", location_name, "Serial #", asset.serial_number or "—"],
+        ["Manufacturer / Supplier", manufacturer_name, "Date Acquired", date_received],
+        ["Category", asset.category.name if asset.category else "—", "Purchase Price", amount_paid],
+    ]
+    if work_order.due_date:
+        asset_data.append([
+            "Work Order Due",
+            work_order.due_date.strftime("%B %d, %Y"),
+            "WO Status",
+            work_order.get_status_display(),
+        ])
+    else:
+        asset_data.append([
+            "Work Order Created",
+            work_order.created_at.strftime("%B %d, %Y"),
+            "WO Status",
+            work_order.get_status_display(),
+        ])
+
+    asset_table = Table(
+        asset_data,
+        colWidths=[1.5 * inch, 2.2 * inch, 1.5 * inch, 2.0 * inch],
+    )
+    asset_table.setStyle(
+        TableStyle(
+            [
+                ("FONTNAME", (0, 0), (0, -1), "Helvetica-Bold"),
+                ("FONTNAME", (2, 0), (2, -1), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 9),
+                ("BACKGROUND", (0, 0), (0, -1), colors.HexColor("#f0f0f0")),
+                ("BACKGROUND", (2, 0), (2, -1), colors.HexColor("#f0f0f0")),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#cccccc")),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("PADDING", (0, 0), (-1, -1), 4),
+            ]
+        )
+    )
+    story.append(asset_table)
+    story.append(Spacer(1, 8))
+
+    # ── Task description ──────────────────────────────────────────────────────
+    if item.description:
+        story.append(Paragraph("Task Description", subheading_style))
+        story.append(Paragraph(item.description, normal_style))
+        story.append(Spacer(1, 4))
+
+    # ── Estimated time/cost ───────────────────────────────────────────────────
+    meta_parts = []
+    if item.estimated_time_minutes:
+        meta_parts.append(f"Est. Time: {item.estimated_time_minutes} min")
+    if item.estimated_cost:
+        meta_parts.append(f"Est. Cost: ${item.estimated_cost:.2f}")
+    if item.interval_days:
+        meta_parts.append(f"Interval: every {item.interval_days} days")
+    if meta_parts:
+        story.append(Paragraph("  |  ".join(meta_parts), small_style))
+        story.append(Spacer(1, 4))
+
+    story.append(HRFlowable(width="100%", thickness=0.5, color=colors.HexColor("#cccccc")))
+
+    # ── Materials checklist ───────────────────────────────────────────────────
+    materials = list(item.materials.all())
+    if materials:
+        story.append(Paragraph("Materials Required", subheading_style))
+        mat_header = [
+            Paragraph("☐", label_style),
+            Paragraph("Material", label_style),
+            Paragraph("Qty", label_style),
+            Paragraph("Unit", label_style),
+            Paragraph("Notes", label_style),
+        ]
+        mat_rows = [mat_header]
+        for mat in materials:
+            mat_rows.append(
+                [
+                    "☐",
+                    Paragraph(mat.name, normal_style),
+                    str(mat.quantity).rstrip("0").rstrip("."),
+                    mat.unit or "—",
+                    Paragraph(mat.notes or "", small_style),
+                ]
+            )
+        mat_table = Table(
+            mat_rows,
+            colWidths=[0.3 * inch, 2.8 * inch, 0.7 * inch, 0.7 * inch, 2.7 * inch],
+        )
+        mat_table.setStyle(
+            TableStyle(
+                [
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, -1), 9),
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#e8e8e8")),
+                    ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#cccccc")),
+                    ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                    ("PADDING", (0, 0), (-1, -1), 4),
+                    ("ALIGN", (0, 0), (0, -1), "CENTER"),
+                ]
+            )
+        )
+        story.append(mat_table)
+        story.append(Spacer(1, 8))
+
+    # ── Task steps checklist ──────────────────────────────────────────────────
+    task_completions = list(
+        work_order.task_completions.order_by("task_order", "task_title")
+    )
+
+    if task_completions:
+        story.append(Paragraph("Task Steps", subheading_style))
+        task_header = [
+            Paragraph("☐", label_style),
+            Paragraph("#", label_style),
+            Paragraph("Step", label_style),
+            Paragraph("Req.", label_style),
+        ]
+        task_rows = [task_header]
+        for i, tc in enumerate(task_completions, start=1):
+            req_marker = "✱" if tc.is_required else ""
+            task_rows.append(
+                [
+                    "☐",
+                    str(i),
+                    Paragraph(tc.task_title, normal_style),
+                    req_marker,
+                ]
+            )
+        task_table = Table(
+            task_rows,
+            colWidths=[0.3 * inch, 0.4 * inch, 6.0 * inch, 0.5 * inch],
+        )
+        task_table.setStyle(
+            TableStyle(
+                [
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, -1), 9),
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#e8e8e8")),
+                    ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#cccccc")),
+                    ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                    ("PADDING", (0, 0), (-1, -1), 4),
+                    ("ALIGN", (0, 0), (0, -1), "CENTER"),
+                    ("ALIGN", (3, 0), (3, -1), "CENTER"),
+                ]
+            )
+        )
+        story.append(task_table)
+        story.append(
+            Paragraph("✱ = Required step", small_style)
+        )
+        story.append(Spacer(1, 8))
+    elif item.instructions:
+        # Fall back to instructions text if no structured tasks
+        story.append(Paragraph("Instructions", subheading_style))
+        story.append(Paragraph(item.instructions, normal_style))
+        story.append(Spacer(1, 8))
+
+    story.append(HRFlowable(width="100%", thickness=1, color=colors.black))
+
+    # ── Sign-off section ──────────────────────────────────────────────────────
+    story.append(Paragraph("Work Order Sign-Off", subheading_style))
+
+    signoff_data = [
+        [
+            Paragraph("Completed By (print name):", label_style),
+            "_" * 40,
+            Paragraph("Date Completed:", label_style),
+            "_" * 20,
+        ],
+        [
+            Paragraph("Signature:", label_style),
+            "_" * 40,
+            Paragraph("Time Spent (min):", label_style),
+            "_" * 20,
+        ],
+        [
+            Paragraph("Notes / Observations:", label_style),
+            "",
+            "",
+            "",
+        ],
+    ]
+    signoff_table = Table(
+        signoff_data,
+        colWidths=[1.8 * inch, 2.5 * inch, 1.5 * inch, 1.4 * inch],
+    )
+    signoff_table.setStyle(
+        TableStyle(
+            [
+                ("FONTSIZE", (0, 0), (-1, -1), 9),
+                ("VALIGN", (0, 0), (-1, -1), "BOTTOM"),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+                ("SPAN", (1, 2), (3, 2)),
+            ]
+        )
+    )
+    story.append(signoff_table)
+
+    # Notes lines
+    for _ in range(3):
+        story.append(HRFlowable(width="100%", thickness=0.5, color=colors.HexColor("#aaaaaa")))
+        story.append(Spacer(1, 14))
+
+    # Footer
+    story.append(HRFlowable(width="100%", thickness=0.5, color=colors.HexColor("#cccccc")))
+    story.append(
+        Paragraph(
+            f"Work Order ID: {work_order.id}  |  Asset: {asset.asset_tag or asset.name}  |  "
+            f"Scan the QR code to access the digital version.",
+            small_style,
+        )
+    )
+
+    doc.build(story)
+    return buf.getvalue()

--- a/backend/inventory/utils/work_order_pdf.py
+++ b/backend/inventory/utils/work_order_pdf.py
@@ -117,7 +117,7 @@ def generate_work_order_pdf(work_order: "WorkOrder", base_url: str = "") -> byte
         [
             Paragraph(item.title, subheading_style),
             Paragraph(
-                f"<font size='7' color='#666666'>Scan to open digital version</font>",
+                "<font size='7' color='#666666'>Scan to open digital version</font>",
                 small_style,
             ),
         ],

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -38,7 +38,6 @@ from .models import (
     UsageLog,
     WorkOrder,
     WorkOrderMaterialUsage,
-    WorkOrderPhoto,
     WorkOrderTaskCompletion,
 )
 from .serializers import (
@@ -2565,8 +2564,6 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=["get"])
     def pdf(self, request, pk=None):
         """Generate a printable PDF work order form."""
-        from django.conf import settings as django_settings
-
         from .utils.work_order_pdf import generate_work_order_pdf
 
         work_order = self.get_object()

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -32,9 +32,14 @@ from .models import (
     MaintenanceItem,
     MaintenanceLog,
     MaintenanceMaterial,
+    MaintenanceTask,
     PriceHistory,
     Supplier,
     UsageLog,
+    WorkOrder,
+    WorkOrderMaterialUsage,
+    WorkOrderPhoto,
+    WorkOrderTaskCompletion,
 )
 from .serializers import (
     AssetPartSerializer,
@@ -50,10 +55,16 @@ from .serializers import (
     MaintenanceItemSerializer,
     MaintenanceLogSerializer,
     MaintenanceMaterialSerializer,
+    MaintenanceTaskSerializer,
     PriceHistorySerializer,
     SupplierDetailSerializer,
     SupplierSerializer,
     UsageLogSerializer,
+    WorkOrderListSerializer,
+    WorkOrderMaterialUsageSerializer,
+    WorkOrderPhotoSerializer,
+    WorkOrderSerializer,
+    WorkOrderTaskCompletionSerializer,
 )
 
 
@@ -2462,43 +2473,6 @@ class InventoryReportViewSet(viewsets.ViewSet):
         return Response({"error": "Invalid report type"}, status=status.HTTP_400_BAD_REQUEST)
 
 
-class MaintenanceItemViewSet(viewsets.ModelViewSet):
-    """API endpoint for asset maintenance items (PM tasks)."""
-
-    queryset = MaintenanceItem.objects.prefetch_related("materials").select_related("asset").all()
-    serializer_class = MaintenanceItemSerializer
-    permission_classes = [IsAuthenticatedOrReadOnly]
-
-    def get_queryset(self):
-        queryset = super().get_queryset()
-        asset_id = self.request.query_params.get("asset")
-        if asset_id:
-            queryset = queryset.filter(asset_id=asset_id)
-        is_active = self.request.query_params.get("is_active")
-        if is_active is not None:
-            queryset = queryset.filter(is_active=is_active.lower() == "true")
-        return queryset
-
-    @action(detail=True, methods=["post"], permission_classes=[IsAuthenticated])
-    def complete(self, request, pk=None):
-        """Log completion of a maintenance task and update its last_completed_at."""
-        item = self.get_object()
-        data = request.data.copy()
-        data["maintenance_item"] = str(item.id)
-
-        serializer = MaintenanceLogSerializer(data=data)
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-        log = serializer.save(completed_by=request.user)
-
-        # Update the item's last_completed_at timestamp
-        item.last_completed_at = log.completed_at
-        item.save(update_fields=["last_completed_at"])
-
-        return Response(MaintenanceLogSerializer(log).data, status=status.HTTP_201_CREATED)
-
-
 class MaintenanceMaterialViewSet(viewsets.ModelViewSet):
     """API endpoint for maintenance materials."""
 
@@ -2532,6 +2506,309 @@ class MaintenanceLogViewSet(viewsets.ReadOnlyModelViewSet):
         if asset:
             queryset = queryset.filter(maintenance_item__asset_id=asset)
         return queryset
+
+
+class MaintenanceTaskViewSet(viewsets.ModelViewSet):
+    """API endpoint for maintenance task steps (line items within a MaintenanceItem)."""
+
+    queryset = MaintenanceTask.objects.select_related("maintenance_item__asset").all()
+    serializer_class = MaintenanceTaskSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        maintenance_item = self.request.query_params.get("maintenance_item")
+        if maintenance_item:
+            queryset = queryset.filter(maintenance_item_id=maintenance_item)
+        return queryset
+
+
+class WorkOrderViewSet(viewsets.ModelViewSet):
+    """API endpoint for preventive maintenance work orders."""
+
+    queryset = WorkOrder.objects.select_related(
+        "maintenance_item__asset__location",
+        "maintenance_item__asset__manufacturer",
+        "maintenance_item__asset__category",
+        "assigned_to",
+    ).prefetch_related(
+        "task_completions__completed_by",
+        "task_completions__task",
+        "material_usage__material",
+        "photos__uploaded_by",
+        "maintenance_item__materials",
+    ).all()
+    permission_classes = [IsAuthenticated]
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return WorkOrderListSerializer
+        return WorkOrderSerializer
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        maintenance_item = self.request.query_params.get("maintenance_item")
+        if maintenance_item:
+            queryset = queryset.filter(maintenance_item_id=maintenance_item)
+        asset = self.request.query_params.get("asset")
+        if asset:
+            queryset = queryset.filter(maintenance_item__asset_id=asset)
+        wo_status = self.request.query_params.get("status")
+        if wo_status:
+            queryset = queryset.filter(status=wo_status)
+        return queryset
+
+    @action(detail=True, methods=["get"])
+    def pdf(self, request, pk=None):
+        """Generate a printable PDF work order form."""
+        from django.conf import settings as django_settings
+
+        from .utils.work_order_pdf import generate_work_order_pdf
+
+        work_order = self.get_object()
+        base_url = request.build_absolute_uri("/").rstrip("/")
+        pdf_bytes = generate_work_order_pdf(work_order, base_url=base_url)
+
+        response = HttpResponse(pdf_bytes, content_type="application/pdf")
+        short_id = work_order.short_id.replace(" ", "-")
+        response["Content-Disposition"] = (
+            f'inline; filename="work-order-{short_id}.pdf"'
+        )
+        return response
+
+    @action(detail=True, methods=["post"], permission_classes=[IsAuthenticated])
+    def add_photo(self, request, pk=None):
+        """Upload a photo to this work order."""
+        work_order = self.get_object()
+        serializer = WorkOrderPhotoSerializer(
+            data=request.data, context={"request": request}
+        )
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        serializer.save(work_order=work_order, uploaded_by=request.user)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=["patch"], url_path="tasks/(?P<task_id>[^/.]+)/complete")
+    def complete_task(self, request, pk=None, task_id=None):
+        """Toggle completion of a specific task step within this work order."""
+        work_order = self.get_object()
+        try:
+            tc = work_order.task_completions.get(id=task_id)
+        except WorkOrderTaskCompletion.DoesNotExist:
+            return Response(
+                {"detail": "Task completion record not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        is_completed = request.data.get("is_completed")
+        if is_completed is None:
+            return Response(
+                {"detail": "is_completed is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        tc.is_completed = bool(is_completed)
+        if tc.is_completed and not tc.completed_at:
+            tc.completed_at = timezone.now()
+            tc.completed_by = request.user
+        elif not tc.is_completed:
+            tc.completed_at = None
+            tc.completed_by = None
+        if "notes" in request.data:
+            tc.notes = request.data["notes"]
+        tc.save()
+
+        # Update work order status to in_progress if any task is completed
+        if tc.is_completed and work_order.status == WorkOrder.STATUS_OPEN:
+            work_order.status = WorkOrder.STATUS_IN_PROGRESS
+            work_order.save(update_fields=["status", "updated_at"])
+
+        return Response(WorkOrderTaskCompletionSerializer(tc).data)
+
+    @action(detail=True, methods=["patch"], url_path="materials/(?P<material_id>[^/.]+)/toggle")
+    def toggle_material(self, request, pk=None, material_id=None):
+        """Toggle whether a material was used in this work order."""
+        work_order = self.get_object()
+        try:
+            usage = work_order.material_usage.get(id=material_id)
+        except WorkOrderMaterialUsage.DoesNotExist:
+            return Response(
+                {"detail": "Material usage record not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        was_used = request.data.get("was_used")
+        if was_used is None:
+            return Response(
+                {"detail": "was_used is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        usage.was_used = bool(was_used)
+        usage.save(update_fields=["was_used"])
+        return Response(WorkOrderMaterialUsageSerializer(usage).data)
+
+
+class MaintenanceItemViewSet(viewsets.ModelViewSet):
+    """API endpoint for asset maintenance items (PM tasks)."""
+
+    queryset = MaintenanceItem.objects.prefetch_related("materials", "tasks").select_related("asset").all()
+    serializer_class = MaintenanceItemSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        asset_id = self.request.query_params.get("asset")
+        if asset_id:
+            queryset = queryset.filter(asset_id=asset_id)
+        is_active = self.request.query_params.get("is_active")
+        if is_active is not None:
+            queryset = queryset.filter(is_active=is_active.lower() == "true")
+        return queryset
+
+    @action(detail=True, methods=["post"], permission_classes=[IsAuthenticated])
+    def complete(self, request, pk=None):
+        """Log completion of a maintenance task and update its last_completed_at."""
+        item = self.get_object()
+        data = request.data.copy()
+        data["maintenance_item"] = str(item.id)
+
+        serializer = MaintenanceLogSerializer(data=data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        log = serializer.save(completed_by=request.user)
+
+        # Update the item's last_completed_at timestamp
+        item.last_completed_at = log.completed_at
+        item.save(update_fields=["last_completed_at"])
+
+        return Response(MaintenanceLogSerializer(log).data, status=status.HTTP_201_CREATED)
+
+    @action(detail=False, methods=["get"])
+    def due_this_week(self, request):
+        """Return maintenance items due within the next 7 days."""
+        now = timezone.now()
+        week_out = now + timedelta(days=7)
+        items = []
+        qs = (
+            self.get_queryset()
+            .filter(is_active=True, interval_days__isnull=False)
+            .select_related("asset__location")
+        )
+        for item in qs:
+            next_due = item.next_due_at
+            if next_due is None or next_due <= week_out:
+                items.append(item)
+        serializer = MaintenanceItemSerializer(items, many=True)
+        return Response(serializer.data)
+
+    @action(detail=False, methods=["get"])
+    def due_this_month(self, request):
+        """Return maintenance items due within the next 30 days."""
+        now = timezone.now()
+        month_out = now + timedelta(days=30)
+        items = []
+        qs = (
+            self.get_queryset()
+            .filter(is_active=True, interval_days__isnull=False)
+            .select_related("asset__location")
+        )
+        for item in qs:
+            next_due = item.next_due_at
+            if next_due is None or next_due <= month_out:
+                items.append(item)
+        serializer = MaintenanceItemSerializer(items, many=True)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=["post"], permission_classes=[IsAuthenticated])
+    def generate_work_order(self, request, pk=None):
+        """Create a work order for this maintenance item, pre-populated with tasks and materials."""
+        item = self.get_object()
+
+        with transaction.atomic():
+            due_date = request.data.get("due_date") or (
+                item.next_due_at.date() if item.next_due_at else None
+            )
+            wo = WorkOrder.objects.create(
+                maintenance_item=item,
+                due_date=due_date,
+                notes=request.data.get("notes", ""),
+            )
+
+            # Create task completion records for all tasks
+            tasks = list(item.tasks.order_by("order", "title"))
+            for task in tasks:
+                WorkOrderTaskCompletion.objects.create(
+                    work_order=wo,
+                    task=task,
+                    task_title=task.title,
+                    task_order=task.order,
+                    is_required=task.is_required,
+                )
+
+            # Create material usage records for all materials
+            materials = list(item.materials.all())
+            for mat in materials:
+                WorkOrderMaterialUsage.objects.create(
+                    work_order=wo,
+                    material=mat,
+                    material_name=mat.name,
+                    quantity_planned=mat.quantity,
+                    unit=mat.unit,
+                )
+
+        serializer = WorkOrderSerializer(wo, context={"request": request})
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    @action(detail=False, methods=["post"], permission_classes=[IsAuthenticated])
+    def generate_work_orders_bulk(self, request):
+        """Generate work orders for all overdue or due-this-week maintenance items."""
+        now = timezone.now()
+        week_out = now + timedelta(days=7)
+        created = []
+        qs = self.get_queryset().filter(is_active=True, interval_days__isnull=False)
+
+        with transaction.atomic():
+            for item in qs:
+                next_due = item.next_due_at
+                is_due = next_due is None or next_due <= week_out
+
+                if not is_due:
+                    continue
+
+                # Skip if there's already an open/in-progress WO for this item
+                existing = item.work_orders.filter(
+                    status__in=[WorkOrder.STATUS_OPEN, WorkOrder.STATUS_IN_PROGRESS]
+                ).exists()
+                if existing:
+                    continue
+
+                due_date = next_due.date() if next_due else now.date()
+                wo = WorkOrder.objects.create(
+                    maintenance_item=item,
+                    due_date=due_date,
+                )
+                for task in item.tasks.order_by("order", "title"):
+                    WorkOrderTaskCompletion.objects.create(
+                        work_order=wo,
+                        task=task,
+                        task_title=task.title,
+                        task_order=task.order,
+                        is_required=task.is_required,
+                    )
+                for mat in item.materials.all():
+                    WorkOrderMaterialUsage.objects.create(
+                        work_order=wo,
+                        material=mat,
+                        material_name=mat.name,
+                        quantity_planned=mat.quantity,
+                        unit=mat.unit,
+                    )
+                created.append(str(wo.id))
+
+        return Response(
+            {"created": len(created), "work_order_ids": created},
+            status=status.HTTP_201_CREATED,
+        )
 
 
 class AssetReportViewSet(viewsets.ViewSet):

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -2526,18 +2526,22 @@ class MaintenanceTaskViewSet(viewsets.ModelViewSet):
 class WorkOrderViewSet(viewsets.ModelViewSet):
     """API endpoint for preventive maintenance work orders."""
 
-    queryset = WorkOrder.objects.select_related(
-        "maintenance_item__asset__location",
-        "maintenance_item__asset__manufacturer",
-        "maintenance_item__asset__category",
-        "assigned_to",
-    ).prefetch_related(
-        "task_completions__completed_by",
-        "task_completions__task",
-        "material_usage__material",
-        "photos__uploaded_by",
-        "maintenance_item__materials",
-    ).all()
+    queryset = (
+        WorkOrder.objects.select_related(
+            "maintenance_item__asset__location",
+            "maintenance_item__asset__manufacturer",
+            "maintenance_item__asset__category",
+            "assigned_to",
+        )
+        .prefetch_related(
+            "task_completions__completed_by",
+            "task_completions__task",
+            "material_usage__material",
+            "photos__uploaded_by",
+            "maintenance_item__materials",
+        )
+        .all()
+    )
     permission_classes = [IsAuthenticated]
 
     def get_serializer_class(self):
@@ -2571,18 +2575,14 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
 
         response = HttpResponse(pdf_bytes, content_type="application/pdf")
         short_id = work_order.short_id.replace(" ", "-")
-        response["Content-Disposition"] = (
-            f'inline; filename="work-order-{short_id}.pdf"'
-        )
+        response["Content-Disposition"] = f'inline; filename="work-order-{short_id}.pdf"'
         return response
 
     @action(detail=True, methods=["post"], permission_classes=[IsAuthenticated])
     def add_photo(self, request, pk=None):
         """Upload a photo to this work order."""
         work_order = self.get_object()
-        serializer = WorkOrderPhotoSerializer(
-            data=request.data, context={"request": request}
-        )
+        serializer = WorkOrderPhotoSerializer(data=request.data, context={"request": request})
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         serializer.save(work_order=work_order, uploaded_by=request.user)
@@ -2650,7 +2650,9 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
 class MaintenanceItemViewSet(viewsets.ModelViewSet):
     """API endpoint for asset maintenance items (PM tasks)."""
 
-    queryset = MaintenanceItem.objects.prefetch_related("materials", "tasks").select_related("asset").all()
+    queryset = (
+        MaintenanceItem.objects.prefetch_related("materials", "tasks").select_related("asset").all()
+    )
     serializer_class = MaintenanceItemSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
 

--- a/backend/reorder_queue/views.py
+++ b/backend/reorder_queue/views.py
@@ -1647,6 +1647,19 @@ class AnalyticsViewSet(viewsets.ViewSet):
 
         overdue_maintenance_count = len(overdue_asset_ids)
 
+        # Also count MaintenanceItems that are overdue or due this week
+        from inventory.models import MaintenanceItem
+
+        now_dt = timezone.now()
+        week_out = now_dt + timedelta(days=7)
+        pm_due_this_week = 0
+        pm_overdue = 0
+        for mi in MaintenanceItem.objects.filter(is_active=True, interval_days__isnull=False):
+            if mi.is_overdue:
+                pm_overdue += 1
+            elif mi.next_due_at and mi.next_due_at <= week_out:
+                pm_due_this_week += 1
+
         # 4. QR Code Scans in last 7 days with daily breakdown
         # Note: We count unique assets and inventory items scanned per day
         # If an item is scanned multiple times in a day, we only count it once for that day
@@ -1722,6 +1735,8 @@ class AnalyticsViewSet(viewsets.ViewSet):
                 "open_item_requests": open_item_requests,
                 "open_locations_with_problems": open_locations_with_problems,
                 "assets_overdue_maintenance": overdue_maintenance_count,
+                "pm_overdue": pm_overdue,
+                "pm_due_this_week": pm_due_this_week,
                 "qr_scans_total": total_qr_scans,
                 "qr_scans_by_day": qr_scans_by_day,
                 "last_updated": timezone.now().isoformat(),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,8 @@ import LocationFormPage from './pages/LocationFormPage';
 import LocationListPage from './pages/LocationListPage';
 import LocationScanPage from './pages/LocationScanPage';
 import LogisticsDashboard from './pages/LogisticsDashboard';
+import MaintenanceDashboard from './pages/MaintenanceDashboard';
+import WorkOrderPage from './pages/WorkOrderPage';
 import PurchaseOrderFormPage from './pages/PurchaseOrderFormPage';
 import PurchaseOrderListPage from './pages/PurchaseOrderListPage';
 import PurchaseOrderPage from './pages/PurchaseOrderPage';
@@ -162,6 +164,10 @@ function AppContent() {
           <Route path="/facilities/tv-dashboard" element={<TVDashboard />} />
           <Route path="/facilities/tv-dashboard/:location" element={<TVDashboard />} />
           <Route path="/facilities/logistics" element={<LogisticsDashboard />} />
+
+          {/* Preventive Maintenance */}
+          <Route path="/maintenance/dashboard" element={<WorkspaceLayout><MaintenanceDashboard /></WorkspaceLayout>} />
+          <Route path="/maintenance/work-orders/:id" element={<WorkspaceLayout><WorkOrderPage /></WorkspaceLayout>} />
           <Route path="/facilities/checklist/:checklistId/complete/:completionId" element={<WorkspaceLayout><ChecklistCompletionPage /></WorkspaceLayout>} />
 
           {/* SIGs Workspace */}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -117,6 +117,14 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed = false, isMobileOpen = f
       ],
     },
     {
+      id: 'maintenance',
+      label: 'Maintenance',
+      icon: '🔧',
+      items: [
+        { path: '/maintenance/dashboard', label: 'PM Dashboard', icon: '📋', requiresAuth: true },
+      ],
+    },
+    {
       id: 'sigs',
       label: 'SIGs',
       icon: '👥',

--- a/frontend/src/pages/LogisticsDashboard.tsx
+++ b/frontend/src/pages/LogisticsDashboard.tsx
@@ -16,6 +16,8 @@ interface LogisticsDashboardResponse {
   open_item_requests: number;
   open_locations_with_problems: number;
   assets_overdue_maintenance: number;
+  pm_overdue: number;
+  pm_due_this_week: number;
   qr_scans_total: number;
   qr_scans_by_day: QRScanDay[];
   last_updated: string;
@@ -51,6 +53,8 @@ const LogisticsDashboard: React.FC = () => {
         open_item_requests: Number(rawData.open_item_requests) || 0,
         open_locations_with_problems: Number(rawData.open_locations_with_problems) || 0,
         assets_overdue_maintenance: Number(rawData.assets_overdue_maintenance) || 0,
+        pm_overdue: Number(rawData.pm_overdue) || 0,
+        pm_due_this_week: Number(rawData.pm_due_this_week) || 0,
         qr_scans_total: Number(rawData.qr_scans_total) || 0,
         qr_scans_by_day: Array.isArray(rawData.qr_scans_by_day) ? rawData.qr_scans_by_day : [],
         last_updated: rawData.last_updated || new Date().toISOString(),
@@ -362,6 +366,22 @@ const LogisticsDashboard: React.FC = () => {
           <div className="metric-label">Assets Overdue Maintenance</div>
           <div className="metric-value">
             {typeof data.assets_overdue_maintenance === 'number' ? data.assets_overdue_maintenance : 0}
+          </div>
+        </div>
+
+        {/* PM Items Overdue */}
+        <div className={`metric-card${data.pm_overdue > 0 ? ' metric-card--alert' : ''}`}>
+          <div className="metric-label">PM Tasks Overdue</div>
+          <div className="metric-value" style={{ color: data.pm_overdue > 0 ? '#fa5252' : 'inherit' }}>
+            {typeof data.pm_overdue === 'number' ? data.pm_overdue : 0}
+          </div>
+        </div>
+
+        {/* PM Items Due This Week */}
+        <div className="metric-card">
+          <div className="metric-label">PM Due This Week</div>
+          <div className="metric-value">
+            {typeof data.pm_due_this_week === 'number' ? data.pm_due_this_week : 0}
           </div>
         </div>
 

--- a/frontend/src/pages/MaintenanceDashboard.tsx
+++ b/frontend/src/pages/MaintenanceDashboard.tsx
@@ -1,0 +1,515 @@
+import {
+  ActionIcon,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Container,
+  Divider,
+  Group,
+  Loader,
+  Modal,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+} from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import {
+  IconAlertTriangle,
+  IconCalendar,
+  IconCalendarEvent,
+  IconCheck,
+  IconClipboardList,
+  IconFileText,
+  IconPlus,
+  IconRefresh,
+} from '@tabler/icons-react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { maintenanceAPI, workOrderAPI } from '../services/api';
+import { MaintenanceItem, WorkOrder } from '../types';
+
+const STATUS_COLORS: Record<string, string> = {
+  open: 'blue',
+  in_progress: 'yellow',
+  blocked: 'red',
+  completed: 'green',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  open: 'Open',
+  in_progress: 'In Progress',
+  blocked: 'Blocked',
+  completed: 'Completed',
+};
+
+interface StatCardProps {
+  title: string;
+  value: number;
+  icon: React.ReactNode;
+  color: string;
+  description?: string;
+}
+
+const StatCard: React.FC<StatCardProps> = ({ title, value, icon, color, description }) => (
+  <Card withBorder p="md" radius="md">
+    <Group justify="space-between" mb="xs">
+      <Text size="sm" c="dimmed" fw={500}>{title}</Text>
+      <Box c={color}>{icon}</Box>
+    </Group>
+    <Text size="2rem" fw={700} c={color}>{value}</Text>
+    {description && <Text size="xs" c="dimmed" mt={4}>{description}</Text>}
+  </Card>
+);
+
+interface MaintenanceItemRowProps {
+  item: MaintenanceItem;
+  onGenerateWorkOrder: (item: MaintenanceItem) => void;
+  generating: boolean;
+}
+
+const MaintenanceItemRow: React.FC<MaintenanceItemRowProps> = ({
+  item,
+  onGenerateWorkOrder,
+  generating,
+}) => {
+  const daysOverdue = item.days_overdue;
+  const nextDue = item.next_due_at ? new Date(item.next_due_at) : null;
+  const daysUntilDue = nextDue
+    ? Math.ceil((nextDue.getTime() - Date.now()) / (1000 * 60 * 60 * 24))
+    : null;
+
+  return (
+    <Card
+      withBorder
+      p="sm"
+      radius="sm"
+      mb="xs"
+      style={{ borderLeft: `4px solid ${item.is_overdue ? '#fa5252' : '#fd7e14'}` }}
+    >
+      <Group justify="space-between" wrap="nowrap">
+        <Box style={{ flex: 1, minWidth: 0 }}>
+          <Group gap="xs" mb={4}>
+            <Text fw={600} size="sm" truncate>
+              {item.title}
+            </Text>
+            {item.is_overdue && (
+              <Badge color="red" size="xs">
+                {daysOverdue != null ? `${daysOverdue}d overdue` : 'Overdue'}
+              </Badge>
+            )}
+            {!item.is_overdue && daysUntilDue != null && (
+              <Badge color="orange" variant="light" size="xs">
+                Due in {daysUntilDue}d
+              </Badge>
+            )}
+          </Group>
+          <Text size="xs" c="dimmed">
+            {item.asset_name}
+            {item.asset_tag && ` · ${item.asset_tag}`}
+          </Text>
+          {item.materials.length > 0 && (
+            <Text size="xs" c="dimmed">
+              {item.materials.length} material{item.materials.length !== 1 ? 's' : ''} needed
+            </Text>
+          )}
+        </Box>
+        <Group gap="xs" wrap="nowrap">
+          <Tooltip label="Generate Work Order">
+            <ActionIcon
+              variant="light"
+              color="blue"
+              size="md"
+              onClick={() => onGenerateWorkOrder(item)}
+              loading={generating}
+            >
+              <IconPlus size={16} />
+            </ActionIcon>
+          </Tooltip>
+          <Tooltip label="View Asset">
+            <ActionIcon
+              variant="light"
+              color="gray"
+              size="md"
+              component={Link}
+              to={`/assets/${item.asset}`}
+            >
+              <IconClipboardList size={16} />
+            </ActionIcon>
+          </Tooltip>
+        </Group>
+      </Group>
+    </Card>
+  );
+};
+
+const WorkOrderRow: React.FC<{ wo: WorkOrder }> = ({ wo }) => {
+  const dueDate = wo.due_date ? new Date(wo.due_date) : null;
+  const apiBaseUrl = process.env.REACT_APP_API_URL || '';
+
+  return (
+    <Card
+      withBorder
+      p="sm"
+      radius="sm"
+      mb="xs"
+      style={{
+        borderLeft: `4px solid ${wo.is_overdue ? '#fa5252' : '#228be6'}`,
+      }}
+    >
+      <Group justify="space-between" wrap="nowrap">
+        <Box style={{ flex: 1, minWidth: 0 }}>
+          <Group gap="xs" mb={4}>
+            <Text fw={600} size="sm" truncate>
+              {wo.short_id}
+            </Text>
+            <Badge color={STATUS_COLORS[wo.status] || 'gray'} size="xs">
+              {STATUS_LABELS[wo.status] || wo.status}
+            </Badge>
+            {wo.is_overdue && (
+              <Badge color="red" size="xs">Overdue</Badge>
+            )}
+          </Group>
+          <Text size="xs" c="dimmed" truncate>
+            {wo.maintenance_item_title} · {wo.asset_name}
+          </Text>
+          {dueDate && (
+            <Text size="xs" c="dimmed">
+              Due: {dueDate.toLocaleDateString()}
+            </Text>
+          )}
+          {wo.task_total_count != null && wo.task_total_count > 0 && (
+            <Text size="xs" c="dimmed">
+              Tasks: {wo.task_completion_count}/{wo.task_total_count} completed
+            </Text>
+          )}
+        </Box>
+        <Group gap="xs" wrap="nowrap">
+          <Tooltip label="Open Work Order">
+            <ActionIcon
+              variant="light"
+              color="blue"
+              size="md"
+              component={Link}
+              to={`/maintenance/work-orders/${wo.id}`}
+            >
+              <IconClipboardList size={16} />
+            </ActionIcon>
+          </Tooltip>
+          <Tooltip label="Print PDF">
+            <ActionIcon
+              variant="light"
+              color="gray"
+              size="md"
+              component="a"
+              href={`${apiBaseUrl}/inventory/work-orders/${wo.id}/pdf/`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <IconFileText size={16} />
+            </ActionIcon>
+          </Tooltip>
+        </Group>
+      </Group>
+    </Card>
+  );
+};
+
+const MaintenanceDashboard: React.FC = () => {
+  const [overdueItems, setOverdueItems] = useState<MaintenanceItem[]>([]);
+  const [dueThisWeek, setDueThisWeek] = useState<MaintenanceItem[]>([]);
+  const [dueThisMonth, setDueThisMonth] = useState<MaintenanceItem[]>([]);
+  const [openWorkOrders, setOpenWorkOrders] = useState<WorkOrder[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [generatingBulk, setGeneratingBulk] = useState(false);
+  const [generatingFor, setGeneratingFor] = useState<string | null>(null);
+  const [bulkConfirmOpened, { open: openBulkConfirm, close: closeBulkConfirm }] = useDisclosure(false);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [weekRes, monthRes, ordersRes] = await Promise.all([
+        workOrderAPI.getDueThisWeek(),
+        workOrderAPI.getDueThisMonth(),
+        workOrderAPI.listWorkOrders({ status: 'open' }),
+      ]);
+
+      const weekItems: MaintenanceItem[] = Array.isArray(weekRes.data)
+        ? weekRes.data
+        : (weekRes.data as any).results || [];
+      const monthItems: MaintenanceItem[] = Array.isArray(monthRes.data)
+        ? monthRes.data
+        : (monthRes.data as any).results || [];
+      const orders: WorkOrder[] = Array.isArray(ordersRes.data)
+        ? ordersRes.data
+        : (ordersRes.data as any).results || [];
+
+      const overdue = weekItems.filter((i) => i.is_overdue);
+      const thisWeekOnly = weekItems.filter(
+        (i) => !i.is_overdue && monthItems.some((m) => m.id === i.id)
+      );
+      const thisMonthOnly = monthItems.filter(
+        (m) => !weekItems.some((w) => w.id === m.id)
+      );
+
+      setOverdueItems(overdue);
+      setDueThisWeek(weekItems.filter((i) => !i.is_overdue));
+      setDueThisMonth(thisMonthOnly);
+      setOpenWorkOrders(orders);
+    } catch {
+      notifications.show({
+        title: 'Error',
+        message: 'Failed to load maintenance data.',
+        color: 'red',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleGenerateWorkOrder = async (item: MaintenanceItem) => {
+    setGeneratingFor(item.id);
+    try {
+      await workOrderAPI.generateWorkOrder(item.id);
+      notifications.show({
+        title: 'Work Order Created',
+        message: `Work order created for: ${item.title}`,
+        color: 'green',
+        icon: <IconCheck size={16} />,
+      });
+      loadData();
+    } catch {
+      notifications.show({
+        title: 'Error',
+        message: 'Failed to create work order.',
+        color: 'red',
+      });
+    } finally {
+      setGeneratingFor(null);
+    }
+  };
+
+  const handleBulkGenerate = async () => {
+    closeBulkConfirm();
+    setGeneratingBulk(true);
+    try {
+      const res = await workOrderAPI.generateBulkWorkOrders();
+      notifications.show({
+        title: 'Work Orders Generated',
+        message: `Created ${res.data.created} work order(s).`,
+        color: 'green',
+        icon: <IconCheck size={16} />,
+      });
+      loadData();
+    } catch {
+      notifications.show({
+        title: 'Error',
+        message: 'Failed to generate work orders.',
+        color: 'red',
+      });
+    } finally {
+      setGeneratingBulk(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Container py="xl">
+        <Group justify="center">
+          <Loader />
+          <Text c="dimmed">Loading maintenance data…</Text>
+        </Group>
+      </Container>
+    );
+  }
+
+  return (
+    <Container size="xl" py="md">
+      <Group justify="space-between" mb="md">
+        <Title order={2}>Preventive Maintenance</Title>
+        <Group>
+          <Button
+            leftSection={<IconRefresh size={16} />}
+            variant="default"
+            size="sm"
+            onClick={loadData}
+            loading={loading}
+          >
+            Refresh
+          </Button>
+          <Button
+            leftSection={<IconPlus size={16} />}
+            size="sm"
+            onClick={openBulkConfirm}
+            loading={generatingBulk}
+          >
+            Generate Due Work Orders
+          </Button>
+        </Group>
+      </Group>
+
+      {/* Stats row */}
+      <SimpleGrid cols={{ base: 2, sm: 4 }} mb="lg">
+        <StatCard
+          title="Overdue"
+          value={overdueItems.length}
+          icon={<IconAlertTriangle size={20} />}
+          color={overdueItems.length > 0 ? 'red' : 'green'}
+          description="Past due date"
+        />
+        <StatCard
+          title="Due This Week"
+          value={dueThisWeek.length}
+          icon={<IconCalendar size={20} />}
+          color="orange"
+          description="Next 7 days"
+        />
+        <StatCard
+          title="Due This Month"
+          value={dueThisMonth.length}
+          icon={<IconCalendarEvent size={20} />}
+          color="blue"
+          description="Next 30 days"
+        />
+        <StatCard
+          title="Open Work Orders"
+          value={openWorkOrders.length}
+          icon={<IconClipboardList size={20} />}
+          color="teal"
+          description="Awaiting completion"
+        />
+      </SimpleGrid>
+
+      <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
+        {/* Overdue Items */}
+        <Box>
+          <Group mb="sm">
+            <IconAlertTriangle size={18} color="red" />
+            <Title order={4} c="red">Overdue Tasks</Title>
+            <Badge color="red">{overdueItems.length}</Badge>
+          </Group>
+          {overdueItems.length === 0 ? (
+            <Card withBorder p="md" radius="sm">
+              <Group>
+                <IconCheck size={16} color="green" />
+                <Text size="sm" c="dimmed">No overdue tasks — great work!</Text>
+              </Group>
+            </Card>
+          ) : (
+            <Stack gap={0}>
+              {overdueItems.map((item) => (
+                <MaintenanceItemRow
+                  key={item.id}
+                  item={item}
+                  onGenerateWorkOrder={handleGenerateWorkOrder}
+                  generating={generatingFor === item.id}
+                />
+              ))}
+            </Stack>
+          )}
+        </Box>
+
+        {/* Due This Week */}
+        <Box>
+          <Group mb="sm">
+            <IconCalendar size={18} color="orange" />
+            <Title order={4} c="orange">Due This Week</Title>
+            <Badge color="orange">{dueThisWeek.length}</Badge>
+          </Group>
+          {dueThisWeek.length === 0 ? (
+            <Card withBorder p="md" radius="sm">
+              <Text size="sm" c="dimmed">No tasks due this week.</Text>
+            </Card>
+          ) : (
+            <Stack gap={0}>
+              {dueThisWeek.map((item) => (
+                <MaintenanceItemRow
+                  key={item.id}
+                  item={item}
+                  onGenerateWorkOrder={handleGenerateWorkOrder}
+                  generating={generatingFor === item.id}
+                />
+              ))}
+            </Stack>
+          )}
+        </Box>
+
+        {/* Open Work Orders */}
+        <Box>
+          <Group mb="sm">
+            <IconClipboardList size={18} color="teal" />
+            <Title order={4}>Open Work Orders</Title>
+            <Badge color="teal">{openWorkOrders.length}</Badge>
+          </Group>
+          {openWorkOrders.length === 0 ? (
+            <Card withBorder p="md" radius="sm">
+              <Text size="sm" c="dimmed">No open work orders.</Text>
+            </Card>
+          ) : (
+            <Stack gap={0}>
+              {openWorkOrders.slice(0, 10).map((wo) => (
+                <WorkOrderRow key={wo.id} wo={wo} />
+              ))}
+              {openWorkOrders.length > 10 && (
+                <Text size="xs" c="dimmed" ta="center" mt="xs">
+                  +{openWorkOrders.length - 10} more
+                </Text>
+              )}
+            </Stack>
+          )}
+        </Box>
+
+        {/* Due This Month */}
+        <Box>
+          <Group mb="sm">
+            <IconCalendarEvent size={18} color="blue" />
+            <Title order={4} c="blue">Due This Month</Title>
+            <Badge color="blue">{dueThisMonth.length}</Badge>
+          </Group>
+          {dueThisMonth.length === 0 ? (
+            <Card withBorder p="md" radius="sm">
+              <Text size="sm" c="dimmed">No additional tasks due this month.</Text>
+            </Card>
+          ) : (
+            <Stack gap={0}>
+              {dueThisMonth.map((item) => (
+                <MaintenanceItemRow
+                  key={item.id}
+                  item={item}
+                  onGenerateWorkOrder={handleGenerateWorkOrder}
+                  generating={generatingFor === item.id}
+                />
+              ))}
+            </Stack>
+          )}
+        </Box>
+      </SimpleGrid>
+
+      {/* Bulk Generate Confirmation Modal */}
+      <Modal
+        opened={bulkConfirmOpened}
+        onClose={closeBulkConfirm}
+        title="Generate Work Orders"
+        size="sm"
+      >
+        <Text size="sm" mb="md">
+          This will create work orders for all overdue and due-this-week maintenance tasks
+          that don't already have an open work order. Continue?
+        </Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeBulkConfirm}>Cancel</Button>
+          <Button color="blue" onClick={handleBulkGenerate}>Generate</Button>
+        </Group>
+      </Modal>
+    </Container>
+  );
+};
+
+export default MaintenanceDashboard;

--- a/frontend/src/pages/WorkOrderPage.tsx
+++ b/frontend/src/pages/WorkOrderPage.tsx
@@ -1,0 +1,503 @@
+import {
+  ActionIcon,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Checkbox,
+  Container,
+  FileButton,
+  Group,
+  Image,
+  Loader,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  Title,
+  Tooltip,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import {
+  IconAlertTriangle,
+  IconCamera,
+  IconCheck,
+  IconClipboard,
+  IconFileText,
+  IconPhoto,
+  IconTag,
+} from '@tabler/icons-react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { workOrderAPI } from '../services/api';
+import { WorkOrder, WorkOrderStatus } from '../types';
+
+const STATUS_OPTIONS = [
+  { value: 'open', label: 'Open' },
+  { value: 'in_progress', label: 'In Progress' },
+  { value: 'blocked', label: 'Blocked' },
+  { value: 'completed', label: 'Completed' },
+];
+
+const STATUS_COLORS: Record<WorkOrderStatus, string> = {
+  open: 'blue',
+  in_progress: 'yellow',
+  blocked: 'red',
+  completed: 'green',
+};
+
+const WorkOrderPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [workOrder, setWorkOrder] = useState<WorkOrder | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [savingStatus, setSavingStatus] = useState(false);
+  const [togglingTask, setTogglingTask] = useState<string | null>(null);
+  const [togglingMaterial, setTogglingMaterial] = useState<string | null>(null);
+  const [uploadingPhoto, setUploadingPhoto] = useState(false);
+  const [notes, setNotes] = useState('');
+  const [savingNotes, setSavingNotes] = useState(false);
+  const resetPhotoRef = useRef<() => void>(null);
+
+  const apiBaseUrl = process.env.REACT_APP_API_URL || '';
+
+  const loadWorkOrder = useCallback(async () => {
+    if (!id) return;
+    try {
+      const res = await workOrderAPI.getWorkOrder(id);
+      setWorkOrder(res.data);
+      setNotes(res.data.notes || '');
+    } catch {
+      notifications.show({
+        title: 'Error',
+        message: 'Failed to load work order.',
+        color: 'red',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    loadWorkOrder();
+  }, [loadWorkOrder]);
+
+  const handleStatusChange = async (newStatus: string | null) => {
+    if (!workOrder || !newStatus) return;
+    setSavingStatus(true);
+    try {
+      const res = await workOrderAPI.updateWorkOrder(workOrder.id, {
+        status: newStatus as WorkOrderStatus,
+      });
+      setWorkOrder(res.data);
+      notifications.show({
+        title: 'Status Updated',
+        message: `Work order status set to ${newStatus.replace('_', ' ')}.`,
+        color: 'green',
+        icon: <IconCheck size={16} />,
+      });
+    } catch {
+      notifications.show({
+        title: 'Error',
+        message: 'Failed to update status.',
+        color: 'red',
+      });
+    } finally {
+      setSavingStatus(false);
+    }
+  };
+
+  const handleToggleTask = async (taskCompletionId: string, isCompleted: boolean) => {
+    if (!workOrder) return;
+    setTogglingTask(taskCompletionId);
+    try {
+      await workOrderAPI.completeTask(workOrder.id, taskCompletionId, { is_completed: isCompleted });
+      await loadWorkOrder();
+    } catch {
+      notifications.show({
+        title: 'Error',
+        message: 'Failed to update task.',
+        color: 'red',
+      });
+    } finally {
+      setTogglingTask(null);
+    }
+  };
+
+  const handleToggleMaterial = async (materialUsageId: string, wasUsed: boolean) => {
+    if (!workOrder) return;
+    setTogglingMaterial(materialUsageId);
+    try {
+      await workOrderAPI.toggleMaterial(workOrder.id, materialUsageId, wasUsed);
+      await loadWorkOrder();
+    } catch {
+      notifications.show({
+        title: 'Error',
+        message: 'Failed to update material.',
+        color: 'red',
+      });
+    } finally {
+      setTogglingMaterial(null);
+    }
+  };
+
+  const handleSaveNotes = async () => {
+    if (!workOrder) return;
+    setSavingNotes(true);
+    try {
+      const res = await workOrderAPI.updateWorkOrder(workOrder.id, { notes });
+      setWorkOrder(res.data);
+      notifications.show({
+        title: 'Notes Saved',
+        message: 'Work order notes updated.',
+        color: 'green',
+        icon: <IconCheck size={16} />,
+      });
+    } catch {
+      notifications.show({
+        title: 'Error',
+        message: 'Failed to save notes.',
+        color: 'red',
+      });
+    } finally {
+      setSavingNotes(false);
+    }
+  };
+
+  const handlePhotoUpload = async (file: File | null) => {
+    if (!file || !workOrder) return;
+    setUploadingPhoto(true);
+    try {
+      const formData = new FormData();
+      formData.append('image', file);
+      formData.append('work_order', workOrder.id);
+      await workOrderAPI.addPhoto(workOrder.id, formData);
+      await loadWorkOrder();
+      notifications.show({
+        title: 'Photo Uploaded',
+        message: 'Photo added to work order.',
+        color: 'green',
+        icon: <IconCheck size={16} />,
+      });
+    } catch {
+      notifications.show({
+        title: 'Error',
+        message: 'Failed to upload photo.',
+        color: 'red',
+      });
+    } finally {
+      setUploadingPhoto(false);
+      resetPhotoRef.current?.();
+    }
+  };
+
+  if (loading) {
+    return (
+      <Container py="xl">
+        <Group justify="center">
+          <Loader />
+          <Text c="dimmed">Loading work order…</Text>
+        </Group>
+      </Container>
+    );
+  }
+
+  if (!workOrder) {
+    return (
+      <Container py="xl">
+        <Text c="red">Work order not found.</Text>
+        <Button mt="sm" variant="default" onClick={() => navigate('/maintenance/dashboard')}>
+          Back to Dashboard
+        </Button>
+      </Container>
+    );
+  }
+
+  const completedTasks = workOrder.task_completions.filter((t) => t.is_completed).length;
+  const totalTasks = workOrder.task_completions.length;
+  const allTasksDone = totalTasks > 0 && completedTasks === totalTasks;
+
+  return (
+    <Container size="sm" py="md">
+      {/* Header */}
+      <Card withBorder p="md" radius="md" mb="md">
+        <Group justify="space-between" mb="xs" wrap="nowrap">
+          <Box style={{ flex: 1, minWidth: 0 }}>
+            <Group gap="xs" mb={4}>
+              <Text fw={700} size="lg">{workOrder.short_id}</Text>
+              <Badge color={STATUS_COLORS[workOrder.status]} size="md">
+                {workOrder.status.replace('_', ' ')}
+              </Badge>
+              {workOrder.is_overdue && (
+                <Badge color="red" variant="filled" size="sm">
+                  <Group gap={4}>
+                    <IconAlertTriangle size={12} />
+                    Overdue
+                  </Group>
+                </Badge>
+              )}
+            </Group>
+            <Text fw={600} size="sm" truncate>{workOrder.maintenance_item_title}</Text>
+            <Text size="xs" c="dimmed">
+              {workOrder.asset_name}
+              {workOrder.asset_tag && ` · ${workOrder.asset_tag}`}
+            </Text>
+            {workOrder.due_date && (
+              <Text size="xs" c="dimmed">
+                Due: {new Date(workOrder.due_date).toLocaleDateString()}
+              </Text>
+            )}
+          </Box>
+          <Stack gap="xs">
+            <Tooltip label="Print PDF">
+              <ActionIcon
+                variant="light"
+                color="gray"
+                size="lg"
+                component="a"
+                href={`${apiBaseUrl}/inventory/work-orders/${workOrder.id}/pdf/`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <IconFileText size={20} />
+              </ActionIcon>
+            </Tooltip>
+          </Stack>
+        </Group>
+
+        {/* Status selector */}
+        <Select
+          label="Status"
+          data={STATUS_OPTIONS}
+          value={workOrder.status}
+          onChange={handleStatusChange}
+          disabled={savingStatus}
+          size="md"
+          mt="xs"
+        />
+      </Card>
+
+      {/* Task Steps */}
+      {workOrder.task_completions.length > 0 && (
+        <Card withBorder p="md" radius="md" mb="md">
+          <Group mb="sm" justify="space-between">
+            <Group gap="xs">
+              <IconClipboard size={18} />
+              <Title order={5}>Task Steps</Title>
+            </Group>
+            <Text size="sm" c={allTasksDone ? 'green' : 'dimmed'} fw={600}>
+              {completedTasks}/{totalTasks}
+              {allTasksDone && <IconCheck size={14} style={{ marginLeft: 4 }} />}
+            </Text>
+          </Group>
+          <Stack gap="xs">
+            {workOrder.task_completions.map((tc) => (
+              <Box
+                key={tc.id}
+                p="sm"
+                style={{
+                  borderRadius: 8,
+                  backgroundColor: tc.is_completed ? '#f0fff4' : '#f8f9fa',
+                  border: `1px solid ${tc.is_completed ? '#69db7c' : '#dee2e6'}`,
+                  opacity: togglingTask === tc.id ? 0.6 : 1,
+                }}
+              >
+                <Group gap="md" align="flex-start" wrap="nowrap">
+                  <Checkbox
+                    checked={tc.is_completed}
+                    onChange={(e) => handleToggleTask(tc.id, e.currentTarget.checked)}
+                    disabled={togglingTask === tc.id}
+                    size="lg"
+                    mt={2}
+                  />
+                  <Box style={{ flex: 1 }}>
+                    <Group gap="xs">
+                      <Text
+                        fw={tc.is_completed ? 400 : 600}
+                        size="md"
+                        td={tc.is_completed ? 'line-through' : 'none'}
+                        c={tc.is_completed ? 'dimmed' : 'inherit'}
+                      >
+                        {tc.task_title}
+                      </Text>
+                      {tc.is_required && !tc.is_completed && (
+                        <Badge color="red" size="xs" variant="light">Required</Badge>
+                      )}
+                    </Group>
+                    {tc.is_completed && tc.completed_at && (
+                      <Text size="xs" c="green">
+                        ✓ {tc.completed_by_name || 'Done'} · {new Date(tc.completed_at).toLocaleString()}
+                      </Text>
+                    )}
+                  </Box>
+                </Group>
+              </Box>
+            ))}
+          </Stack>
+        </Card>
+      )}
+
+      {/* Materials */}
+      {workOrder.material_usage.length > 0 && (
+        <Card withBorder p="md" radius="md" mb="md">
+          <Group mb="sm" gap="xs">
+            <IconTag size={18} />
+            <Title order={5}>Materials</Title>
+          </Group>
+          <Stack gap="xs">
+            {workOrder.material_usage.map((mu) => (
+              <Box
+                key={mu.id}
+                p="sm"
+                style={{
+                  borderRadius: 8,
+                  backgroundColor: mu.was_used ? '#f0fff4' : '#f8f9fa',
+                  border: `1px solid ${mu.was_used ? '#69db7c' : '#dee2e6'}`,
+                  opacity: togglingMaterial === mu.id ? 0.6 : 1,
+                }}
+              >
+                <Group gap="md" wrap="nowrap">
+                  <Checkbox
+                    checked={mu.was_used}
+                    onChange={(e) => handleToggleMaterial(mu.id, e.currentTarget.checked)}
+                    disabled={togglingMaterial === mu.id}
+                    size="lg"
+                    label={
+                      <Box>
+                        <Text
+                          fw={mu.was_used ? 400 : 600}
+                          size="md"
+                          td={mu.was_used ? 'line-through' : 'none'}
+                          c={mu.was_used ? 'dimmed' : 'inherit'}
+                        >
+                          {mu.material_name}
+                        </Text>
+                        <Text size="xs" c="dimmed">
+                          {mu.quantity_planned}
+                          {mu.unit ? ` ${mu.unit}` : ''}
+                        </Text>
+                      </Box>
+                    }
+                  />
+                </Group>
+              </Box>
+            ))}
+          </Stack>
+        </Card>
+      )}
+
+      {/* Notes */}
+      <Card withBorder p="md" radius="md" mb="md">
+        <Title order={5} mb="sm">Notes</Title>
+        <Textarea
+          value={notes}
+          onChange={(e) => setNotes(e.currentTarget.value)}
+          placeholder="Add notes about this work order…"
+          autosize
+          minRows={3}
+          maxRows={8}
+          mb="sm"
+        />
+        <Button
+          size="sm"
+          onClick={handleSaveNotes}
+          loading={savingNotes}
+          leftSection={<IconCheck size={16} />}
+        >
+          Save Notes
+        </Button>
+      </Card>
+
+      {/* Photos */}
+      <Card withBorder p="md" radius="md" mb="md">
+        <Group mb="sm" justify="space-between">
+          <Group gap="xs">
+            <IconPhoto size={18} />
+            <Title order={5}>Photos</Title>
+            {workOrder.photos.length > 0 && (
+              <Badge color="gray" size="sm">{workOrder.photos.length}</Badge>
+            )}
+          </Group>
+          <FileButton
+            resetRef={resetPhotoRef}
+            onChange={handlePhotoUpload}
+            accept="image/*"
+          >
+            {(props) => (
+              <Button
+                {...props}
+                size="sm"
+                variant="light"
+                leftSection={<IconCamera size={16} />}
+                loading={uploadingPhoto}
+              >
+                Add Photo
+              </Button>
+            )}
+          </FileButton>
+        </Group>
+
+        {workOrder.photos.length === 0 ? (
+          <Text size="sm" c="dimmed" ta="center" py="sm">
+            No photos yet. Tap "Add Photo" to document the work.
+          </Text>
+        ) : (
+          <Group gap="xs" wrap="wrap">
+            {workOrder.photos.map((photo) => (
+              <Box key={photo.id} style={{ position: 'relative' }}>
+                <Image
+                  src={photo.image_url || photo.image}
+                  w={120}
+                  h={90}
+                  fit="cover"
+                  radius="sm"
+                  alt={photo.caption || 'Work order photo'}
+                  style={{ cursor: 'pointer' }}
+                  onClick={() => window.open(photo.image_url || photo.image, '_blank')}
+                />
+                {photo.caption && (
+                  <Text size="xs" c="dimmed" ta="center" mt={2} w={120} truncate>
+                    {photo.caption}
+                  </Text>
+                )}
+              </Box>
+            ))}
+          </Group>
+        )}
+      </Card>
+
+      {/* Completion CTA */}
+      {workOrder.status !== 'completed' && allTasksDone && (
+        <Card withBorder p="md" radius="md" mb="md" style={{ borderColor: '#51cf66', backgroundColor: '#f0fff4' }}>
+          <Group gap="xs" mb="xs">
+            <IconCheck size={18} color="green" />
+            <Text fw={600} c="green">All tasks completed!</Text>
+          </Group>
+          <Text size="sm" c="dimmed" mb="sm">
+            Mark this work order as completed to finalize it.
+          </Text>
+          <Button
+            color="green"
+            leftSection={<IconCheck size={16} />}
+            onClick={() => handleStatusChange('completed')}
+            loading={savingStatus}
+            fullWidth
+            size="md"
+          >
+            Mark as Completed
+          </Button>
+        </Card>
+      )}
+
+      <Button
+        variant="default"
+        fullWidth
+        onClick={() => navigate('/maintenance/dashboard')}
+      >
+        Back to Dashboard
+      </Button>
+    </Container>
+  );
+};
+
+export default WorkOrderPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3,7 +3,7 @@
  */
 import * as Sentry from '@sentry/react';
 import axios from 'axios';
-import { Asset, AssetPart, AssetProblem, AssetProblemsData, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, ItemSupplier, Location, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, NotificationPreferences, PendingReordersData, QRScansData, RecentSearch, ReorderRequest, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult } from '../types';
+import { Asset, AssetPart, AssetProblem, AssetProblemsData, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, ItemSupplier, Location, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, NotificationPreferences, PendingReordersData, QRScansData, RecentSearch, ReorderRequest, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderPhoto, WorkOrderTaskCompletion } from '../types';
 
 /**
  * Resolves the API base URL based on environment.
@@ -471,6 +471,70 @@ export const maintenanceAPI = {
 
   listLogs: (params?: { maintenance_item?: string; asset?: string }) =>
     api.get<{ results: MaintenanceLog[] }>('/inventory/maintenance-logs/', { params }),
+};
+
+// Maintenance Task API (sub-task steps within a MaintenanceItem)
+export const maintenanceTaskAPI = {
+  listTasks: (maintenanceItemId: string) =>
+    api.get<{ results: MaintenanceTask[] }>('/inventory/maintenance-tasks/', {
+      params: { maintenance_item: maintenanceItemId },
+    }),
+
+  createTask: (data: Partial<MaintenanceTask>) =>
+    api.post<MaintenanceTask>('/inventory/maintenance-tasks/', data),
+
+  updateTask: (id: string, data: Partial<MaintenanceTask>) =>
+    api.patch<MaintenanceTask>(`/inventory/maintenance-tasks/${id}/`, data),
+
+  deleteTask: (id: string) => api.delete(`/inventory/maintenance-tasks/${id}/`),
+};
+
+// Work Order API
+export const workOrderAPI = {
+  listWorkOrders: (params?: { asset?: string; maintenance_item?: string; status?: string }) =>
+    api.get<{ results: WorkOrder[] }>('/inventory/work-orders/', { params }),
+
+  getWorkOrder: (id: string) => api.get<WorkOrder>(`/inventory/work-orders/${id}/`),
+
+  createWorkOrder: (data: Partial<WorkOrder>) =>
+    api.post<WorkOrder>('/inventory/work-orders/', data),
+
+  updateWorkOrder: (id: string, data: Partial<WorkOrder>) =>
+    api.patch<WorkOrder>(`/inventory/work-orders/${id}/`, data),
+
+  getPdfUrl: (id: string) => `/inventory/work-orders/${id}/pdf/`,
+
+  generateWorkOrder: (maintenanceItemId: string, data?: { due_date?: string; notes?: string }) =>
+    api.post<WorkOrder>(`/inventory/maintenance-items/${maintenanceItemId}/generate_work_order/`, data || {}),
+
+  generateBulkWorkOrders: () =>
+    api.post<{ created: number; work_order_ids: string[] }>(
+      '/inventory/maintenance-items/generate_work_orders_bulk/',
+      {}
+    ),
+
+  completeTask: (workOrderId: string, taskCompletionId: string, data: { is_completed: boolean; notes?: string }) =>
+    api.patch<WorkOrderTaskCompletion>(
+      `/inventory/work-orders/${workOrderId}/tasks/${taskCompletionId}/complete/`,
+      data
+    ),
+
+  toggleMaterial: (workOrderId: string, materialUsageId: string, wasUsed: boolean) =>
+    api.patch(
+      `/inventory/work-orders/${workOrderId}/materials/${materialUsageId}/toggle/`,
+      { was_used: wasUsed }
+    ),
+
+  addPhoto: (workOrderId: string, formData: FormData) =>
+    api.post<WorkOrderPhoto>(`/inventory/work-orders/${workOrderId}/add_photo/`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    }),
+
+  getDueThisWeek: () =>
+    api.get<MaintenanceItem[]>('/inventory/maintenance-items/due_this_week/'),
+
+  getDueThisMonth: () =>
+    api.get<MaintenanceItem[]>('/inventory/maintenance-items/due_this_month/'),
 };
 
 // Asset Parts API

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -372,6 +372,7 @@ export interface MaintenanceItem {
   days_overdue: number | null;
   next_due_at: string | null;
   materials: MaintenanceMaterial[];
+  tasks: MaintenanceTask[];
   created_at: string;
   updated_at: string;
 }
@@ -388,6 +389,80 @@ export interface MaintenanceLog {
   cost_incurred: string | null;
   notes: string;
   created_at: string;
+}
+
+export interface MaintenanceTask {
+  id: string;
+  maintenance_item: string;
+  order: number;
+  title: string;
+  description: string;
+  is_required: boolean;
+  created_at: string;
+}
+
+export type WorkOrderStatus = 'open' | 'in_progress' | 'blocked' | 'completed';
+
+export interface WorkOrderTaskCompletion {
+  id: string;
+  work_order: string;
+  task: string | null;
+  task_title: string;
+  task_order: number;
+  is_required: boolean;
+  is_completed: boolean;
+  completed_by: number | null;
+  completed_by_name: string | null;
+  completed_at: string | null;
+  notes: string;
+  created_at: string;
+}
+
+export interface WorkOrderMaterialUsage {
+  id: string;
+  work_order: string;
+  material: string | null;
+  material_name: string;
+  quantity_planned: string;
+  unit: string;
+  was_used: boolean;
+  created_at: string;
+}
+
+export interface WorkOrderPhoto {
+  id: string;
+  work_order: string;
+  image: string;
+  image_url: string | null;
+  caption: string;
+  uploaded_by: number | null;
+  uploaded_by_name: string | null;
+  uploaded_at: string;
+}
+
+export interface WorkOrder {
+  id: string;
+  short_id: string;
+  maintenance_item: string;
+  maintenance_item_title: string;
+  asset_name: string;
+  asset_tag: string;
+  asset_id: string;
+  status: WorkOrderStatus;
+  due_date: string | null;
+  assigned_to: number | null;
+  assigned_to_name: string | null;
+  completed_by_name: string;
+  completed_at: string | null;
+  notes: string;
+  is_overdue: boolean;
+  task_completions: WorkOrderTaskCompletion[];
+  material_usage: WorkOrderMaterialUsage[];
+  photos: WorkOrderPhoto[];
+  task_completion_count?: number;
+  task_total_count?: number;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface SiteSettings {


### PR DESCRIPTION
## Summary

- Add work order models, serializers, views, and migration (`0044_add_work_orders.py`)
- PDF generation for work orders (`backend/inventory/utils/work_order_pdf.py`)
- New `MaintenanceDashboard` and `WorkOrderPage` frontend pages
- Sidebar navigation and app routing updates
- Logistics dashboard integration

Closes oms-1qj

## Notes

GT internal files stripped from polecat branch before merge.

## Test plan

- [ ] Apply migration: `python manage.py migrate`
- [ ] Create a work order and verify PDF generation
- [ ] Verify Maintenance Dashboard loads and shows work orders
- [ ] Verify Work Order page CRUD operations
- [ ] Check sidebar navigation links

🤖 Merged by Refinery (oms/refinery) via [Claude Code](https://claude.com/claude-code)