### PR TITLE
feat(dialogs): convert Phase 2d popups to Mantine modals (oms-1dv)

### DIFF
--- a/frontend/src/__tests__/pages/WebhookListPage.test.tsx
+++ b/frontend/src/__tests__/pages/WebhookListPage.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Tests for WebhookListPage — focuses on the Mantine modal delete flow
+ * introduced as part of Phase 2d popup conversion (oms-1dv).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import WebhookListPage from '../../pages/WebhookListPage';
+import * as api from '../../services/api';
+import { confirmDelete, showError } from '../../utils/dialogs';
+
+jest.mock('../../services/api');
+
+jest.mock('../../utils/dialogs', () => ({
+  confirmDelete: jest.fn(),
+  showError: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+describe('WebhookListPage delete flow', () => {
+  const baseWebhook = {
+    id: 42,
+    name: 'Reorder Webhook',
+    url: 'https://example.com/hook',
+    description: 'Test hook',
+    event_type: 'reorder_request_created',
+    event_type_display: 'Reorder Request Created',
+    is_active: true,
+    success_rate: 100,
+    total_triggers: 3,
+    last_triggered_at: null,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (api.webhooksAPI.listWebhooks as jest.Mock).mockResolvedValue({
+      data: { results: [baseWebhook] },
+    });
+  });
+
+  const renderPage = () =>
+    render(
+      <MantineProvider>
+        <MemoryRouter>
+          <WebhookListPage />
+        </MemoryRouter>
+      </MantineProvider>,
+    );
+
+  it('opens a confirm modal when delete is clicked and deletes on confirm', async () => {
+    (api.webhooksAPI.deleteWebhook as jest.Mock).mockResolvedValue({});
+
+    renderPage();
+    await screen.findByText('Reorder Webhook');
+
+    const deleteButton = await screen.findByTitle('Delete');
+    deleteButton.click();
+
+    expect(confirmDelete).toHaveBeenCalledTimes(1);
+    const [message, onConfirm] = (confirmDelete as jest.Mock).mock.calls[0];
+    expect(message).toContain('Reorder Webhook');
+
+    await onConfirm();
+
+    expect(api.webhooksAPI.deleteWebhook).toHaveBeenCalledWith(42);
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a Mantine error notification when delete fails', async () => {
+    (api.webhooksAPI.deleteWebhook as jest.Mock).mockRejectedValue({
+      response: { data: { detail: 'Not allowed' } },
+    });
+
+    renderPage();
+    await screen.findByText('Reorder Webhook');
+
+    const deleteButton = await screen.findByTitle('Delete');
+    deleteButton.click();
+
+    const [, onConfirm] = (confirmDelete as jest.Mock).mock.calls[0];
+    await onConfirm();
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith('Not allowed');
+    });
+  });
+});

--- a/frontend/src/components/ErrorFallback.tsx
+++ b/frontend/src/components/ErrorFallback.tsx
@@ -4,6 +4,7 @@
  */
 import * as Sentry from '@sentry/react';
 import React, { useState } from 'react';
