### PR TITLE
feat(sentry): wire release tagging end-to-end (oms-rod)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -197,6 +197,66 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  upload-sourcemaps:
+    name: 📤 Upload Frontend Source Maps to Sentry
+    runs-on: ubuntu-latest
+    needs: [determine-tags, build-frontend]
+    if: |
+      needs.determine-tags.outputs.should_build == 'true' &&
+      (github.ref == 'refs/heads/main' ||
+       (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main'))
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Get git hash
+        id: git
+        run: |
+          GIT_HASH=$(git rev-parse --short HEAD)
+          echo "hash=$GIT_HASH" >> $GITHUB_OUTPUT
+          echo "🔍 Git hash: $GIT_HASH"
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend (with source maps)
+        working-directory: frontend
+        env:
+          REACT_APP_API_URL: /api
+          REACT_APP_SENTRY_DSN: ${{ secrets.REACT_APP_SENTRY_DSN }}
+          REACT_APP_SENTRY_ENVIRONMENT: production
+          REACT_APP_GIT_HASH: ${{ steps.git.outputs.hash }}
+          REACT_APP_GITHUB_URL: https://github.com/${{ github.repository }}
+          GENERATE_SOURCEMAP: "true"
+        run: npm run build
+
+      - name: Upload source maps to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          GIT_HASH: ${{ steps.git.outputs.hash }}
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ] || [ -z "$SENTRY_ORG" ] || [ -z "$SENTRY_PROJECT" ]; then
+            echo "⚠️  Sentry secrets not configured (SENTRY_AUTH_TOKEN / SENTRY_ORG / SENTRY_PROJECT) — skipping source map upload."
+            exit 0
+          fi
+          npm install -g @sentry/cli
+          sentry-cli releases new "$GIT_HASH"
+          sentry-cli releases files "$GIT_HASH" upload-sourcemaps ./frontend/build/static/js --url-prefix '~/static/js' --rewrite
+          sentry-cli releases finalize "$GIT_HASH"
+          echo "✅ Source maps uploaded for release $GIT_HASH"
+
   build-complete:
     name: ✅ Build Complete
     runs-on: ubuntu-latest

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -369,6 +369,7 @@ SENTRY_DSN = config(
     default="https://af885209b7663c58d3fe82ace2863941@o4510248461074432.ingest.us.sentry.io/4510248465661952",
 )
 SENTRY_ENVIRONMENT = config("SENTRY_ENVIRONMENT", default="development")
+SENTRY_RELEASE = config("SENTRY_RELEASE", default=None)
 
 if SENTRY_DSN:
     sentry_sdk.init(
@@ -380,6 +381,7 @@ if SENTRY_DSN:
         ],
         enable_logs=True,
         environment=SENTRY_ENVIRONMENT,
+        release=SENTRY_RELEASE,
         # Set traces_sample_rate to 1.0 to capture 100% of transactions for performance monitoring.
         # Adjust this value in production to reduce overhead
         traces_sample_rate=1.0 if DEBUG else 0.1,

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -63,6 +63,8 @@ services:
       - CSRF_TRUSTED_ORIGINS=https://${DOMAIN:-dallas.openmakersuite.net}
       - CORS_ALLOWED_ORIGINS=https://${DOMAIN:-dallas.openmakersuite.net}
       - FRONTEND_URL=https://${DOMAIN:-dallas.openmakersuite.net}
+      - SENTRY_RELEASE=${GIT_HASH}
+      - SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT:-production}
     depends_on:
       db:
         condition: service_healthy
@@ -98,6 +100,8 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - CELERY_BROKER_URL=redis://redis:6379/0
       - SKIP_DB_MIGRATIONS=1
+      - SENTRY_RELEASE=${GIT_HASH}
+      - SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT:-production}
     depends_on:
       db:
         condition: service_healthy

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -16,7 +16,8 @@ const sentryDsn = process.env.REACT_APP_SENTRY_DSN;
 if (sentryDsn) {
   Sentry.init({
     dsn: sentryDsn,
-    environment: process.env.NODE_ENV || 'development',
+    environment: process.env.REACT_APP_SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'development',
+    release: process.env.REACT_APP_GIT_HASH || undefined,
     integrations: [
       new Sentry.BrowserTracing({
         // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.


### PR DESCRIPTION
## Summary
Completes release-context wiring for Sentry. Before this change, backend errors had no release tag and frontend stack traces showed minified JS.

- **Backend** (`backend/config/settings.py`, `docker-compose.prod.yml`) — exposes `SENTRY_RELEASE=${GIT_HASH}` and `SENTRY_ENVIRONMENT` to the backend and celery-worker services; Django's sentry init reads the release from env so every captured event is tagged.
- **Frontend** (`frontend/src/index.tsx`) — passes the release into the Sentry SDK init so the bundled source maps line up.
- **CI** (`.github/workflows/docker-build.yml`) — adds a job that uploads frontend source maps to Sentry on tag push via `sentry-cli releases files ... upload-sourcemaps`. Release name is the short git hash so it matches the backend env var and the docker build arg.

Rebased by refinery; `docker-compose.prod.yml` now adds `SENTRY_RELEASE`/`SENTRY_ENVIRONMENT` env entries without touching #172/#174 content.

Source: bead `oms-rod` · MR `oms-wisp-5az` · polecat `jasper`

🤖 Merged via Refinery (Claude Code) · rebased by refinery