### PR TITLE
fix(frontend): rename dialogs.ts to .tsx + add CI build step (oms-azb)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,14 @@ jobs:
           CI: true
           NODE_OPTIONS: "--dns-result-order=ipv4first"
 
+      - name: Build production bundle
+        run: |
+          cd frontend
+          npm run build
+        env:
+          CI: false
+          NODE_OPTIONS: "--dns-result-order=ipv4first"
+
       - name: Verify coverage files exist
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
         run: |

--- a/frontend/src/utils/dialogs.tsx
+++ b/frontend/src/utils/dialogs.tsx
@@ -38,7 +38,7 @@ export function showInfo(message: string, title?: string): void {
 export function confirmDelete(message: string, onConfirm: () => void): void {
   modals.openConfirmModal({
     title: 'Confirm deletion',
-    children: React.createElement(Text, { size: 'sm' }, message),
+    children: <Text size="sm">{message}</Text>,
     labels: DEFAULT_DELETE_LABELS,
     confirmProps: { color: 'red' },
     onConfirm,
@@ -56,7 +56,7 @@ export function confirmAction(
 ): void {
   modals.openConfirmModal({
     title,
-    children: React.createElement(Text, { size: 'sm' }, message),
+    children: <Text size="sm">{message}</Text>,
     labels: options.labels ?? DEFAULT_CONFIRM_LABELS,
     confirmProps: options.color ? { color: options.color } : undefined,
     onConfirm,
@@ -92,29 +92,23 @@ const PromptForm: React.FC<PromptFormProps> = ({
     onCancel();
   };
 
-  return React.createElement(
-    'form',
-    { onSubmit: handleSubmit },
-    React.createElement(
-      Stack,
-      null,
-      React.createElement(TextInput, {
-        label,
-        placeholder,
-        autoFocus: true,
-        ...form.getInputProps('value'),
-      }),
-      React.createElement(
-        Group,
-        { justify: 'flex-end' },
-        React.createElement(
-          Button,
-          { variant: 'default', onClick: handleCancel, type: 'button' },
-          'Cancel',
-        ),
-        React.createElement(Button, { type: 'submit' }, 'Submit'),
-      ),
-    ),
+  return (
+    <form onSubmit={handleSubmit}>
+      <Stack>
+        <TextInput
+          label={label}
+          placeholder={placeholder}
+          autoFocus
+          {...form.getInputProps('value')}
+        />
+        <Group justify="flex-end">
+          <Button variant="default" onClick={handleCancel} type="button">
+            Cancel
+          </Button>
+          <Button type="submit">Submit</Button>
+        </Group>
+      </Stack>
+    </form>
   );
 };
 
@@ -147,17 +141,19 @@ export function promptInput(
       modalId,
       title,
       onClose: () => resolveOnce(null),
-      children: React.createElement(PromptForm, {
-        modalId,
-        label,
-        initialValue: options.initialValue ?? '',
-        placeholder: options.placeholder,
-        onSubmit: (value) => {
-          if (onSubmit) onSubmit(value);
-          resolveOnce(value);
-        },
-        onCancel: () => resolveOnce(null),
-      }),
+      children: (
+        <PromptForm
+          modalId={modalId}
+          label={label}
+          initialValue={options.initialValue ?? ''}
+          placeholder={options.placeholder}
+          onSubmit={(value) => {
+            if (onSubmit) onSubmit(value);
+            resolveOnce(value);
+          }}
+          onCancel={() => resolveOnce(null)}
+        />
+      ),
     });
   });
 }


### PR DESCRIPTION
## Summary
`npm run build` failed with TS2769 in `src/utils/dialogs.ts:41` — `React.createElement(Text, { size: 'sm' }, message)` made TypeScript infer Mantine's polymorphic `Text` as the SVG `<symbol>` element. Introduced in 61cc67e (PR #185, oms-76s dialogs infrastructure). Tests passed because `docker-compose` uses `frontend/Dockerfile` (`npm start`), not `Dockerfile.prod` (`npm run build`), so CI never exercised the prod build.

- Rename `dialogs.ts` → `dialogs.tsx` and rewrite the body to use JSX, which gives Mantine's polymorphic `Text` the right inferred type.
- Add a CI step that runs `npm run build` so the prod build is guarded going forward.

Source: bead `oms-azb` · MR `oms-wisp-24a` · polecat `jasper`

🤖 Merged via Refinery (Claude Code)