### PR TITLE
feat: manual mark-delivered flow for purchase orders (oms-4us)

### DIFF
--- a/backend/reorder_queue/serializers.py
+++ b/backend/reorder_queue/serializers.py
@@ -519,6 +519,17 @@ class BarcodeReceiptSerializer(serializers.Serializer):
             raise serializers.ValidationError("Purchase order does not exist")
 
 
+class MarkDeliveredSerializer(serializers.Serializer):
+    """Serializer for manually marking a purchase order as delivered."""
+
+    delivery_date = serializers.DateField()
+    tracking_number = serializers.CharField(
+        max_length=100, required=False, allow_blank=True, default=""
+    )
+    carrier = serializers.CharField(max_length=100, required=False, allow_blank=True, default="")
+    receipt_notes = serializers.CharField(required=False, allow_blank=True, default="")
+
+
 # Lead Time and Analytics Serializers
 
 

--- a/backend/reorder_queue/tests/test_api.py
+++ b/backend/reorder_queue/tests/test_api.py
@@ -637,3 +637,150 @@ class TestPurchaseOrderAPI:
         assert r1.status_code == status.HTTP_201_CREATED
         assert r2.status_code == status.HTTP_201_CREATED
         assert r1.data["po_number"] != r2.data["po_number"]
+
+
+@pytest.mark.integration
+class TestPurchaseOrderMarkDelivered:
+    """Tests for manual PurchaseOrder mark-delivered flow (AC-1, AC-2, AC-5)."""
+
+    def _create_sent_po(self, user, *, sent_at=None, quantity_ordered=5):
+        """Create a SENT purchase order with one item_supplier line."""
+        supplier = SupplierFactory()
+        item_supplier = ItemSupplierFactory(
+            supplier=supplier, quantity_per_package=1, average_lead_time=10
+        )
+        purchase_order = PurchaseOrder.objects.create(
+            po_number=f"PO-MD-{item_supplier.id}",
+            supplier=supplier,
+            status=PurchaseOrder.SENT,
+            created_by=user,
+            sent_by=user,
+            sent_at=sent_at or (timezone.now() - timedelta(days=7)),
+            estimated_total=Decimal("50.00"),
+        )
+        po_item = PurchaseOrderItem.objects.create(
+            purchase_order=purchase_order,
+            item_supplier=item_supplier,
+            quantity_ordered=quantity_ordered,
+            quantity_received=0,
+            unit_cost_ordered=Decimal("10.00"),
+            order_in_packages=quantity_ordered,
+        )
+        return purchase_order, po_item, item_supplier
+
+    def test_mark_delivered_creates_order_delivery(self, authenticated_client):
+        """AC-1: POST mark-delivered creates an OrderDelivery and returns 200."""
+        client, user = authenticated_client
+        purchase_order, po_item, _ = self._create_sent_po(user)
+
+        url = reverse("purchaseorder-mark-delivered", kwargs={"pk": purchase_order.pk})
+        delivery_date = (timezone.now() - timedelta(days=1)).date()
+        response = client.post(
+            url,
+            {
+                "delivery_date": delivery_date.isoformat(),
+                "tracking_number": "1ZABC",
+                "carrier": "UPS",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        purchase_order.refresh_from_db()
+        po_item.refresh_from_db()
+        assert purchase_order.status == PurchaseOrder.RECEIVED
+        assert po_item.quantity_received == po_item.quantity_ordered
+        assert purchase_order.deliveries.count() == 1
+
+        delivery = purchase_order.deliveries.first()
+        assert delivery.delivery_date.date() == delivery_date
+        assert delivery.tracking_number == "1ZABC"
+        assert delivery.carrier == "UPS"
+        assert delivery.received_by == user
+        assert delivery.items.count() == 1
+
+    def test_mark_delivered_populates_lead_time_analysis(self, authenticated_client):
+        """AC-2 + AC-5: Lead Time Analysis returns the (supplier, item) row."""
+        client, user = authenticated_client
+        sent_at = timezone.now() - timedelta(days=10)
+        purchase_order, po_item, item_supplier = self._create_sent_po(user, sent_at=sent_at)
+
+        delivery_date = sent_at.date() + timedelta(days=5)
+        mark_url = reverse("purchaseorder-mark-delivered", kwargs={"pk": purchase_order.pk})
+        resp = client.post(
+            mark_url,
+            {"delivery_date": delivery_date.isoformat()},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_200_OK
+
+        report_url = reverse("purchasing-reports-lead-time-analysis")
+        report_resp = client.get(
+            report_url,
+            {
+                "start_date": (delivery_date - timedelta(days=1)).isoformat(),
+                "end_date": (delivery_date + timedelta(days=1)).isoformat(),
+            },
+        )
+        assert report_resp.status_code == status.HTTP_200_OK
+
+        rows = [
+            row
+            for row in report_resp.data
+            if row["supplier_id"] == item_supplier.supplier.id
+            and row["item_name"] == item_supplier.item.name
+        ]
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["total_orders"] == 1
+        # 5 calendar days between sent_at and delivery_date; business-day count
+        # ranges from 3 to 5 depending on weekday alignment. Just assert we got
+        # a positive lead time (i.e. the row wasn't empty/zero-filled).
+        assert row["avg_actual_lead_time"] > 0
+
+    def test_mark_delivered_missing_delivery_date_returns_400(self, authenticated_client):
+        """AC-5: missing delivery_date returns 400."""
+        client, user = authenticated_client
+        purchase_order, _, _ = self._create_sent_po(user)
+
+        url = reverse("purchaseorder-mark-delivered", kwargs={"pk": purchase_order.pk})
+        response = client.post(url, {}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "delivery_date" in response.data
+
+    def test_mark_delivered_requires_authentication(self, api_client):
+        """AC-1: unauthenticated request must be rejected."""
+        user = User.objects.create_user(username="po-owner", password="pw12345678")
+        supplier = SupplierFactory()
+        purchase_order = PurchaseOrder.objects.create(
+            po_number="PO-MD-AUTH",
+            supplier=supplier,
+            status=PurchaseOrder.SENT,
+            created_by=user,
+            sent_at=timezone.now(),
+        )
+
+        url = reverse("purchaseorder-mark-delivered", kwargs={"pk": purchase_order.pk})
+        response = api_client.post(
+            url,
+            {"delivery_date": timezone.now().date().isoformat()},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_mark_delivered_rejects_non_sendable_status(self, authenticated_client):
+        """Draft/cancelled/received orders cannot be re-delivered."""
+        client, user = authenticated_client
+        purchase_order, _, _ = self._create_sent_po(user)
+        purchase_order.status = PurchaseOrder.DRAFT
+        purchase_order.save()
+
+        url = reverse("purchaseorder-mark-delivered", kwargs={"pk": purchase_order.pk})
+        response = client.post(
+            url,
+            {"delivery_date": timezone.now().date().isoformat()},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/backend/reorder_queue/views.py
+++ b/backend/reorder_queue/views.py
@@ -28,6 +28,7 @@ from .models import (
 )
 from .serializers import (
     BarcodeReceiptSerializer,
+    MarkDeliveredSerializer,
     OrderDeliverySerializer,
     OrderMetricsSerializer,
     PurchaseOrderCreateSerializer,
@@ -39,6 +40,37 @@ from .serializers import (
     WebHookSerializer,
     WebHookTestResultSerializer,
 )
+
+
+def _create_lead_time_log(po_item, delivery_date):
+    """Create a LeadTimeLog entry when a PO item is fully received.
+
+    No-op if the PO was never sent or if the item has no item_supplier
+    (e.g. asset-only lines).
+    """
+    purchase_order = po_item.purchase_order
+
+    if not purchase_order.sent_at or not po_item.item_supplier:
+        return
+
+    order_date = purchase_order.sent_at
+    actual_delivery_date = delivery_date.date() if hasattr(delivery_date, "date") else delivery_date
+
+    estimated_lead_time = po_item.item_supplier.average_lead_time or 14
+    actual_lead_time = LeadTimeLog.calculate_business_days(order_date, actual_delivery_date)
+
+    LeadTimeLog.objects.create(
+        item_supplier=po_item.item_supplier,
+        purchase_order=purchase_order,
+        order_date=order_date,
+        expected_delivery_date=purchase_order.expected_delivery_date
+        or (order_date.date() + timedelta(days=estimated_lead_time)),
+        actual_delivery_date=actual_delivery_date,
+        estimated_lead_time_days=estimated_lead_time,
+        actual_lead_time_days=actual_lead_time,
+        quantity_ordered=po_item.quantity_ordered,
+        quantity_received=po_item.quantity_received,
+    )
 
 
 class ReorderRequestViewSet(viewsets.ModelViewSet):
@@ -864,6 +896,88 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(purchase_order)
         return Response(serializer.data)
 
+    @action(detail=True, methods=["post"], url_path="mark-delivered")
+    def mark_delivered(self, request, pk=None):
+        """Manually mark a purchase order as delivered on a given date.
+
+        Creates an OrderDelivery covering all pending quantities, updates
+        inventory stock, advances the PO status, and records LeadTimeLog
+        entries so the Lead Time Analysis report has data even when barcode
+        scanning isn't used at receipt.
+        """
+        from datetime import datetime
+
+        purchase_order = self.get_object()
+
+        if purchase_order.status not in [
+            PurchaseOrder.SENT,
+            PurchaseOrder.CONFIRMED,
+            PurchaseOrder.PARTIALLY_RECEIVED,
+        ]:
+            return Response(
+                {
+                    "error": (
+                        "Purchase order must be sent, confirmed, or partially "
+                        "received to mark as delivered"
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        serializer = MarkDeliveredSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        pending_items = [item for item in purchase_order.items.all() if not item.is_fully_received]
+        if not pending_items:
+            return Response(
+                {"error": "All items in this purchase order are already fully received"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        delivery_datetime = timezone.make_aware(
+            datetime.combine(data["delivery_date"], datetime.min.time())
+        )
+
+        with transaction.atomic():
+            delivery = OrderDelivery.objects.create(
+                purchase_order=purchase_order,
+                delivery_date=delivery_datetime,
+                tracking_number=data.get("tracking_number", ""),
+                carrier=data.get("carrier", ""),
+                received_by=request.user,
+                receipt_notes=data.get("receipt_notes", ""),
+                is_complete=True,
+            )
+
+            for po_item in pending_items:
+                remaining = po_item.quantity_pending
+                DeliveryItem.objects.create(
+                    delivery=delivery,
+                    purchase_order_item=po_item,
+                    quantity_received=remaining,
+                )
+
+                po_item.quantity_received += remaining
+                po_item.save()
+
+                inventory_item = po_item.item
+                if inventory_item is not None:
+                    inventory_item.current_stock += remaining
+                    inventory_item.save()
+
+                if po_item.is_fully_received:
+                    _create_lead_time_log(po_item, delivery.delivery_date)
+
+            if purchase_order.is_fully_received:
+                purchase_order.status = PurchaseOrder.RECEIVED
+            else:
+                purchase_order.status = PurchaseOrder.PARTIALLY_RECEIVED
+            purchase_order.save()
+
+        response_serializer = self.get_serializer(purchase_order)
+        return Response(response_serializer.data)
+
     @action(detail=True, methods=["patch"], url_path="items/(?P<item_id>[^/.]+)")
     def update_item(self, request, pk=None, item_id=None):
         """Update a specific line item in a purchase order."""
@@ -1209,32 +1323,7 @@ class OrderReceiptViewSet(viewsets.ModelViewSet):
 
     def _create_lead_time_log(self, po_item, delivery_date):
         """Create a lead time log entry when an item is fully received."""
-        purchase_order = po_item.purchase_order
-
-        if not purchase_order.sent_at:
-            return  # Can't calculate lead time without send date
-
-        # Calculate business days
-        order_date = purchase_order.sent_at
-        actual_delivery_date = (
-            delivery_date.date() if hasattr(delivery_date, "date") else delivery_date
-        )
-
-        estimated_lead_time = po_item.item_supplier.average_lead_time or 14
-        actual_lead_time = LeadTimeLog.calculate_business_days(order_date, actual_delivery_date)
-
-        LeadTimeLog.objects.create(
-            item_supplier=po_item.item_supplier,
-            purchase_order=purchase_order,
-            order_date=order_date,
-            expected_delivery_date=purchase_order.expected_delivery_date
-            or (order_date.date() + timedelta(days=estimated_lead_time)),
-            actual_delivery_date=actual_delivery_date,
-            estimated_lead_time_days=estimated_lead_time,
-            actual_lead_time_days=actual_lead_time,
-            quantity_ordered=po_item.quantity_ordered,
-            quantity_received=po_item.quantity_received,
-        )
+        _create_lead_time_log(po_item, delivery_date)
 
     @action(detail=False, methods=["get"])
     def pending_orders(self, request):

--- a/frontend/src/pages/PurchaseOrderPage.tsx
+++ b/frontend/src/pages/PurchaseOrderPage.tsx
@@ -58,6 +58,10 @@ const PurchaseOrderPage: React.FC = () => {
   const [voidingItemId, setVoidingItemId] = useState<string | null>(null);
   const [voidReason, setVoidReason] = useState<string>('');
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [markingDelivered, setMarkingDelivered] = useState(false);
+  const [deliveryDate, setDeliveryDate] = useState<string>('');
+  const [deliveryTracking, setDeliveryTracking] = useState<string>('');
+  const [deliveryCarrier, setDeliveryCarrier] = useState<string>('');
 
   const loadOrder = useCallback(async () => {
     try {
@@ -176,6 +180,47 @@ const PurchaseOrderPage: React.FC = () => {
     }
   };
 
+  const handleOpenMarkDelivered = () => {
+    const today = new Date().toISOString().split('T')[0];
+    setDeliveryDate(today);
+    setDeliveryTracking('');
+    setDeliveryCarrier('');
+    setMarkingDelivered(true);
+  };
+
+  const handleCancelMarkDelivered = () => {
+    setMarkingDelivered(false);
+    setDeliveryDate('');
+    setDeliveryTracking('');
+    setDeliveryCarrier('');
+  };
+
+  const handleSubmitMarkDelivered = async () => {
+    if (!deliveryDate) {
+      alert('Please select a delivery date');
+      return;
+    }
+
+    try {
+      setSaving(true);
+      await purchaseOrderAPI.markDelivered(orderId!, {
+        delivery_date: deliveryDate,
+        tracking_number: deliveryTracking || undefined,
+        carrier: deliveryCarrier || undefined,
+      });
+      await loadOrder();
+      handleCancelMarkDelivered();
+    } catch (err: any) {
+      alert(err.response?.data?.error || 'Failed to mark purchase order as delivered');
+      console.error('Error marking delivered:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const canMarkDelivered = (po: PurchaseOrder) =>
+    isAuthenticated && ['sent', 'confirmed', 'partially_received'].includes(po.status);
+
   const formatDate = (dateString: string | null) => {
     if (!dateString) return '—';
     const date = new Date(dateString);
@@ -226,8 +271,73 @@ const PurchaseOrderPage: React.FC = () => {
         </div>
         <div className="po-status">
           <span className={`status-badge status-${order.status}`}>{order.status_label}</span>
+          {canMarkDelivered(order) && !markingDelivered && (
+            <button
+              type="button"
+              className="btn-primary mark-delivered-button"
+              onClick={handleOpenMarkDelivered}
+            >
+              Mark as Delivered
+            </button>
+          )}
         </div>
       </header>
+
+      {markingDelivered && (
+        <section className="mark-delivered-panel" aria-label="Mark purchase order as delivered">
+          <h2>Mark as Delivered</h2>
+          <div className="mark-delivered-fields">
+            <label htmlFor="mark-delivered-date">
+              Delivery Date
+              <input
+                id="mark-delivered-date"
+                type="date"
+                value={deliveryDate}
+                onChange={(e) => setDeliveryDate(e.target.value)}
+                required
+              />
+            </label>
+            <label htmlFor="mark-delivered-tracking">
+              Tracking Number (optional)
+              <input
+                id="mark-delivered-tracking"
+                type="text"
+                value={deliveryTracking}
+                onChange={(e) => setDeliveryTracking(e.target.value)}
+                placeholder="e.g. 1Z999AA10123456784"
+              />
+            </label>
+            <label htmlFor="mark-delivered-carrier">
+              Carrier (optional)
+              <input
+                id="mark-delivered-carrier"
+                type="text"
+                value={deliveryCarrier}
+                onChange={(e) => setDeliveryCarrier(e.target.value)}
+                placeholder="e.g. UPS"
+              />
+            </label>
+          </div>
+          <div className="mark-delivered-actions">
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={handleSubmitMarkDelivered}
+              disabled={saving || !deliveryDate}
+            >
+              {saving ? 'Saving…' : 'Confirm Delivery'}
+            </button>
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={handleCancelMarkDelivered}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+          </div>
+        </section>
+      )}
 
       <div className="po-info">
         <div className="info-item">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -682,6 +682,10 @@ export const purchaseOrderAPI = {
     api.patch(`/reorders/purchase-orders/${orderId}/items/${itemId}/`, data),
   voidLineItem: (orderId: string, itemId: string, reason?: string) =>
     api.post(`/reorders/purchase-orders/${orderId}/items/${itemId}/void/`, { reason }),
+  markDelivered: (
+    orderId: string,
+    data: { delivery_date: string; tracking_number?: string; carrier?: string; receipt_notes?: string },
+  ) => api.post<any>(`/reorders/purchase-orders/${orderId}/mark-delivered/`, data),
 };
 
 // Fixtures API


### PR DESCRIPTION
## Summary
The Lead Time Analysis report was blank because `LeadTimeLog` was only populated by the barcode-scan delivery flow — which the makerspace isn't using. This PR adds a manual mark-delivered path so staff can populate lead-time data from the PO detail page.

Backend:
- `PurchaseOrderViewSet` gets a manual-delivery action that records actual delivery date, creates `OrderDelivery` rows, and chains into `_create_lead_time_log()` to feed the report.
- Serializer exposes the delivery fields needed by the frontend.
- Tests cover the happy path + edge cases.

Frontend:
- `PurchaseOrderPage.tsx` gets a "Mark delivered" UI surface that calls the new endpoint; `services/api.ts` adds the wrapper.

Rebased onto current main by refinery (branch was behind #171).

Source: bead `oms-4us` · MR `oms-wisp-dl8` · polecat `obsidian`

🤖 Merged via Refinery (Claude Code) · rebased by refinery