### PR TITLE
fix(postmark): make .env.prod the single source of truth (oms-g7s)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -40,3 +40,14 @@ EMAIL_HOST_USER=your-email@gmail.com
 EMAIL_HOST_PASSWORD=your-app-password
 EMAIL_USE_TLS=True
 DEFAULT_FROM_EMAIL=noreply@dallas.openmakersuite.net
+
+# Postmark (outbound + inbound email)
+# To route outbound mail through Postmark, set:
+#   EMAIL_BACKEND=anymail.backends.postmark.EmailBackend
+# POSTMARK_SERVER_TOKEN is required for outbound; POSTMARK_INBOUND_TOKEN is the
+# shared secret Postmark sends as ?token=... or X-Postmark-Webhook-Token to
+# /api/inventory/webhooks/postmark-inbound-work-order/. If POSTMARK_INBOUND_TOKEN
+# is empty, the inbound endpoint returns 503 ("Postmark inbound is not configured.").
+EMAIL_BACKEND=anymail.backends.postmark.EmailBackend
+POSTMARK_SERVER_TOKEN=
+POSTMARK_INBOUND_TOKEN=

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,15 +5,23 @@ git pull
 
 echo "🚀 Deploying Dallas Makerspace Inventory Management System..."
 
-# Check if .env file exists
-if [ ! -f .env ]; then
-    echo "❌ Error: .env file not found!"
-    echo "Please create a .env file from .env.prod.example"
+# Check if .env.prod file exists. .env.prod is the single source of truth for
+# production env vars: it is consumed both by this deploy script (for shell
+# variable substitution in docker-compose.prod.yml) and by docker-compose
+# directly via `env_file: .env.prod` on the backend and celery services. Keeping
+# everything pointed at one file avoids the class of bug where a secret is set
+# in one env file but the runtime reads a different one (oms-g7s).
+if [ ! -f .env.prod ]; then
+    echo "❌ Error: .env.prod file not found!"
+    echo "Please create a .env.prod file from .env.prod.example"
     exit 1
 fi
 
 # Load environment variables
-export $(cat .env | grep -v '^#' | xargs)
+set -a
+# shellcheck disable=SC1091
+. ./.env.prod
+set +a
 
 # Get git hash for build
 export GIT_HASH=$(git rev-parse --short HEAD 2>/dev/null || echo "dev")

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,7 +53,7 @@ services:
     expose:
       - 8000
     env_file:
-      - .env
+      - .env.prod
     environment:
       - DEBUG=0
       - DATABASE_URL=postgresql://${POSTGRES_USER:-makerspace}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-makerspace_inventory}
@@ -93,7 +93,7 @@ services:
     volumes:
       - media_volume:/app/media
     env_file:
-      - .env
+      - .env.prod
     environment:
       - DEBUG=0
       - DATABASE_URL=postgresql://${POSTGRES_USER:-makerspace}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-makerspace_inventory}


### PR DESCRIPTION
## Summary
Postmark inbound webhooks were failing in prod because `POSTMARK_SERVER_TOKEN` / `POSTMARK_INBOUND_TOKEN` were defined in `.env.prod` but the backend container wasn't actually reading them — `deploy.sh` and `docker-compose.prod.yml` had drifted to a partial-`.env` model where some vars came from a different env file.

- `docker-compose.prod.yml` — backend + celery now consistently load `.env.prod` (matches the rest of the prod env).
- `deploy.sh` — verifies `.env.prod` exists, exports the documented Postmark vars on each deploy, surfaces a clear error when missing.
- `.env.prod.example` — adds `POSTMARK_INBOUND_TOKEN` (was previously only in the backend example) and a comment documenting the inbound-webhook flow.

Source: bead `oms-g7s` · MR `oms-wisp-yj7` · polecat `amber`

🤖 Merged via Refinery (Claude Code)