### PR TITLE
chore: track polecat pre-commit setup hook for rig rebuild durability (hq-vhch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,24 @@ CI fails on `isort`, `black`, and `flake8` — all three must be green locally b
 pip install pre-commit && pre-commit install
 ```
 
+### Polecat rig setup (gt worktrees)
+
+Gas Town polecats run `pre-commit install` automatically via a setup hook in
+`.runtime/setup-hooks/` when a worktree is spawned. `.runtime/` is gitignored
+and gets rebuilt from scratch by `gt rig add oms` / rig rebuilds, so the
+tracked source of truth lives in `scripts/polecat-hooks/`.
+
+After `gt rig add oms` (or any rig rebuild), re-install the hook:
+
+```
+cp scripts/polecat-hooks/* .runtime/setup-hooks/
+chmod +x .runtime/setup-hooks/*
+```
+
+Source of truth is `scripts/polecat-hooks/`; `.runtime/` is rebuilt state. Do
+not edit the copies under `.runtime/setup-hooks/` — edit the tracked script
+and re-copy.
+
 ## "Tests pass" means more than pytest
 
 A green `pytest` run is necessary but not sufficient. Before declaring a task done:

--- a/scripts/polecat-hooks/02-install-pre-commit.sh
+++ b/scripts/polecat-hooks/02-install-pre-commit.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Install pre-commit hooks in the polecat worktree (hq-ahf / hq-3rl Part B).
+#
+# CI enforces black, isort, and flake8 via pre-commit. Without the git hook
+# installed locally, polecats commit code that fails CI and waste a round trip.
+# This hook runs `pre-commit install` in the spawned worktree so `git commit`
+# runs the same checks CI does.
+#
+# Note: in linked worktrees, `pre-commit install` writes to the shared
+# commondir hooks path (e.g. .repo.git/hooks/pre-commit), so all worktrees of
+# this repo share the installed hook. Running this per-spawn is idempotent.
+
+set -euo pipefail
+
+WORKTREE="$GT_WORKTREE_PATH"
+
+if [[ ! -f "$WORKTREE/.pre-commit-config.yaml" ]]; then
+  echo "install-pre-commit: no .pre-commit-config.yaml in $WORKTREE, skipping" >&2
+  exit 0
+fi
+
+if ! command -v pre-commit >/dev/null 2>&1; then
+  echo "install-pre-commit: pre-commit not on PATH, skipping" >&2
+  exit 0
+fi
+
+cd "$WORKTREE"
+pre-commit install >&2
+echo "install-pre-commit: installed hook in $WORKTREE" >&2


### PR DESCRIPTION
## Summary
- Adds `scripts/polecat-hooks/02-install-pre-commit.sh` as the tracked source of truth for the polecat pre-commit install hook.
- Documents the post-rebuild re-install one-liner in `CLAUDE.md`.
- Follow-up to hq-ahf: the live hook in `.runtime/setup-hooks/` works but `.runtime/` is gitignored, so a fresh rig rebuild loses it. This makes the hook durable.

## Test plan
- [x] Hook content matches the live working version (idempotent, uses `GT_WORKTREE_PATH`, safe fallbacks if `pre-commit` or `.pre-commit-config.yaml` missing).
- [x] Live `.runtime/setup-hooks/02-install-pre-commit.sh` untouched.
- [ ] Simulate rebuild: delete `.runtime/setup-hooks/02-install-pre-commit.sh`, run the documented one-liner, spawn a polecat, verify `pre-commit` hook installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)