### PR TITLE
fix(checklists): camera permission flow for QR scanner (oms-o7n)

### DIFF
--- a/backend/config/middleware.py
+++ b/backend/config/middleware.py
@@ -1,0 +1,22 @@
+"""Custom middleware for the OMS backend."""
+
+
+class PermissionsPolicyMiddleware:
+    """Set a Permissions-Policy header allowing camera/microphone access.
+
+    Modern browsers (Chrome 94+, Safari 16+) require an explicit
+    Permissions-Policy header to enable getUserMedia in many embedded or
+    cross-origin contexts. The QR-code checklist scanner needs camera access
+    on every page that loads it, so the simplest correct policy is to allow
+    camera site-wide and disallow microphone (we never use it).
+    """
+
+    HEADER_VALUE = "camera=*, microphone=()"
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        response.setdefault("Permissions-Policy", self.HEADER_VALUE)
+        return response

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -87,6 +87,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "config.middleware.PermissionsPolicyMiddleware",
 ]
 
 ROOT_URLCONF = "config.urls"

--- a/backend/config/tests/test_middleware.py
+++ b/backend/config/tests/test_middleware.py
@@ -1,0 +1,41 @@
+"""Tests for custom config middleware."""
+
+from django.http import HttpResponse
+from django.test import RequestFactory
+
+import pytest
+
+from config.middleware import PermissionsPolicyMiddleware
+
+
+@pytest.mark.unit
+class TestPermissionsPolicyMiddleware:
+    """Verify Permissions-Policy header is set so getUserMedia works."""
+
+    def test_sets_permissions_policy_header(self):
+        request = RequestFactory().get("/")
+        middleware = PermissionsPolicyMiddleware(lambda req: HttpResponse("ok"))
+
+        response = middleware(request)
+
+        assert response["Permissions-Policy"] == "camera=*, microphone=()"
+
+    def test_does_not_overwrite_existing_header(self):
+        """If a downstream view already set the header, respect it."""
+        request = RequestFactory().get("/")
+
+        def view(req):
+            resp = HttpResponse("ok")
+            resp["Permissions-Policy"] = "camera=()"
+            return resp
+
+        middleware = PermissionsPolicyMiddleware(view)
+        response = middleware(request)
+
+        assert response["Permissions-Policy"] == "camera=()"
+
+    def test_header_present_through_django_test_client(self, client):
+        """Sanity check that the middleware is wired into MIDDLEWARE."""
+        response = client.get("/admin/login/")
+        assert "Permissions-Policy" in response
+        assert "camera=*" in response["Permissions-Policy"]

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -28,6 +28,7 @@ testpaths =
     customization
     donations/tests
     dashboard/tests
+    config/tests
 markers =
     unit: Unit tests
     integration: Integration tests

