### PR TITLE
feat(deploy): document env-driven email/webhook/public-URL settings (oms-djl)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -64,9 +64,48 @@ EMQX_API_KEY=
 EMQX_API_SECRET=
 
 # Email (Optional - configure for sending emails)
+# EMAIL_BACKEND defaults to django.core.mail.backends.console.EmailBackend in
+# settings.py, which is wrong for production. Set this to either Postmark
+# (anymail.backends.postmark.EmailBackend) or SMTP
+# (django.core.mail.backends.smtp.EmailBackend).
+EMAIL_BACKEND=anymail.backends.postmark.EmailBackend
 EMAIL_HOST=smtp.gmail.com
 EMAIL_PORT=587
 EMAIL_HOST_USER=your-email@gmail.com
 EMAIL_HOST_PASSWORD=your-app-password
 EMAIL_USE_TLS=True
 DEFAULT_FROM_EMAIL=noreply@dallas.openmakersuite.net
+
+# Logistics distribution-list address that receives high/urgent
+# LocationProblem alerts. Empty disables email alerts.
+LOGISTICS_ALERT_EMAIL=logistics@dallasmakerspace.org
+
+# Postmark outbound API token (required when EMAIL_BACKEND is the Postmark
+# anymail backend). Pull from your Postmark server's API Tokens page.
+POSTMARK_SERVER_TOKEN=
+
+# Postmark inbound webhook shared secret. The inbound work-order endpoint is
+# unauthenticated (Postmark does not ship a request signature), so this token
+# must match the `?token=` query param or `X-Postmark-Webhook-Token` header
+# Postmark is configured to send. Empty -> the endpoint returns 503.
+POSTMARK_INBOUND_TOKEN=
+
+# Shared secret used by IoT devices (ForgeKey, ESP32, etc.) to authenticate
+# anonymous traffic-count pings to /api/location-checkins/webhook/. Empty
+# disables the endpoint (returns 503).
+LOCATION_PING_TOKEN=
+
+# Public iframe URL embedded in shared_traffic kiosk content blocks. Updating
+# this changes the live-traffic feed on every screen at the site at once.
+TRAFFIC_URL=https://embed.waze.com/iframe?zoom=14&lat=32.945552&lon=-96.912503&ct=livemap
+
+# WHMCS API credentials for the maker-box (personal storage bin) verification
+# flow. URL/identifier/secret are all required; missing any -> the scan
+# endpoint degrades to a 503 instead of failing requests.
+WHMCS_API_URL=
+WHMCS_API_IDENTIFIER=
+WHMCS_API_SECRET=
+WHMCS_API_ACCESSKEY=
+
+# GitHub repo URL baked into the frontend bundle for the "report a bug" link.
+GITHUB_URL=https://github.com/uid0/openmakersuite

--- a/deploy/helm/openmakersuite/README.md
+++ b/deploy/helm/openmakersuite/README.md
@@ -63,6 +63,28 @@ helm install oms ./deploy/helm/openmakersuite \
 All probes are tunable under `<component>.probes.{liveness,readiness,startup}`
 and can be disabled by setting `enabled: false` per probe.
 
