### PR TITLE
chore(gitignore): ignore .beads/ runtime contents (oms-eal)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,7 +81,9 @@ Thumbs.db
 # Gas Town / Polecat runtime files
 .runtime/
 .claude/
-.beads/redirect
+.beads/*
+!.beads/redirect
+!.beads/routes.jsonl
 
 # Per-developer overrides (CLAUDE.md itself is committed — project conventions)
 CLAUDE.local.md


### PR DESCRIPTION
## Summary
Stops `verify-done` from intermittently failing on the mayor's rig clone (`~/gt/oms/mayor/rig`) because of accumulated untracked `.beads/` runtime files (`issues.jsonl`, `dolt-server.lock`, `.local_version`, …).

`.gitignore`:
- Add `.beads/`.
- Keep tracked routing config explicitly (e.g. `!.beads/redirect`) so cross-rig dependency tracking still works.

Source: bead `oms-eal` · MR `oms-wisp-9q9` · polecat `topaz`

🤖 Merged via Refinery (Claude Code)