### PR TITLE
fix(deps): bump node-forge override to 1.4.0 (oms-ghy)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13268,9 +13268,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
-      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -116,6 +116,6 @@
     "webpack-dev-server": ">=5.2.1",
     "postcss": ">=8.4.31",
     "test-exclude": ">=7.0.1",
-    "node-forge": "1.3.2"
+    "node-forge": "1.4.0"
   }
 }


### PR DESCRIPTION
## Summary
Bumps the `frontend/package.json` `node-forge` override to **1.4.0**, which patches the `BigInteger.modInverse()` infinite-loop DoS in the bundled `jsbn` (calling `modInverse(0)` previously hung indefinitely at 100% CPU).

- `frontend/package.json` — override bumped.
- `frontend/package-lock.json` — regenerated.

Source: bead `oms-ghy` · MR `oms-wisp-gcs` · polecat `obsidian`

🤖 Merged via Refinery (Claude Code)