+## Configuration sources
+
+Where each setting category lives:
+
+| Category                | Helm values path                                                                       | Rendered as                       |
+| ----------------------- | -------------------------------------------------------------------------------------- | --------------------------------- |
+| Hostnames / CORS / CSRF | `domain`, `extraAllowedHosts`, `extraCsrfTrustedOrigins`, `extraCorsAllowedOrigins`    | ConfigMap `<rel>-openmakersuite-env` |
+| Database URL            | `postgresql.*` (bundled) or `externalDatabase.url` / `existingSecret`                  | Secret `<rel>-openmakersuite-database` |
+| Redis URL               | `redis.*` (bundled) or `externalRedis.url` / `existingSecret`                          | Secret `<rel>-openmakersuite-redis`    |
+| Sentry                  | `env.sentry.{environment,release}` + `secrets.values.SENTRY_DSN`                       | ConfigMap (env) + Secret (DSN)    |
+| Email transport         | `env.email.{backend,host,port,useTls,defaultFrom,logisticsAlert}`                      | ConfigMap                         |
+| Email credentials       | `secrets.values.{EMAIL_HOST_USER,EMAIL_HOST_PASSWORD,POSTMARK_SERVER_TOKEN}`           | Secret                            |
+| Inbound webhooks        | `secrets.values.{POSTMARK_INBOUND_TOKEN,LOCATION_PING_TOKEN}`                          | Secret                            |
+| Public iframe URLs      | `env.publicUrls.{traffic,weather,github}`                                              | ConfigMap                         |
+| WHMCS API               | `env.whmcs.apiUrl` + `secrets.values.WHMCS_API_{IDENTIFIER,SECRET,ACCESSKEY}`          | ConfigMap (URL) + Secret (creds)  |
+| EMQX MQTT               | `env.emqx.*` + `secrets.values.{EMQX_*,MQTT_BROKER_*}`                                 | ConfigMap + Secret                |
+| ForgeKey signing key    | `secrets.values.FORGEKEY_FIRMWARE_SIGNING_KEY`                                         | Secret                            |
+
+`backend.extraEnv`, `frontend.extraEnv`, and `celery.extraEnv` accept raw
+container env entries for anything outside this list (including
+`valueFrom.secretKeyRef` references to externally managed Secrets).
+
 ## Secrets handling
 
 Sensitive values (Django `SECRET_KEY`, Sentry DSN, EMQX credentials, mail

--- a/deploy/helm/openmakersuite/templates/configmap.yaml
+++ b/deploy/helm/openmakersuite/templates/configmap.yaml
@@ -22,6 +22,36 @@ data:
   EMQX_API_URL: {{ . | quote }}
   {{- end }}
   {{- end }}
+  {{- with .Values.env.email.backend }}
+  EMAIL_BACKEND: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.env.email.host }}
+  EMAIL_HOST: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.env.email.port }}
+  EMAIL_PORT: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.env.email.useTls }}
+  EMAIL_USE_TLS: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.env.email.defaultFrom }}
+  DEFAULT_FROM_EMAIL: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.env.email.logisticsAlert }}
+  LOGISTICS_ALERT_EMAIL: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.env.publicUrls.traffic }}
+  TRAFFIC_URL: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.env.publicUrls.weather }}
+  WEATHER_URL: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.env.publicUrls.github }}
+  GITHUB_URL: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.env.whmcs.apiUrl }}
+  WHMCS_API_URL: {{ . | quote }}
+  {{- end }}
   {{- range $key, $value := .Values.env.extra }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/deploy/helm/openmakersuite/values.yaml
+++ b/deploy/helm/openmakersuite/values.yaml
@@ -290,6 +290,30 @@ env:
     host: emqx
     port: 1883
     apiUrl: ""
+  # Outbound email transport. Defaults to console (development-safe). Set
+  # `backend` to "anymail.backends.postmark.EmailBackend" (with
+  # secrets.values.POSTMARK_SERVER_TOKEN) or
+  # "django.core.mail.backends.smtp.EmailBackend" (with `host`/`port`/`useTls`
+  # and secrets.values.EMAIL_HOST_USER/EMAIL_HOST_PASSWORD).
+  email:
+    backend: ""
+    host: ""
+    port: ""
+    useTls: ""
+    defaultFrom: ""
+    # Distribution list that receives high/urgent LocationProblem alerts.
+    # Empty disables email alerts.
+    logisticsAlert: ""
+  # Public iframe URLs embedded by kiosk shared-content blocks. Override per
+  # site so the same chart renders the local traffic/weather feed.
+  publicUrls:
+    traffic: ""
+    weather: ""
+    github: ""
+  # WHMCS API endpoint (URL is non-secret; credentials live under
+  # secrets.values).
+  whmcs:
+    apiUrl: ""
   extra: {}
 
 # Sensitive values land in a chart-managed Secret unless `existingSecret`
@@ -307,7 +331,11 @@ secrets:
     EMQX_API_KEY: ""
     EMQX_API_SECRET: ""
     FORGEKEY_FIRMWARE_SIGNING_KEY: ""
-    EMAIL_HOST: ""
     EMAIL_HOST_USER: ""
     EMAIL_HOST_PASSWORD: ""
-    DEFAULT_FROM_EMAIL: ""
+    POSTMARK_SERVER_TOKEN: ""
+    POSTMARK_INBOUND_TOKEN: ""
+    LOCATION_PING_TOKEN: ""
+    WHMCS_API_IDENTIFIER: ""
+    WHMCS_API_SECRET: ""
+    WHMCS_API_ACCESSKEY: ""

--- a/deploy/k8s/base/configmap.yaml
+++ b/deploy/k8s/base/configmap.yaml
@@ -14,3 +14,23 @@ data:
   CORS_ALLOWED_ORIGINS: "https://openmakersuite.local"
   FRONTEND_URL: "https://openmakersuite.local"
   SENTRY_ENVIRONMENT: "production"
+  # Outbound email transport. Empty -> Django falls back to the console
+  # backend (development-safe). Set to "anymail.backends.postmark.EmailBackend"
+  # (with POSTMARK_SERVER_TOKEN in oms-secrets) or
+  # "django.core.mail.backends.smtp.EmailBackend" (with EMAIL_HOST_USER /
+  # EMAIL_HOST_PASSWORD in oms-secrets).
+  EMAIL_BACKEND: ""
+  EMAIL_HOST: ""
+  EMAIL_PORT: ""
+  EMAIL_USE_TLS: ""
+  DEFAULT_FROM_EMAIL: ""
+  # Distribution list that receives high/urgent LocationProblem alerts.
+  # Empty disables email alerts.
+  LOGISTICS_ALERT_EMAIL: ""
+  # Public iframe URLs embedded by kiosk shared-content blocks.
+  TRAFFIC_URL: ""
+  WEATHER_URL: ""
+  GITHUB_URL: ""
+  # WHMCS API endpoint for the maker-box verification flow. Credentials live
+  # in oms-secrets (WHMCS_API_IDENTIFIER / WHMCS_API_SECRET / WHMCS_API_ACCESSKEY).
+  WHMCS_API_URL: ""

--- a/deploy/k8s/base/secret-app.yaml
+++ b/deploy/k8s/base/secret-app.yaml
@@ -27,7 +27,20 @@ stringData:
   EMQX_API_KEY: ""
   EMQX_API_SECRET: ""
   FORGEKEY_FIRMWARE_SIGNING_KEY: ""
-  EMAIL_HOST: ""
+  # SMTP credentials. Non-secret email config (host, port, TLS, from-address,
+  # backend selection) lives in oms-env (configmap.yaml) — only secrets land here.
   EMAIL_HOST_USER: ""
   EMAIL_HOST_PASSWORD: ""
-  DEFAULT_FROM_EMAIL: ""
+  # Outbound Postmark API token (for anymail.backends.postmark.EmailBackend).
+  POSTMARK_SERVER_TOKEN: ""
+  # Inbound webhook shared secret. Empty -> the work-order intake endpoint
+  # returns 503.
+  POSTMARK_INBOUND_TOKEN: ""
+  # Shared secret used by IoT devices for /api/location-checkins/webhook/.
+  # Empty -> the endpoint returns 503.
+  LOCATION_PING_TOKEN: ""
+  # WHMCS API credentials for the maker-box verification flow. Endpoint URL
+  # is non-secret and lives in oms-env (WHMCS_API_URL).
+  WHMCS_API_IDENTIFIER: ""
+  WHMCS_API_SECRET: ""
+  WHMCS_API_ACCESSKEY: ""


### PR DESCRIPTION
## Summary
- New `.env.prod.example` (+39 LOC) and matching wiring in deploy/helm + deploy/k8s configmap/secret-app
- Documents email (SMTP), webhook signing, and public-URL settings as env-driven config so prod deploys don't need code changes for these

## Test plan
- [x] Pre-verified by polecat

🤖 Generated with [Claude Code](https://claude.com/claude-code)