### PR TITLE
feat: allow staff to create SIGs from the frontend (oms-ktq)

### DIFF
--- a/backend/membership/serializers.py
+++ b/backend/membership/serializers.py
@@ -118,6 +118,27 @@ class SIGSerializer(serializers.ModelSerializer):
         return SIGAdmin.is_sig_admin(request.user, obj)
 
 
+class SIGCreateSerializer(serializers.ModelSerializer):
+    """Writable serializer for creating/updating SIGs (Groups)."""
+
+    class Meta:
+        model = Group
+        fields = ["id", "name"]
+        read_only_fields = ["id"]
+
+    def validate_name(self, value):
+        """Ensure SIG name is non-empty and unique."""
+        name = (value or "").strip()
+        if not name:
+            raise serializers.ValidationError("SIG name is required.")
+        qs = Group.objects.filter(name=name)
+        if self.instance is not None:
+            qs = qs.exclude(pk=self.instance.pk)
+        if qs.exists():
+            raise serializers.ValidationError("A SIG with this name already exists.")
+        return name
+
+
 class UserSerializer(serializers.ModelSerializer):
     """Serializer for User model (for member management)."""
 

--- a/backend/membership/tests/test_sig_api.py
+++ b/backend/membership/tests/test_sig_api.py
@@ -78,6 +78,98 @@ class TestSIGAPI:
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
+    def test_create_sig_as_staff(self, authenticated_client):
+        """Staff users can create a new SIG via POST /membership/sigs/."""
+        client, user = authenticated_client
+        user.is_staff = True
+        user.save()
+
+        url = reverse("sig-list")
+        response = client.post(url, {"name": "New SIG"})
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["name"] == "New SIG"
+        assert Group.objects.filter(name="New SIG").exists()
+
+    def test_create_sig_as_superuser(self, authenticated_client):
+        """Superusers can create a new SIG."""
+        client, user = authenticated_client
+        user.is_superuser = True
+        user.save()
+
+        url = reverse("sig-list")
+        response = client.post(url, {"name": "Super SIG"})
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Group.objects.filter(name="Super SIG").exists()
+
+    def test_create_sig_as_non_staff_forbidden(self, authenticated_client):
+        """Non-staff users cannot create SIGs (403)."""
+        client, _user = authenticated_client
+
+        url = reverse("sig-list")
+        response = client.post(url, {"name": "Nope SIG"})
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert not Group.objects.filter(name="Nope SIG").exists()
+
+    def test_create_sig_requires_auth(self, api_client):
+        """Unauthenticated requests are rejected."""
+        url = reverse("sig-list")
+        response = api_client.post(url, {"name": "Anon SIG"})
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert not Group.objects.filter(name="Anon SIG").exists()
+
+    def test_create_sig_rejects_blank_name(self, authenticated_client):
+        """Blank/missing names return 400."""
+        client, user = authenticated_client
+        user.is_staff = True
+        user.save()
+
+        url = reverse("sig-list")
+        response = client.post(url, {"name": "   "})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_create_sig_rejects_duplicate_name(self, authenticated_client):
+        """Duplicate SIG names return 400."""
+        client, user = authenticated_client
+        user.is_staff = True
+        user.save()
+        Group.objects.create(name="Existing SIG")
+
+        url = reverse("sig-list")
+        response = client.post(url, {"name": "Existing SIG"})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_update_sig_as_staff(self, authenticated_client):
+        """Staff can rename a SIG via PATCH."""
+        client, user = authenticated_client
+        user.is_staff = True
+        user.save()
+        group = Group.objects.create(name="Old Name")
+
+        url = reverse("sig-detail", kwargs={"pk": group.pk})
+        response = client.patch(url, {"name": "New Name"})
+
+        assert response.status_code == status.HTTP_200_OK
+        group.refresh_from_db()
+        assert group.name == "New Name"
+
+    def test_delete_sig_as_non_staff_forbidden(self, authenticated_client):
+        """Non-staff SIG admins cannot delete their SIG."""
+        client, user = authenticated_client
+        group = Group.objects.create(name="My SIG")
+        SIGAdmin.objects.create(user=user, group=group, is_active=True)
+
+        url = reverse("sig-detail", kwargs={"pk": group.pk})
+        response = client.delete(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert Group.objects.filter(pk=group.pk).exists()
+
 
 @pytest.mark.integration
 class TestSIGMemberAPI:

--- a/backend/membership/views.py
+++ b/backend/membership/views.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import Group
 
 from rest_framework import status, viewsets
 from rest_framework.decorators import action, api_view, permission_classes
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -14,6 +15,7 @@ from .models import SIGAdmin, User, UserRegistrationToken
 from .serializers import (
     ChangePasswordSerializer,
     SIGAdminSerializer,
+    SIGCreateSerializer,
     SIGMemberSerializer,
     SIGSerializer,
     TokenValidationSerializer,
@@ -24,11 +26,12 @@ from .serializers import (
 from .utils import get_user_managed_sigs, is_sig_admin
 
 
-class SIGViewSet(viewsets.ReadOnlyModelViewSet):
+class SIGViewSet(viewsets.ModelViewSet):
     """
     ViewSet for SIG (Special Interest Group) operations.
 
-    Allows SIG admins to view their SIGs and get details.
+    Read access is open to SIG admins (for their SIGs) and staff (all SIGs).
+    Create/update/delete is restricted to staff and superusers.
     """
 
     queryset = Group.objects.all()
@@ -46,11 +49,37 @@ class SIGViewSet(viewsets.ReadOnlyModelViewSet):
         # Regular users see only SIGs they administer
         return get_user_managed_sigs(user)
 
+    def get_serializer_class(self):
+        """Use a writable serializer for create/update actions."""
+        if self.action in ("create", "update", "partial_update"):
+            return SIGCreateSerializer
+        return SIGSerializer
+
     def get_serializer_context(self):
         """Add request to serializer context."""
         context = super().get_serializer_context()
         context["request"] = self.request
         return context
+
+    def _require_staff(self):
+        user = self.request.user
+        if not (user.is_authenticated and (user.is_superuser or user.is_staff)):
+            raise PermissionDenied("Only staff users can manage SIGs.")
+
+    def perform_create(self, serializer):
+        """Only staff/superusers can create SIGs."""
+        self._require_staff()
+        serializer.save()
+
+    def perform_update(self, serializer):
+        """Only staff/superusers can update SIGs."""
+        self._require_staff()
+        serializer.save()
+
+    def perform_destroy(self, instance):
+        """Only staff/superusers can delete SIGs."""
+        self._require_staff()
+        instance.delete()
 
     @action(detail=True, methods=["get"])
     def details(self, request, pk=None):

--- a/frontend/src/__tests__/SIGDashboard.test.tsx
+++ b/frontend/src/__tests__/SIGDashboard.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Unit tests for SIG Dashboard component
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import SIGDashboard from '../pages/SIGDashboard';
 import * as sigAPI from '../services/api';
@@ -12,6 +12,7 @@ jest.mock('../services/api', () => ({
     listMySIGs: jest.fn(),
     getSIGMembers: jest.fn(),
     getSIGDetails: jest.fn(),
+    createSIG: jest.fn(),
   },
   assetsAPI: {
     listAssets: jest.fn(),
@@ -47,6 +48,7 @@ const MockedSIGDashboard = () => (
 describe('SIGDashboard', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    localStorage.clear();
   });
 
   it('should show loading state initially', () => {
@@ -128,6 +130,110 @@ describe('SIGDashboard', () => {
     expect(screen.getByText('Members')).toBeInTheDocument();
     expect(screen.getByText('Assets')).toBeInTheDocument();
     expect(screen.getByText('Inventory Items')).toBeInTheDocument();
+  });
+
+  it('should hide Create SIG button for non-staff users', async () => {
+    (sigAPI.sigAPI.listMySIGs as jest.Mock).mockResolvedValue({
+      data: { results: mockSIGs },
+    });
+    (sigAPI.assetsAPI.listAssets as jest.Mock).mockResolvedValue({ data: { results: [] } });
+    (sigAPI.inventoryAPI.listItems as jest.Mock).mockResolvedValue({ data: { results: [] } });
+    (sigAPI.reorderAPI.getSIGPendingRequests as jest.Mock).mockResolvedValue({ data: [] });
+    (sigAPI.sigAPI.getSIGMembers as jest.Mock).mockResolvedValue({ data: [] });
+
+    render(<MockedSIGDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('SIG Dashboard')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: /Create SIG/i })).not.toBeInTheDocument();
+  });
+
+  it('should show Create SIG button for staff users and create a SIG', async () => {
+    localStorage.setItem('is_staff', 'true');
+
+    (sigAPI.sigAPI.listMySIGs as jest.Mock)
+      .mockResolvedValueOnce({ data: { results: mockSIGs } })
+      .mockResolvedValueOnce({
+        data: {
+          results: [
+            ...mockSIGs,
+            {
+              id: 2,
+              name: 'Created SIG',
+              member_count: 0,
+              asset_count: 0,
+              inventory_count: 0,
+              admins: [],
+              is_user_admin: false,
+            },
+          ],
+        },
+      });
+    (sigAPI.assetsAPI.listAssets as jest.Mock).mockResolvedValue({ data: { results: [] } });
+    (sigAPI.inventoryAPI.listItems as jest.Mock).mockResolvedValue({ data: { results: [] } });
+    (sigAPI.reorderAPI.getSIGPendingRequests as jest.Mock).mockResolvedValue({ data: [] });
+    (sigAPI.sigAPI.getSIGMembers as jest.Mock).mockResolvedValue({ data: [] });
+    (sigAPI.sigAPI.createSIG as jest.Mock).mockResolvedValue({
+      data: { id: 2, name: 'Created SIG' },
+    });
+
+    render(<MockedSIGDashboard />);
+
+    const createBtn = await screen.findByRole('button', { name: /Create SIG/i });
+    fireEvent.click(createBtn);
+
+    const nameInput = await screen.findByLabelText(/Name/i);
+    fireEvent.change(nameInput, { target: { value: 'Created SIG' } });
+
+    const submitBtn = screen.getByRole('button', { name: /^Create$/i });
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(sigAPI.sigAPI.createSIG).toHaveBeenCalledWith({ name: 'Created SIG' });
+    });
+
+    await waitFor(() => {
+      expect(sigAPI.sigAPI.listMySIGs).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('should show Create SIG button on empty state for staff', async () => {
+    localStorage.setItem('is_superuser', 'true');
+    (sigAPI.sigAPI.listMySIGs as jest.Mock).mockResolvedValue({ data: { results: [] } });
+
+    render(<MockedSIGDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No SIGs exist yet/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /Create SIG/i })).toBeInTheDocument();
+  });
+
+  it('should surface backend error when create fails', async () => {
+    localStorage.setItem('is_staff', 'true');
+    (sigAPI.sigAPI.listMySIGs as jest.Mock).mockResolvedValue({ data: { results: mockSIGs } });
+    (sigAPI.assetsAPI.listAssets as jest.Mock).mockResolvedValue({ data: { results: [] } });
+    (sigAPI.inventoryAPI.listItems as jest.Mock).mockResolvedValue({ data: { results: [] } });
+    (sigAPI.reorderAPI.getSIGPendingRequests as jest.Mock).mockResolvedValue({ data: [] });
+    (sigAPI.sigAPI.getSIGMembers as jest.Mock).mockResolvedValue({ data: [] });
+    (sigAPI.sigAPI.createSIG as jest.Mock).mockRejectedValue({
+      response: { data: { name: ['A SIG with this name already exists.'] } },
+    });
+
+    render(<MockedSIGDashboard />);
+
+    const createBtn = await screen.findByRole('button', { name: /Create SIG/i });
+    fireEvent.click(createBtn);
+
+    const nameInput = await screen.findByLabelText(/Name/i);
+    fireEvent.change(nameInput, { target: { value: 'Duplicate' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/already exists/i);
+    });
   });
 
   it('should switch between tabs', async () => {

--- a/frontend/src/pages/SIGDashboard.tsx
+++ b/frontend/src/pages/SIGDashboard.tsx
@@ -20,6 +20,15 @@ const SIGDashboard: React.FC = () => {
   const [inventory, setInventory] = useState<InventoryItem[]>([]);
   const [reorderRequests, setReorderRequests] = useState<ReorderRequest[]>([]);
   const [members, setMembers] = useState<any[]>([]);
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [newSIGName, setNewSIGName] = useState('');
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const isStaff = typeof window !== 'undefined' && (
+    localStorage.getItem('is_staff') === 'true' ||
+    localStorage.getItem('is_superuser') === 'true'
+  );
 
   useEffect(() => {
     loadSIGs();
@@ -45,6 +54,42 @@ const SIGDashboard: React.FC = () => {
       console.error('Error loading SIGs:', error);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const openCreateModal = () => {
+    setNewSIGName('');
+    setCreateError(null);
+    setShowCreateModal(true);
+  };
+
+  const closeCreateModal = () => {
+    setShowCreateModal(false);
+    setNewSIGName('');
+    setCreateError(null);
+  };
+
+  const handleCreateSIG = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const name = newSIGName.trim();
+    if (!name) {
+      setCreateError('SIG name is required.');
+      return;
+    }
+    try {
+      setCreating(true);
+      setCreateError(null);
+      await sigAPI.createSIG({ name });
+      closeCreateModal();
+      await loadSIGs();
+    } catch (err: any) {
+      const detail =
+        err?.response?.data?.name?.[0] ||
+        err?.response?.data?.detail ||
+        'Failed to create SIG.';
+      setCreateError(detail);
+    } finally {
+      setCreating(false);
     }
   };
 
@@ -80,11 +125,55 @@ const SIGDashboard: React.FC = () => {
     return <div className="sig-dashboard-loading">Loading SIGs...</div>;
   }
 
+  const createModal = showCreateModal && (
+    <div className="sig-create-modal">
+      <div className="modal-content">
+        <div className="modal-header">
+          <h2>Create SIG</h2>
+          <button onClick={closeCreateModal} className="close-btn" aria-label="Close">
+            ✗
+          </button>
+        </div>
+        <form onSubmit={handleCreateSIG} className="modal-body">
+          <label htmlFor="new-sig-name">Name</label>
+          <input
+            id="new-sig-name"
+            type="text"
+            value={newSIGName}
+            onChange={(e) => setNewSIGName(e.target.value)}
+            placeholder="SIG name"
+            autoFocus
+            disabled={creating}
+          />
+          {createError && <p className="error-message" role="alert">{createError}</p>}
+          <div className="modal-actions">
+            <button type="button" onClick={closeCreateModal} disabled={creating}>
+              Cancel
+            </button>
+            <button type="submit" disabled={creating || !newSIGName.trim()}>
+              {creating ? 'Creating…' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+
   if (sigs.length === 0) {
     return (
       <div className="sig-dashboard-empty">
         <h1>SIG Dashboard</h1>
-        <p>You are not an admin of any SIGs.</p>
+        {isStaff ? (
+          <>
+            <p>No SIGs exist yet.</p>
+            <button className="create-sig-btn" onClick={openCreateModal}>
+              Create SIG
+            </button>
+          </>
+        ) : (
+          <p>You are not an admin of any SIGs.</p>
+        )}
+        {createModal}
       </div>
     );
   }
@@ -108,6 +197,11 @@ const SIGDashboard: React.FC = () => {
               </option>
             ))}
           </select>
+        )}
+        {isStaff && (
+          <button className="create-sig-btn" onClick={openCreateModal}>
+            Create SIG
+          </button>
         )}
       </div>
 
@@ -254,6 +348,7 @@ const SIGDashboard: React.FC = () => {
           </div>
         </>
       )}
+      {createModal}
     </div>
   );
 };

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -713,6 +713,15 @@ export const sigAPI = {
   getSIGDetails: (id: number) =>
     api.get<SIG>(`/membership/sigs/${id}/details/`),
 
+  createSIG: (data: { name: string }) =>
+    api.post<{ id: number; name: string }>('/membership/sigs/', data),
+
+  updateSIG: (id: number, data: { name: string }) =>
+    api.put<{ id: number; name: string }>(`/membership/sigs/${id}/`, data),
+
+  deleteSIG: (id: number) =>
+    api.delete(`/membership/sigs/${id}/`),
+
   getSIGMembers: (sigId: number) =>
     api.get<SIGMember[]>(`/membership/sigs/${sigId}/members/`),
 


### PR DESCRIPTION
## Summary
Promotes `SIGViewSet` from `ReadOnlyModelViewSet` to `ModelViewSet` with staff-gated create/update/destroy, adds `SIGCreateSerializer`, wires a staff-only "Create SIG" button + modal on `SIGDashboard`, and extends `sigAPI` with `createSIG`/`updateSIG`/`deleteSIG`.

## Acceptance (from bead oms-ktq)
- AC-1/6: POST /membership/sigs/ returns 201 for staff, 403 for non-staff
- AC-2: Non-staff receive 403 on create attempts
- AC-3: SIGDashboard shows staff-only Create SIG button; modal submits via `sigAPI.createSIG()` and refreshes the list
- AC-4/5: Existing read endpoints and Django admin paths are unchanged

## Test plan
- [ ] Backend: `pytest backend/membership/tests/test_sig_api.py`
- [ ] Frontend: `npm test -- SIGDashboard.test.tsx`
- [ ] Manual: as staff user, create a SIG from the frontend; as non-staff user, confirm button hidden and direct POST returns 403

Closes oms-ktq. (PR opened by mayor — polecat's automated `gh pr create` likely failed due to `@` character in branch name `polecat/obsidian/oms-ktq@mo8eclki`. Tracked separately for durable fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)