### PR TITLE
fix(po): migrate order_in_packages from boolean to integer (oms-qqn)

### DIFF
--- a/backend/reorder_queue/migrations/0016_fix_order_in_packages_column_type.py
+++ b/backend/reorder_queue/migrations/0016_fix_order_in_packages_column_type.py
@@ -1,0 +1,48 @@
+from django.db import migrations
+
+FORWARD_SQL = """
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'reorder_queue_purchaseorderitem'
+          AND column_name = 'order_in_packages'
+          AND data_type = 'boolean'
+    ) THEN
+        ALTER TABLE reorder_queue_purchaseorderitem
+            ALTER COLUMN order_in_packages DROP DEFAULT;
+        ALTER TABLE reorder_queue_purchaseorderitem
+            ALTER COLUMN order_in_packages TYPE integer
+            USING CASE WHEN order_in_packages THEN 1 ELSE 0 END;
+        ALTER TABLE reorder_queue_purchaseorderitem
+            ALTER COLUMN order_in_packages SET DEFAULT 0;
+        ALTER TABLE reorder_queue_purchaseorderitem
+            ADD CONSTRAINT reorder_queue_purchaseorderitem_order_in_packages_check
+            CHECK (order_in_packages >= 0);
+    END IF;
+END $$;
+"""
+
+
+def forward(apps, schema_editor):
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    with schema_editor.connection.cursor() as cursor:
+        cursor.execute(FORWARD_SQL)
+
+
+def reverse(apps, schema_editor):
+    # No-op: boolean was the broken state; we don't restore it.
+    return
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("reorder_queue", "0015_fix_constraint_syntax_for_freeform"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, reverse),
+    ]

--- a/backend/reorder_queue/tests/test_models.py
+++ b/backend/reorder_queue/tests/test_models.py
@@ -10,8 +10,8 @@ from django.utils import timezone
 import pytest
 from freezegun import freeze_time
 
-from inventory.tests.factories import InventoryItemFactory, SupplierFactory
-from reorder_queue.models import PurchaseOrder, ReorderRequest
+from inventory.tests.factories import InventoryItemFactory, ItemSupplierFactory, SupplierFactory
+from reorder_queue.models import PurchaseOrder, PurchaseOrderItem, ReorderRequest
 from reorder_queue.tests.factories import ReorderRequestFactory, UserFactory
 
 pytestmark = pytest.mark.django_db
@@ -146,3 +146,33 @@ class TestPurchaseOrderModel:
 
         assert po1.po_number == "PO-2024-0001"
         assert po2.po_number == "PO-2024-0002"
+
+
+@pytest.mark.unit
+class TestPurchaseOrderItemOrderInPackages:
+    """Regression tests for oms-qqn: order_in_packages must accept integers.
+
+    Production drifted to a boolean column, breaking PO create with
+    `column "order_in_packages" is of type boolean but expression is of
+    type integer`. Migration 0016 corrects the column type in PostgreSQL.
+    These tests assert the model and storage accept non-boolean integer
+    values.
+    """
+
+    def test_order_in_packages_stores_large_integer(self):
+        supplier = SupplierFactory()
+        user = UserFactory()
+        item_supplier = ItemSupplierFactory(supplier=supplier)
+
+        po = PurchaseOrder.objects.create(supplier=supplier, created_by=user)
+        po_item = PurchaseOrderItem.objects.create(
+            purchase_order=po,
+            item_supplier=item_supplier,
+            quantity_ordered=25,
+            unit_cost_ordered=Decimal("1.00"),
+            order_in_packages=7,
+        )
+
+        po_item.refresh_from_db()
+        assert po_item.order_in_packages == 7
+        assert not isinstance(po_item.order_in_packages, bool)


### PR DESCRIPTION
## Summary
Production PO creates were failing with `DatatypeMismatch: column "order_in_packages" is of type boolean but expression is of type integer`. Migration `0013` defines the column as `PositiveIntegerField`, and the Django model matches — but the production column had drifted to `boolean`.

- New migration `0016_fix_order_in_packages_column_type.py` — detects the boolean column in PostgreSQL and converts it to integer with `USING CASE WHEN order_in_packages THEN 1 ELSE 0 END`, restores the default, and adds the `CHECK (>= 0)` constraint.
- No-op on non-PostgreSQL backends and on PG instances where the column is already integer.
- Regression test in `test_models.py` asserts `order_in_packages` stores integer values and is not stored as a bool.

Source: bead `oms-qqn` · MR `oms-wisp-3rc` · polecat `topaz`

🤖 Merged via Refinery (Claude Code)