### PR TITLE
feat: auto-approve reorder requests from SIG leaders and admins (oms-ntz)

### DIFF
--- a/backend/membership/tests/test_sigadmin.py
+++ b/backend/membership/tests/test_sigadmin.py
@@ -15,6 +15,7 @@ from membership.utils import (
     get_user_managed_sigs,
     is_logistics_member,
     is_sig_admin,
+    should_auto_approve_reorder,
 )
 
 
@@ -125,7 +126,8 @@ class TestSIGPermissionUtils:
                 )
                 table_exists = cursor.fetchone() is not None
                 if not table_exists:
-                    cursor.execute("""
+                    cursor.execute(
+                        """
                         CREATE TABLE auth_user_groups (
                             id INTEGER PRIMARY KEY AUTOINCREMENT,
                             user_id INTEGER NOT NULL,
@@ -134,18 +136,22 @@ class TestSIGPermissionUtils:
                             FOREIGN KEY (user_id) REFERENCES auth_user(id),
                             FOREIGN KEY (group_id) REFERENCES auth_group(id)
                         );
-                        """)
+                        """
+                    )
             elif connection.vendor == "postgresql":
-                cursor.execute("""
+                cursor.execute(
+                    """
                     SELECT EXISTS (
                         SELECT FROM information_schema.tables
                         WHERE table_schema = 'public'
                         AND table_name = 'auth_user_groups'
                     );
-                    """)
+                    """
+                )
                 table_exists = cursor.fetchone()[0]
                 if not table_exists:
-                    cursor.execute("""
+                    cursor.execute(
+                        """
                         CREATE TABLE auth_user_groups (
                             id SERIAL PRIMARY KEY,
                             user_id INTEGER NOT NULL,
@@ -156,7 +162,8 @@ class TestSIGPermissionUtils:
                         );
                         CREATE INDEX auth_user_groups_user_id_idx ON auth_user_groups(user_id);
                         CREATE INDEX auth_user_groups_group_id_idx ON auth_user_groups(group_id);
-                        """)
+                        """
+                    )
             # For other databases, assume table exists (migration should have created it)
 
         # Use through model directly to ensure migrations are applied
@@ -304,3 +311,58 @@ class TestSIGPermissionUtils:
         assert can_create_reorder_request(sig_admin, non_requestable) is False
         assert can_create_reorder_request(staff_user, non_requestable) is True
         assert can_create_reorder_request(logistics_user, non_requestable) is True
+
+    def test_should_auto_approve_reorder(self):
+        """Test should_auto_approve_reorder helper (oms-ntz)."""
+        from django.contrib.auth import get_user_model
+
+        from inventory.tests.factories import InventoryItemFactory
+
+        User = get_user_model()
+
+        # Setup: three groups and users
+        sig_a = Group.objects.create(name="SIG A")
+        sig_b = Group.objects.create(name="SIG B")
+        coo = Group.objects.create(name="COO")
+        logistics = Group.objects.create(name="Logistics")
+
+        leader_a = UserFactory()
+        SIGAdmin.objects.create(user=leader_a, group=sig_a, is_active=True)
+
+        board_member = UserFactory()
+        User.groups.through.objects.create(user=board_member, group=coo)
+
+        logistics_user = UserFactory()
+        User.groups.through.objects.create(user=logistics_user, group=logistics)
+
+        staff_user = UserFactory(is_staff=True)
+        regular_user = UserFactory()
+
+        item_a = InventoryItemFactory(owning_group=sig_a)
+        item_b = InventoryItemFactory(owning_group=sig_b)
+        space_item = InventoryItemFactory(owning_group=None)
+
+        # Staff always auto-approves
+        assert should_auto_approve_reorder(staff_user, item_a) is True
+        assert should_auto_approve_reorder(staff_user, space_item) is True
+
+        # Logistics always auto-approves
+        assert should_auto_approve_reorder(logistics_user, item_a) is True
+        assert should_auto_approve_reorder(logistics_user, space_item) is True
+
+        # COO always auto-approves
+        assert should_auto_approve_reorder(board_member, item_a) is True
+        assert should_auto_approve_reorder(board_member, space_item) is True
+
+        # SIG leader auto-approves only for items in their SIG
+        assert should_auto_approve_reorder(leader_a, item_a) is True
+        assert should_auto_approve_reorder(leader_a, item_b) is False
+        # Space-owned items are not auto-approved for SIG leaders
+        assert should_auto_approve_reorder(leader_a, space_item) is False
+
+        # Regular user never auto-approves
+        assert should_auto_approve_reorder(regular_user, item_a) is False
+        assert should_auto_approve_reorder(regular_user, space_item) is False
+
+        # Anonymous / None user never auto-approves
+        assert should_auto_approve_reorder(None, item_a) is False

