### PR TITLE
perf(tests): remove autouse overhead from backend test fixtures (oms-6yy)

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -105,8 +105,7 @@ def ensure_auth_user_groups_table(django_db_setup, django_db_blocker):
                 )
                 table_exists = cursor.fetchone() is not None
                 if not table_exists:
-                    cursor.execute(
-                        """
+                    cursor.execute("""
                         CREATE TABLE auth_user_groups (
                             id INTEGER PRIMARY KEY AUTOINCREMENT,
                             user_id INTEGER NOT NULL,
@@ -119,22 +118,18 @@ def ensure_auth_user_groups_table(django_db_setup, django_db_blocker):
                             ON auth_user_groups(user_id);
                         CREATE INDEX auth_user_groups_group_id_idx
                             ON auth_user_groups(group_id);
-                        """
-                    )
+                        """)
             elif connection.vendor == "postgresql":
-                cursor.execute(
-                    """
+                cursor.execute("""
                     SELECT EXISTS (
                         SELECT FROM information_schema.tables
                         WHERE table_schema = 'public'
                         AND table_name = 'auth_user_groups'
                     );
-                    """
-                )
+                    """)
                 table_exists = cursor.fetchone()[0]
                 if not table_exists:
-                    cursor.execute(
-                        """
+                    cursor.execute("""
                         CREATE TABLE auth_user_groups (
                             id SERIAL PRIMARY KEY,
                             user_id INTEGER NOT NULL,
@@ -147,5 +142,4 @@ def ensure_auth_user_groups_table(django_db_setup, django_db_blocker):
                             ON auth_user_groups(user_id);
                         CREATE INDEX auth_user_groups_group_id_idx
                             ON auth_user_groups(group_id);
-                        """
-                    )
+                        """)

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -55,17 +55,12 @@ def sample_image():
     )
 
 
-@pytest.fixture(autouse=True)
-def enable_db_access_for_all_tests(db):
-    """Automatically enable database access for all tests."""
-    pass
-
-
-@pytest.fixture(autouse=True)
-def use_locmem_cache(settings):
+@pytest.fixture(autouse=True, scope="session")
+def use_locmem_cache():
     """Route cache operations to local memory to avoid Redis during tests."""
+    from django.conf import settings as django_settings
 
-    settings.CACHES = {
+    django_settings.CACHES = {
         "default": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "test-cache",
@@ -93,49 +88,64 @@ def configure_celery_for_tests(settings):
     settings.CELERY_CACHE_BACKEND = "memory"
 
 
-@pytest.fixture(autouse=True)
-def ensure_auth_user_groups_table(db):
-    """Ensure auth_user_groups table exists for tests."""
+@pytest.fixture(autouse=True, scope="session")
+def ensure_auth_user_groups_table(django_db_setup, django_db_blocker):
+    """Ensure auth_user_groups table exists for the session.
+
+    Runs once after Django sets up the test database instead of on every test.
+    """
     from django.db import connection
 
-    with connection.cursor() as cursor:
-        if connection.vendor == "sqlite":
-            cursor.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='auth_user_groups';"
-            )
-            table_exists = cursor.fetchone() is not None
-            if not table_exists:
-                cursor.execute("""
-                    CREATE TABLE auth_user_groups (
-                        id INTEGER PRIMARY KEY AUTOINCREMENT,
-                        user_id INTEGER NOT NULL,
-                        group_id INTEGER NOT NULL,
-                        UNIQUE(user_id, group_id),
-                        FOREIGN KEY (user_id) REFERENCES auth_user(id),
-                        FOREIGN KEY (group_id) REFERENCES auth_group(id)
+    with django_db_blocker.unblock():
+        with connection.cursor() as cursor:
+            if connection.vendor == "sqlite":
+                cursor.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' "
+                    "AND name='auth_user_groups';"
+                )
+                table_exists = cursor.fetchone() is not None
+                if not table_exists:
+                    cursor.execute(
+                        """
+                        CREATE TABLE auth_user_groups (
+                            id INTEGER PRIMARY KEY AUTOINCREMENT,
+                            user_id INTEGER NOT NULL,
+                            group_id INTEGER NOT NULL,
+                            UNIQUE(user_id, group_id),
+                            FOREIGN KEY (user_id) REFERENCES auth_user(id),
+                            FOREIGN KEY (group_id) REFERENCES auth_group(id)
+                        );
+                        CREATE INDEX auth_user_groups_user_id_idx
+                            ON auth_user_groups(user_id);
+                        CREATE INDEX auth_user_groups_group_id_idx
+                            ON auth_user_groups(group_id);
+                        """
+                    )
+            elif connection.vendor == "postgresql":
+                cursor.execute(
+                    """
+                    SELECT EXISTS (
+                        SELECT FROM information_schema.tables
+                        WHERE table_schema = 'public'
+                        AND table_name = 'auth_user_groups'
                     );
-                    CREATE INDEX auth_user_groups_user_id_idx ON auth_user_groups(user_id);
-                    CREATE INDEX auth_user_groups_group_id_idx ON auth_user_groups(group_id);
-                    """)
-        elif connection.vendor == "postgresql":
-            cursor.execute("""
-                SELECT EXISTS (
-                    SELECT FROM information_schema.tables
-                    WHERE table_schema = 'public'
-                    AND table_name = 'auth_user_groups'
-                );
-                """)
-            table_exists = cursor.fetchone()[0]
-            if not table_exists:
-                cursor.execute("""
-                    CREATE TABLE auth_user_groups (
-                        id SERIAL PRIMARY KEY,
-                        user_id INTEGER NOT NULL,
-                        group_id INTEGER NOT NULL,
-                        UNIQUE(user_id, group_id),
-                        FOREIGN KEY (user_id) REFERENCES auth_user(id) ON DELETE CASCADE,
-                        FOREIGN KEY (group_id) REFERENCES auth_group(id) ON DELETE CASCADE
-                    );
-                    CREATE INDEX auth_user_groups_user_id_idx ON auth_user_groups(user_id);
-                    CREATE INDEX auth_user_groups_group_id_idx ON auth_user_groups(group_id);
-                    """)
+                    """
+                )
+                table_exists = cursor.fetchone()[0]
+                if not table_exists:
+                    cursor.execute(
+                        """
+                        CREATE TABLE auth_user_groups (
+                            id SERIAL PRIMARY KEY,
+                            user_id INTEGER NOT NULL,
+                            group_id INTEGER NOT NULL,
+                            UNIQUE(user_id, group_id),
+                            FOREIGN KEY (user_id) REFERENCES auth_user(id) ON DELETE CASCADE,
+                            FOREIGN KEY (group_id) REFERENCES auth_group(id) ON DELETE CASCADE
+                        );
+                        CREATE INDEX auth_user_groups_user_id_idx
+                            ON auth_user_groups(user_id);
+                        CREATE INDEX auth_user_groups_group_id_idx
+                            ON auth_user_groups(group_id);
+                        """
+                    )

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -59,13 +59,31 @@ def sample_image():
 def use_locmem_cache():
     """Route cache operations to local memory to avoid Redis during tests."""
     from django.conf import settings as django_settings
+    from django.core.signals import setting_changed
 
-    django_settings.CACHES = {
+    new_caches = {
         "default": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "test-cache",
         }
     }
+    django_settings.CACHES = new_caches
+    # Fire setting_changed so Django resets cached cache-handler state
+    # (clear_cache_handlers in django.test.signals). Without this, any
+    # caches[...] access made before this fixture runs (e.g. at import
+    # time in a xdist worker) keeps a stale backend reference.
+    setting_changed.send(sender=None, setting="CACHES", value=new_caches, enter=True)
+
+
+@pytest.fixture(autouse=True)
+def clear_locmem_cache():
+    """Clear the locmem cache between tests so counters (rate limits,
+    throttles) don't bleed across tests under the session-scoped cache."""
+    from django.core.cache import cache
+
+    cache.clear()
+    yield
+    cache.clear()
 
 
 @pytest.fixture

--- a/backend/dashboard/tests/test_models.py
+++ b/backend/dashboard/tests/test_models.py
@@ -7,6 +7,8 @@ import pytest
 from dashboard.models import DashboardWidget
 from dashboard.tests.factories import DashboardWidgetFactory, UserFactory
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.unit
 class TestDashboardWidgetModel:

--- a/backend/forgekey/tests/test_models.py
+++ b/backend/forgekey/tests/test_models.py
@@ -24,6 +24,8 @@ from inventory.tests.factories import AssetFactory
 
 User = get_user_model()
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.unit
 class TestDeviceTypeModel:

--- a/backend/inventory/tests/test_api.py
+++ b/backend/inventory/tests/test_api.py
@@ -16,6 +16,8 @@ from inventory.tests.factories import (
     UsageLogFactory,
 )
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.integration
 class TestSupplierAPI:

--- a/backend/inventory/tests/test_models.py
+++ b/backend/inventory/tests/test_models.py
@@ -15,6 +15,8 @@ from inventory.tests.factories import (
     UsageLogFactory,
 )
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.unit
 class TestSupplierModel:

--- a/backend/inventory/tests/test_qr_code_service.py
+++ b/backend/inventory/tests/test_qr_code_service.py
@@ -13,6 +13,8 @@ from customization.models import SiteSettings
 from inventory.services.qr_code_service import QRCodeService
 from inventory.tests.factories import AssetFactory, InventoryItemFactory, LocationFactory
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.unit
 class TestQRCodeService:

--- a/backend/inventory/tests/test_supplier_api.py
+++ b/backend/inventory/tests/test_supplier_api.py
@@ -12,6 +12,8 @@ from rest_framework import status
 from inventory.models import Supplier
 from inventory.tests.factories import InventoryItemFactory, ItemSupplierFactory, SupplierFactory
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.integration
 class TestSupplierAPI:

--- a/backend/inventory/tests/test_tasks.py
+++ b/backend/inventory/tests/test_tasks.py
@@ -10,6 +10,8 @@ from inventory.tasks import generate_index_card, generate_qr_code, update_averag
 from inventory.tests.factories import InventoryItemFactory
 from reorder_queue.tests.factories import ReorderRequestFactory
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.unit
 class TestInventoryTasks:

--- a/backend/inventory/tests/test_utils.py
+++ b/backend/inventory/tests/test_utils.py
@@ -11,6 +11,8 @@ from inventory.tests.factories import InventoryItemFactory
 from inventory.utils.pdf_generator import generate_bulk_cards, generate_item_card
 from inventory.utils.qr_generator import generate_qr_code_image, save_qr_code_to_item
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.unit
 class TestQRCodeGeneration:

--- a/backend/inventory/tests/test_work_order_ingest.py
+++ b/backend/inventory/tests/test_work_order_ingest.py
@@ -31,6 +31,8 @@ from inventory.services.work_order_ingest import apply_submission, parse_work_or
 from inventory.tests.factories import AssetFactory
 from inventory.utils.work_order_pdf import generate_work_order_pdf
 
+pytestmark = pytest.mark.django_db
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers
 # ─────────────────────────────────────────────────────────────────────────────

--- a/backend/membership/tests/test_models.py
+++ b/backend/membership/tests/test_models.py
@@ -14,6 +14,8 @@ from membership.models import Membership
 
 User = get_user_model()
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.unit
 class TestUserModel:

--- a/backend/membership/tests/test_registration_token.py
+++ b/backend/membership/tests/test_registration_token.py
@@ -13,6 +13,8 @@ from membership.models import UserRegistrationToken
 
 User = get_user_model()
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.unit
 class TestUserRegistrationToken:

--- a/backend/membership/tests/test_sig_api.py
+++ b/backend/membership/tests/test_sig_api.py
@@ -12,6 +12,8 @@ from inventory.tests.factories import AssetFactory, InventoryItemFactory
 from membership.models import SIGAdmin
 from membership.tests.factories import UserFactory
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.integration
 class TestSIGAPI:

--- a/backend/membership/tests/test_sigadmin.py
+++ b/backend/membership/tests/test_sigadmin.py
@@ -127,8 +127,7 @@ class TestSIGPermissionUtils:
                 )
                 table_exists = cursor.fetchone() is not None
                 if not table_exists:
-                    cursor.execute(
-                        """
+                    cursor.execute("""
                         CREATE TABLE auth_user_groups (
                             id INTEGER PRIMARY KEY AUTOINCREMENT,
                             user_id INTEGER NOT NULL,
@@ -137,22 +136,18 @@ class TestSIGPermissionUtils:
                             FOREIGN KEY (user_id) REFERENCES auth_user(id),
                             FOREIGN KEY (group_id) REFERENCES auth_group(id)
                         );
-                        """
-                    )
+                        """)
             elif connection.vendor == "postgresql":
-                cursor.execute(
-                    """
+                cursor.execute("""
                     SELECT EXISTS (
                         SELECT FROM information_schema.tables
                         WHERE table_schema = 'public'
                         AND table_name = 'auth_user_groups'
                     );
-                    """
-                )
+                    """)
                 table_exists = cursor.fetchone()[0]
                 if not table_exists:
-                    cursor.execute(
-                        """
+                    cursor.execute("""
                         CREATE TABLE auth_user_groups (
                             id SERIAL PRIMARY KEY,
                             user_id INTEGER NOT NULL,
@@ -163,8 +158,7 @@ class TestSIGPermissionUtils:
                         );
                         CREATE INDEX auth_user_groups_user_id_idx ON auth_user_groups(user_id);
                         CREATE INDEX auth_user_groups_group_id_idx ON auth_user_groups(group_id);
-                        """
-                    )
+                        """)
             # For other databases, assume table exists (migration should have created it)
 
         # Use through model directly to ensure migrations are applied

--- a/backend/membership/tests/test_sigadmin.py
+++ b/backend/membership/tests/test_sigadmin.py
@@ -17,6 +17,8 @@ from membership.utils import (
     is_sig_admin,
 )
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.unit
 class TestSIGAdminModel:
@@ -125,7 +127,8 @@ class TestSIGPermissionUtils:
                 )
                 table_exists = cursor.fetchone() is not None
                 if not table_exists:
