### PR TITLE
fix(nginx): certbot --cert-name prevents lineage fork (oms-8ba)

### DIFF
--- a/nginx/docker-entrypoint.d/10-letsencrypt.sh
+++ b/nginx/docker-entrypoint.d/10-letsencrypt.sh
@@ -63,6 +63,7 @@ request_cert() {
 
     echo "[letsencrypt] Requesting certificates for: $LETSENCRYPT_DOMAINS"
     if certbot certonly --webroot -w "$WEBROOT" $domain_args \
+        --cert-name "$PRIMARY_DOMAIN" \
         --email "${LETSENCRYPT_EMAIL}" \
         --agree-tos --no-eff-email \
         --keep-until-expiring \
@@ -84,6 +85,6 @@ if [ -n "${LETSENCRYPT_EMAIL:-}" ]; then
     ) &
 
     # Set up cron job to renew certificates daily (certbot renew only renews if expiring within 30 days)
-    printf '0 3 * * * certbot renew --webroot -w %s --quiet --deploy-hook "nginx -s reload"\n' "$WEBROOT" > /etc/crontabs/root
+    printf '0 3 * * * certbot renew --cert-name %s --webroot -w %s --quiet --deploy-hook "nginx -s reload"\n' "$PRIMARY_DOMAIN" "$WEBROOT" > /etc/crontabs/root
     crond -b -l 2
 fi


### PR DESCRIPTION
## Summary
Adds `--cert-name "$PRIMARY_DOMAIN"` to the `certbot certonly` invocation and the nightly cron renewal in `nginx/docker-entrypoint.d/10-letsencrypt.sh`.

Without `--cert-name`, any condition that retriggers a fresh `certonly` (fresh container, domain list change, cert wipe) made certbot create a sibling `${DOMAIN}-0001/` lineage instead of reusing the canonical one. The nginx template references `${DOMAIN}`, so TLS stayed broken until an operator manually edited the template to the forked path. Pinning the cert name removes that manual step — certbot now always writes into the canonical lineage.

Source: bead `oms-8ba` · MR `oms-wisp-57r` · polecat `onyx`

🤖 Merged via Refinery (Claude Code)