--- a/backend/membership/utils.py
+++ b/backend/membership/utils.py
@@ -140,6 +140,45 @@ def is_logistics_member(user):
         return False
 
 
+def should_auto_approve_reorder(user, item):
+    """
+    Check if a reorder request by this user for this item should be auto-approved.
+
+    Auto-approval applies to users with administrative authority over the item:
+    - Staff/superusers
+    - Board Member proxies (members of the "COO" group)
+    - Members of the "Logistics" group
+    - SIG admins of the item's owning group (bounded to that SIG only)
+
+    Args:
+        user: The user creating the reorder request
+        item: The inventory item being requested
+
+    Returns:
+        bool: True if the request should land as "approved", False for default pending.
+    """
+    if not user or not user.is_authenticated:
+        return False
+
+    if user.is_staff or user.is_superuser:
+        return True
+
+    if is_logistics_member(user):
+        return True
+
+    try:
+        coo_group = Group.objects.get(name="COO")
+        if coo_group in user.groups.all():
+            return True
+    except Group.DoesNotExist:
+        pass
+
+    if item is not None and item.owning_group and is_sig_admin(user, item.owning_group):
+        return True
+
+    return False
+
+
 def can_create_reorder_request(user, item):
     """
     Check if a user can create a reorder request for an inventory item.

--- a/backend/reorder_queue/tests/test_api.py
+++ b/backend/reorder_queue/tests/test_api.py
@@ -335,6 +335,121 @@ class TestReorderRequestAPI:
 
 
 @pytest.mark.integration
+class TestReorderRequestAutoApprove:
+    """Tests for auto-approval of reorder requests by admins/leaders (oms-ntz)."""
+
+    def _post_reorder(self, client, item, **extra):
+        url = reverse("reorderrequest-list")
+        data = {"item": str(item.id), "quantity": 5}
+        data.update(extra)
+        return client.post(url, data, format="json")
+
+    def test_sig_leader_auto_approve(self, api_client):
+        """SIG leader of the item's owning group → auto-approved."""
+        from django.contrib.auth.models import Group
+
+        from membership.models import SIGAdmin
+
+        sig = Group.objects.create(name="Woodshop SIG")
+        leader = User.objects.create_user(username="sig-leader", password="pass12345")
+        SIGAdmin.objects.create(user=leader, group=sig, is_active=True)
+        item = InventoryItemFactory(owning_group=sig)
+
+        api_client.force_authenticate(user=leader)
+        response = self._post_reorder(api_client, item)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["status"] == "approved"
+        assert response.data["reviewed_by"] == leader.id
+        assert response.data["reviewed_at"] is not None
+
+    def test_board_member_auto_approve(self, api_client):
+        """A user in the COO group (Board Member proxy) → auto-approved."""
+        from django.contrib.auth.models import Group
+
+        coo_group = Group.objects.create(name="COO")
+        board_user = User.objects.create_user(username="board", password="pass12345")
+        User.groups.through.objects.create(user=board_user, group=coo_group)
+        item = InventoryItemFactory()
+
+        api_client.force_authenticate(user=board_user)
+        response = self._post_reorder(api_client, item)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["status"] == "approved"
+        assert response.data["reviewed_by"] == board_user.id
+        assert response.data["reviewed_at"] is not None
+
+    def test_logistics_auto_approve(self, api_client):
+        """A Logistics group member → auto-approved."""
+        from django.contrib.auth.models import Group
+
+        logistics = Group.objects.create(name="Logistics")
+        log_user = User.objects.create_user(username="logistics", password="pass12345")
+        User.groups.through.objects.create(user=log_user, group=logistics)
+        item = InventoryItemFactory()
+
+        api_client.force_authenticate(user=log_user)
+        response = self._post_reorder(api_client, item)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["status"] == "approved"
+        assert response.data["reviewed_by"] == log_user.id
+
+    def test_staff_auto_approve(self, api_client):
+        """Staff/superusers → auto-approved."""
+        staff_user = User.objects.create_user(
+            username="staffer", password="pass12345", is_staff=True
+        )
+        item = InventoryItemFactory()
+
+        api_client.force_authenticate(user=staff_user)
+        response = self._post_reorder(api_client, item)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["status"] == "approved"
+        assert response.data["reviewed_by"] == staff_user.id
+
+    def test_regular_user_requires_approval(self, api_client):
+        """Regular authenticated members → pending (current behavior preserved)."""
+        user = User.objects.create_user(username="regular", password="pass12345")
+        item = InventoryItemFactory()
+
+        api_client.force_authenticate(user=user)
+        response = self._post_reorder(api_client, item)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["status"] == "pending"
+        assert response.data["reviewed_by"] is None
+        assert response.data["reviewed_at"] is None
+
+    def test_sig_leader_unrelated_sig_requires_approval(self, api_client):
+        """SIG leader auto-approval is scoped to their own SIG's items.
+
+        A SIG A leader requesting a space-owned item (which they are permitted to
+        request as an authenticated user) does NOT get auto-approved — auto-approval
+        is bounded to items of the SIG they actually lead.
+        """
+        from django.contrib.auth.models import Group
+
+        from membership.models import SIGAdmin
+
+        sig_a = Group.objects.create(name="SIG A")
+        leader_a = User.objects.create_user(username="leader-a", password="pass12345")
+        SIGAdmin.objects.create(user=leader_a, group=sig_a, is_active=True)
+        # Space-owned item (no owning_group) — any authenticated user may request,
+        # but SIG admin authority of sig_a should not extend to it.
+        space_item = InventoryItemFactory(owning_group=None)
+
+        api_client.force_authenticate(user=leader_a)
+        response = self._post_reorder(api_client, space_item)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["status"] == "pending"
+        assert response.data["reviewed_by"] is None
+
+
+@pytest.mark.integration
 class TestPurchaseOrderAPI:
     """Tests for PurchaseOrder API endpoints."""
 