--- a/frontend/src/__tests__/components/QRScanner.test.tsx
+++ b/frontend/src/__tests__/components/QRScanner.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Tests for QRScanner permission/error paths.
+ *
+ * The component now does an explicit getUserMedia preflight before handing
+ * off to html5-qrcode, so we exercise the permission DOMException paths and
+ * verify they map to clear, structured error messages with a retry button.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import QRScanner, { QRScannerError } from '../../components/QRScanner';
+
+// html5-qrcode loads the browser's WebAssembly decoder on import, which jsdom
+// can't satisfy. We don't reach into it in these tests.
+jest.mock('html5-qrcode', () => ({
+  Html5Qrcode: jest.fn().mockImplementation(() => ({
+    start: jest.fn().mockResolvedValue(undefined),
+    stop: jest.fn().mockResolvedValue(undefined),
+    clear: jest.fn().mockResolvedValue(undefined),
+    getRunningTrackCapabilities: jest.fn().mockReturnValue({}),
+    applyVideoConstraints: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+const setMediaDevices = (overrides: Partial<MediaDevices>) => {
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: {
+      getUserMedia: jest.fn(),
+      enumerateDevices: jest.fn().mockResolvedValue([]),
+      ...overrides,
+    },
+  });
+};
+
+const setSecureContext = (value: boolean) => {
+  Object.defineProperty(window, 'isSecureContext', {
+    configurable: true,
+    value,
+  });
+};
+
+const makeDomException = (name: string): DOMException => {
+  const err = new Error(`${name} simulated`) as Error & { name: string };
+  err.name = name;
+  return err as unknown as DOMException;
+};
+
+describe('QRScanner — permission handling', () => {
+  beforeEach(() => {
+    setSecureContext(true);
+  });
+
+  it('shows a clear permission-denied message and notifies the parent on NotAllowedError', async () => {
+    const onScanError = jest.fn();
+    setMediaDevices({
+      getUserMedia: jest.fn().mockRejectedValue(makeDomException('NotAllowedError')),
+    });
+
+    render(<QRScanner onScanSuccess={jest.fn()} onScanError={onScanError} />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveAttribute('data-error-kind', 'permission-denied');
+    expect(alert).toHaveTextContent(/camera access denied/i);
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+
+    await waitFor(() => expect(onScanError).toHaveBeenCalled());
+    const lastCallArg = onScanError.mock.calls[onScanError.mock.calls.length - 1][0] as QRScannerError;
+    expect(lastCallArg.kind).toBe('permission-denied');
+  });
+
+  it('classifies NotFoundError as no-camera', async () => {
+    setMediaDevices({
+      getUserMedia: jest.fn().mockRejectedValue(makeDomException('NotFoundError')),
+    });
+
+    render(<QRScanner onScanSuccess={jest.fn()} />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveAttribute('data-error-kind', 'no-camera');
+    expect(alert).toHaveTextContent(/no camera detected/i);
+  });
+
+  it('reports insecure-context when window.isSecureContext is false', async () => {
+    setSecureContext(false);
+    setMediaDevices({});
+
+    render(<QRScanner onScanSuccess={jest.fn()} />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveAttribute('data-error-kind', 'insecure-context');
+    expect(alert).toHaveTextContent(/https/i);
+  });
+
+  it('clicking "Try again" re-requests permission', async () => {
+    const getUserMedia = jest
+      .fn()
+      .mockRejectedValueOnce(makeDomException('NotAllowedError'))
+      .mockResolvedValueOnce({
+        getTracks: () => [{ stop: jest.fn() }],
+      } as unknown as MediaStream);
+
+    setMediaDevices({ getUserMedia });
+
+    render(<QRScanner onScanSuccess={jest.fn()} />);
+
+    await screen.findByRole('alert');
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not show a generic "Failed to start camera" on permission denial', async () => {
+    setMediaDevices({
+      getUserMedia: jest.fn().mockRejectedValue(makeDomException('NotAllowedError')),
+    });
+
+    render(<QRScanner onScanSuccess={jest.fn()} />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).not.toHaveTextContent(/failed to start camera/i);
+  });
+});

--- a/frontend/src/components/QRScanner.tsx
+++ b/frontend/src/components/QRScanner.tsx
@@ -3,17 +3,58 @@
  * Mobile-optimized QR code scanner using html5-qrcode
  */
 import { Html5Qrcode } from 'html5-qrcode';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import '../styles/QRScanner.css';
+
+export type QRScannerErrorKind =
+  | 'permission-denied'
+  | 'no-camera'
+  | 'insecure-context'
+  | 'unsupported'
+  | 'unknown';
+
+export interface QRScannerError {
+  kind: QRScannerErrorKind;
+  message: string;
+}
 
 interface QRScannerProps {
   onScanSuccess: (decodedText: string) => void;
-  onScanError?: (error: string) => void;
+  onScanError?: (error: QRScannerError) => void;
   onClose?: () => void;
   fps?: number;
   qrbox?: { width: number; height: number };
   aspectRatio?: number;
 }
+
+const PERMISSION_DENIED_MESSAGE =
+  'Camera access denied. Enable camera permission for this site in your browser settings, then tap "Try again".';
+const NO_CAMERA_MESSAGE =
+  'No camera detected on this device. Connect a camera and reload, or enter the code manually.';
+const INSECURE_CONTEXT_MESSAGE =
+  'Camera access requires HTTPS. Open this page over https:// (or http://localhost) and try again.';
+const UNSUPPORTED_MESSAGE =
+  'This browser does not support camera access. Try Chrome, Safari, or Firefox.';
+
+const classifyMediaError = (err: unknown): QRScannerError => {
+  const name = (err as { name?: string } | null)?.name;
+  const fallback = (err as { message?: string } | null)?.message;
+  switch (name) {
+    case 'NotAllowedError':
+    case 'SecurityError':
+    case 'PermissionDeniedError':
+      return { kind: 'permission-denied', message: PERMISSION_DENIED_MESSAGE };
+    case 'NotFoundError':
+    case 'OverconstrainedError':
+    case 'DevicesNotFoundError':
+      return { kind: 'no-camera', message: NO_CAMERA_MESSAGE };
+    case 'NotSupportedError':
+    case 'TypeError':
+      return { kind: 'unsupported', message: UNSUPPORTED_MESSAGE };
+    default:
+      return { kind: 'unknown', message: fallback || 'Failed to start camera.' };
+  }
+};
 
 const QRScanner: React.FC<QRScannerProps> = ({
   onScanSuccess,
@@ -26,34 +67,99 @@ const QRScanner: React.FC<QRScannerProps> = ({
   const scannerRef = useRef<HTMLDivElement>(null);
   const html5QrCodeRef = useRef<Html5Qrcode | null>(null);
   const [isScanning, setIsScanning] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<QRScannerError | null>(null);
   const [torchEnabled, setTorchEnabled] = useState(false);
   const [hasMultipleCameras, setHasMultipleCameras] = useState(false);
   const [currentCameraId, setCurrentCameraId] = useState<string | null>(null);
   const [availableCameras, setAvailableCameras] = useState<MediaDeviceInfo[]>([]);
+  const [permissionGranted, setPermissionGranted] = useState(false);
+  const [retryToken, setRetryToken] = useState(0);
   const scannerIdRef = useRef(`qr-scanner-${Date.now()}-${Math.random()}`);
 
-  // Detect available cameras
+  const reportError = useCallback(
+    (qrError: QRScannerError) => {
+      setError(qrError);
+      setIsScanning(false);
+      if (onScanError) {
+        onScanError(qrError);
+      }
+    },
+    [onScanError]
+  );
+
+  // Explicit getUserMedia preflight to force the browser permission prompt.
+  // Without this, html5-qrcode swallows the DOMException and surfaces a
+  // generic "Failed to start camera" instead of letting the browser ask the
+  // user. We request the stream, then immediately stop tracks so html5-qrcode
+  // can take its own stream when it starts.
   useEffect(() => {
+    let cancelled = false;
+
+    const requestPermission = async () => {
+      if (
+        typeof window === 'undefined' ||
+        !window.isSecureContext ||
+        !navigator.mediaDevices?.getUserMedia
+      ) {
+        if (typeof window !== 'undefined' && window.isSecureContext === false) {
+          reportError({ kind: 'insecure-context', message: INSECURE_CONTEXT_MESSAGE });
+        } else {
+          reportError({ kind: 'unsupported', message: UNSUPPORTED_MESSAGE });
+        }
+        return;
+      }
+
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: 'environment' },
+        });
+        stream.getTracks().forEach((track) => track.stop());
+        if (cancelled) return;
+        setPermissionGranted(true);
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        reportError(classifyMediaError(err));
+      }
+    };
+
+    requestPermission();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [retryToken, reportError]);
+
+  // Detect available cameras (only after permission so labels populate)
+  useEffect(() => {
+    if (!permissionGranted) return;
+    let cancelled = false;
     const detectCameras = async () => {
       try {
         const devices = await navigator.mediaDevices.enumerateDevices();
+        if (cancelled) return;
         const videoDevices = devices.filter((device) => device.kind === 'videoinput');
         setAvailableCameras(videoDevices);
         setHasMultipleCameras(videoDevices.length > 1);
-        if (videoDevices.length > 0) {
-          setCurrentCameraId(videoDevices[0].deviceId);
+        if (videoDevices.length === 0) {
+          reportError({ kind: 'no-camera', message: NO_CAMERA_MESSAGE });
+          return;
         }
+        setCurrentCameraId((prev) => prev ?? videoDevices[0].deviceId);
       } catch (err) {
-        console.error('Error detecting cameras:', err);
+        if (cancelled) return;
+        reportError(classifyMediaError(err));
       }
     };
     detectCameras();
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [permissionGranted, reportError]);
 
   // Start scanning
   useEffect(() => {
-    if (!scannerRef.current || !currentCameraId) return;
+    if (!scannerRef.current || !currentCameraId || !permissionGranted) return;
 
     const startScanning = async () => {
       try {
@@ -89,7 +195,7 @@ const QRScanner: React.FC<QRScannerProps> = ({
             // Error callback - ignore most errors as they're just "no QR code found"
             if (errorMessage && !errorMessage.includes('No QR code found')) {
               if (onScanError) {
-                onScanError(errorMessage);
+                onScanError({ kind: 'unknown', message: errorMessage });
               }
             }
           }
@@ -97,13 +203,8 @@ const QRScanner: React.FC<QRScannerProps> = ({
 
         setIsScanning(true);
         setError(null);
-      } catch (err: any) {
-        const errorMsg = err.message || 'Failed to start camera';
-        setError(errorMsg);
-        setIsScanning(false);
-        if (onScanError) {
-          onScanError(errorMsg);
-        }
+      } catch (err) {
+        reportError(classifyMediaError(err));
       }
     };
 
@@ -113,7 +214,14 @@ const QRScanner: React.FC<QRScannerProps> = ({
       stopScanning();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentCameraId, fps, aspectRatio, onScanSuccess, onScanError]);
+  }, [currentCameraId, permissionGranted, fps, aspectRatio]);
+
+  const handleRetry = () => {
+    setError(null);
+    setPermissionGranted(false);
+    setCurrentCameraId(null);
+    setRetryToken((token) => token + 1);
+  };
 
   const stopScanning = async () => {
     if (html5QrCodeRef.current && isScanning) {
@@ -180,9 +288,16 @@ const QRScanner: React.FC<QRScannerProps> = ({
       </div>
 
       {error && (
-        <div className="qr-scanner-error">
-          <p>{error}</p>
-          <button onClick={() => setError(null)}>Dismiss</button>
+        <div
+          className="qr-scanner-error"
+          role="alert"
+          data-error-kind={error.kind}
+        >
+          <p>{error.message}</p>
+          <div className="qr-scanner-error-actions">
+            <button onClick={handleRetry}>Try again</button>
+            <button onClick={handleClose}>Close</button>
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/ChecklistCompletionPage.tsx
+++ b/frontend/src/pages/ChecklistCompletionPage.tsx
@@ -4,7 +4,7 @@
  */
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import QRScanner from '../components/QRScanner';
+import QRScanner, { QRScannerError } from '../components/QRScanner';
 import { useNotifications } from '../hooks/useNotifications';
 import { checklistsAPI, inventoryAPI } from '../services/api';
 import '../styles/ScanPage.css';
@@ -203,8 +203,15 @@ const ChecklistCompletionPage: React.FC = () => {
     processScannedCode(decodedText);
   };
 
-  const handleScanError = (error: string) => {
-    notifications.showError('Scan Error', error);
+  const handleScanError = (scanError: QRScannerError) => {
+    const titleByKind: Record<QRScannerError['kind'], string> = {
+      'permission-denied': 'Camera access denied',
+      'no-camera': 'No camera detected',
+      'insecure-context': 'HTTPS required',
+      unsupported: 'Browser not supported',
+      unknown: 'Scan error',
+    };
+    notifications.showError(titleByKind[scanError.kind], scanError.message);
   };
 
   const handleCloseScanner = () => {

--- a/frontend/src/pages/CodeEntryPage.tsx
+++ b/frontend/src/pages/CodeEntryPage.tsx
@@ -5,7 +5,7 @@
  */
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import QRScanner from '../components/QRScanner';
+import QRScanner, { QRScannerError } from '../components/QRScanner';
 import { inventoryAPI } from '../services/api';
 import '../styles/ScanPage.css';
 
@@ -91,7 +91,7 @@ const CodeEntryPage: React.FC = () => {
     processScannedCode(decodedText);
   };
 
-  const handleScanError = (error: string) => {
+  const handleScanError = (_error: QRScannerError) => {
     // Error handling is done in the scanner component
   };
 


### PR DESCRIPTION
## Summary
Resubmit of PR #209. Adds the consumer-side type fix that the previous TS build flagged, and includes a second consumer (`CodeEntryPage`) that had the same out-of-date `handleScanError` signature.

Backend (unchanged from PR #209):
- New middleware adds `Permissions-Policy: camera=*`; registered in `settings.py`. Test coverage in `test_middleware.py`.

Frontend:
- `QRScanner.tsx` does an explicit `getUserMedia({ video: true })` pre-flight before `Html5Qrcode.start()`; surfaces granular `QRScannerError` shapes.
- `ChecklistCompletionPage.tsx` + `CodeEntryPage.tsx` — `handleScanError` updated to the new `QRScannerError` signature.
- `QRScanner.test.tsx` covers granted / denied / no-camera / retry.

Source: bead `oms-o7n` resubmit · MR `oms-wisp-ad1` · polecat `opal`

🤖 Merged via Refinery (Claude Code)