### PR TITLE
fix(deps): bump serialize-javascript override to 7.0.5 (oms-e0m)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15268,15 +15268,6 @@
         "performance-now": "^2.1.0"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -16578,12 +16569,12 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-index": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -117,7 +117,7 @@
     "postcss": ">=8.4.31",
     "test-exclude": ">=7.0.1",
     "svgo": "^3.2.0",
-    "serialize-javascript": "^6.0.2",
+    "serialize-javascript": "^7.0.5",
     "underscore": "^1.13.7",
     "node-forge": "1.4.0"
   }


### PR DESCRIPTION
## Summary
Bumps the `serialize-javascript` override to **7.0.5** — patches the `RegExp.flags` / `Date.prototype.toISOString()` code-injection path (incomplete CVE-2020-7660 fix). An attacker controlling input to `serialize()` could inject JS via a spoofed `.flags` that later evaluates under `eval` / `new Function` / `<script>`.

- `frontend/package.json` — override bumped from `^6.0.2` → `^7.0.5`.
- `frontend/package-lock.json` — regenerated.

Source: Dependabot alert #49 · bead `oms-e0m` · MR `oms-wisp-73a` · polecat `jasper`

🤖 Merged via Refinery (Claude Code)