### PR TITLE
fix(reorder-queue): use Mantine DateInput in Mark Ordered modal (oms-fvj)

### DIFF
--- a/frontend/src/__tests__/pages/AdminDashboard.test.tsx
+++ b/frontend/src/__tests__/pages/AdminDashboard.test.tsx
@@ -7,7 +7,7 @@
  */
 import { MantineProvider } from '@mantine/core';
 import { ModalsProvider } from '@mantine/modals';
-import { Notifications } from '@mantine/notifications';
+import { Notifications, notifications } from '@mantine/notifications';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 
@@ -102,6 +102,7 @@ const buildRequest = (overrides: Partial<ReorderRequest>): ReorderRequest => ({
 
 beforeEach(() => {
   jest.clearAllMocks();
+  notifications.clean();
   mockAssetsAPI.getNotCheckedIn.mockResolvedValue({ data: [] } as any);
   mockInventoryAPI.listItems.mockResolvedValue({ data: { results: [] } } as any);
   mockReorderAPI.listRequests.mockResolvedValue({ data: { results: [] } } as any);
@@ -157,6 +158,35 @@ describe('AdminDashboard — mark ordered flow', () => {
         order_number: 'PO-123',
         estimated_delivery: '2026-05-01',
         actual_cost: 42.5,
+      });
+    });
+
+    expect(
+      await screen.findByText('Marked as ordered with tracking information'),
+    ).toBeInTheDocument();
+  });
+
+  it('normalizes a non-ISO date entry to YYYY-MM-DD before submit', async () => {
+    mockReorderAPI.getPendingRequests.mockResolvedValue({
+      data: [buildRequest({ id: 8, status: 'approved' })],
+    } as any);
+    mockReorderAPI.markOrdered.mockResolvedValue({ data: {} } as any);
+
+    renderDashboard();
+
+    const markOrderedBtn = await screen.findByRole('button', { name: /mark ordered/i });
+    fireEvent.click(markOrderedBtn);
+
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.change(within(dialog).getByLabelText(/estimated delivery date/i), {
+      target: { value: '05/01/2026' },
+    });
+
+    fireEvent.click(within(dialog).getByRole('button', { name: /mark ordered/i }));
+
+    await waitFor(() => {
+      expect(mockReorderAPI.markOrdered).toHaveBeenCalledWith(8, {
+        estimated_delivery: '2026-05-01',
       });
     });
 

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -3,8 +3,10 @@
  * Manage reorder queue, view pending requests, and access supplier cart links
  */
 import { Button, Group, Stack, TextInput } from '@mantine/core';
+import { DateInput } from '@mantine/dates';
 import { useForm } from '@mantine/form';
 import { modals } from '@mantine/modals';
+import dayjs from 'dayjs';
 import React, { useCallback, useEffect, useState } from 'react';
 import { assetsAPI, inventoryAPI, reorderAPI } from '../services/api';
 import '../styles/AdminDashboard.css';
@@ -13,7 +15,7 @@ import { promptInput, showError, showSuccess } from '../utils/dialogs';
 
 interface MarkOrderedValues {
   orderNumber: string;
-  estimatedDelivery: string;
+  estimatedDelivery: Date | null;
   actualCost: string;
 }
 
@@ -24,7 +26,7 @@ interface MarkOrderedFormProps {
 
 const MarkOrderedForm: React.FC<MarkOrderedFormProps> = ({ modalId, onSubmit }) => {
   const form = useForm<MarkOrderedValues>({
-    initialValues: { orderNumber: '', estimatedDelivery: '', actualCost: '' },
+    initialValues: { orderNumber: '', estimatedDelivery: null, actualCost: '' },
   });
 
   const handleSubmit = form.onSubmit((values) => {
@@ -40,9 +42,11 @@ const MarkOrderedForm: React.FC<MarkOrderedFormProps> = ({ modalId, onSubmit }) 
           placeholder="Optional"
           {...form.getInputProps('orderNumber')}
         />
-        <TextInput
+        <DateInput
           label="Estimated delivery date"
-          placeholder="YYYY-MM-DD (optional)"
+          placeholder="Select date (optional)"
+          valueFormat="YYYY-MM-DD"
+          clearable
           {...form.getInputProps('estimatedDelivery')}
         />
         <TextInput
@@ -223,7 +227,9 @@ const AdminDashboard: React.FC = () => {
             try {
               const data: any = {};
               if (values.orderNumber) data.order_number = values.orderNumber;
-              if (values.estimatedDelivery) data.estimated_delivery = values.estimatedDelivery;
+              if (values.estimatedDelivery) {
+                data.estimated_delivery = dayjs(values.estimatedDelivery).format('YYYY-MM-DD');
+              }
               if (values.actualCost) data.actual_cost = parseFloat(values.actualCost);
 
               await reorderAPI.markOrdered(id, data);


### PR DESCRIPTION
## Summary
"Mark Ordered" modal in the admin dashboard failed to save: the modal was using a plain text `<input type="date">`, but the backend expected ISO date format and the new Mantine modal stack from PR #192 was passing the raw browser value through unsanitized — empty/locale-formatted dates posted as `""` or non-ISO strings, hitting the serializer 400.

- `AdminDashboard.tsx` — switch the date field to `@mantine/dates DateInput` (already a project dep), normalized ISO output.
- `AdminDashboard.test.tsx` — extends the mark-ordered flow tests to assert ISO payload submitted.

Source: bead `oms-fvj` · MR `oms-wisp-gw3` · polecat `amber`

🤖 Merged via Refinery (Claude Code)