+import { showError } from '../utils/dialogs';
 import './ErrorFallback.css';
 
 interface ErrorFallbackProps {
@@ -31,7 +32,7 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({ error, resetError, eventI
     e.preventDefault();
     
     if (!feedback.trim()) {
-      alert('Please tell us what you were doing when this error occurred.');
+      showError('Please tell us what you were doing when this error occurred.');
       return;
     }
 
@@ -90,7 +91,7 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({ error, resetError, eventI
       }, 3000);
     } catch (err) {
       console.error('Error submitting feedback:', err);
-      alert('Failed to submit feedback. Please try again.');
+      showError('Failed to submit feedback. Please try again.');
     } finally {
       setSubmitting(false);
     }

--- a/frontend/src/pages/DonationItemScanPage.tsx
+++ b/frontend/src/pages/DonationItemScanPage.tsx
@@ -7,6 +7,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { donationsAPI } from '../services/api';
 import '../styles/ScanPage.css';
 import { Disposition, DispositionType, DonationItem, KeptDestination, SaleMethod } from '../types';
+import { showError } from '../utils/dialogs';
 
 const DonationItemScanPage: React.FC = () => {
   const { itemId } = useParams<{ itemId: string }>();
@@ -78,7 +79,7 @@ const DonationItemScanPage: React.FC = () => {
       setActionSuccess('Item information updated successfully');
       setTimeout(() => setActionSuccess(null), 3000);
     } catch (err: any) {
-      alert(err.response?.data?.detail || 'Failed to update item');
+      showError(err.response?.data?.detail || 'Failed to update item');
       console.error('Error updating item:', err);
     } finally {
       setSubmitting(false);
@@ -89,27 +90,27 @@ const DonationItemScanPage: React.FC = () => {
     if (!item || !isLoggedIn || !dispositionType) return;
 
     if (!dispositionType) {
-      alert('Please select a disposition type');
+      showError('Please select a disposition type');
       return;
     }
 
     // Validate required fields based on disposition type
     if (dispositionType === 'sold' || dispositionType === 'auctioned') {
       if (!saleMethod) {
-        alert('Please select a sale method');
+        showError('Please select a sale method');
         return;
       }
     }
 
     if (dispositionType === 'kept') {
       if (!keptDestination) {
-        alert('Please select where the item is being kept');
+        showError('Please select where the item is being kept');
         return;
       }
     }
 
     if (quantity > (item.remaining_quantity || item.quantity)) {
-      alert(`Quantity cannot exceed remaining quantity (${item.remaining_quantity || item.quantity})`);
+      showError(`Quantity cannot exceed remaining quantity (${item.remaining_quantity || item.quantity})`);
       return;
     }
 
@@ -155,7 +156,7 @@ const DonationItemScanPage: React.FC = () => {
       
       setTimeout(() => setActionSuccess(null), 3000);
     } catch (err: any) {
-      alert(err.response?.data?.detail || 'Failed to create disposition');
+      showError(err.response?.data?.detail || 'Failed to create disposition');
       console.error('Error creating disposition:', err);
     } finally {
       setSubmitting(false);

--- a/frontend/src/pages/PurchaseOrderPage.tsx
+++ b/frontend/src/pages/PurchaseOrderPage.tsx
@@ -6,6 +6,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { purchaseOrderAPI } from '../services/api';
 import '../styles/PurchaseOrderPage.css';
+import { confirmAction, showError } from '../utils/dialogs';
 
 interface PurchaseOrderItem {
   id: string;
@@ -119,7 +120,7 @@ const PurchaseOrderPage: React.FC = () => {
   const handleSaveLineCost = async (itemId: string, item: PurchaseOrderItem) => {
     const lineCostValue = parseFloat(lineCost);
     if (isNaN(lineCostValue) || lineCostValue < 0) {
-      alert('Please enter a valid line cost (must be a positive number)');
+      showError('Please enter a valid line cost (must be a positive number)');
       return;
     }
 
@@ -132,7 +133,7 @@ const PurchaseOrderPage: React.FC = () => {
       setEditingCostItemId(null);
       setLineCost('');
     } catch (err: any) {
-      alert(err.response?.data?.error || 'Failed to update line cost');
+      showError(err.response?.data?.error || 'Failed to update line cost');
       console.error('Error updating line cost:', err);
     } finally {
       setSaving(false);
@@ -149,35 +150,38 @@ const PurchaseOrderPage: React.FC = () => {
       setEditingItemId(null);
       setShipmentDate('');
     } catch (err: any) {
-      alert(err.response?.data?.error || 'Failed to update shipment date');
+      showError(err.response?.data?.error || 'Failed to update shipment date');
       console.error('Error updating shipment date:', err);
     } finally {
       setSaving(false);
     }
   };
 
-  const handleVoidItem = async (itemId: string) => {
+  const handleVoidItem = (itemId: string) => {
     if (!voidReason.trim()) {
-      alert('Please provide a reason for voiding this line item');
+      showError('Please provide a reason for voiding this line item');
       return;
     }
 
-    if (!window.confirm('Are you sure you want to void this line item? This will also mark the item as discontinued from this supplier.')) {
-      return;
-    }
-
-    try {
-      setSaving(true);
-      await purchaseOrderAPI.voidLineItem(orderId!, itemId, voidReason);
-      await loadOrder(); // Reload to get updated data
-      setVoidingItemId(null);
-      setVoidReason('');
-    } catch (err: any) {
-      alert(err.response?.data?.error || 'Failed to void line item');
-      console.error('Error voiding line item:', err);
-    } finally {
-      setSaving(false);
-    }
+    confirmAction(
+      'Void line item?',
+      'Are you sure you want to void this line item? This will also mark the item as discontinued from this supplier.',
+      async () => {
+        try {
+          setSaving(true);
+          await purchaseOrderAPI.voidLineItem(orderId!, itemId, voidReason);
+          await loadOrder(); // Reload to get updated data
+          setVoidingItemId(null);
+          setVoidReason('');
+        } catch (err: any) {
+          showError(err.response?.data?.error || 'Failed to void line item');
+          console.error('Error voiding line item:', err);
+        } finally {
+          setSaving(false);
+        }
+      },
+      { labels: { confirm: 'Void', cancel: 'Cancel' }, color: 'red' },
+    );
   };
 
   const handleOpenMarkDelivered = () => {
@@ -197,7 +201,7 @@ const PurchaseOrderPage: React.FC = () => {
 
   const handleSubmitMarkDelivered = async () => {
     if (!deliveryDate) {
-      alert('Please select a delivery date');
+      showError('Please select a delivery date');
       return;
     }
 
@@ -211,7 +215,7 @@ const PurchaseOrderPage: React.FC = () => {
       await loadOrder();
       handleCancelMarkDelivered();
     } catch (err: any) {
-      alert(err.response?.data?.error || 'Failed to mark purchase order as delivered');
+      showError(err.response?.data?.error || 'Failed to mark purchase order as delivered');
       console.error('Error marking delivered:', err);
     } finally {
       setSaving(false);

--- a/frontend/src/pages/ScanPage.tsx
+++ b/frontend/src/pages/ScanPage.tsx
@@ -9,6 +9,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { checklistsAPI, inventoryAPI, reorderAPI } from '../services/api';
 import '../styles/ScanPage.css';
 import { Checklist, InventoryItem, ItemSupplier } from '../types';
+import { promptInput, showError } from '../utils/dialogs';
 
 const ScanPage: React.FC = () => {
   const { itemId } = useParams<{ itemId: string }>();
@@ -106,13 +107,13 @@ const ScanPage: React.FC = () => {
       if (isLoggedIn) {
         userName = localStorage.getItem('username') || undefined;
       } else {
-        const promptResult = prompt('Enter your name (optional):');
+        const promptResult = await promptInput('Start checklist', 'Enter your name (optional)');
         userName = promptResult || undefined;
       }
       const completion = await checklistsAPI.startChecklist(checklistId, userName);
       navigate(`/checklist/${checklistId}/complete/${completion.data.id}`);
     } catch (err: any) {
-      alert(err.response?.data?.detail || 'Failed to start checklist');
+      showError(err.response?.data?.detail || 'Failed to start checklist');
     }
   };
 
@@ -174,7 +175,7 @@ const ScanPage: React.FC = () => {
 
     // Logged in user: Use supplier selection and package quantities
     if (!selectedSupplier) {
-      alert('Please select a supplier.');
+      showError('Please select a supplier.');
       return;
     }
 
@@ -196,7 +197,7 @@ const ScanPage: React.FC = () => {
         navigate('/');
       }, 3000);
     } catch (err: any) {
-      alert(err.response?.data?.detail || 'Failed to submit reorder request');
+      showError(err.response?.data?.detail || 'Failed to submit reorder request');
       console.error('Error submitting reorder:', err);
     } finally {
       setSubmitting(false);

--- a/frontend/src/pages/WebhookDetailPage.tsx
+++ b/frontend/src/pages/WebhookDetailPage.tsx
@@ -23,6 +23,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { webhooksAPI } from '../services/api';
 import '../styles/WebhookDetailPage.css';
 import { Webhook, WebhookTestResult } from '../types';
+import { confirmDelete, showError } from '../utils/dialogs';
 
 const WebhookDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -135,20 +136,18 @@ const WebhookDetailPage: React.FC = () => {
     setTimeout(poll, pollInterval);
   };
 
-  const handleDelete = async () => {
+  const handleDelete = () => {
     if (!id || !webhook) return;
 
-    if (!window.confirm(`Are you sure you want to delete webhook "${webhook.name}"?`)) {
-      return;
-    }
-
-    try {
-      await webhooksAPI.deleteWebhook(Number(id));
-      navigate('/settings/webhooks');
-    } catch (err: any) {
-      console.error('Error deleting webhook:', err);
-      alert(err.response?.data?.detail || 'Failed to delete webhook');
-    }
+    confirmDelete(`Are you sure you want to delete webhook "${webhook.name}"?`, async () => {
+      try {
+        await webhooksAPI.deleteWebhook(Number(id));
+        navigate('/settings/webhooks');
+      } catch (err: any) {
+        console.error('Error deleting webhook:', err);
+        showError(err.response?.data?.detail || 'Failed to delete webhook');
+      }
+    });
   };
 
   const getSuccessRateColor = (rate: number | null) => {

--- a/frontend/src/pages/WebhookListPage.tsx
+++ b/frontend/src/pages/WebhookListPage.tsx
@@ -20,6 +20,7 @@ import { useNavigate } from 'react-router-dom';
 import { webhooksAPI } from '../services/api';
 import '../styles/WebhookListPage.css';
 import { Webhook } from '../types';
+import { confirmDelete, showError } from '../utils/dialogs';
 
 const EVENT_TYPE_OPTIONS: Array<{ value: string; label: string }> = [
   { value: '', label: 'All Event Types' },
@@ -85,18 +86,16 @@ const WebhookListPage: React.FC = () => {
     return filtered;
   }, [webhooks, searchTerm, selectedEventType, selectedStatus]);
 
-  const handleDelete = async (id: number, name: string) => {
-    if (!window.confirm(`Are you sure you want to delete webhook "${name}"?`)) {
-      return;
-    }
-
-    try {
-      await webhooksAPI.deleteWebhook(id);
-      await loadWebhooks();
-    } catch (err: any) {
-      console.error('Error deleting webhook:', err);
-      alert(err.response?.data?.detail || 'Failed to delete webhook');
-    }
+  const handleDelete = (id: number, name: string) => {
+    confirmDelete(`Are you sure you want to delete webhook "${name}"?`, async () => {
+      try {
+        await webhooksAPI.deleteWebhook(id);
+        await loadWebhooks();
+      } catch (err: any) {
+        console.error('Error deleting webhook:', err);
+        showError(err.response?.data?.detail || 'Failed to delete webhook');
+      }
+    });
   };
 
   const getSuccessRateColor = (rate: number | null) => {


### PR DESCRIPTION
## Summary
Phase 2d of the popup→modals migration (parent: oms-76s Phase 1 / PR #185). Converts 14 remaining `alert/confirm/prompt` sites across:

- `frontend/src/pages/PurchaseOrderPage.tsx` (5)
- `frontend/src/pages/DonationItemScanPage.tsx` (8)
- `frontend/src/pages/ScanPage.tsx` (3)
- `frontend/src/pages/WebhookListPage.tsx` (2)
- `frontend/src/pages/WebhookDetailPage.tsx` (2)
- Bonus: `ErrorFallback.tsx` polish

Uses `showError/showSuccess/confirmDelete/confirmAction/promptInput` from `src/utils/dialogs.tsx`. Adds a `WebhookListPage.test.tsx` covering the confirm-delete flow.

Source: bead `oms-1dv` · MR `oms-wisp-c7w` · polecat `quartz`

🤖 Merged via Refinery (Claude Code)