### PR TITLE
feat(deploy): Helm chart for OpenMakerSuite (oms-d2i)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,9 @@ repos:
       - id: end-of-file-fixer
         exclude: ^(backend/.*migrations/|frontend/.*)
       - id: check-yaml
+        # Helm chart templates contain Go templating syntax ({{ ... }}) that
+        # is not valid YAML until rendered.
+        exclude: ^deploy/helm/.*/templates/
       - id: check-added-large-files
         args: ["--maxkb=1000"]
       - id: check-json

--- a/deploy/helm/openmakersuite/.helmignore
+++ b/deploy/helm/openmakersuite/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/openmakersuite/Chart.yaml
+++ b/deploy/helm/openmakersuite/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: openmakersuite
+description: |
+  Helm chart for OpenMakerSuite — a makerspace inventory and operations
+  platform. Renders the Django backend, the React frontend (served by nginx),
+  the Celery worker, an optional Flower dashboard, optional in-cluster
+  PostgreSQL and Redis (or pointers to external instances), an Ingress with
+  TLS hooks, persistence for static/media, secrets, a one-shot migrations
+  Job, and standard Kubernetes health probes. Covers AC-8.
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - django
+  - react
+  - celery
+  - makerspace
+home: https://github.com/uid0/openmakersuite
+sources:
+  - https://github.com/uid0/openmakersuite
+maintainers:
+  - name: OpenMakerSuite
+    url: https://github.com/uid0/openmakersuite

--- a/deploy/helm/openmakersuite/README.md
+++ b/deploy/helm/openmakersuite/README.md
@@ -1,0 +1,102 @@
+# OpenMakerSuite Helm Chart
+
+Helm chart for deploying [OpenMakerSuite](https://github.com/uid0/openmakersuite)
+to Kubernetes. Mirrors the production topology from `docker-compose.prod.yml`:
+Django backend, React frontend served by nginx, Celery worker, optional Flower
+dashboard, optional in-cluster PostgreSQL and Redis (or external instances),
+Ingress with TLS hooks, persistence for static/media, secrets, and a one-shot
+migrations Job.
+
+## Quick start
+
+```bash
+helm install oms ./deploy/helm/openmakersuite \
+  --namespace oms --create-namespace \
+  --set domain=oms.example.com \
+  --set ingress.enabled=true \
+  --set backend.image.tag=1.2.3 \
+  --set frontend.image.tag=1.2.3
+```
+
+The chart bundles PostgreSQL + Redis by default for evaluation. Disable both
+and point at managed services for production:
+
+```bash
+helm install oms ./deploy/helm/openmakersuite \
+  --set postgresql.enabled=false \
+  --set externalDatabase.url=postgresql://oms:hunter2@db.prod.svc:5432/makerspace_inventory \
+  --set redis.enabled=false \
+  --set externalRedis.url=redis://redis.prod.svc:6379/0 \
+  --set secrets.existingSecret=oms-app-secrets
+```
+
+## What it renders
+
+| Resource                | When                                                                 |
+| ----------------------- | -------------------------------------------------------------------- |
+| `Deployment` backend    | always                                                               |
+| `Deployment` frontend   | always                                                               |
+| `Deployment` celery     | `celery.enabled=true` (default)                                      |
+| `Deployment` flower     | `flower.enabled=true`                                                |
+| `StatefulSet` postgres  | `postgresql.enabled=true` (default)                                  |
+| `Deployment` redis      | `redis.enabled=true` (default)                                       |
+| `Service` for each app  | always                                                               |
+| `Ingress`               | `ingress.enabled=true`                                               |
+| `PersistentVolumeClaim` | `persistence.{static,media}.enabled=true` and per-component flags    |
+| `Secret` (app)          | unless `secrets.existingSecret` is set                               |
+| `Secret` (database)     | always — wraps either bundled or external connection string          |
+| `Secret` (redis)        | always — wraps either bundled or external connection string          |
+| `Secret` (postgres)     | bundled postgres only, unless `auth.existingSecret` is set           |
+| `ConfigMap`             | always — non-secret env (DEBUG, ALLOWED_HOSTS, SENTRY_*, etc.)       |
+| `ServiceAccount`        | `serviceAccount.create=true` (default)                               |
+| `Job` migrations        | `migrations.enabled=true` (default), pre-install/pre-upgrade hook    |
+
+## Health probes
+
+- **Backend**: HTTP `/api/dashboard/health/` for liveness and readiness
+- **Frontend**: HTTP `/` against the nginx container
+- **Celery**: `celery inspect ping` exec probe
+- **Flower**: TCP socket on the flower port
+- **Postgres**: `pg_isready` against the configured user/database
+- **Redis**: `redis-cli ping`
+
+All probes are tunable under `<component>.probes.{liveness,readiness,startup}`
+and can be disabled by setting `enabled: false` per probe.
+
+## Secrets handling
+
+Sensitive values (Django `SECRET_KEY`, Sentry DSN, EMQX credentials, mail
+credentials, etc.) live in a chart-managed `Secret` named
+`<release>-openmakersuite-secrets`. `SECRET_KEY` is generated automatically
+on first install and persisted across upgrades via `helm.sh/resource-policy: keep`.
+
+To bring your own Secret instead, populate it with the same keys
+(`SECRET_KEY`, `SENTRY_DSN`, …) and set:
+
+```yaml
+secrets:
+  existingSecret: my-secret-name
+```
+
+The bundled Postgres password works the same way: set
+`postgresql.auth.existingSecret` to skip the chart-managed Secret.
+
+## Migrations
+
+`python manage.py migrate --no-input` runs as a Helm pre-install/pre-upgrade
+hook by default. Set `migrations.useHooks=false` to ship it as a regular Job
+instead, or `migrations.enabled=false` to skip it entirely.
+
+## Validating local changes
+
+```bash
+helm lint deploy/helm/openmakersuite
+helm template oms deploy/helm/openmakersuite > /tmp/render.yaml
+helm template oms deploy/helm/openmakersuite \
+  --set postgresql.enabled=false --set redis.enabled=false \
+  --set externalDatabase.url=postgresql://u:p@db:5432/oms \
+  --set externalRedis.url=redis://r:6379/0 \
+  > /tmp/render-external.yaml
+```
+
+See `values.yaml` for the full set of overridable values.

--- a/deploy/helm/openmakersuite/templates/NOTES.txt
+++ b/deploy/helm/openmakersuite/templates/NOTES.txt
@@ -1,0 +1,41 @@
+OpenMakerSuite has been deployed.
+
+Release name: {{ .Release.Name }}
+Namespace:    {{ .Release.Namespace }}
+
+Backend service:  {{ include "openmakersuite.backendServiceName" . }}:{{ .Values.backend.service.port }}
+Frontend service: {{ include "openmakersuite.frontendServiceName" . }}:{{ .Values.frontend.service.port }}
+{{- if .Values.flower.enabled }}
+Flower service:   {{ include "openmakersuite.flowerServiceName" . }}:{{ .Values.flower.service.port }}
+{{- end }}
+
+{{- if .Values.ingress.enabled }}
+Ingress hosts:
+{{- range .Values.ingress.hosts }}
+  - {{- if $.Values.ingress.tls }} https://{{ else }} http://{{ end }}{{ .host }}
+{{- end }}
+{{- else }}
+Ingress is disabled. To reach the frontend run:
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "openmakersuite.frontendServiceName" . }} 8080:{{ .Values.frontend.service.port }}
+{{- end }}
+
+{{- if .Values.postgresql.enabled }}
+
+A bundled PostgreSQL StatefulSet was installed at
+  {{ include "openmakersuite.postgresHost" . }}:{{ .Values.postgresql.service.port }}
+For production traffic point externalDatabase.url at a managed database
+and set postgresql.enabled=false instead.
+{{- end }}
+
+{{- if .Values.redis.enabled }}
+
+A bundled Redis Deployment was installed at
+  {{ include "openmakersuite.redisHost" . }}:{{ .Values.redis.service.port }}
+{{- end }}
+
+{{- if .Values.migrations.enabled }}
+
+Database migrations ran as a {{ if .Values.migrations.useHooks }}pre-install/pre-upgrade hook Job{{ else }}standalone Job{{ end }}.
+Inspect the result with:
+  kubectl --namespace {{ .Release.Namespace }} get jobs -l app.kubernetes.io/component=migrations -l app.kubernetes.io/instance={{ .Release.Name }}
+{{- end }}

