### PR TITLE
docs: add CLAUDE.md + .criteria/ workflow split (hq-3rl)

### DIFF
--- a/.criteria/README.md
+++ b/.criteria/README.md
@@ -1,0 +1,34 @@
+# Acceptance Criteria
+
+Contract directory between Codex (author) and Claude Code (implementer).
+
+## File format
+
+One file per feature: `.criteria/<short-slug>.md`
+
+```markdown
+# <Feature name>
+
+## Context
+<1-3 sentences: why this exists, what problem it solves>
+
+## Scope
+- In: <bullet list of what's included>
+- Out: <bullet list of explicitly excluded>
+
+## Criteria
+
+### AC-1: <short name>
+- **Given** <precondition>
+- **When** <action>
+- **Then** <observable outcome>
+
+### AC-2: ...
+```
+
+## Rules
+
+- Criteria must be observable (testable from outside the system) — no "code should be clean".
+- One AC = one test (ideally). If an AC needs multiple tests, split it.
+- Codex writes these. Claude reads and implements. Neither crosses the line.
+- When Claude ships, the PR description references AC-N for each commit/change.

--- a/.gitignore
+++ b/.gitignore
@@ -78,5 +78,7 @@ Thumbs.db
 # Gas Town / Polecat runtime files
 .runtime/
 .claude/
-CLAUDE.md
 .beads/redirect
+
+# Per-developer overrides (CLAUDE.md itself is committed — project conventions)
+CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # Project Instructions
 
+## Workflow Roles (Codex vs Claude Code)
+
+Two coding agents work this repo with split responsibilities:
+
+- **Codex** — acceptance criteria author. Given a feature request, writes `.criteria/<slug>.md` in the format described in `.criteria/README.md`. Does not modify files under `backend/`, `frontend/`, migrations, or tests.
+- **Claude Code** — implementer. Reads `.criteria/*.md` and writes code + tests to satisfy every AC. See `CLAUDE.md` for the full role spec and project conventions.
+
+The rest of this file applies to both agents.
+
 ## Code Style
 
 - There is a .devcontainer environment for editing and running this application in development mode.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# Claude Code
+
+Project conventions and role assignment for Claude Code in openmakersuite. Also read `AGENTS.md` for shared project standards that apply to all agents.
+
+## Project Layout
+
+- `backend/` — Python 3.11, Django 5.1 + Django REST Framework, Celery, PostgreSQL.
+  - Virtualenv from `backend/requirements.txt` + `backend/requirements-dev.txt`.
+  - Tests: `cd backend && pytest`.
+- `frontend/` — React + TypeScript + Vite, npm.
+  - Tests: `cd frontend && npm test`.
+- `.github/workflows/ci.yml` is the source of truth for what CI enforces.
+
+## Before committing
+
+Run `pre-commit run --all-files`. If that's not installed, at minimum:
+
+```
+cd backend && isort --profile black . && black --check . && flake8 .
+```
+
+CI fails on `isort`, `black`, and `flake8` — all three must be green locally before you push, or CI will reject the PR. Pre-commit install once per worktree:
+
+```
+pip install pre-commit && pre-commit install
+```
+
+## "Tests pass" means more than pytest
+
+A green `pytest` run is necessary but not sufficient. Before declaring a task done:
+
+1. `cd backend && pytest` — backend test suite green.
+2. `cd frontend && npm test` — frontend test suite green.
+3. `pre-commit run --all-files` — all lint/format hooks green.
+4. No new warnings in the diff.
+
+If any of the above fails, the work is not done — surface the failure, don't paper over it.
+
+## Workflow Roles (Codex vs Claude Code)
+
+Two coding agents share this repo with split responsibilities:
+
+- **Codex** — acceptance criteria author. Given a feature request, writes `.criteria/<slug>.md` in the format described in `.criteria/README.md`. Does not modify `backend/`, `frontend/`, migrations, or tests.
+- **Claude Code** — implementer. Reads `.criteria/*.md` and writes code + tests to satisfy every AC. Does not edit `.criteria/`.
+
+## Your job (Claude Code)
+
+Given a `.criteria/<slug>.md` file, implement code changes in `backend/` and/or `frontend/` to satisfy every criterion. Write tests that map one-to-one to the Given/When/Then blocks.
+
+### Boundaries
+
+- Do not write, edit, or delete files under `.criteria/`. Those are Codex's output.
+- If a criterion is ambiguous, underspecified, or contradicts existing code, stop and surface the conflict — do not invent the intent.
+- If acceptance requires changes beyond what the criteria describe (schema migration, config, infra), call them out before implementing rather than silently expanding scope.
+
+### Done means
+
+- All criteria tests pass.
+- `pre-commit run --all-files` is clean (or at minimum: `black --check`, `isort --check-only`, `flake8` on backend).
+- Both test suites green (`pytest`, `npm test`).
+- PR description references AC-N for each change so reviewers can trace intent.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` at repo root with project conventions: layout, test commands, pre-commit workflow, full definition of "done".
- Adds `.criteria/README.md` documenting the Codex→Claude acceptance-criteria handoff format.
- Adds a Workflow Roles section to `AGENTS.md` pointing at both halves.
- Removes the blanket `CLAUDE.md` ignore in `.gitignore` (it was hiding committed project conventions); keeps `CLAUDE.local.md` ignored for per-developer overrides.

## Why

Every polecat PR this week has failed CI on `isort` (#154, #155). Root cause: agents interpret "tests pass" as `pytest`/`npm test` only, not the full CI lint suite. `CLAUDE.md` now says so explicitly.

Addresses bead **hq-3rl Part A**. Part B (install pre-commit in polecat spawn template) is Gas Town–side infra and stays as a separate bead.

## Test plan

- [ ] CI green
- [ ] Review CLAUDE.md / AGENTS.md wording
- [ ] Confirm next polecat PR references the lint steps before push