### PR TITLE
fix(reorder): coerce float unit_cost to Decimal in PO create (oms-vo1)

### DIFF
--- a/backend/reorder_queue/serializers.py
+++ b/backend/reorder_queue/serializers.py
@@ -2,6 +2,8 @@
 Serializers for reorder queue API.
 """
 
+from decimal import Decimal, InvalidOperation
+
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 
@@ -288,7 +290,7 @@ class PurchaseOrderCreateSerializer(serializers.ModelSerializer):
         )
 
         # Create line items
-        total_cost = 0
+        total_cost = Decimal("0.00")
         for idx, item_data in enumerate(items_data):
             quantity = item_data.get("quantity", 1)
             notes = item_data.get("notes", "")
@@ -321,11 +323,16 @@ class PurchaseOrderCreateSerializer(serializers.ModelSerializer):
 
                     # Get unit_cost override if provided, otherwise use item_supplier.unit_cost
                     unit_cost_override = item_data.get("unit_cost")
-                    unit_cost_ordered = (
-                        unit_cost_override
-                        if unit_cost_override is not None
-                        else (item_supplier.unit_cost or 0)
-                    )
+                    if unit_cost_override is not None:
+                        try:
+                            unit_cost_ordered = Decimal(str(unit_cost_override))
+                        except (InvalidOperation, ValueError):
+                            raise serializers.ValidationError(
+                                f"Item at index {idx}: unit_cost must be numeric, "
+                                f"got {unit_cost_override!r}"
+                            )
+                    else:
+                        unit_cost_ordered = item_supplier.unit_cost or Decimal("0.00")
 
                     # Get expected_shipment_date if provided
                     expected_shipment_date = item_data.get("expected_shipment_date")
@@ -356,6 +363,12 @@ class PurchaseOrderCreateSerializer(serializers.ModelSerializer):
                     raise serializers.ValidationError(
                         f"unit_cost is required when purchasing asset {asset_id}"
                     )
+                try:
+                    unit_cost = Decimal(str(unit_cost))
+                except (InvalidOperation, ValueError):
+                    raise serializers.ValidationError(
+                        f"Item at index {idx}: unit_cost must be numeric, " f"got {unit_cost!r}"
+                    )
 
                 try:
                     from inventory.models import Asset
@@ -380,7 +393,7 @@ class PurchaseOrderCreateSerializer(serializers.ModelSerializer):
 
                     total_cost += line_item.estimated_cost
 
-                except (Asset.DoesNotExist, DjangoValidationError, ValueError, TypeError):
+                except (Asset.DoesNotExist, DjangoValidationError, ValueError):
                     raise serializers.ValidationError(f"Invalid asset id: {asset_id}")
 
             # Handle freeform line items
@@ -396,6 +409,12 @@ class PurchaseOrderCreateSerializer(serializers.ModelSerializer):
                 if unit_cost is None:
                     raise serializers.ValidationError(
                         f"unit_cost is required for freeform item: {description}"
+                    )
+                try:
+                    unit_cost = Decimal(str(unit_cost))
+                except (InvalidOperation, ValueError):
+                    raise serializers.ValidationError(
+                        f"Item at index {idx}: unit_cost must be numeric, " f"got {unit_cost!r}"
                     )
 
                 # Create the freeform line item (freeform items don't have package information)

--- a/backend/reorder_queue/tests/test_api.py
+++ b/backend/reorder_queue/tests/test_api.py
@@ -638,6 +638,98 @@ class TestPurchaseOrderAPI:
         assert r2.status_code == status.HTTP_201_CREATED
         assert r1.data["po_number"] != r2.data["po_number"]
 
+    def test_create_po_inventory_plus_freeform_with_float_unit_cost_returns_201(
+        self, authenticated_client
+    ):
+        """Inventory line (Decimal total) + freeform line with float unit_cost must not 500."""
+        client, _ = authenticated_client
+
+        supplier = SupplierFactory()
+        item_supplier = ItemSupplierFactory(supplier=supplier, quantity_per_package=1)
+        # ItemSupplier.save() recomputes unit_cost from package_cost / quantity_per_package,
+        # so pin both to get a deterministic unit_cost.
+        item_supplier.package_cost = Decimal("2.00")
+        item_supplier.quantity_per_package = 1
+        item_supplier.save()
+
+        url = reverse("purchaseorder-list")
+        data = {
+            "supplier": supplier.id,
+            "items": [
+                {"item_supplier_id": item_supplier.id, "quantity": 3},
+                {"description": "Custom part", "quantity": 2, "unit_cost": 12.50},
+            ],
+        }
+        response = client.post(url, data, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        po = PurchaseOrder.objects.get(id=response.data["id"])
+        # 3 * 2.00 + 2 * 12.50 = 6.00 + 25.00 = 31.00
+        assert po.estimated_total == Decimal("31.00")
+        assert po.items.count() == 2
+
+    def test_create_po_inventory_plus_asset_with_float_unit_cost_returns_201(
+        self, authenticated_client
+    ):
+        """Inventory line (Decimal total) + asset line with float unit_cost must not 400/500."""
+        from inventory.tests.factories import AssetFactory
+
+        client, _ = authenticated_client
+
+        supplier = SupplierFactory()
+        item_supplier = ItemSupplierFactory(supplier=supplier, quantity_per_package=1)
+        item_supplier.package_cost = Decimal("4.00")
+        item_supplier.quantity_per_package = 1
+        item_supplier.save()
+        asset = AssetFactory(manufacturer=supplier)
+
+        url = reverse("purchaseorder-list")
+        data = {
+            "supplier": supplier.id,
+            "items": [
+                {"item_supplier_id": item_supplier.id, "quantity": 2},
+                {"asset_id": str(asset.id), "quantity": 1, "unit_cost": 99.99},
+            ],
+        }
+        response = client.post(url, data, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        # Regression guard: the asset branch must not mask the arithmetic TypeError
+        # as an "Invalid asset id" 400.
+        assert "Invalid asset id" not in str(response.data)
+        po = PurchaseOrder.objects.get(id=response.data["id"])
+        # 2 * 4.00 + 1 * 99.99 = 8.00 + 99.99 = 107.99
+        assert po.estimated_total == Decimal("107.99")
+        assert po.items.count() == 2
+
+    def test_create_po_freeform_plus_inventory_with_float_unit_cost_returns_201(
+        self, authenticated_client
+    ):
+        """Ordering sanity: freeform first, then inventory — still must not 500."""
+        client, _ = authenticated_client
+
+        supplier = SupplierFactory()
+        item_supplier = ItemSupplierFactory(supplier=supplier, quantity_per_package=1)
+        item_supplier.package_cost = Decimal("3.00")
+        item_supplier.quantity_per_package = 1
+        item_supplier.save()
+
+        url = reverse("purchaseorder-list")
+        data = {
+            "supplier": supplier.id,
+            "items": [
+                {"description": "Custom part", "quantity": 2, "unit_cost": 12.50},
+                {"item_supplier_id": item_supplier.id, "quantity": 4},
+            ],
+        }
+        response = client.post(url, data, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        po = PurchaseOrder.objects.get(id=response.data["id"])
+        # 2 * 12.50 + 4 * 3.00 = 25.00 + 12.00 = 37.00
+        assert po.estimated_total == Decimal("37.00")
+        assert po.items.count() == 2
+
 
 @pytest.mark.integration
 class TestPurchaseOrderMarkDelivered:


### PR DESCRIPTION
## Summary
`PurchaseOrderCreateSerializer.create()` crashed with `TypeError: Decimal + float` when a PO mixed an inventory-item line (total becomes `Decimal`) with an asset or freeform line whose `unit_cost` arrived as a JSON float and stayed a Python `float`.

- **500 for inventory + freeform** (float `unit_cost`).
- **400 "Invalid asset id" for inventory + asset** (float `unit_cost`) — the asset branch's `TypeError` catch (widened in oms-dxz / PR #163) was masking the arithmetic bug.

Fix:
- Initialise `total_cost = Decimal("0.00")`.
- Coerce payload `unit_cost` to `Decimal(str(…))` in the asset, freeform, and inventory-override branches; non-numeric `unit_cost` now returns a 400 with an explicit message.
- Drop `TypeError` from the asset branch's except-tuple so arithmetic bugs stop being misreported as "Invalid asset id". Keep `(Asset.DoesNotExist, DjangoValidationError, ValueError)`.

Three regression tests in `test_api.py` cover inventory+freeform, inventory+asset, and freeform+inventory ordering with float `unit_cost` payloads.

Source: bead `oms-vo1` · MR `oms-wisp-6uq` · polecat `jasper`

🤖 Merged via Refinery (Claude Code)