### PR TITLE
fix(notifications): route PUT/PATCH to /preferences/ (oms-hvz)

### DIFF
--- a/backend/notifications/tests.py
+++ b/backend/notifications/tests.py
@@ -5,7 +5,7 @@ Tests for notifications app.
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from .models import Notification
+from .models import Notification, NotificationPreference
 from .services import create_bulk_notifications, create_notification, notify_admins
 
 User = get_user_model()
@@ -234,3 +234,90 @@ class NotificationViewSetTest(TestCase):
         response = client.delete(f"/api/notifications/{notification_id}/")
         self.assertEqual(response.status_code, 204)
         self.assertFalse(Notification.objects.filter(id=notification_id).exists())
+
+
+class NotificationPreferenceViewTest(TestCase):
+    """Tests for NotificationPreferenceView API."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="prefuser", email="pref@example.com", password="testpass123"
+        )
+
+    def _authed_client(self):
+        from rest_framework.test import APIClient
+        from rest_framework_simplejwt.tokens import RefreshToken
+
+        client = APIClient()
+        refresh = RefreshToken.for_user(self.user)
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
+        return client
+
+    def test_get_preferences_requires_auth(self):
+        from rest_framework.test import APIClient
+
+        response = APIClient().get("/api/notifications/preferences/")
+        self.assertEqual(response.status_code, 401)
+
+    def test_get_preferences_creates_defaults_for_fresh_user(self):
+        self.assertFalse(NotificationPreference.objects.filter(user=self.user).exists())
+
+        response = self._authed_client().get("/api/notifications/preferences/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["email_enabled"])
+        self.assertTrue(response.data["in_app_enabled"])
+        self.assertEqual(response.data["recent_pages_limit"], 8)
+        self.assertTrue(NotificationPreference.objects.filter(user=self.user).exists())
+
+    def test_put_preferences_updates_and_persists(self):
+        response = self._authed_client().put(
+            "/api/notifications/preferences/",
+            data={
+                "email_enabled": False,
+                "in_app_enabled": False,
+                "supply_alerts": False,
+                "maintenance_alerts": False,
+                "order_updates": False,
+                "system_notifications": False,
+                "recent_pages_limit": 5,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["email_enabled"])
+        self.assertEqual(response.data["recent_pages_limit"], 5)
+
+        prefs = NotificationPreference.objects.get(user=self.user)
+        self.assertFalse(prefs.email_enabled)
+        self.assertFalse(prefs.in_app_enabled)
+        self.assertEqual(prefs.recent_pages_limit, 5)
+
+    def test_patch_preferences_partial_update(self):
+        NotificationPreference.objects.create(
+            user=self.user, email_enabled=True, recent_pages_limit=8
+        )
+
+        response = self._authed_client().patch(
+            "/api/notifications/preferences/",
+            data={"recent_pages_limit": 20},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["recent_pages_limit"], 20)
+        self.assertTrue(response.data["email_enabled"])  # unchanged
+
+        prefs = NotificationPreference.objects.get(user=self.user)
+        self.assertEqual(prefs.recent_pages_limit, 20)
+        self.assertTrue(prefs.email_enabled)
+
+    def test_put_preferences_validation_error(self):
+        response = self._authed_client().put(
+            "/api/notifications/preferences/",
+            data={"recent_pages_limit": 999},  # exceeds MaxValueValidator(50)
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)

--- a/backend/notifications/urls.py
+++ b/backend/notifications/urls.py
@@ -6,12 +6,16 @@ from django.urls import include, path
 
 from rest_framework.routers import DefaultRouter
 
-from .views import NotificationPreferenceViewSet, NotificationViewSet
+from .views import NotificationPreferenceView, NotificationViewSet
 
 router = DefaultRouter()
 router.register(r"", NotificationViewSet, basename="notification")
-router.register(r"preferences", NotificationPreferenceViewSet, basename="notification-preference")
 
 urlpatterns = [
+    path(
+        "preferences/",
+        NotificationPreferenceView.as_view(),
+        name="notification-preferences",
+    ),
     path("", include(router.urls)),
 ]

--- a/backend/notifications/views.py
+++ b/backend/notifications/views.py
@@ -2,10 +2,11 @@
 Views for notification API.
 """
 
-from rest_framework import status, viewsets
+from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
 from rest_framework_simplejwt.authentication import JWTAuthentication
 
 from .models import Notification, NotificationPreference
@@ -63,34 +64,32 @@ class NotificationViewSet(viewsets.ModelViewSet):
         return Response({"status": "marked all as read", "updated": updated})
 
 
-class NotificationPreferenceViewSet(viewsets.ViewSet):
+class NotificationPreferenceView(APIView):
     """
-    ViewSet for managing user notification preferences.
+    Singleton view for the current user's notification preferences.
 
-    Auto-creates preferences on first access with default values.
+    GET/PUT/PATCH all act on the row owned by request.user, auto-creating it
+    with defaults on first access.
     """
 
     authentication_classes = (JWTAuthentication,)
     permission_classes = [IsAuthenticated]
-    serializer_class = NotificationPreferenceSerializer
 
-    def list(self, request):
-        """Get current user's notification preferences."""
-        preferences, created = NotificationPreference.objects.get_or_create(user=request.user)
-        serializer = self.get_serializer(preferences)
+    def _get_preferences(self, user):
+        preferences, _ = NotificationPreference.objects.get_or_create(user=user)
+        return preferences
+
+    def get(self, request):
+        preferences = self._get_preferences(request.user)
+        serializer = NotificationPreferenceSerializer(preferences)
         return Response(serializer.data)
 
-    def retrieve(self, request, pk=None):
-        """Get current user's notification preferences (alias for list)."""
-        preferences, created = NotificationPreference.objects.get_or_create(user=request.user)
-        serializer = self.get_serializer(preferences)
+    def put(self, request):
+        preferences = self._get_preferences(request.user)
+        serializer = NotificationPreferenceSerializer(preferences, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
         return Response(serializer.data)
 
-    def update(self, request):
-        """Update current user's notification preferences."""
-        preferences, created = NotificationPreference.objects.get_or_create(user=request.user)
-        serializer = self.get_serializer(preferences, data=request.data, partial=True)
-        if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    def patch(self, request):
+        return self.put(request)


### PR DESCRIPTION
## Summary
`/settings/profile` was showing "Failed to load notification preferences: Not found." Frontend hit `/api/notifications/preferences/`, but the backend routed writes (PUT/PATCH) differently, causing a 404 for updates and cascading into a failed load.

- `backend/notifications/urls.py` — route both read and write to `/preferences/` consistently.
- `backend/notifications/views.py` — consolidate the preferences view so GET/PUT/PATCH share the same URL and serializer path.
- `backend/notifications/tests.py` — covers create-on-first-access, GET/PUT/PATCH round-trips, and auth.

Source: bead `oms-hvz` · MR `oms-wisp-7cy` · polecat `obsidian`

🤖 Merged via Refinery (Claude Code)