### PR TITLE
chore(deps): bump black to 26.3.1 and apply formatting (hq-zza)

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -105,8 +105,7 @@ def ensure_auth_user_groups_table(db):
             )
             table_exists = cursor.fetchone() is not None
             if not table_exists:
-                cursor.execute(
-                    """
+                cursor.execute("""
                     CREATE TABLE auth_user_groups (
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         user_id INTEGER NOT NULL,
@@ -117,22 +116,18 @@ def ensure_auth_user_groups_table(db):
                     );
                     CREATE INDEX auth_user_groups_user_id_idx ON auth_user_groups(user_id);
                     CREATE INDEX auth_user_groups_group_id_idx ON auth_user_groups(group_id);
-                    """
-                )
+                    """)
         elif connection.vendor == "postgresql":
-            cursor.execute(
-                """
+            cursor.execute("""
                 SELECT EXISTS (
                     SELECT FROM information_schema.tables
                     WHERE table_schema = 'public'
                     AND table_name = 'auth_user_groups'
                 );
-                """
-            )
+                """)
             table_exists = cursor.fetchone()[0]
             if not table_exists:
-                cursor.execute(
-                    """
+                cursor.execute("""
                     CREATE TABLE auth_user_groups (
                         id SERIAL PRIMARY KEY,
                         user_id INTEGER NOT NULL,
@@ -143,5 +138,4 @@ def ensure_auth_user_groups_table(db):
                     );
                     CREATE INDEX auth_user_groups_user_id_idx ON auth_user_groups(user_id);
                     CREATE INDEX auth_user_groups_group_id_idx ON auth_user_groups(group_id);
-                    """
-                )
+                    """)

--- a/backend/create_dev_user.py
+++ b/backend/create_dev_user.py
@@ -3,6 +3,7 @@
 Quick script to create a development superuser.
 Usage: python create_dev_user.py
 """
+
 import os
 
 import django

--- a/backend/inventory/tests/test_asset_part_deletion.py
+++ b/backend/inventory/tests/test_asset_part_deletion.py
@@ -198,8 +198,7 @@ class TestAssetPartDeletionWithAssetProblems:
 
         # Verify the constraint exists and is SET NULL
         with connection.cursor() as cursor:
-            cursor.execute(
-                """
+            cursor.execute("""
                 SELECT
                     tc.constraint_name,
                     rc.delete_rule
@@ -211,8 +210,7 @@ class TestAssetPartDeletionWithAssetProblems:
                 WHERE tc.table_name = 'inventory_assetproblem'
                     AND tc.constraint_type = 'FOREIGN KEY'
                     AND kcu.column_name = 'part_id'
-            """
-            )
+            """)
             result = cursor.fetchone()
 
             assert result is not None, "Foreign key constraint should exist"

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/backend/membership/tests/test_sigadmin.py
+++ b/backend/membership/tests/test_sigadmin.py
@@ -125,8 +125,7 @@ class TestSIGPermissionUtils:
                 )
                 table_exists = cursor.fetchone() is not None
                 if not table_exists:
-                    cursor.execute(
-                        """
+                    cursor.execute("""
                         CREATE TABLE auth_user_groups (
                             id INTEGER PRIMARY KEY AUTOINCREMENT,
                             user_id INTEGER NOT NULL,
@@ -135,22 +134,18 @@ class TestSIGPermissionUtils:
                             FOREIGN KEY (user_id) REFERENCES auth_user(id),
                             FOREIGN KEY (group_id) REFERENCES auth_group(id)
                         );
-                        """
-                    )
+                        """)
             elif connection.vendor == "postgresql":
-                cursor.execute(
-                    """
+                cursor.execute("""
                     SELECT EXISTS (
                         SELECT FROM information_schema.tables
                         WHERE table_schema = 'public'
                         AND table_name = 'auth_user_groups'
                     );
-                    """
-                )
+                    """)
                 table_exists = cursor.fetchone()[0]
                 if not table_exists:
-                    cursor.execute(
-                        """
+                    cursor.execute("""
                         CREATE TABLE auth_user_groups (
                             id SERIAL PRIMARY KEY,
                             user_id INTEGER NOT NULL,
@@ -161,8 +156,7 @@ class TestSIGPermissionUtils:
                         );
                         CREATE INDEX auth_user_groups_user_id_idx ON auth_user_groups(user_id);
                         CREATE INDEX auth_user_groups_group_id_idx ON auth_user_groups(group_id);
-                        """
-                    )
+                        """)
             # For other databases, assume table exists (migration should have created it)
 
         # Use through model directly to ensure migrations are applied

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -8,7 +8,7 @@ pre-commit==3.6.0
 flake8==7.0.0
 flake8-docstrings==1.7.0
 flake8-bugbear==24.1.17
-black==24.10.0
+black==26.3.1
 isort==5.13.2
 
 # Django Tools


### PR DESCRIPTION
## Summary

Pre-lands the black 24.10.0 → 26.3.1 bump from dependabot PR #151, plus the 6 files that need reformatting to match the new black. Once this merges, #151 rebases and its `black --check` step becomes a no-op.

## Why

Dependabot PR #151 bumps four packages in the `pip` group (pillow, requests, pytest, **black**). CI fails on the black step because 26.3.1 rejects formatting that 24.10.0 accepted — mostly triple-quoted string arg collapses and blank lines after module docstrings.

Rather than fix it inside the dependabot branch (which auto-regenerates), land the black bump + reformat separately here. Dependabot's branch will converge on rebase.

Attribution: the reformatting commit was produced by polecat `oms/obsidian` working `hq-zza`. It was pushed to `polecat/obsidian-mo867ycr` but no PR was opened because the polecat's `gt done` couldn't find hq-zza in the oms-rig beads DB (it's town-scope). Mayor cherry-picked the real commit onto a clean branch here (skipping a stray `.runtime/` auto-save commit) and is opening the PR on obsidian's behalf. See hq-0ae for the systemic dispatch-reliability pattern.

## Test plan

- [x] `black --check .` clean in `backend/` (210 files, all pass with 26.3.1).
- [x] `isort --check-only .` clean in `backend/`.
- [ ] CI backend-tests green.
- [ ] #151 rebased after this merges; its CI passes.