### PR TITLE
feat(nginx): comprehensive CSP for Sentry / YouTube / Waze / Wunderground (oms-fl6)

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -8,7 +8,6 @@
       name="description"
       content="Makerspace Inventory Management System"
     />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.sentry-cdn.com https://browser.sentry-cdn.com; worker-src 'self' blob:; connect-src 'self' http://localhost:8000 http://127.0.0.1:8000 https://*.ingest.sentry.io; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:;">
     <title>Makerspace Inventory</title>
     <script src="https://js.sentry-cdn.com/48f74e122b301e64b6a7f8bebd8b59c4.min.js" crossorigin="anonymous"></script>
   </head>

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -39,7 +39,7 @@ server {
     root /app/frontend;
     index index.html;
 
-    add_header Content-Security-Policy "default-src 'self'; frame-src https://www.wunderground.com https://embed.waze.com; connect-src 'self' https://*.ingest.us.sentry.io;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.sentry-cdn.com https://js.sentry-cdn.com https://browser.sentry-cdn.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://i.ytimg.com https:; font-src 'self' data:; connect-src 'self' wss: https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://sentry.io; frame-src 'self' https://www.wunderground.com https://embed.waze.com https://www.youtube.com https://www.youtube-nocookie.com; worker-src 'self' blob:; media-src 'self' https:;" always;
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
@@ -117,14 +117,14 @@ server {
         alias /app/staticfiles/;
         expires 30d;
         add_header Cache-Control "public, immutable";
-        add_header Content-Security-Policy "default-src 'self'; frame-src https://www.wunderground.com https://embed.waze.com" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.sentry-cdn.com https://js.sentry-cdn.com https://browser.sentry-cdn.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://i.ytimg.com https:; font-src 'self' data:; connect-src 'self' wss: https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://sentry.io; frame-src 'self' https://www.wunderground.com https://embed.waze.com https://www.youtube.com https://www.youtube-nocookie.com; worker-src 'self' blob:; media-src 'self' https:;" always;
     }
 
     location /media/ {
         alias /app/media/;
         expires 7d;
         add_header Cache-Control "public";
-        add_header Content-Security-Policy "default-src 'self'; frame-src https://www.wunderground.com https://embed.waze.com" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.sentry-cdn.com https://js.sentry-cdn.com https://browser.sentry-cdn.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://i.ytimg.com https:; font-src 'self' data:; connect-src 'self' wss: https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://sentry.io; frame-src 'self' https://www.wunderground.com https://embed.waze.com https://www.youtube.com https://www.youtube-nocookie.com; worker-src 'self' blob:; media-src 'self' https:;" always;
     }
 
     location / {


### PR DESCRIPTION
## Summary
Expands the CSP from PR #255 to allow Sentry's full URL set (ingest + browser SDK CDN), YouTube embeds (`youtube.com`, `youtube-nocookie.com`, `ytimg.com`), Waze, Wunderground, and the inline-style/blob/data needs Mantine and React app icons require.

- `nginx/templates/default.conf.template` — single CSP directive at HTTPS server scope (and re-declared in static/media location blocks since nginx `add_header` inheritance is replaced).
- `frontend/public/index.html` — removes the redundant `<meta http-equiv="Content-Security-Policy">` so server-side header is the single source of truth.

Source: bead `oms-fl6` · MR `oms-wisp-284` · polecat `amber`

🤖 Merged via Refinery (Claude Code)