--- a/deploy/helm/openmakersuite/templates/_helpers.tpl
+++ b/deploy/helm/openmakersuite/templates/_helpers.tpl
@@ -1,0 +1,265 @@
+{{/*
+Common helpers for the openmakersuite chart. Anything that's reused by more
+than one resource lives here.
+*/}}
+
+{{- define "openmakersuite.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "openmakersuite.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "openmakersuite.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "openmakersuite.labels" -}}
+helm.sh/chart: {{ include "openmakersuite.chart" . }}
+{{ include "openmakersuite.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: openmakersuite
+{{- end -}}
+
+{{- define "openmakersuite.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openmakersuite.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "openmakersuite.componentLabels" -}}
+{{ include "openmakersuite.labels" . }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{- define "openmakersuite.componentSelectorLabels" -}}
+{{ include "openmakersuite.selectorLabels" . }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{- define "openmakersuite.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "openmakersuite.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the image reference for a component. Falls back through the
+component's image stanza, the chart-wide image registry, and the chart
+appVersion when no tag is set. Argument: dict "component" "backend".
+*/}}
+{{- define "openmakersuite.image" -}}
+{{- $top := .top -}}
+{{- $comp := .component -}}
+{{- $img := index $top.Values $comp "image" -}}
+{{- $registry := default "" $top.Values.image.registry -}}
+{{- $repo := default (printf "openmakersuite/%s" $comp) $img.repository -}}
+{{- if eq $repo "" -}}
+{{- $repo = printf "openmakersuite/%s" $comp -}}
+{{- end -}}
+{{- $tag := default $top.Chart.AppVersion $img.tag -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Workers that share the backend image (celery, flower, migrations) call this
+helper so a single backend image override propagates everywhere. The component
+can still override `repository`/`tag` to ship a different image.
+*/}}
+{{- define "openmakersuite.workerImage" -}}
+{{- $top := .top -}}
+{{- $comp := .component -}}
+{{- $img := index $top.Values $comp "image" -}}
+{{- $registry := default "" $top.Values.image.registry -}}
+{{- $repo := default $top.Values.backend.image.repository $img.repository -}}
+{{- if eq $repo "" -}}
+{{- $repo = $top.Values.backend.image.repository -}}
+{{- end -}}
+{{- $tag := default (default $top.Chart.AppVersion $top.Values.backend.image.tag) $img.tag -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "openmakersuite.imagePullSecrets" -}}
+{{- with .Values.image.pullSecrets -}}
+imagePullSecrets:
+{{ toYaml . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Names for chart-managed resources. Centralised so renaming is a one-line change.
+*/}}
+{{- define "openmakersuite.configMapName" -}}
+{{ include "openmakersuite.fullname" . }}-env
+{{- end -}}
+
+{{- define "openmakersuite.secretName" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{ .Values.secrets.existingSecret }}
+{{- else -}}
+{{ include "openmakersuite.fullname" . }}-secrets
+{{- end -}}
+{{- end -}}
+
+{{- define "openmakersuite.postgresSecretName" -}}
+{{- if .Values.postgresql.auth.existingSecret -}}
+{{ .Values.postgresql.auth.existingSecret }}
+{{- else -}}
+{{ include "openmakersuite.fullname" . }}-postgresql
+{{- end -}}
+{{- end -}}
+
+{{- define "openmakersuite.postgresSecretPasswordKey" -}}
+{{- if .Values.postgresql.auth.existingSecret -}}
+{{ .Values.postgresql.auth.existingSecretPasswordKey }}
+{{- else -}}
+postgres-password
+{{- end -}}
+{{- end -}}
+
+{{- define "openmakersuite.databaseSecretName" -}}
+{{- if .Values.externalDatabase.existingSecret -}}
+{{ .Values.externalDatabase.existingSecret }}
+{{- else -}}
+{{ include "openmakersuite.fullname" . }}-database
+{{- end -}}
+{{- end -}}
+
+{{- define "openmakersuite.databaseSecretUrlKey" -}}
+{{- if .Values.externalDatabase.existingSecret -}}
+{{ .Values.externalDatabase.existingSecretUrlKey }}
+{{- else -}}
+database-url
+{{- end -}}
+{{- end -}}
+
+{{- define "openmakersuite.redisSecretName" -}}
+{{- if .Values.externalRedis.existingSecret -}}
+{{ .Values.externalRedis.existingSecret }}
+{{- else -}}
+{{ include "openmakersuite.fullname" . }}-redis
+{{- end -}}
+{{- end -}}
+
+{{- define "openmakersuite.redisSecretUrlKey" -}}
+{{- if .Values.externalRedis.existingSecret -}}
+{{ .Values.externalRedis.existingSecretUrlKey }}
+{{- else -}}
+redis-url
+{{- end -}}
+{{- end -}}
+
+{{/*
+Service hostnames for the bundled stateful services.
+*/}}
+{{- define "openmakersuite.postgresHost" -}}
+{{ include "openmakersuite.fullname" . }}-postgresql
+{{- end -}}
+
+{{- define "openmakersuite.redisHost" -}}
+{{ include "openmakersuite.fullname" . }}-redis
+{{- end -}}
+
+{{- define "openmakersuite.backendServiceName" -}}
+{{ include "openmakersuite.fullname" . }}-backend
+{{- end -}}
+
+{{- define "openmakersuite.frontendServiceName" -}}
+{{ include "openmakersuite.fullname" . }}-frontend
+{{- end -}}
+
+{{- define "openmakersuite.flowerServiceName" -}}
+{{ include "openmakersuite.fullname" . }}-flower
+{{- end -}}
+
+{{/*
+Ensures we have a SECRET_KEY even when the operator forgot to set one.
+Helm's `lookup` keeps a previously generated value across upgrades.
+*/}}
+{{- define "openmakersuite.secretKey" -}}
+{{- if .Values.secrets.values.SECRET_KEY -}}
+{{ .Values.secrets.values.SECRET_KEY }}
+{{- else -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "openmakersuite.secretName" .) -}}
+{{- if and $existing (index $existing.data "SECRET_KEY") -}}
+{{ index $existing.data "SECRET_KEY" | b64dec }}
+{{- else -}}
+{{ randAlphaNum 50 }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "openmakersuite.postgresPassword" -}}
+{{- if .Values.postgresql.auth.password -}}
+{{ .Values.postgresql.auth.password }}
+{{- else -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "openmakersuite.postgresSecretName" .) -}}
+{{- if and $existing (index $existing.data "postgres-password") -}}
+{{ index $existing.data "postgres-password" | b64dec }}
+{{- else -}}
+{{ randAlphaNum 32 }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Inline env vars that resolve from the chart-managed Secrets containing
+DATABASE_URL, REDIS_URL, and the Django SECRET_KEY. Always rendered, regardless
+of install mode (bundled vs external Postgres/Redis), because the Secret name
+is selected upstream by `openmakersuite.databaseSecretName` / `redisSecretName`.
+*/}}
+{{- define "openmakersuite.appEnvVars" -}}
+- name: DATABASE_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "openmakersuite.databaseSecretName" . }}
+      key: {{ include "openmakersuite.databaseSecretUrlKey" . }}
+- name: REDIS_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "openmakersuite.redisSecretName" . }}
+      key: {{ include "openmakersuite.redisSecretUrlKey" . }}
+- name: CELERY_BROKER_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "openmakersuite.redisSecretName" . }}
+      key: {{ include "openmakersuite.redisSecretUrlKey" . }}
+- name: SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "openmakersuite.secretName" . }}
+      key: SECRET_KEY
+{{- end -}}
+
+{{/*
+envFrom entries that pull the non-secret app config map and the optional
+sensitive Secret (rendered as `optional: true` so a missing/empty Secret
+doesn't break startup).
+*/}}
+{{- define "openmakersuite.appEnvFrom" -}}
+- configMapRef:
+    name: {{ include "openmakersuite.configMapName" . }}
+- secretRef:
+    name: {{ include "openmakersuite.secretName" . }}
+    optional: true
+{{- end -}}