-                    cursor.execute("""
+                    cursor.execute(
+                        """
                         CREATE TABLE auth_user_groups (
                             id INTEGER PRIMARY KEY AUTOINCREMENT,
                             user_id INTEGER NOT NULL,
@@ -134,18 +137,22 @@ class TestSIGPermissionUtils:
                             FOREIGN KEY (user_id) REFERENCES auth_user(id),
                             FOREIGN KEY (group_id) REFERENCES auth_group(id)
                         );
-                        """)
+                        """
+                    )
             elif connection.vendor == "postgresql":
-                cursor.execute("""
+                cursor.execute(
+                    """
                     SELECT EXISTS (
                         SELECT FROM information_schema.tables
                         WHERE table_schema = 'public'
                         AND table_name = 'auth_user_groups'
                     );
-                    """)
+                    """
+                )
                 table_exists = cursor.fetchone()[0]
                 if not table_exists:
-                    cursor.execute("""
+                    cursor.execute(
+                        """
                         CREATE TABLE auth_user_groups (
                             id SERIAL PRIMARY KEY,
                             user_id INTEGER NOT NULL,
@@ -156,7 +163,8 @@ class TestSIGPermissionUtils:
                         );
                         CREATE INDEX auth_user_groups_user_id_idx ON auth_user_groups(user_id);
                         CREATE INDEX auth_user_groups_group_id_idx ON auth_user_groups(group_id);
-                        """)
+                        """
+                    )
             # For other databases, assume table exists (migration should have created it)
 
         # Use through model directly to ensure migrations are applied

