### PR TITLE
feat(nginx): CSP header + /mqttadmin reverse proxy to EMQX (oms-8fq)

### DIFF
--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -2,6 +2,10 @@ upstream backend {
     server backend:8000;
 }
 
+upstream emqx_dashboard {
+    server emqx:18083;
+}
+
 server {
     listen 80;
     server_name ${LETSENCRYPT_DOMAINS};
@@ -35,8 +39,26 @@ server {
     root /app/frontend;
     index index.html;
 
+    add_header Content-Security-Policy "default-src 'self'; frame-src https://www.wunderground.com https://embed.waze.com" always;
+
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
+    }
+
+    location = /mqttadmin {
+        return 301 $scheme://$host/mqttadmin/;
+    }
+
+    location /mqttadmin/ {
+        proxy_pass http://emqx_dashboard/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_redirect off;
     }
 
     location /admin/ {
@@ -95,12 +117,14 @@ server {
         alias /app/staticfiles/;
         expires 30d;
         add_header Cache-Control "public, immutable";
+        add_header Content-Security-Policy "default-src 'self'; frame-src https://www.wunderground.com https://embed.waze.com" always;
     }
 
     location /media/ {
         alias /app/media/;
         expires 7d;
         add_header Cache-Control "public";
+        add_header Content-Security-Policy "default-src 'self'; frame-src https://www.wunderground.com https://embed.waze.com" always;
     }
 
     location / {


### PR DESCRIPTION
## Summary
- Adds the requested `Content-Security-Policy: default-src 'self'; frame-src https://www.wunderground.com https://embed.waze.com` at the HTTPS `server` scope, with the `/django-static/` and `/media/` location blocks re-declaring CSP because nginx `add_header` inheritance is replaced (not merged) when a location declares its own.
- Adds an upstream `emqx_dashboard -> emqx:18083` and a `/mqttadmin/` location reverse-proxying to the EMQX dashboard with websocket upgrade headers; bare `/mqttadmin` redirects to `/mqttadmin/` so it doesn't fall through to the SPA catch-all.

Smoke test post-deploy:
- `curl -I https://<host>/` — `Content-Security-Policy` header present.
- `curl https://<host>/mqttadmin/` — EMQX dashboard HTML.

⚠️ Polecat noted Mantine inline styles may violate strict `default-src 'self'`; if the SPA console shows CSP violations after deploy, expand CSP (`style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' wss: https:`) in a follow-up PR.

Source: bead `oms-8fq` · MR `oms-wisp-3zz` · polecat `amber`

🤖 Merged via Refinery (Claude Code)