### PR TITLE
fix(sentry): remove duplicate Sentry loader script (oms-48c)

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,7 +9,6 @@
       content="Makerspace Inventory Management System"
     />
     <title>Makerspace Inventory</title>
-    <script src="https://js.sentry-cdn.com/48f74e122b301e64b6a7f8bebd8b59c4.min.js" crossorigin="anonymous"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Summary
Frontend Sentry events weren't reaching the project: `frontend/public/index.html` was loading the Sentry **loader script** in addition to the SDK already initialized in `src/index.tsx`. Two competing init paths meant the loader-managed instance silently swallowed events the bundled instance produced.

Removes the loader script — the bundled SDK init in `src/index.tsx` (with the release tagging from PR #175 and the CSP allowances landed in PR #257) is now the only path.

Validation steps (post-deploy):
1. Trigger a manual `Sentry.captureMessage('frontend smoke test')` in the dev console.
2. Lands in Sentry within ~60 s, tagged with `environment=production` and the deployed git release.
3. Replay session shows up under Replays.
4. Zero CSP violations in DevTools.

Source: bead `oms-48c` · MR `oms-wisp-ido` · polecat `amber`

🤖 Merged via Refinery (Claude Code)