--- a/backend/reorder_queue/views.py
+++ b/backend/reorder_queue/views.py
@@ -99,6 +99,20 @@ class ReorderRequestViewSet(viewsets.ModelViewSet):
         self.perform_create(serializer)
         headers = self.get_success_headers(serializer.data)
 
+        # Auto-approve for users with administrative authority over the item.
+        # Done here (not in perform_create) so the serializer's create() can run
+        # with the public-facing field set unchanged, then we elevate status.
+        if user.is_authenticated:
+            from membership.utils import should_auto_approve_reorder
+
+            if should_auto_approve_reorder(user, serializer.instance.item):
+                serializer.instance.status = ReorderRequest.APPROVED
+                serializer.instance.reviewed_by = user
+                serializer.instance.reviewed_at = timezone.now()
+                serializer.instance.save(
+                    update_fields=["status", "reviewed_by", "reviewed_at", "updated_at"]
+                )
+
         # Return full details
         instance = ReorderRequest.objects.get(id=serializer.instance.id)
         output_serializer = ReorderRequestSerializer(instance)


### PR DESCRIPTION
## Summary
`ReorderRequestViewSet.perform_create()` now auto-approves when the requester should not require approval:

- new helper `should_auto_approve_reorder(user, item)` in `backend/membership/utils.py` returns True for `is_staff` / `is_superuser`, COO group members, logistics members, or SIG admins of `item.owning_group`.
- In `backend/reorder_queue/views.py`, the helper is called at create time. When True, the request is saved with `status="approved"`, `reviewed_by=request.user`, `reviewed_at=now()`. Otherwise the existing pending default is preserved.

Adds tests in `backend/membership/tests/test_sigadmin.py` and `backend/reorder_queue/tests/test_api.py` covering each auto-approve role and the non-qualifying fallback.

Source: bead `oms-ntz` · MR `oms-wisp-0n1` · polecat `quartz`

🤖 Merged via Refinery (Claude Code) · rebased by refinery