### PR TITLE
feat(sidebar): resizable Recent panel with persisted height (oms-stt)

### DIFF
--- a/frontend/src/__tests__/components/RecentPages.test.tsx
+++ b/frontend/src/__tests__/components/RecentPages.test.tsx
@@ -1,16 +1,25 @@
 /**
  * Recent Pages Component Tests
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { BrowserRouter, MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import RecentPages from '../../components/RecentPages';
 
-const renderWithRouter = (initialEntries = ['/']) => {
+const renderWithRouter = (initialEntries = ['/'], isCollapsed = false) => {
   return render(
     <MemoryRouter initialEntries={initialEntries}>
-      <RecentPages />
+      <RecentPages isCollapsed={isCollapsed} />
     </MemoryRouter>
+  );
+};
+
+const seedRecentPages = () => {
+  localStorage.setItem(
+    'recentPages',
+    JSON.stringify([
+      { path: '/inventory', label: 'Inventory Dashboard', timestamp: Date.now() },
+    ])
   );
 };
 
@@ -74,6 +83,95 @@ describe('RecentPages Component', () => {
     renderWithRouter(['/facilities/tv-dashboard']);
     // Should not track TV dashboard
     expect(localStorage.getItem('recentPages')).toBeNull();
+  });
+
+  describe('resize handle', () => {
+    const getScrollContainer = () => screen.getByTestId('recent-pages-scroll');
+    const getHandle = () => screen.getByRole('separator', { name: /resize recent pages/i });
+    const queryHandle = () =>
+      screen.queryByRole('separator', { name: /resize recent pages/i });
+
+    it('renders a resize handle when expanded with recent pages', () => {
+      seedRecentPages();
+      renderWithRouter(['/']);
+      expect(getHandle()).toBeInTheDocument();
+    });
+
+    it('hides the resize handle when sidebar is collapsed', () => {
+      seedRecentPages();
+      renderWithRouter(['/'], true);
+      expect(queryHandle()).not.toBeInTheDocument();
+    });
+
+    it('uses default height of 200px when no saved height', () => {
+      seedRecentPages();
+      renderWithRouter(['/']);
+      expect(getScrollContainer().style.height).toBe('200px');
+    });
+
+    it('loads persisted height from localStorage on mount', () => {
+      localStorage.setItem('recentPagesHeight', '350');
+      seedRecentPages();
+      renderWithRouter(['/']);
+      expect(getScrollContainer().style.height).toBe('350px');
+    });
+
+    it('clamps persisted height below the minimum', () => {
+      localStorage.setItem('recentPagesHeight', '20');
+      seedRecentPages();
+      renderWithRouter(['/']);
+      expect(getScrollContainer().style.height).toBe('100px');
+    });
+
+    it('clamps persisted height above the maximum', () => {
+      localStorage.setItem('recentPagesHeight', '9999');
+      seedRecentPages();
+      renderWithRouter(['/']);
+      expect(getScrollContainer().style.height).toBe('600px');
+    });
+
+    it('drags to grow the panel and persists the new height', () => {
+      seedRecentPages();
+      renderWithRouter(['/']);
+
+      fireEvent.mouseDown(getHandle(), { clientY: 500 });
+      // Drag up 100px grows panel (anchored at bottom)
+      fireEvent.mouseMove(document, { clientY: 400 });
+      expect(getScrollContainer().style.height).toBe('300px');
+
+      fireEvent.mouseUp(document);
+      expect(localStorage.getItem('recentPagesHeight')).toBe('300');
+    });
+
+    it('clamps drag within min/max bounds', () => {
+      seedRecentPages();
+      renderWithRouter(['/']);
+
+      // Drag way down (shrinks) past minimum
+      fireEvent.mouseDown(getHandle(), { clientY: 500 });
+      fireEvent.mouseMove(document, { clientY: 9999 });
+      expect(getScrollContainer().style.height).toBe('100px');
+      fireEvent.mouseUp(document);
+
+      // Drag way up (grows) past maximum
+      fireEvent.mouseDown(getHandle(), { clientY: 500 });
+      fireEvent.mouseMove(document, { clientY: -9999 });
+      expect(getScrollContainer().style.height).toBe('600px');
+      fireEvent.mouseUp(document);
+    });
+
+    it('ignores mousemove after mouseup (drag state cleanup)', () => {
+      seedRecentPages();
+      renderWithRouter(['/']);
+
+      fireEvent.mouseDown(getHandle(), { clientY: 500 });
+      fireEvent.mouseMove(document, { clientY: 450 });
+      expect(getScrollContainer().style.height).toBe('250px');
+      fireEvent.mouseUp(document);
+      // Further moves after mouseup should not change height
+      fireEvent.mouseMove(document, { clientY: 100 });
+      expect(getScrollContainer().style.height).toBe('250px');
+    });
   });
 });
 

--- a/frontend/src/components/RecentPages.tsx
+++ b/frontend/src/components/RecentPages.tsx
@@ -2,7 +2,7 @@
  * Recent Pages Component
  * Tracks and displays recently visited pages
  */
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { notificationsAPI } from '../services/api';
 import '../styles/RecentPages.css';