--- a/backend/reorder_queue/tests/test_api.py
+++ b/backend/reorder_queue/tests/test_api.py
@@ -18,6 +18,8 @@ from reorder_queue.tests.factories import ReorderRequestFactory
 
 User = get_user_model()
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.integration
 class TestReorderRequestAPI:

--- a/backend/reorder_queue/tests/test_models.py
+++ b/backend/reorder_queue/tests/test_models.py
@@ -14,6 +14,8 @@ from inventory.tests.factories import InventoryItemFactory, SupplierFactory
 from reorder_queue.models import PurchaseOrder, ReorderRequest
 from reorder_queue.tests.factories import ReorderRequestFactory, UserFactory
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.unit
 class TestReorderRequestModel:


### PR DESCRIPTION
## Summary
2nd resubmit of oms-6yy — rebased onto current main. Addresses PR #168's rate-limit test regressions by restoring per-test cache isolation.

- `enable_db_access_for_all_tests` — autouse removed. Tests that need DB opt in via module-level `pytestmark = pytest.mark.django_db`.
- `ensure_auth_user_groups_table` — converted to session-scoped autouse depending on `django_db_setup`.
- `use_locmem_cache` — converted to session-scoped autouse; now also emits `setting_changed` so Django resets cached cache-handler state (stale Redis backend pointers from module-import-time `caches[...]` access in xdist workers).
- **New** `clear_locmem_cache` — function-scoped autouse that calls `cache.clear()` before/after each test so rate-limit counters and other cached state don't bleed across tests (fixes the #168 regression).
- `black 26.3.1` formatting applied.

Polecat verified locally under `pytest -n auto` (matches CI xdist): 446 passed / 2 skipped. Previously-failing `TestQRCodeRateLimitingAPI` tests now pass.

Source: bead `oms-6yy` · MR `oms-wisp-60m` · polecat `obsidian` (2nd resubmit)

🤖 Merged via Refinery (Claude Code) · rebased by refinery