--- a/deploy/helm/openmakersuite/templates/backend-deployment.yaml
+++ b/deploy/helm/openmakersuite/templates/backend-deployment.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openmakersuite.fullname" . }}-backend
+  labels:
+    {{- include "openmakersuite.componentLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "backend") | nindent 4 }}
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "backend") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "backend") | nindent 8 }}
+      annotations:
+        # Roll the backend pods whenever non-secret env or sensitive
+        # values change so the new values land without a manual restart.
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret-app.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "openmakersuite.serviceAccountName" . }}
+      {{- include "openmakersuite.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: backend
+          image: {{ include "openmakersuite.image" (dict "top" $ "component" "backend") | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            {{- toYaml .Values.backend.command | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            {{- include "openmakersuite.appEnvVars" . | nindent 12 }}
+            {{- with .Values.backend.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- include "openmakersuite.appEnvFrom" . | nindent 12 }}
+          {{- if .Values.backend.probes.liveness.enabled }}
+          livenessProbe:
+            {{- omit .Values.backend.probes.liveness "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.backend.probes.readiness.enabled }}
+          readinessProbe:
+            {{- omit .Values.backend.probes.readiness "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.backend.probes.startup.enabled }}
+          startupProbe:
+            {{- omit .Values.backend.probes.startup "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.persistence.static.enabled }}
+            - name: static
+              mountPath: {{ .Values.persistence.static.mountPath }}
+            {{- end }}
+            {{- if .Values.persistence.media.enabled }}
+            - name: media
+              mountPath: {{ .Values.persistence.media.mountPath }}
+            {{- end }}
+      volumes:
+        {{- if .Values.persistence.static.enabled }}
+        - name: static
+          persistentVolumeClaim:
+            claimName: {{ include "openmakersuite.fullname" . }}-static
+        {{- end }}
+        {{- if .Values.persistence.media.enabled }}
+        - name: media
+          persistentVolumeClaim:
+            claimName: {{ include "openmakersuite.fullname" . }}-media
+        {{- end }}
+      {{- with .Values.backend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/openmakersuite/templates/backend-service.yaml
+++ b/deploy/helm/openmakersuite/templates/backend-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openmakersuite.backendServiceName" . }}
+  labels:
+    {{- include "openmakersuite.componentLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "backend") | nindent 4 }}
+spec:
+  type: {{ .Values.backend.service.type }}
+  ports:
+    - port: {{ .Values.backend.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "backend") | nindent 4 }}

--- a/deploy/helm/openmakersuite/templates/celery-deployment.yaml
+++ b/deploy/helm/openmakersuite/templates/celery-deployment.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.celery.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openmakersuite.fullname" . }}-celery
+  labels:
+    {{- include "openmakersuite.componentLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "celery") | nindent 4 }}
+spec:
+  replicas: {{ .Values.celery.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "celery") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "celery") | nindent 8 }}
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret-app.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "openmakersuite.serviceAccountName" . }}
+      {{- include "openmakersuite.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: celery
+          image: {{ include "openmakersuite.workerImage" (dict "top" $ "component" "celery") | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            {{- toYaml .Values.celery.command | nindent 12 }}
+          env:
+            {{- include "openmakersuite.appEnvVars" . | nindent 12 }}
+            {{- with .Values.celery.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- include "openmakersuite.appEnvFrom" . | nindent 12 }}
+          # Celery has no HTTP endpoint — use a "process is alive" probe so
+          # Kubernetes restarts hung workers without inventing a fake server.
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - celery -A config inspect ping -d celery@$HOSTNAME -t 10
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            timeoutSeconds: 15
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.celery.resources | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.persistence.media.enabled }}
+            - name: media
+              mountPath: {{ .Values.persistence.media.mountPath }}
+            {{- end }}
+      volumes:
+        {{- if .Values.persistence.media.enabled }}
+        - name: media
+          persistentVolumeClaim:
+            claimName: {{ include "openmakersuite.fullname" . }}-media
+        {{- end }}
+      {{- with .Values.celery.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/openmakersuite/templates/configmap.yaml
+++ b/deploy/helm/openmakersuite/templates/configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openmakersuite.configMapName" . }}
+  labels:
+    {{- include "openmakersuite.labels" . | nindent 4 }}
+data:
+  DEBUG: {{ .Values.env.debug | quote }}
+  DJANGO_SETTINGS_MODULE: {{ .Values.env.djangoSettingsModule | quote }}
+  ALLOWED_HOSTS: {{ concat (list .Values.domain) .Values.extraAllowedHosts | join "," | quote }}
+  CSRF_TRUSTED_ORIGINS: {{ concat (list (printf "https://%s" .Values.domain)) .Values.extraCsrfTrustedOrigins | join "," | quote }}
+  CORS_ALLOWED_ORIGINS: {{ concat (list (printf "https://%s" .Values.domain)) .Values.extraCorsAllowedOrigins | join "," | quote }}
+  FRONTEND_URL: {{ printf "https://%s" .Values.domain | quote }}
+  SENTRY_ENVIRONMENT: {{ .Values.env.sentry.environment | quote }}
+  {{- with .Values.env.sentry.release }}
+  SENTRY_RELEASE: {{ . | quote }}
+  {{- end }}
+  {{- if .Values.env.emqx.enabled }}
+  MQTT_BROKER_HOST: {{ .Values.env.emqx.host | quote }}
+  MQTT_BROKER_PORT: {{ .Values.env.emqx.port | quote }}
+  {{- with .Values.env.emqx.apiUrl }}
+  EMQX_API_URL: {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  {{- range $key, $value := .Values.env.extra }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/deploy/helm/openmakersuite/templates/flower-deployment.yaml
+++ b/deploy/helm/openmakersuite/templates/flower-deployment.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.flower.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openmakersuite.fullname" . }}-flower
+  labels:
+    {{- include "openmakersuite.componentLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "flower") | nindent 4 }}
+spec:
+  replicas: {{ .Values.flower.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "flower") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "flower") | nindent 8 }}
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret-app.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "openmakersuite.serviceAccountName" . }}
+      {{- include "openmakersuite.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: flower
+          image: {{ include "openmakersuite.workerImage" (dict "top" $ "component" "flower") | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            {{- toYaml .Values.flower.command | nindent 12 }}
+          ports:
+            - name: flower
+              containerPort: 5555
+              protocol: TCP
+          env:
+            {{- include "openmakersuite.appEnvVars" . | nindent 12 }}
+          envFrom:
+            {{- include "openmakersuite.appEnvFrom" . | nindent 12 }}
+          {{- if .Values.flower.probes.liveness.enabled }}
+          livenessProbe:
+            {{- omit .Values.flower.probes.liveness "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.flower.probes.readiness.enabled }}
+          readinessProbe:
+            {{- omit .Values.flower.probes.readiness "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.flower.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openmakersuite.flowerServiceName" . }}
+  labels:
+    {{- include "openmakersuite.componentLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "flower") | nindent 4 }}
+spec:
+  type: {{ .Values.flower.service.type }}
+  ports:
+    - port: {{ .Values.flower.service.port }}
+      targetPort: flower
+      protocol: TCP
+      name: flower
+  selector:
+    {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "flower") | nindent 4 }}
+{{- end }}

--- a/deploy/helm/openmakersuite/templates/frontend-deployment.yaml
+++ b/deploy/helm/openmakersuite/templates/frontend-deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openmakersuite.fullname" . }}-frontend
+  labels:
+    {{- include "openmakersuite.componentLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "frontend") | nindent 4 }}
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "frontend") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "frontend") | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "openmakersuite.serviceAccountName" . }}
+      {{- include "openmakersuite.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: frontend
+          image: {{ include "openmakersuite.image" (dict "top" $ "component" "frontend") | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.frontend.containerPort }}
+              protocol: TCP
+          {{- with .Values.frontend.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.frontend.probes.liveness.enabled }}
+          livenessProbe:
+            {{- omit .Values.frontend.probes.liveness "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.frontend.probes.readiness.enabled }}
+          readinessProbe:
+            {{- omit .Values.frontend.probes.readiness "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+      {{- with .Values.frontend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/openmakersuite/templates/frontend-service.yaml
+++ b/deploy/helm/openmakersuite/templates/frontend-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openmakersuite.frontendServiceName" . }}
+  labels:
+    {{- include "openmakersuite.componentLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "frontend") | nindent 4 }}
+spec:
+  type: {{ .Values.frontend.service.type }}
+  ports:
+    - port: {{ .Values.frontend.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "frontend") | nindent 4 }}

--- a/deploy/helm/openmakersuite/templates/ingress.yaml
+++ b/deploy/helm/openmakersuite/templates/ingress.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "openmakersuite.fullname" . }}
+  labels:
+    {{- include "openmakersuite.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ default "Prefix" .pathType }}
+            backend:
+              service:
+                {{- if eq (default "frontend" .service) "backend" }}
+                name: {{ include "openmakersuite.backendServiceName" $ }}
+                port:
+                  number: {{ $.Values.backend.service.port }}
+                {{- else if eq .service "flower" }}
+                name: {{ include "openmakersuite.flowerServiceName" $ }}
+                port:
+                  number: {{ $.Values.flower.service.port }}
+                {{- else }}
+                name: {{ include "openmakersuite.frontendServiceName" $ }}
+                port:
+                  number: {{ $.Values.frontend.service.port }}
+                {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/openmakersuite/templates/migrations-job.yaml
+++ b/deploy/helm/openmakersuite/templates/migrations-job.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "openmakersuite.fullname" . }}-migrate-{{ now | unixEpoch }}
+  labels:
+    {{- include "openmakersuite.componentLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "migrations") | nindent 4 }}
+  {{- if .Values.migrations.useHooks }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- end }}
+spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.migrations.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "migrations") | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "openmakersuite.serviceAccountName" . }}
+      {{- include "openmakersuite.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: migrate
+          image: {{ include "openmakersuite.workerImage" (dict "top" $ "component" "celery") | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - python
+            - manage.py
+            - migrate
+            - --no-input
+          env:
+            {{- include "openmakersuite.appEnvVars" . | nindent 12 }}
+          envFrom:
+            {{- include "openmakersuite.appEnvFrom" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+{{- end }}

--- a/deploy/helm/openmakersuite/templates/postgres.yaml
+++ b/deploy/helm/openmakersuite/templates/postgres.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "openmakersuite.postgresHost" . }}
+  labels:
+    {{- include "openmakersuite.componentLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "postgresql") | nindent 4 }}
+spec:
+  serviceName: {{ include "openmakersuite.postgresHost" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "postgresql") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "postgresql") | nindent 8 }}
+    spec:
+      {{- include "openmakersuite.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: postgres
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.auth.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.auth.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "openmakersuite.postgresSecretName" . }}
+                  key: {{ include "openmakersuite.postgresSecretPasswordKey" . }}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgresql.auth.username }}
+                - -d
+                - {{ .Values.postgresql.auth.database }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgresql.auth.username }}
+                - -d
+                - {{ .Values.postgresql.auth.database }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      {{- if not .Values.postgresql.persistence.enabled }}
+      volumes:
+        - name: data
+          emptyDir: {}
+      {{- end }}
+  {{- if .Values.postgresql.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          {{- toYaml .Values.postgresql.persistence.accessModes | nindent 10 }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size | quote }}
+        {{- with .Values.postgresql.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+  {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openmakersuite.postgresHost" . }}
+  labels:
+    {{- include "openmakersuite.componentLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "postgresql") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.postgresql.service.port }}
+      targetPort: postgres
+      protocol: TCP
+      name: postgres
+  selector:
+    {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "postgresql") | nindent 4 }}
+{{- end }}

--- a/deploy/helm/openmakersuite/templates/pvc-app.yaml
+++ b/deploy/helm/openmakersuite/templates/pvc-app.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.persistence.static.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "openmakersuite.fullname" . }}-static
+  labels:
+    {{- include "openmakersuite.labels" . | nindent 4 }}
+    app.kubernetes.io/component: static
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.static.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.static.size | quote }}
+  {{- with .Values.persistence.static.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}
+{{- if .Values.persistence.media.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "openmakersuite.fullname" . }}-media
+  labels:
+    {{- include "openmakersuite.labels" . | nindent 4 }}
+    app.kubernetes.io/component: media
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.media.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.media.size | quote }}
+  {{- with .Values.persistence.media.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/openmakersuite/templates/redis.yaml
+++ b/deploy/helm/openmakersuite/templates/redis.yaml
@@ -1,0 +1,97 @@
+{{- if .Values.redis.enabled }}
+{{- if .Values.redis.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "openmakersuite.redisHost" . }}
+  labels:
+    {{- include "openmakersuite.componentLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "redis") | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.redis.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.redis.persistence.size | quote }}
+  {{- with .Values.redis.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openmakersuite.redisHost" . }}
+  labels:
+    {{- include "openmakersuite.componentLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "redis") | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "redis") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "redis") | nindent 8 }}
+    spec:
+      {{- include "openmakersuite.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          {{- if .Values.redis.persistence.enabled }}
+          # Append-only mode keeps the dataset durable across restarts when
+          # we mount a PVC. Disable persistence for ephemeral installs.
+          args:
+            - --appendonly
+            - "yes"
+          {{- end }}
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          {{- if .Values.redis.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "openmakersuite.redisHost" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openmakersuite.redisHost" . }}
+  labels:
+    {{- include "openmakersuite.componentLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "redis") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.redis.service.port }}
+      targetPort: redis
+      protocol: TCP
+      name: redis
+  selector:
+    {{- include "openmakersuite.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" "redis") | nindent 4 }}
+{{- end }}

--- a/deploy/helm/openmakersuite/templates/secret-app.yaml
+++ b/deploy/helm/openmakersuite/templates/secret-app.yaml
@@ -1,0 +1,20 @@
+{{- if not .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openmakersuite.secretName" . }}
+  labels:
+    {{- include "openmakersuite.labels" . | nindent 4 }}
+  annotations:
+    # Persisting the auto-generated SECRET_KEY across upgrades — Helm's
+    # `lookup` reads the previous Secret so we don't churn the value.
+    "helm.sh/resource-policy": keep
+type: Opaque
+stringData:
+  SECRET_KEY: {{ include "openmakersuite.secretKey" . | quote }}
+  {{- range $key, $value := .Values.secrets.values }}
+  {{- if and (ne $key "SECRET_KEY") $value }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/openmakersuite/templates/secret-database.yaml
+++ b/deploy/helm/openmakersuite/templates/secret-database.yaml
@@ -1,0 +1,35 @@
+{{/*
+Database connection string Secret. The chart manages this even when an
+external database is configured (unless the user supplied an existing
+Secret) so the rest of the chart can always reference one canonical
+DATABASE_URL secret key.
+*/}}
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openmakersuite.databaseSecretName" . }}
+  labels:
+    {{- include "openmakersuite.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  database-url: {{ printf "postgresql://%s:%s@%s:%d/%s"
+      .Values.postgresql.auth.username
+      (include "openmakersuite.postgresPassword" .)
+      (include "openmakersuite.postgresHost" .)
+      (int .Values.postgresql.service.port)
+      .Values.postgresql.auth.database | quote }}
+{{- else if not .Values.externalDatabase.existingSecret }}
+{{- if not .Values.externalDatabase.url }}
+{{- fail "Either postgresql.enabled=true, externalDatabase.url, or externalDatabase.existingSecret must be set." }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openmakersuite.databaseSecretName" . }}
+  labels:
+    {{- include "openmakersuite.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  database-url: {{ .Values.externalDatabase.url | quote }}
+{{- end }}

--- a/deploy/helm/openmakersuite/templates/secret-postgres.yaml
+++ b/deploy/helm/openmakersuite/templates/secret-postgres.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.postgresql.enabled (not .Values.postgresql.auth.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openmakersuite.postgresSecretName" . }}
+  labels:
+    {{- include "openmakersuite.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+  annotations:
+    # Persist the generated postgres password across upgrades.
+    "helm.sh/resource-policy": keep
+type: Opaque
+stringData:
+  postgres-password: {{ include "openmakersuite.postgresPassword" . | quote }}
+{{- end }}

--- a/deploy/helm/openmakersuite/templates/secret-redis.yaml
+++ b/deploy/helm/openmakersuite/templates/secret-redis.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openmakersuite.redisSecretName" . }}
+  labels:
+    {{- include "openmakersuite.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  redis-url: {{ printf "redis://%s:%d/0"
+      (include "openmakersuite.redisHost" .)
+      (int .Values.redis.service.port) | quote }}
+{{- else if not .Values.externalRedis.existingSecret }}
+{{- if not .Values.externalRedis.url }}
+{{- fail "Either redis.enabled=true, externalRedis.url, or externalRedis.existingSecret must be set." }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openmakersuite.redisSecretName" . }}
+  labels:
+    {{- include "openmakersuite.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  redis-url: {{ .Values.externalRedis.url | quote }}
+{{- end }}

--- a/deploy/helm/openmakersuite/templates/serviceaccount.yaml
+++ b/deploy/helm/openmakersuite/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openmakersuite.serviceAccountName" . }}
+  labels:
+    {{- include "openmakersuite.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/openmakersuite/values.yaml
+++ b/deploy/helm/openmakersuite/values.yaml
@@ -1,0 +1,313 @@
+# Default values for openmakersuite.
+# This is a YAML-formatted file. Override any of these in your own values
+# file, e.g. `helm install oms ./deploy/helm/openmakersuite -f my-values.yaml`.
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Image registry / pull-secret defaults shared by backend, frontend, celery,
+# and flower. Per-component image stanzas override `repository`/`tag`.
+image:
+  registry: ghcr.io
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+# Domain settings used to populate ALLOWED_HOSTS / CSRF / CORS in the backend
+# and to wire the Ingress host. Override `domain` per environment.
+domain: openmakersuite.local
+extraAllowedHosts: []
+extraCsrfTrustedOrigins: []
+extraCorsAllowedOrigins: []
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podSecurityContext: {}
+securityContext: {}
+
+backend:
+  image:
+    repository: openmakersuite/backend
+    # Defaults to .Chart.AppVersion when empty.
+    tag: ""
+  replicaCount: 2
+  command:
+    - gunicorn
+    - config.wsgi:application
+    - --bind=0.0.0.0:8000
+    - --workers=4
+    - --timeout=120
+  service:
+    type: ClusterIP
+    port: 8000
+  probes:
+    liveness:
+      enabled: true
+      httpGet:
+        path: /api/dashboard/health/
+        port: http
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readiness:
+      enabled: true
+      httpGet:
+        path: /api/dashboard/health/
+        port: http
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    startup:
+      enabled: false
+      httpGet:
+        path: /api/dashboard/health/
+        port: http
+      periodSeconds: 5
+      failureThreshold: 30
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnv: []
+
+frontend:
+  # The frontend image is expected to be an nginx-based container that
+  # already bakes in the built React assets and listens on port 8080 (or
+  # whatever you set in `containerPort`). The reference image is
+  # produced by `frontend/Dockerfile.prod` plus the nginx image in
+  # `nginx/Dockerfile` published as a single artifact.
+  image:
+    repository: openmakersuite/frontend
+    tag: ""
+  replicaCount: 2
+  containerPort: 8080
+  service:
+    type: ClusterIP
+    port: 80
+  probes:
+    liveness:
+      enabled: true
+      httpGet:
+        path: /
+        port: http
+      initialDelaySeconds: 10
+      periodSeconds: 30
+      timeoutSeconds: 3
+      failureThreshold: 3
+    readiness:
+      enabled: true
+      httpGet:
+        path: /
+        port: http
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 3
+      failureThreshold: 3
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnv: []
+
+celery:
+  enabled: true
+  replicaCount: 1
+  # The celery worker reuses the backend image.
+  image:
+    repository: ""
+    tag: ""
+  command:
+    - celery
+    - -A
+    - config
+    - worker
+    - -l
+    - info
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnv:
+    - name: SKIP_DB_MIGRATIONS
+      value: "1"
+
+flower:
+  enabled: false
+  replicaCount: 1
+  image:
+    repository: ""
+    tag: ""
+  command:
+    - celery
+    - -A
+    - config
+    - flower
+    - --port=5555
+  service:
+    type: ClusterIP
+    port: 5555
+  probes:
+    liveness:
+      enabled: true
+      tcpSocket:
+        port: flower
+      initialDelaySeconds: 30
+      periodSeconds: 30
+    readiness:
+      enabled: true
+      tcpSocket:
+        port: flower
+      initialDelaySeconds: 5
+      periodSeconds: 10
+  resources: {}
+
+# Bundled PostgreSQL — turn off and set externalDatabase.url for managed DBs.
+postgresql:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "15.17-alpine"
+    pullPolicy: IfNotPresent
+  auth:
+    database: makerspace_inventory
+    username: makerspace
+    # If empty AND no existingSecret, a 32-char password is generated
+    # at install time and stored in the chart-managed Secret.
+    password: ""
+    existingSecret: ""
+    existingSecretPasswordKey: postgres-password
+  service:
+    port: 5432
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+  resources: {}
+
+externalDatabase:
+  # Used when postgresql.enabled = false. Supply a full DATABASE_URL
+  # (postgresql://user:pass@host:5432/db) via either `url` or by
+  # referencing an existing Secret.
+  url: ""
+  existingSecret: ""
+  existingSecretUrlKey: database-url
+
+# Bundled Redis — turn off and set externalRedis.url for managed Redis.
+redis:
+  enabled: true
+  image:
+    repository: redis
+    tag: "7.4.8-alpine"
+    pullPolicy: IfNotPresent
+  service:
+    port: 6379
+  persistence:
+    enabled: false
+    size: 5Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+  resources: {}
+
+externalRedis:
+  url: ""
+  existingSecret: ""
+  existingSecretUrlKey: redis-url
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  # Hosts and TLS sections follow the standard Ingress shape. The default
+  # path "/api" routes to the backend Service, and "/" routes to the
+  # frontend Service. Override `paths` to change that.
+  hosts:
+    - host: openmakersuite.local
+      paths:
+        - path: /api
+          pathType: Prefix
+          service: backend
+        - path: /static
+          pathType: Prefix
+          service: backend
+        - path: /media
+          pathType: Prefix
+          service: backend
+        - path: /
+          pathType: Prefix
+          service: frontend
+  tls: []
+  #  - secretName: openmakersuite-tls
+  #    hosts:
+  #      - openmakersuite.local
+
+# Persistence for backend-collected static assets and uploaded media.
+# Disable either to use an emptyDir (fine for ephemeral dev clusters).
+persistence:
+  static:
+    enabled: true
+    size: 2Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    mountPath: /app/staticfiles
+  media:
+    enabled: true
+    size: 20Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    mountPath: /app/media
+
+# One-shot Job that runs `python manage.py migrate` before every install/upgrade.
+migrations:
+  enabled: true
+  backoffLimit: 3
+  activeDeadlineSeconds: 600
+  resources: {}
+  # Use Helm hooks so migrations run before the rollout is updated. Set
+  # to false to ship migrations alongside the deploy (e.g. for cluster
+  # configurations that block hook resources).
+  useHooks: true
+
+# Application-level (non-secret) environment toggles. These end up in the
+# generated ConfigMap.
+env:
+  debug: "0"
+  djangoSettingsModule: "config.settings"
+  sentry:
+    environment: production
+    release: ""
+  emqx:
+    enabled: false
+    host: emqx
+    port: 1883
+    apiUrl: ""
+  extra: {}
+
+# Sensitive values land in a chart-managed Secret unless `existingSecret`
+# is set, in which case the chart references it as-is and ignores the
+# `values` block.
+secrets:
+  existingSecret: ""
+  values:
+    SECRET_KEY: ""
+    SENTRY_DSN: ""
+    REACT_APP_SENTRY_DSN: ""
+    MQTT_BROKER_USERNAME: ""
+    MQTT_BROKER_PASSWORD: ""
+    EMQX_DASHBOARD_PASSWORD: ""
+    EMQX_API_KEY: ""
+    EMQX_API_SECRET: ""
+    FORGEKEY_FIRMWARE_SIGNING_KEY: ""
+    EMAIL_HOST: ""
+    EMAIL_HOST_USER: ""
+    EMAIL_HOST_PASSWORD: ""
+    DEFAULT_FROM_EMAIL: ""


### PR DESCRIPTION
## Summary
- New Helm chart at `deploy/helm/openmakersuite/` (Chart, values, templates for backend/frontend/celery/flower/postgres/redis/ingress/migrations-job/secrets/SA/PVCs)
- Three deploy modes validated: bundled DB+Redis, external managed DB+Redis, existing-Secret
- Health probes mirror docker-compose; excludes `deploy/helm/*/templates/` from pre-commit's check-yaml (Go template syntax)
- Covers AC-8

## Test plan
- [x] `helm lint --strict` and `helm template` under all three modes — pre-verified by polecat

🤖 Generated with [Claude Code](https://claude.com/claude-code)