@@ -15,10 +15,29 @@ interface RecentPage {
 
 const DEFAULT_RECENT_PAGES_LIMIT = 8;
 const STORAGE_KEY = 'recentPages';
+const HEIGHT_STORAGE_KEY = 'recentPagesHeight';
+const MIN_HEIGHT = 100;
+const MAX_HEIGHT = 600;
+const DEFAULT_HEIGHT = 200;
+const COLLAPSED_HEIGHT = 80;
+
+const clampHeight = (value: number): number =>
+  Math.max(MIN_HEIGHT, Math.min(MAX_HEIGHT, value));
 
 const RecentPages: React.FC<{ isCollapsed?: boolean }> = ({ isCollapsed = false }) => {
   const [recentPages, setRecentPages] = useState<RecentPage[]>([]);
   const [displayLimit, setDisplayLimit] = useState<number>(DEFAULT_RECENT_PAGES_LIMIT);
+  const [userHeight, setUserHeight] = useState<number>(() => {
+    if (typeof window === 'undefined') return DEFAULT_HEIGHT;
+    const stored = localStorage.getItem(HEIGHT_STORAGE_KEY);
+    if (stored) {
+      const parsed = parseInt(stored, 10);
+      if (!Number.isNaN(parsed)) return clampHeight(parsed);
+    }
+    return DEFAULT_HEIGHT;
+  });
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStateRef = useRef<{ startY: number; startHeight: number } | null>(null);
   const location = useLocation();
 
   // Route to label mapping for display
@@ -139,6 +158,43 @@ const RecentPages: React.FC<{ isCollapsed?: boolean }> = ({ isCollapsed = false 
     setRecentPages(updatedPages);
   }, [location.pathname]);
 
+  const startDrag = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      dragStateRef.current = { startY: event.clientY, startHeight: userHeight };
+      setIsDragging(true);
+    },
+    [userHeight]
+  );
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handleMove = (event: MouseEvent) => {
+      const state = dragStateRef.current;
+      if (!state) return;
+      // Handle sits above the scroll area; dragging up (delta negative) grows panel.
+      const delta = event.clientY - state.startY;
+      setUserHeight(clampHeight(state.startHeight - delta));
+    };
+
+    const handleUp = () => {
+      setIsDragging(false);
+      dragStateRef.current = null;
+    };
+
+    document.addEventListener('mousemove', handleMove);
+    document.addEventListener('mouseup', handleUp);
+    return () => {
+      document.removeEventListener('mousemove', handleMove);
+      document.removeEventListener('mouseup', handleUp);
+    };
+  }, [isDragging]);
+
+  useEffect(() => {
+    localStorage.setItem(HEIGHT_STORAGE_KEY, String(userHeight));
+  }, [userHeight]);
+
   if (recentPages.length === 0) {
     return null;
   }
@@ -146,11 +202,26 @@ const RecentPages: React.FC<{ isCollapsed?: boolean }> = ({ isCollapsed = false 
   // Limit displayed pages based on user preference
   const displayedPages = recentPages.slice(0, displayLimit);
   const hasMorePages = recentPages.length > displayLimit;
+  const effectiveHeight = isCollapsed ? COLLAPSED_HEIGHT : userHeight;
+  const showHandle = !isCollapsed;
 
   return (
     <div className="recent-pages">
+      {showHandle && (
+        <div
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label="Resize recent pages"
+          className={`recent-pages-resize-handle${isDragging ? ' dragging' : ''}`}
+          onMouseDown={startDrag}
+        />
+      )}
       {!isCollapsed && <h3 className="recent-pages-title">Recent</h3>}
-      <div className="recent-pages-scroll-container">
+      <div
+        className="recent-pages-scroll-container"
+        data-testid="recent-pages-scroll"
+        style={{ height: effectiveHeight }}
+      >
         <ul className="recent-pages-list">
           {displayedPages.map((page) => (
             <li key={`${page.path}-${page.timestamp}`} className="recent-page-item">

--- a/frontend/src/styles/RecentPages.css
+++ b/frontend/src/styles/RecentPages.css
@@ -17,11 +17,41 @@
 }
 
 .recent-pages-scroll-container {
-  max-height: 400px;
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-width: thin;
   scrollbar-color: #c0c0c0 #f5f5f5;
+}
+
+.recent-pages-resize-handle {
+  height: 6px;
+  margin: 0 -16px 8px -16px;
+  cursor: ns-resize;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    #e0e0e0 50%,
+    transparent 100%
+  );
+  transition: background 0.15s ease;
+  touch-action: none;
+  user-select: none;
+}
+
+.recent-pages-resize-handle:hover,
+.recent-pages-resize-handle.dragging {
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    #667eea 50%,
+    transparent 100%
+  );
+}
+
+@media (max-width: 767px) {
+  .recent-pages-resize-handle {
+    display: none;
+  }
 }
 
 .recent-pages-scroll-container::-webkit-scrollbar {

--- a/frontend/src/styles/Sidebar.css
+++ b/frontend/src/styles/Sidebar.css
@@ -25,6 +25,7 @@
 
 .sidebar-nav {
   flex: 1;
+  min-height: 300px;
   padding: 16px 0 8px 0;
   overflow-y: auto;
 }


### PR DESCRIPTION
## Summary
Recent-pages sidebar panel grew unbounded; user wanted it adjustable. This makes the panel resizable via a drag handle at its top edge, and persists the chosen height to `localStorage`.

- `RecentPages.tsx` — drag handle, min/max clamping, pointer-based resize; reads/writes `localStorage['recentPagesHeight']`.
- `RecentPages.css` — removes the hard-coded `max-height: 400px`; drives height from state; cursor/hover styles for the handle.
- `Sidebar.css` — minor layout tweak to accommodate the handle.
- Tests cover: initial height from storage, drag updates height, persistence across mount, min/max clamping.

Source: bead `oms-stt` · MR `oms-wisp-cde` · polecat `jasper`

🤖 Merged via Refinery (Claude Code)