### PR TITLE
feat(frontend): forms and views for electrical circuits & network drops (oms-a5f)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,15 +12,19 @@ import MaintenanceItemFormPage from './pages/MaintenanceItemFormPage';
 import AssetReportPage from './pages/AssetReportPage';
 import AssetScanPage from './pages/AssetScanPage';
 import AssetsPage from './pages/AssetsPage';
+import BreakerFormPage from './pages/BreakerFormPage';
+import BreakerTracePage from './pages/BreakerTracePage';
 import CategoryFormPage from './pages/CategoryFormPage';
 import CategoryListPage from './pages/CategoryListPage';
 import ChecklistCompletionPage from './pages/ChecklistCompletionPage';
 import CodeEntryPage from './pages/CodeEntryPage';
 import DashboardPage from './pages/DashboardPage';
 import DonationItemScanPage from './pages/DonationItemScanPage';
+import ElectricalCircuitsPage from './pages/ElectricalCircuitsPage';
 import FixtureScanPage from './pages/FixtureScanPage';
 import ForgeKeyDevicesPage from './pages/ForgeKeyDevicesPage';
 import HomePage from './pages/HomePage';
+import LightSwitchFormPage from './pages/LightSwitchFormPage';
 import InventoryItemDetailPage from './pages/InventoryItemDetailPage';
 import InventoryItemFormPage from './pages/InventoryItemFormPage';
 import InventoryListPage from './pages/InventoryListPage';
@@ -36,6 +40,8 @@ import MakerBoxAdminPage from './pages/MakerBoxAdminPage';
 import MakerBoxScanPage from './pages/MakerBoxScanPage';
 import MaintenanceDashboard from './pages/MaintenanceDashboard';
 import MaintenanceDashboardPage from './pages/MaintenanceDashboardPage';
+import NetworkDropFormPage from './pages/NetworkDropFormPage';
+import OutletFormPage from './pages/OutletFormPage';
 import ThirdPartyWorkOrderPage from './pages/ThirdPartyWorkOrderPage';
 import WorkOrderPage from './pages/WorkOrderPage';
 import PurchaseOrderFormPage from './pages/PurchaseOrderFormPage';
@@ -181,6 +187,18 @@ function AppContent() {
           <Route path="/facilities/logistics" element={<LogisticsDashboard />} />
           <Route path="/facilities/maker-boxes/scan" element={<WorkspaceLayout><MakerBoxScanPage /></WorkspaceLayout>} />
           <Route path="/facilities/maker-boxes" element={<WorkspaceLayout><MakerBoxAdminPage /></WorkspaceLayout>} />
+
+          {/* Electrical circuits & network drops (oms-a5f) */}
+          <Route path="/facilities/electrical" element={<WorkspaceLayout><ElectricalCircuitsPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/breakers/new" element={<WorkspaceLayout><BreakerFormPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/breakers/:id/edit" element={<WorkspaceLayout><BreakerFormPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/breakers/:id/trace" element={<WorkspaceLayout><BreakerTracePage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/outlets/new" element={<WorkspaceLayout><OutletFormPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/outlets/:id/edit" element={<WorkspaceLayout><OutletFormPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/light-switches/new" element={<WorkspaceLayout><LightSwitchFormPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/light-switches/:id/edit" element={<WorkspaceLayout><LightSwitchFormPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/network-drops/new" element={<WorkspaceLayout><NetworkDropFormPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/network-drops/:id/edit" element={<WorkspaceLayout><NetworkDropFormPage /></WorkspaceLayout>} />
 
           {/* Preventive Maintenance */}
           <Route path="/maintenance" element={<WorkspaceLayout><MaintenanceDashboardPage /></WorkspaceLayout>} />

--- a/frontend/src/__tests__/pages/BreakerTracePage.test.tsx
+++ b/frontend/src/__tests__/pages/BreakerTracePage.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Tests for BreakerTracePage (oms-a5f).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import BreakerTracePage from '../../pages/BreakerTracePage';
+import * as api from '../../services/api';
+
+jest.mock('../../services/api');
+
+const renderAt = (path: string) =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route
+            path="/facilities/electrical/breakers/:id/trace"
+            element={<BreakerTracePage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('BreakerTracePage', () => {
+  const breaker = {
+    id: 5,
+    location: 1,
+    location_name: 'Electrical Room',
+    panel: 'A',
+    breaker_number: '12',
+    amperage: 30,
+    voltage: 240,
+    poles: 2,
+    description: 'Wood shop saw',
+    notes: '',
+    is_active: true,
+    created_at: '',
+    updated_at: '',
+  };
+  const outlet = {
+    id: 11,
+    location: 2,
+    location_name: 'Wood shop',
+    identifier: 'bench-1',
+    breaker: 5,
+    breaker_label: 'A / 12',
+    outlet_type: 'nema_5_20',
+    description: '',
+    plugged_in_notes: 'Table saw',
+    photo: null,
+    is_active: true,
+    created_at: '',
+    updated_at: '',
+  };
+  const matchingSwitch = {
+    id: 21,
+    location: 2,
+    location_name: 'Wood shop',
+    identifier: 'door-east',
+    controls_location: 2,
+    controls_location_name: 'Wood shop',
+    breaker: 5,
+    breaker_label: 'A / 12',
+    description: '',
+    notes: '',
+    is_active: true,
+    created_at: '',
+    updated_at: '',
+  };
+  const otherSwitch = { ...matchingSwitch, id: 22, breaker: 99, identifier: 'unrelated' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (api.electricalCircuitsAPI.getBreaker as jest.Mock).mockResolvedValue({
+      data: breaker,
+    });
+    (api.electricalCircuitsAPI.listOutlets as jest.Mock).mockResolvedValue({
+      data: { results: [outlet] },
+    });
+    (api.electricalCircuitsAPI.listLightSwitches as jest.Mock).mockResolvedValue({
+      data: { results: [matchingSwitch, otherSwitch] },
+    });
+  });
+
+  it('shows outlets and only switches that match the breaker', async () => {
+    renderAt('/facilities/electrical/breakers/5/trace');
+
+    expect(await screen.findByText(/Trace: A \/ 12/)).toBeInTheDocument();
+    // Outlet rendered
+    expect(screen.getByText('bench-1')).toBeInTheDocument();
+    expect(screen.getByText('Table saw')).toBeInTheDocument();
+    // Matching switch rendered, unrelated one filtered out
+    expect(screen.getByText('door-east')).toBeInTheDocument();
+    expect(screen.queryByText('unrelated')).not.toBeInTheDocument();
+
+    // Outlets request was filtered server-side by breaker id
+    expect(api.electricalCircuitsAPI.listOutlets).toHaveBeenCalledWith({
+      breaker: '5',
+    });
+  });
+
+  it('renders an error state when the breaker fails to load', async () => {
+    (api.electricalCircuitsAPI.getBreaker as jest.Mock).mockRejectedValue({
+      response: { data: { detail: 'Not found' } },
+    });
+    renderAt('/facilities/electrical/breakers/999/trace');
+    expect(await screen.findByText('Not found')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/ElectricalCircuitsPage.test.tsx
+++ b/frontend/src/__tests__/pages/ElectricalCircuitsPage.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Tests for ElectricalCircuitsPage (oms-a5f).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ElectricalCircuitsPage from '../../pages/ElectricalCircuitsPage';
+import * as api from '../../services/api';
+import { confirmDelete, showError } from '../../utils/dialogs';
+
+jest.mock('../../services/api');
+
+jest.mock('../../utils/dialogs', () => ({
+  confirmDelete: jest.fn(),
+  showError: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <ElectricalCircuitsPage />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('ElectricalCircuitsPage', () => {
+  const breaker = {
+    id: 1,
+    location: 1,
+    location_name: 'Electrical Room',
+    panel: 'A',
+    breaker_number: '12',
+    amperage: 20,
+    voltage: 120,
+    poles: 1,
+    description: 'Wood shop',
+    notes: '',
+    is_active: true,
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (api.inventoryAPI.listLocations as jest.Mock).mockResolvedValue({
+      data: { results: [{ id: 1, name: 'Electrical Room' }] },
+    });
+    (api.electricalCircuitsAPI.listBreakers as jest.Mock).mockResolvedValue({
+      data: { results: [breaker] },
+    });
+    (api.electricalCircuitsAPI.listOutlets as jest.Mock).mockResolvedValue({
+      data: { results: [] },
+    });
+    (api.electricalCircuitsAPI.listLightSwitches as jest.Mock).mockResolvedValue({
+      data: { results: [] },
+    });
+    (api.electricalCircuitsAPI.listNetworkDrops as jest.Mock).mockResolvedValue({
+      data: { results: [] },
+    });
+  });
+
+  it('lists breakers in the breakers tab on mount', async () => {
+    renderPage();
+    expect(await screen.findByText('A / 12')).toBeInTheDocument();
+    // 'Electrical Room' may appear in both the location filter dropdown and the row
+    expect(screen.getAllByText('Electrical Room').length).toBeGreaterThan(0);
+    expect(screen.getByText('20A')).toBeInTheDocument();
+    expect(api.electricalCircuitsAPI.listBreakers).toHaveBeenCalled();
+  });
+
+  it('opens a confirm modal and deletes a breaker on confirm', async () => {
+    (api.electricalCircuitsAPI.deleteBreaker as jest.Mock).mockResolvedValue({});
+    renderPage();
+
+    const deleteBtn = await screen.findByTitle('Delete');
+    deleteBtn.click();
+
+    expect(confirmDelete).toHaveBeenCalledTimes(1);
+    const [message, onConfirm] = (confirmDelete as jest.Mock).mock.calls[0];
+    expect(message).toContain('A/12');
+
+    await onConfirm();
+
+    expect(api.electricalCircuitsAPI.deleteBreaker).toHaveBeenCalledWith(1);
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the trace view when the route action is clicked', async () => {
+    renderPage();
+
+    const traceBtn = await screen.findByTitle('Trace fed loads');
+    traceBtn.click();
+
+    expect(mockNavigate).toHaveBeenCalledWith('/facilities/electrical/breakers/1/trace');
+  });
+
+  it('surfaces a Mantine error notification when delete fails', async () => {
+    (api.electricalCircuitsAPI.deleteBreaker as jest.Mock).mockRejectedValue({
+      response: { data: { detail: 'Outlets still depend on it' } },
+    });
+    renderPage();
+
+    const deleteBtn = await screen.findByTitle('Delete');
+    deleteBtn.click();
+
+    const [, onConfirm] = (confirmDelete as jest.Mock).mock.calls[0];
+    await onConfirm();
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith('Outlets still depend on it');
+    });
+  });
+});

--- a/frontend/src/__tests__/services/electricalCircuitsAPI.test.ts
+++ b/frontend/src/__tests__/services/electricalCircuitsAPI.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for electricalCircuitsAPI client (oms-a5f).
+ *
+ * Verifies the wire format hitting the backend at /api/electrical-circuits/...
+ * — particularly that file uploads switch the request to multipart/form-data,
+ * which the OutletViewSet/NetworkDropViewSet require for the photo field.
+ */
+import MockAdapter from 'axios-mock-adapter';
+import { electricalCircuitsAPI } from '../../services/api';
+import api from '../../services/api';
+
+describe('electricalCircuitsAPI', () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(api);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('lists breakers with location and panel filters', async () => {
+    mock.onGet('/electrical-circuits/breakers/').reply((config) => {
+      expect(config.params).toEqual({ location: 7, panel: 'A' });
+      return [200, { results: [] }];
+    });
+    const response = await electricalCircuitsAPI.listBreakers({
+      location: 7,
+      panel: 'A',
+    });
+    expect(response.data.results).toEqual([]);
+  });
+
+  it('normalizes plain-array list responses for outlets', async () => {
+    mock.onGet('/electrical-circuits/outlets/').reply(200, [
+      {
+        id: 1,
+        identifier: 'bench-1',
+        location: 1,
+        location_name: 'Shop',
+        outlet_type: 'standard',
+      },
+    ]);
+    const response = await electricalCircuitsAPI.listOutlets();
+    expect(response.data.results).toHaveLength(1);
+    expect(response.data.results[0].identifier).toBe('bench-1');
+  });
+
+  it('uses multipart/form-data when creating an outlet with a photo', async () => {
+    let capturedHeaders: Record<string, unknown> | undefined;
+    let capturedBody: unknown;
+    mock.onPost('/electrical-circuits/outlets/').reply((config) => {
+      capturedHeaders = config.headers as Record<string, unknown>;
+      capturedBody = config.data;
+      return [201, { id: 99 }];
+    });
+
+    const photo = new File([new Uint8Array([0])], 'outlet.png', { type: 'image/png' });
+    await electricalCircuitsAPI.createOutlet({
+      location: 1,
+      identifier: 'bench-1',
+      outlet_type: 'standard',
+      photo,
+    });
+
+    expect(capturedHeaders?.['Content-Type']).toBe('multipart/form-data');
+    expect(capturedBody).toBeInstanceOf(FormData);
+    const fd = capturedBody as FormData;
+    expect(fd.get('identifier')).toBe('bench-1');
+    expect(fd.get('photo')).toBeInstanceOf(File);
+  });
+
+  it('sends a JSON body when creating an outlet without a photo', async () => {
+    let capturedBody: unknown;
+    mock.onPost('/electrical-circuits/outlets/').reply((config) => {
+      capturedBody = config.data;
+      return [201, { id: 100 }];
+    });
+    await electricalCircuitsAPI.createOutlet({
+      location: 1,
+      identifier: 'bench-2',
+      outlet_type: 'standard',
+    });
+    expect(typeof capturedBody).toBe('string');
+    expect(JSON.parse(capturedBody as string)).toMatchObject({
+      identifier: 'bench-2',
+    });
+  });
+
+  it('passes drop_type filter on network drop list', async () => {
+    mock.onGet('/electrical-circuits/network-drops/').reply((config) => {
+      expect(config.params).toEqual({ drop_type: 'camera' });
+      return [200, { results: [] }];
+    });
+    await electricalCircuitsAPI.listNetworkDrops({ drop_type: 'camera' });
+  });
+});

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -114,6 +114,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed = false, isMobileOpen = f
         { path: '/facilities/tv-dashboard', label: 'TV Dashboard', icon: '📺' },
         { path: '/facilities/logistics', label: 'Logistics', icon: '🚛' },
         { path: '/facilities/forgekey-devices', label: 'ForgeKey Devices', icon: '📡', requiresStaff: true },
+        { path: '/facilities/electrical', label: 'Electrical & Network', icon: '⚡', requiresStaff: true },
       ],
     },
     {

--- a/frontend/src/pages/BreakerFormPage.tsx
+++ b/frontend/src/pages/BreakerFormPage.tsx
@@ -1,0 +1,243 @@
+/**
+ * Breaker Form Page (oms-a5f) — create/edit a circuit breaker.
+ */
+import {
+  Alert,
+  Button,
+  Group,
+  NumberInput,
+  Paper,
+  Select,
+  Stack,
+  Switch,
+  Textarea,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { IconAlertCircle } from '@tabler/icons-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { electricalCircuitsAPI, inventoryAPI } from '../services/api';
+import { Location } from '../types';
+
+interface FormState {
+  location: number | null;
+  panel: string;
+  breaker_number: string;
+  amperage: number | '';
+  voltage: number | '';
+  poles: number | '';
+  description: string;
+  notes: string;
+  is_active: boolean;
+}
+
+const initialState: FormState = {
+  location: null,
+  panel: '',
+  breaker_number: '',
+  amperage: 20,
+  voltage: 120,
+  poles: 1,
+  description: '',
+  notes: '',
+  is_active: true,
+};
+
+const BreakerFormPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const isEdit = Boolean(id);
+
+  const [form, setForm] = useState<FormState>(initialState);
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const locationOptions = useMemo(
+    () => locations.map((l) => ({ value: String(l.id), label: l.name })),
+    [locations],
+  );
+
+  useEffect(() => {
+    inventoryAPI
+      .listLocations()
+      .then((response) => setLocations(response.data.results))
+      .catch((err) => console.error('Failed to load locations', err));
+  }, []);
+
+  useEffect(() => {
+    if (!isEdit || !id) return;
+    setLoading(true);
+    electricalCircuitsAPI
+      .getBreaker(id)
+      .then((response) => {
+        const b = response.data;
+        setForm({
+          location: b.location,
+          panel: b.panel,
+          breaker_number: b.breaker_number,
+          amperage: b.amperage,
+          voltage: b.voltage,
+          poles: b.poles,
+          description: b.description,
+          notes: b.notes,
+          is_active: b.is_active,
+        });
+      })
+      .catch((err) => {
+        setError(err.response?.data?.detail || 'Failed to load breaker');
+      })
+      .finally(() => setLoading(false));
+  }, [id, isEdit]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    if (!form.location) {
+      setError('Location is required.');
+      return;
+    }
+    if (!form.panel.trim() || !form.breaker_number.trim()) {
+      setError('Panel and breaker number are required.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload = {
+        location: form.location,
+        panel: form.panel.trim(),
+        breaker_number: form.breaker_number.trim(),
+        amperage: Number(form.amperage),
+        voltage: Number(form.voltage),
+        poles: Number(form.poles),
+        description: form.description,
+        notes: form.notes,
+        is_active: form.is_active,
+      };
+      if (isEdit && id) {
+        await electricalCircuitsAPI.updateBreaker(id, payload);
+      } else {
+        await electricalCircuitsAPI.createBreaker(payload);
+      }
+      navigate('/facilities/electrical');
+    } catch (err: any) {
+      const data = err.response?.data;
+      const detail =
+        data?.detail ||
+        (typeof data === 'object' && data
+          ? Object.entries(data)
+              .map(([key, value]) => `${key}: ${Array.isArray(value) ? value.join(', ') : value}`)
+              .join('; ')
+          : null) ||
+        'Failed to save breaker';
+      setError(detail);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <div>Loading breaker…</div>;
+  }
+
+  return (
+    <Stack gap="md">
+      <Title order={2}>{isEdit ? 'Edit breaker' : 'New breaker'}</Title>
+      {error && (
+        <Alert icon={<IconAlertCircle size={16} />} color="red" title="Error">
+          {error}
+        </Alert>
+      )}
+      <form onSubmit={handleSubmit}>
+        <Paper p="md" withBorder>
+          <Stack>
+            <Select
+              label="Location (panel cabinet)"
+              placeholder="Select panel location"
+              data={locationOptions}
+              value={form.location ? String(form.location) : null}
+              onChange={(value) =>
+                setForm((s) => ({ ...s, location: value ? Number(value) : null }))
+              }
+              required
+              searchable
+            />
+            <Group grow>
+              <TextInput
+                label="Panel"
+                placeholder="Panel A"
+                value={form.panel}
+                onChange={(e) => setForm((s) => ({ ...s, panel: e.target.value }))}
+                required
+              />
+              <TextInput
+                label="Breaker #"
+                placeholder="12"
+                value={form.breaker_number}
+                onChange={(e) => setForm((s) => ({ ...s, breaker_number: e.target.value }))}
+                required
+              />
+            </Group>
+            <Group grow>
+              <NumberInput
+                label="Amperage"
+                value={form.amperage}
+                onChange={(value) =>
+                  setForm((s) => ({ ...s, amperage: value === '' ? '' : Number(value) }))
+                }
+                min={1}
+                required
+              />
+              <NumberInput
+                label="Voltage"
+                value={form.voltage}
+                onChange={(value) =>
+                  setForm((s) => ({ ...s, voltage: value === '' ? '' : Number(value) }))
+                }
+                min={1}
+              />
+              <NumberInput
+                label="Poles"
+                value={form.poles}
+                onChange={(value) =>
+                  setForm((s) => ({ ...s, poles: value === '' ? '' : Number(value) }))
+                }
+                min={1}
+                max={3}
+              />
+            </Group>
+            <TextInput
+              label="Description"
+              placeholder="Wood shop dust collector"
+              value={form.description}
+              onChange={(e) => setForm((s) => ({ ...s, description: e.target.value }))}
+            />
+            <Textarea
+              label="Notes"
+              value={form.notes}
+              onChange={(e) => setForm((s) => ({ ...s, notes: e.target.value }))}
+              rows={3}
+            />
+            <Switch
+              label="Active"
+              checked={form.is_active}
+              onChange={(e) => setForm((s) => ({ ...s, is_active: e.currentTarget.checked }))}
+            />
+          </Stack>
+          <Group justify="flex-end" mt="xl">
+            <Button variant="subtle" onClick={() => navigate(-1)} type="button">
+              Cancel
+            </Button>
+            <Button type="submit" loading={saving}>
+              {isEdit ? 'Save changes' : 'Create breaker'}
+            </Button>
+          </Group>
+        </Paper>
+      </form>
+    </Stack>
+  );
+};
+
+export default BreakerFormPage;

--- a/frontend/src/pages/BreakerTracePage.tsx
+++ b/frontend/src/pages/BreakerTracePage.tsx
@@ -1,0 +1,200 @@
+/**
+ * Breaker Trace Page (oms-a5f) — show every outlet and light switch fed
+ * from a given breaker so a technician can trace power downstream.
+ */
+import {
+  Alert,
+  Anchor,
+  Badge,
+  Group,
+  Paper,
+  Stack,
+  Table,
+  Text,
+  Title,
+} from '@mantine/core';
+import { IconAlertCircle, IconArrowLeft } from '@tabler/icons-react';
+import React, { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { electricalCircuitsAPI, OUTLET_TYPE_OPTIONS } from '../services/api';
+import { Breaker, LightSwitch, Outlet } from '../types';
+
+const outletTypeLabel = (value: string): string =>
+  OUTLET_TYPE_OPTIONS.find((option) => option.value === value)?.label || value;
+
+const BreakerTracePage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [breaker, setBreaker] = useState<Breaker | null>(null);
+  const [outlets, setOutlets] = useState<Outlet[]>([]);
+  const [switches, setSwitches] = useState<LightSwitch[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    Promise.all([
+      electricalCircuitsAPI.getBreaker(id),
+      electricalCircuitsAPI.listOutlets({ breaker: id }),
+      electricalCircuitsAPI.listLightSwitches({}),
+    ])
+      .then(([breakerResp, outletsResp, switchesResp]) => {
+        if (cancelled) return;
+        setBreaker(breakerResp.data);
+        setOutlets(outletsResp.data.results);
+        // The API filters outlets by breaker server-side, but light switches
+        // do not have a ?breaker filter — narrow client-side.
+        setSwitches(
+          switchesResp.data.results.filter((sw) => String(sw.breaker) === String(id)),
+        );
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err.response?.data?.detail || 'Failed to load breaker trace');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  if (loading) {
+    return <Text>Loading breaker trace…</Text>;
+  }
+
+  if (error || !breaker) {
+    return (
+      <Stack gap="md">
+        <Alert icon={<IconAlertCircle size={16} />} color="red" title="Error">
+          {error || 'Breaker not found'}
+        </Alert>
+        <Anchor component={Link} to="/facilities/electrical">
+          Back to electrical circuits
+        </Anchor>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack gap="md">
+      <Group justify="space-between">
+        <div>
+          <Anchor component={Link} to="/facilities/electrical">
+            <Group gap={4}>
+              <IconArrowLeft size={14} />
+              <Text size="sm">Back to electrical circuits</Text>
+            </Group>
+          </Anchor>
+          <Title order={2}>
+            Trace: {breaker.panel} / {breaker.breaker_number}
+          </Title>
+          <Text c="dimmed">
+            {breaker.amperage}A · {breaker.voltage}V · {breaker.poles}-pole · panel at{' '}
+            {breaker.location_name}
+          </Text>
+        </div>
+      </Group>
+
+      {breaker.description && (
+        <Paper p="md" withBorder>
+          <Text size="sm" fw={500}>
+            Description
+          </Text>
+          <Text>{breaker.description}</Text>
+        </Paper>
+      )}
+
+      <Paper p="md" withBorder>
+        <Group justify="space-between" mb="sm">
+          <Title order={4}>Outlets fed by this breaker</Title>
+          <Badge variant="light">{outlets.length}</Badge>
+        </Group>
+        {outlets.length === 0 ? (
+          <Text c="dimmed">No outlets are currently linked to this breaker.</Text>
+        ) : (
+          <Table>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Identifier</Table.Th>
+                <Table.Th>Location</Table.Th>
+                <Table.Th>Type</Table.Th>
+                <Table.Th>Plugged in</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {outlets.map((outlet) => (
+                <Table.Tr key={outlet.id}>
+                  <Table.Td>
+                    <Anchor
+                      component={Link}
+                      to={`/facilities/electrical/outlets/${outlet.id}/edit`}
+                    >
+                      {outlet.identifier}
+                    </Anchor>
+                  </Table.Td>
+                  <Table.Td>{outlet.location_name}</Table.Td>
+                  <Table.Td>{outletTypeLabel(outlet.outlet_type)}</Table.Td>
+                  <Table.Td>{outlet.plugged_in_notes || '—'}</Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        )}
+      </Paper>
+
+      <Paper p="md" withBorder>
+        <Group justify="space-between" mb="sm">
+          <Title order={4}>Light switches fed by this breaker</Title>
+          <Badge variant="light">{switches.length}</Badge>
+        </Group>
+        {switches.length === 0 ? (
+          <Text c="dimmed">
+            No light switches are currently linked to this breaker.
+          </Text>
+        ) : (
+          <Table>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Identifier</Table.Th>
+                <Table.Th>Mounted at</Table.Th>
+                <Table.Th>Controls</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {switches.map((sw) => (
+                <Table.Tr key={sw.id}>
+                  <Table.Td>
+                    <Anchor
+                      component={Link}
+                      to={`/facilities/electrical/light-switches/${sw.id}/edit`}
+                    >
+                      {sw.identifier}
+                    </Anchor>
+                  </Table.Td>
+                  <Table.Td>{sw.location_name}</Table.Td>
+                  <Table.Td>
+                    {sw.controls_location_name ? (
+                      <Badge color="blue" variant="light">
+                        {sw.controls_location_name}
+                      </Badge>
+                    ) : (
+                      <Text size="sm" c="dimmed">
+                        same location
+                      </Text>
+                    )}
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        )}
+      </Paper>
+    </Stack>
+  );
+};
+
+export default BreakerTracePage;

--- a/frontend/src/pages/ElectricalCircuitsPage.tsx
+++ b/frontend/src/pages/ElectricalCircuitsPage.tsx
@@ -1,0 +1,555 @@
+/**
+ * Electrical Circuits Page (oms-a5f)
+ *
+ * Browse breakers, outlets, light switches, and network drops with filters
+ * by Location. Provides entry points to create/edit forms and the breaker
+ * trace view ("show me everything fed by this breaker").
+ */
+import {
+  ActionIcon,
+  Anchor,
+  Badge,
+  Button,
+  Group,
+  Paper,
+  Select,
+  Stack,
+  Table,
+  Tabs,
+  Text,
+  Title,
+} from '@mantine/core';
+import {
+  IconBolt,
+  IconBulb,
+  IconEdit,
+  IconNetwork,
+  IconPlus,
+  IconPlugConnected,
+  IconRouteAltLeft,
+  IconTrash,
+} from '@tabler/icons-react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import {
+  electricalCircuitsAPI,
+  inventoryAPI,
+  NETWORK_DROP_TYPE_OPTIONS,
+  OUTLET_TYPE_OPTIONS,
+} from '../services/api';
+import {
+  Breaker,
+  LightSwitch,
+  Location,
+  NetworkDrop,
+  NetworkDropType,
+  Outlet,
+} from '../types';
+import { confirmDelete, showError } from '../utils/dialogs';
+
+type ActiveTab = 'breakers' | 'outlets' | 'switches' | 'drops';
+
+const dropTypeLabel = (value: string): string =>
+  NETWORK_DROP_TYPE_OPTIONS.find((option) => option.value === value)?.label || value;
+
+const outletTypeLabel = (value: string): string =>
+  OUTLET_TYPE_OPTIONS.find((option) => option.value === value)?.label || value;
+
+const ElectricalCircuitsPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<ActiveTab>('breakers');
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [locationFilter, setLocationFilter] = useState<string | null>(null);
+  const [dropTypeFilter, setDropTypeFilter] = useState<string | null>(null);
+
+  const [breakers, setBreakers] = useState<Breaker[]>([]);
+  const [outlets, setOutlets] = useState<Outlet[]>([]);
+  const [switches, setSwitches] = useState<LightSwitch[]>([]);
+  const [drops, setDrops] = useState<NetworkDrop[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const locationOptions = useMemo(
+    () =>
+      locations.map((loc) => ({ value: String(loc.id), label: loc.name })),
+    [locations],
+  );
+
+  useEffect(() => {
+    inventoryAPI
+      .listLocations()
+      .then((response) => setLocations(response.data.results))
+      .catch((err) => {
+        console.error('Failed to load locations', err);
+      });
+  }, []);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    const locationParam = locationFilter ? Number(locationFilter) : undefined;
+    try {
+      if (activeTab === 'breakers') {
+        const response = await electricalCircuitsAPI.listBreakers({ location: locationParam });
+        setBreakers(response.data.results);
+      } else if (activeTab === 'outlets') {
+        const response = await electricalCircuitsAPI.listOutlets({ location: locationParam });
+        setOutlets(response.data.results);
+      } else if (activeTab === 'switches') {
+        const response = await electricalCircuitsAPI.listLightSwitches({ location: locationParam });
+        setSwitches(response.data.results);
+      } else if (activeTab === 'drops') {
+        const response = await electricalCircuitsAPI.listNetworkDrops({
+          location: locationParam,
+          drop_type: (dropTypeFilter as NetworkDropType | null) ?? undefined,
+        });
+        setDrops(response.data.results);
+      }
+    } catch (err: any) {
+      showError(err.response?.data?.detail || 'Failed to load records');
+    } finally {
+      setLoading(false);
+    }
+  }, [activeTab, locationFilter, dropTypeFilter]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const handleDeleteBreaker = (breaker: Breaker) => {
+    confirmDelete(`Delete breaker ${breaker.panel}/${breaker.breaker_number}?`, async () => {
+      try {
+        await electricalCircuitsAPI.deleteBreaker(breaker.id);
+        await reload();
+      } catch (err: any) {
+        showError(err.response?.data?.detail || 'Failed to delete breaker');
+      }
+    });
+  };
+
+  const handleDeleteOutlet = (outlet: Outlet) => {
+    confirmDelete(`Delete outlet ${outlet.identifier}?`, async () => {
+      try {
+        await electricalCircuitsAPI.deleteOutlet(outlet.id);
+        await reload();
+      } catch (err: any) {
+        showError(err.response?.data?.detail || 'Failed to delete outlet');
+      }
+    });
+  };
+
+  const handleDeleteSwitch = (sw: LightSwitch) => {
+    confirmDelete(`Delete light switch ${sw.identifier}?`, async () => {
+      try {
+        await electricalCircuitsAPI.deleteLightSwitch(sw.id);
+        await reload();
+      } catch (err: any) {
+        showError(err.response?.data?.detail || 'Failed to delete light switch');
+      }
+    });
+  };
+
+  const handleDeleteDrop = (drop: NetworkDrop) => {
+    confirmDelete(`Delete network drop ${drop.identifier}?`, async () => {
+      try {
+        await electricalCircuitsAPI.deleteNetworkDrop(drop.id);
+        await reload();
+      } catch (err: any) {
+        showError(err.response?.data?.detail || 'Failed to delete network drop');
+      }
+    });
+  };
+
+  const filterBar = (
+    <Paper p="md" withBorder>
+      <Group>
+        <Select
+          label="Location"
+          placeholder="All locations"
+          data={locationOptions}
+          value={locationFilter}
+          onChange={setLocationFilter}
+          clearable
+          searchable
+          style={{ minWidth: 240 }}
+        />
+        {activeTab === 'drops' && (
+          <Select
+            label="Drop type"
+            placeholder="All drop types"
+            data={NETWORK_DROP_TYPE_OPTIONS}
+            value={dropTypeFilter}
+            onChange={setDropTypeFilter}
+            clearable
+            style={{ minWidth: 220 }}
+          />
+        )}
+      </Group>
+    </Paper>
+  );
+
+  const breakersTable = (
+    <Paper withBorder>
+      <Table>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Panel / #</Table.Th>
+            <Table.Th>Location</Table.Th>
+            <Table.Th>Amps</Table.Th>
+            <Table.Th>Voltage</Table.Th>
+            <Table.Th>Poles</Table.Th>
+            <Table.Th>Description</Table.Th>
+            <Table.Th>Status</Table.Th>
+            <Table.Th>Actions</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {breakers.length === 0 ? (
+            <Table.Tr>
+              <Table.Td colSpan={8} style={{ textAlign: 'center', padding: '1.5rem' }}>
+                <Text c="dimmed">{loading ? 'Loading…' : 'No breakers found'}</Text>
+              </Table.Td>
+            </Table.Tr>
+          ) : (
+            breakers.map((breaker) => (
+              <Table.Tr key={breaker.id}>
+                <Table.Td>
+                  <Text fw={500}>
+                    {breaker.panel} / {breaker.breaker_number}
+                  </Text>
+                </Table.Td>
+                <Table.Td>{breaker.location_name}</Table.Td>
+                <Table.Td>{breaker.amperage}A</Table.Td>
+                <Table.Td>{breaker.voltage}V</Table.Td>
+                <Table.Td>{breaker.poles}</Table.Td>
+                <Table.Td>{breaker.description || '—'}</Table.Td>
+                <Table.Td>
+                  {breaker.is_active ? (
+                    <Badge color="green">Active</Badge>
+                  ) : (
+                    <Badge color="gray" variant="light">
+                      Inactive
+                    </Badge>
+                  )}
+                </Table.Td>
+                <Table.Td>
+                  <Group gap="xs">
+                    <ActionIcon
+                      variant="subtle"
+                      title="Trace fed loads"
+                      onClick={() =>
+                        navigate(`/facilities/electrical/breakers/${breaker.id}/trace`)
+                      }
+                    >
+                      <IconRouteAltLeft size={16} />
+                    </ActionIcon>
+                    <ActionIcon
+                      variant="subtle"
+                      title="Edit"
+                      onClick={() =>
+                        navigate(`/facilities/electrical/breakers/${breaker.id}/edit`)
+                      }
+                    >
+                      <IconEdit size={16} />
+                    </ActionIcon>
+                    <ActionIcon
+                      variant="subtle"
+                      color="red"
+                      title="Delete"
+                      onClick={() => handleDeleteBreaker(breaker)}
+                    >
+                      <IconTrash size={16} />
+                    </ActionIcon>
+                  </Group>
+                </Table.Td>
+              </Table.Tr>
+            ))
+          )}
+        </Table.Tbody>
+      </Table>
+    </Paper>
+  );
+
+  const outletsTable = (
+    <Paper withBorder>
+      <Table>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Identifier</Table.Th>
+            <Table.Th>Location</Table.Th>
+            <Table.Th>Type</Table.Th>
+            <Table.Th>Breaker</Table.Th>
+            <Table.Th>Plugged in</Table.Th>
+            <Table.Th>Status</Table.Th>
+            <Table.Th>Actions</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {outlets.length === 0 ? (
+            <Table.Tr>
+              <Table.Td colSpan={7} style={{ textAlign: 'center', padding: '1.5rem' }}>
+                <Text c="dimmed">{loading ? 'Loading…' : 'No outlets found'}</Text>
+              </Table.Td>
+            </Table.Tr>
+          ) : (
+            outlets.map((outlet) => (
+              <Table.Tr key={outlet.id}>
+                <Table.Td>
+                  <Text fw={500}>{outlet.identifier}</Text>
+                </Table.Td>
+                <Table.Td>{outlet.location_name}</Table.Td>
+                <Table.Td>{outletTypeLabel(outlet.outlet_type)}</Table.Td>
+                <Table.Td>{outlet.breaker_label || '—'}</Table.Td>
+                <Table.Td>
+                  <Text size="sm" lineClamp={2}>
+                    {outlet.plugged_in_notes || '—'}
+                  </Text>
+                </Table.Td>
+                <Table.Td>
+                  {outlet.is_active ? (
+                    <Badge color="green">Active</Badge>
+                  ) : (
+                    <Badge color="gray" variant="light">
+                      Inactive
+                    </Badge>
+                  )}
+                </Table.Td>
+                <Table.Td>
+                  <Group gap="xs">
+                    <ActionIcon
+                      variant="subtle"
+                      title="Edit"
+                      onClick={() =>
+                        navigate(`/facilities/electrical/outlets/${outlet.id}/edit`)
+                      }
+                    >
+                      <IconEdit size={16} />
+                    </ActionIcon>
+                    <ActionIcon
+                      variant="subtle"
+                      color="red"
+                      title="Delete"
+                      onClick={() => handleDeleteOutlet(outlet)}
+                    >
+                      <IconTrash size={16} />
+                    </ActionIcon>
+                  </Group>
+                </Table.Td>
+              </Table.Tr>
+            ))
+          )}
+        </Table.Tbody>
+      </Table>
+    </Paper>
+  );
+
+  const switchesTable = (
+    <Paper withBorder>
+      <Table>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Identifier</Table.Th>
+            <Table.Th>Mounted at</Table.Th>
+            <Table.Th>Controls</Table.Th>
+            <Table.Th>Breaker</Table.Th>
+            <Table.Th>Status</Table.Th>
+            <Table.Th>Actions</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {switches.length === 0 ? (
+            <Table.Tr>
+              <Table.Td colSpan={6} style={{ textAlign: 'center', padding: '1.5rem' }}>
+                <Text c="dimmed">{loading ? 'Loading…' : 'No light switches found'}</Text>
+              </Table.Td>
+            </Table.Tr>
+          ) : (
+            switches.map((sw) => (
+              <Table.Tr key={sw.id}>
+                <Table.Td>
+                  <Text fw={500}>{sw.identifier}</Text>
+                </Table.Td>
+                <Table.Td>{sw.location_name}</Table.Td>
+                <Table.Td>
+                  {sw.controls_location_name ? (
+                    <Badge color="blue" variant="light">
+                      {sw.controls_location_name}
+                    </Badge>
+                  ) : (
+                    <Text size="sm" c="dimmed">
+                      same location
+                    </Text>
+                  )}
+                </Table.Td>
+                <Table.Td>{sw.breaker_label || '—'}</Table.Td>
+                <Table.Td>
+                  {sw.is_active ? (
+                    <Badge color="green">Active</Badge>
+                  ) : (
+                    <Badge color="gray" variant="light">
+                      Inactive
+                    </Badge>
+                  )}
+                </Table.Td>
+                <Table.Td>
+                  <Group gap="xs">
+                    <ActionIcon
+                      variant="subtle"
+                      title="Edit"
+                      onClick={() =>
+                        navigate(`/facilities/electrical/light-switches/${sw.id}/edit`)
+                      }
+                    >
+                      <IconEdit size={16} />
+                    </ActionIcon>
+                    <ActionIcon
+                      variant="subtle"
+                      color="red"
+                      title="Delete"
+                      onClick={() => handleDeleteSwitch(sw)}
+                    >
+                      <IconTrash size={16} />
+                    </ActionIcon>
+                  </Group>
+                </Table.Td>
+              </Table.Tr>
+            ))
+          )}
+        </Table.Tbody>
+      </Table>
+    </Paper>
+  );
+
+  const dropsTable = (
+    <Paper withBorder>
+      <Table>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Identifier</Table.Th>
+            <Table.Th>Type</Table.Th>
+            <Table.Th>Location</Table.Th>
+            <Table.Th>Patch panel / port</Table.Th>
+            <Table.Th>MAC / IP</Table.Th>
+            <Table.Th>Status</Table.Th>
+            <Table.Th>Actions</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {drops.length === 0 ? (
+            <Table.Tr>
+              <Table.Td colSpan={7} style={{ textAlign: 'center', padding: '1.5rem' }}>
+                <Text c="dimmed">{loading ? 'Loading…' : 'No network drops found'}</Text>
+              </Table.Td>
+            </Table.Tr>
+          ) : (
+            drops.map((drop) => (
+              <Table.Tr key={drop.id}>
+                <Table.Td>
+                  <Text fw={500}>{drop.identifier}</Text>
+                </Table.Td>
+                <Table.Td>
+                  <Badge variant="light">{dropTypeLabel(drop.drop_type)}</Badge>
+                </Table.Td>
+                <Table.Td>{drop.location_name}</Table.Td>
+                <Table.Td>
+                  {drop.patch_panel ? `${drop.patch_panel} / ${drop.patch_port || '—'}` : '—'}
+                </Table.Td>
+                <Table.Td>
+                  <Stack gap={0}>
+                    {drop.mac_address && <Text size="xs">{drop.mac_address}</Text>}
+                    {drop.ip_address && <Text size="xs">{drop.ip_address}</Text>}
+                    {!drop.mac_address && !drop.ip_address && <Text size="xs" c="dimmed">—</Text>}
+                  </Stack>
+                </Table.Td>
+                <Table.Td>
+                  {drop.is_active ? (
+                    <Badge color="green">Active</Badge>
+                  ) : (
+                    <Badge color="gray" variant="light">
+                      Inactive
+                    </Badge>
+                  )}
+                </Table.Td>
+                <Table.Td>
+                  <Group gap="xs">
+                    <ActionIcon
+                      variant="subtle"
+                      title="Edit"
+                      onClick={() =>
+                        navigate(`/facilities/electrical/network-drops/${drop.id}/edit`)
+                      }
+                    >
+                      <IconEdit size={16} />
+                    </ActionIcon>
+                    <ActionIcon
+                      variant="subtle"
+                      color="red"
+                      title="Delete"
+                      onClick={() => handleDeleteDrop(drop)}
+                    >
+                      <IconTrash size={16} />
+                    </ActionIcon>
+                  </Group>
+                </Table.Td>
+              </Table.Tr>
+            ))
+          )}
+        </Table.Tbody>
+      </Table>
+    </Paper>
+  );
+
+  const newRoute = {
+    breakers: '/facilities/electrical/breakers/new',
+    outlets: '/facilities/electrical/outlets/new',
+    switches: '/facilities/electrical/light-switches/new',
+    drops: '/facilities/electrical/network-drops/new',
+  }[activeTab];
+
+  const newLabel = {
+    breakers: 'New breaker',
+    outlets: 'New outlet',
+    switches: 'New light switch',
+    drops: 'New network drop',
+  }[activeTab];
+
+  return (
+    <Stack gap="md">
+      <Group justify="space-between">
+        <Title order={2}>Electrical Circuits & Network</Title>
+        <Group>
+          <Anchor component={Link} to="/inventory/locations">
+            Locations
+          </Anchor>
+          <Button leftSection={<IconPlus size={16} />} onClick={() => navigate(newRoute)}>
+            {newLabel}
+          </Button>
+        </Group>
+      </Group>
+
+      <Tabs value={activeTab} onChange={(value) => setActiveTab((value as ActiveTab) || 'breakers')}>
+        <Tabs.List>
+          <Tabs.Tab value="breakers" leftSection={<IconBolt size={16} />}>
+            Breakers
+          </Tabs.Tab>
+          <Tabs.Tab value="outlets" leftSection={<IconPlugConnected size={16} />}>
+            Outlets
+          </Tabs.Tab>
+          <Tabs.Tab value="switches" leftSection={<IconBulb size={16} />}>
+            Light switches
+          </Tabs.Tab>
+          <Tabs.Tab value="drops" leftSection={<IconNetwork size={16} />}>
+            Network drops
+          </Tabs.Tab>
+        </Tabs.List>
+      </Tabs>
+
+      {filterBar}
+
+      {activeTab === 'breakers' && breakersTable}
+      {activeTab === 'outlets' && outletsTable}
+      {activeTab === 'switches' && switchesTable}
+      {activeTab === 'drops' && dropsTable}
+    </Stack>
+  );
+};
+
+export default ElectricalCircuitsPage;

--- a/frontend/src/pages/LightSwitchFormPage.tsx
+++ b/frontend/src/pages/LightSwitchFormPage.tsx
@@ -1,0 +1,250 @@
+/**
+ * Light Switch Form Page (oms-a5f) — create/edit a light switch.
+ *
+ * The "controls location" relationship is highlighted because makerspace
+ * switches frequently sit in one location and operate the lights of another.
+ */
+import {
+  Alert,
+  Button,
+  Group,
+  Paper,
+  Select,
+  Stack,
+  Switch,
+  Text,
+  Textarea,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { IconAlertCircle } from '@tabler/icons-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { electricalCircuitsAPI, inventoryAPI } from '../services/api';
+import { Breaker, Location } from '../types';
+
+interface FormState {
+  location: number | null;
+  identifier: string;
+  controls_location: number | null;
+  breaker: number | null;
+  description: string;
+  notes: string;
+  is_active: boolean;
+}
+
+const initialState: FormState = {
+  location: null,
+  identifier: '',
+  controls_location: null,
+  breaker: null,
+  description: '',
+  notes: '',
+  is_active: true,
+};
+
+const LightSwitchFormPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const isEdit = Boolean(id);
+
+  const [form, setForm] = useState<FormState>(initialState);
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [breakers, setBreakers] = useState<Breaker[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const locationOptions = useMemo(
+    () => locations.map((l) => ({ value: String(l.id), label: l.name })),
+    [locations],
+  );
+  const breakerOptions = useMemo(
+    () =>
+      breakers.map((b) => ({
+        value: String(b.id),
+        label: `${b.panel} / ${b.breaker_number} (${b.amperage}A) — ${b.location_name}`,
+      })),
+    [breakers],
+  );
+
+  useEffect(() => {
+    inventoryAPI
+      .listLocations()
+      .then((response) => setLocations(response.data.results))
+      .catch((err) => console.error('Failed to load locations', err));
+    electricalCircuitsAPI
+      .listBreakers({ is_active: true })
+      .then((response) => setBreakers(response.data.results))
+      .catch((err) => console.error('Failed to load breakers', err));
+  }, []);
+
+  useEffect(() => {
+    if (!isEdit || !id) return;
+    setLoading(true);
+    electricalCircuitsAPI
+      .getLightSwitch(id)
+      .then((response) => {
+        const sw = response.data;
+        setForm({
+          location: sw.location,
+          identifier: sw.identifier,
+          controls_location: sw.controls_location,
+          breaker: sw.breaker,
+          description: sw.description,
+          notes: sw.notes,
+          is_active: sw.is_active,
+        });
+      })
+      .catch((err) => {
+        setError(err.response?.data?.detail || 'Failed to load light switch');
+      })
+      .finally(() => setLoading(false));
+  }, [id, isEdit]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    if (!form.location) {
+      setError('Location is required.');
+      return;
+    }
+    if (!form.identifier.trim()) {
+      setError('Identifier is required.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload = {
+        location: form.location,
+        identifier: form.identifier.trim(),
+        controls_location: form.controls_location,
+        breaker: form.breaker,
+        description: form.description,
+        notes: form.notes,
+        is_active: form.is_active,
+      };
+      if (isEdit && id) {
+        await electricalCircuitsAPI.updateLightSwitch(id, payload);
+      } else {
+        await electricalCircuitsAPI.createLightSwitch(payload);
+      }
+      navigate('/facilities/electrical');
+    } catch (err: any) {
+      const data = err.response?.data;
+      const detail =
+        data?.detail ||
+        (typeof data === 'object' && data
+          ? Object.entries(data)
+              .map(([key, value]) => `${key}: ${Array.isArray(value) ? value.join(', ') : value}`)
+              .join('; ')
+          : null) ||
+        'Failed to save light switch';
+      setError(detail);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const sameLocation =
+    form.controls_location !== null && form.location === form.controls_location;
+
+  if (loading) return <div>Loading light switch…</div>;
+
+  return (
+    <Stack gap="md">
+      <Title order={2}>{isEdit ? 'Edit light switch' : 'New light switch'}</Title>
+      {error && (
+        <Alert icon={<IconAlertCircle size={16} />} color="red" title="Error">
+          {error}
+        </Alert>
+      )}
+      <form onSubmit={handleSubmit}>
+        <Paper p="md" withBorder>
+          <Stack>
+            <Select
+              label="Mounted at (where the switch lives)"
+              placeholder="Select location"
+              data={locationOptions}
+              value={form.location ? String(form.location) : null}
+              onChange={(value) =>
+                setForm((s) => ({ ...s, location: value ? Number(value) : null }))
+              }
+              required
+              searchable
+            />
+            <TextInput
+              label="Identifier"
+              placeholder="door-east"
+              value={form.identifier}
+              onChange={(e) => setForm((s) => ({ ...s, identifier: e.target.value }))}
+              required
+            />
+            <Select
+              label="Controls lights at"
+              description="Leave blank if the switch operates the lights of its own location"
+              placeholder="Optional — select location whose lights this switch controls"
+              data={locationOptions}
+              value={form.controls_location ? String(form.controls_location) : null}
+              onChange={(value) =>
+                setForm((s) => ({
+                  ...s,
+                  controls_location: value ? Number(value) : null,
+                }))
+              }
+              clearable
+              searchable
+            />
+            {sameLocation && (
+              <Text c="dimmed" size="xs">
+                Tip: leave this blank if the switch controls the lights of the same
+                location it&apos;s mounted in.
+              </Text>
+            )}
+            <Select
+              label="Breaker (feeds this lighting circuit)"
+              placeholder="Optional — select breaker"
+              data={breakerOptions}
+              value={form.breaker ? String(form.breaker) : null}
+              onChange={(value) =>
+                setForm((s) => ({ ...s, breaker: value ? Number(value) : null }))
+              }
+              clearable
+              searchable
+            />
+            <TextInput
+              label="Description"
+              value={form.description}
+              onChange={(e) =>
+                setForm((s) => ({ ...s, description: e.target.value }))
+              }
+            />
+            <Textarea
+              label="Notes"
+              value={form.notes}
+              onChange={(e) => setForm((s) => ({ ...s, notes: e.target.value }))}
+              rows={3}
+            />
+            <Switch
+              label="Active"
+              checked={form.is_active}
+              onChange={(e) =>
+                setForm((s) => ({ ...s, is_active: e.currentTarget.checked }))
+              }
+            />
+          </Stack>
+          <Group justify="flex-end" mt="xl">
+            <Button variant="subtle" onClick={() => navigate(-1)} type="button">
+              Cancel
+            </Button>
+            <Button type="submit" loading={saving}>
+              {isEdit ? 'Save changes' : 'Create light switch'}
+            </Button>
+          </Group>
+        </Paper>
+      </form>
+    </Stack>
+  );
+};
+
+export default LightSwitchFormPage;

--- a/frontend/src/pages/NetworkDropFormPage.tsx
+++ b/frontend/src/pages/NetworkDropFormPage.tsx
@@ -1,0 +1,293 @@
+/**
+ * Network Drop Form Page (oms-a5f) — create/edit a network jack/drop with photo.
+ */
+import {
+  Alert,
+  Button,
+  FileInput,
+  Group,
+  Image,
+  Paper,
+  Select,
+  Stack,
+  Switch,
+  Textarea,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { IconAlertCircle, IconPhoto } from '@tabler/icons-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  electricalCircuitsAPI,
+  inventoryAPI,
+  NETWORK_DROP_TYPE_OPTIONS,
+} from '../services/api';
+import { Location, NetworkDropType } from '../types';
+
+interface FormState {
+  location: number | null;
+  identifier: string;
+  drop_type: NetworkDropType;
+  patch_panel: string;
+  patch_port: string;
+  mac_address: string;
+  ip_address: string;
+  description: string;
+  notes: string;
+  is_active: boolean;
+}
+
+const initialState: FormState = {
+  location: null,
+  identifier: '',
+  drop_type: 'data',
+  patch_panel: '',
+  patch_port: '',
+  mac_address: '',
+  ip_address: '',
+  description: '',
+  notes: '',
+  is_active: true,
+};
+
+const NetworkDropFormPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const isEdit = Boolean(id);
+
+  const [form, setForm] = useState<FormState>(initialState);
+  const [photoFile, setPhotoFile] = useState<File | null>(null);
+  const [existingPhoto, setExistingPhoto] = useState<string | null>(null);
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const locationOptions = useMemo(
+    () => locations.map((l) => ({ value: String(l.id), label: l.name })),
+    [locations],
+  );
+
+  useEffect(() => {
+    inventoryAPI
+      .listLocations()
+      .then((response) => setLocations(response.data.results))
+      .catch((err) => console.error('Failed to load locations', err));
+  }, []);
+
+  useEffect(() => {
+    if (!isEdit || !id) return;
+    setLoading(true);
+    electricalCircuitsAPI
+      .getNetworkDrop(id)
+      .then((response) => {
+        const d = response.data;
+        setForm({
+          location: d.location,
+          identifier: d.identifier,
+          drop_type: d.drop_type,
+          patch_panel: d.patch_panel,
+          patch_port: d.patch_port,
+          mac_address: d.mac_address,
+          ip_address: d.ip_address || '',
+          description: d.description,
+          notes: d.notes,
+          is_active: d.is_active,
+        });
+        setExistingPhoto(d.photo);
+      })
+      .catch((err) => {
+        setError(err.response?.data?.detail || 'Failed to load network drop');
+      })
+      .finally(() => setLoading(false));
+  }, [id, isEdit]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    if (!form.location) {
+      setError('Location is required.');
+      return;
+    }
+    if (!form.identifier.trim()) {
+      setError('Identifier is required.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload: Record<string, unknown> = {
+        location: form.location,
+        identifier: form.identifier.trim(),
+        drop_type: form.drop_type,
+        patch_panel: form.patch_panel,
+        patch_port: form.patch_port,
+        mac_address: form.mac_address,
+        description: form.description,
+        notes: form.notes,
+        is_active: form.is_active,
+      };
+      if (form.ip_address.trim()) {
+        payload.ip_address = form.ip_address.trim();
+      } else if (isEdit) {
+        payload.ip_address = null;
+      }
+      if (photoFile) {
+        payload.photo = photoFile;
+      }
+      if (isEdit && id) {
+        await electricalCircuitsAPI.updateNetworkDrop(id, payload as any);
+      } else {
+        await electricalCircuitsAPI.createNetworkDrop(payload as any);
+      }
+      navigate('/facilities/electrical');
+    } catch (err: any) {
+      const data = err.response?.data;
+      const detail =
+        data?.detail ||
+        (typeof data === 'object' && data
+          ? Object.entries(data)
+              .map(([key, value]) => `${key}: ${Array.isArray(value) ? value.join(', ') : value}`)
+              .join('; ')
+          : null) ||
+        'Failed to save network drop';
+      setError(detail);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return <div>Loading network drop…</div>;
+
+  return (
+    <Stack gap="md">
+      <Title order={2}>{isEdit ? 'Edit network drop' : 'New network drop'}</Title>
+      {error && (
+        <Alert icon={<IconAlertCircle size={16} />} color="red" title="Error">
+          {error}
+        </Alert>
+      )}
+      <form onSubmit={handleSubmit}>
+        <Paper p="md" withBorder>
+          <Stack>
+            <Select
+              label="Location"
+              placeholder="Select location"
+              data={locationOptions}
+              value={form.location ? String(form.location) : null}
+              onChange={(value) =>
+                setForm((s) => ({ ...s, location: value ? Number(value) : null }))
+              }
+              required
+              searchable
+            />
+            <TextInput
+              label="Identifier"
+              placeholder="wallplate-3A"
+              value={form.identifier}
+              onChange={(e) =>
+                setForm((s) => ({ ...s, identifier: e.target.value }))
+              }
+              required
+            />
+            <Select
+              label="Drop type"
+              data={NETWORK_DROP_TYPE_OPTIONS}
+              value={form.drop_type}
+              onChange={(value) =>
+                setForm((s) => ({
+                  ...s,
+                  drop_type: (value as NetworkDropType) || 'data',
+                }))
+              }
+            />
+            <Group grow>
+              <TextInput
+                label="Patch panel"
+                placeholder="IDF-1 patch panel B"
+                value={form.patch_panel}
+                onChange={(e) =>
+                  setForm((s) => ({ ...s, patch_panel: e.target.value }))
+                }
+              />
+              <TextInput
+                label="Patch port"
+                placeholder="24"
+                value={form.patch_port}
+                onChange={(e) =>
+                  setForm((s) => ({ ...s, patch_port: e.target.value }))
+                }
+              />
+            </Group>
+            <Group grow>
+              <TextInput
+                label="MAC address"
+                placeholder="aa:bb:cc:dd:ee:ff"
+                value={form.mac_address}
+                onChange={(e) =>
+                  setForm((s) => ({ ...s, mac_address: e.target.value }))
+                }
+              />
+              <TextInput
+                label="IP address"
+                placeholder="10.0.0.42"
+                value={form.ip_address}
+                onChange={(e) =>
+                  setForm((s) => ({ ...s, ip_address: e.target.value }))
+                }
+              />
+            </Group>
+            <TextInput
+              label="Description"
+              value={form.description}
+              onChange={(e) =>
+                setForm((s) => ({ ...s, description: e.target.value }))
+              }
+            />
+            <Textarea
+              label="Notes"
+              value={form.notes}
+              onChange={(e) => setForm((s) => ({ ...s, notes: e.target.value }))}
+              rows={3}
+            />
+            <FileInput
+              label="Photo"
+              placeholder="Upload drop photo"
+              accept="image/*"
+              leftSection={<IconPhoto size={16} />}
+              value={photoFile}
+              onChange={setPhotoFile}
+              clearable
+            />
+            {existingPhoto && !photoFile && (
+              <Image
+                src={existingPhoto}
+                alt="Existing network drop photo"
+                radius="md"
+                h={200}
+                fit="contain"
+              />
+            )}
+            <Switch
+              label="Active"
+              checked={form.is_active}
+              onChange={(e) =>
+                setForm((s) => ({ ...s, is_active: e.currentTarget.checked }))
+              }
+            />
+          </Stack>
+          <Group justify="flex-end" mt="xl">
+            <Button variant="subtle" onClick={() => navigate(-1)} type="button">
+              Cancel
+            </Button>
+            <Button type="submit" loading={saving}>
+              {isEdit ? 'Save changes' : 'Create network drop'}
+            </Button>
+          </Group>
+        </Paper>
+      </form>
+    </Stack>
+  );
+};
+
+export default NetworkDropFormPage;

--- a/frontend/src/pages/OutletFormPage.tsx
+++ b/frontend/src/pages/OutletFormPage.tsx
@@ -1,0 +1,259 @@
+/**
+ * Outlet Form Page (oms-a5f) — create/edit an electrical outlet with photo.
+ */
+import {
+  Alert,
+  Button,
+  FileInput,
+  Group,
+  Image,
+  Paper,
+  Select,
+  Stack,
+  Switch,
+  Textarea,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { IconAlertCircle, IconPhoto } from '@tabler/icons-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  electricalCircuitsAPI,
+  inventoryAPI,
+  OUTLET_TYPE_OPTIONS,
+} from '../services/api';
+import { Breaker, Location, OutletType } from '../types';
+
+interface FormState {
+  location: number | null;
+  identifier: string;
+  breaker: number | null;
+  outlet_type: OutletType;
+  description: string;
+  plugged_in_notes: string;
+  is_active: boolean;
+}
+
+const initialState: FormState = {
+  location: null,
+  identifier: '',
+  breaker: null,
+  outlet_type: 'standard',
+  description: '',
+  plugged_in_notes: '',
+  is_active: true,
+};
+
+const OutletFormPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const isEdit = Boolean(id);
+
+  const [form, setForm] = useState<FormState>(initialState);
+  const [photoFile, setPhotoFile] = useState<File | null>(null);
+  const [existingPhoto, setExistingPhoto] = useState<string | null>(null);
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [breakers, setBreakers] = useState<Breaker[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const locationOptions = useMemo(
+    () => locations.map((l) => ({ value: String(l.id), label: l.name })),
+    [locations],
+  );
+  const breakerOptions = useMemo(
+    () =>
+      breakers.map((b) => ({
+        value: String(b.id),
+        label: `${b.panel} / ${b.breaker_number} (${b.amperage}A) — ${b.location_name}`,
+      })),
+    [breakers],
+  );
+
+  useEffect(() => {
+    inventoryAPI
+      .listLocations()
+      .then((response) => setLocations(response.data.results))
+      .catch((err) => console.error('Failed to load locations', err));
+    electricalCircuitsAPI
+      .listBreakers({ is_active: true })
+      .then((response) => setBreakers(response.data.results))
+      .catch((err) => console.error('Failed to load breakers', err));
+  }, []);
+
+  useEffect(() => {
+    if (!isEdit || !id) return;
+    setLoading(true);
+    electricalCircuitsAPI
+      .getOutlet(id)
+      .then((response) => {
+        const o = response.data;
+        setForm({
+          location: o.location,
+          identifier: o.identifier,
+          breaker: o.breaker,
+          outlet_type: o.outlet_type,
+          description: o.description,
+          plugged_in_notes: o.plugged_in_notes,
+          is_active: o.is_active,
+        });
+        setExistingPhoto(o.photo);
+      })
+      .catch((err) => {
+        setError(err.response?.data?.detail || 'Failed to load outlet');
+      })
+      .finally(() => setLoading(false));
+  }, [id, isEdit]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    if (!form.location) {
+      setError('Location is required.');
+      return;
+    }
+    if (!form.identifier.trim()) {
+      setError('Identifier is required.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload = {
+        location: form.location,
+        identifier: form.identifier.trim(),
+        breaker: form.breaker,
+        outlet_type: form.outlet_type,
+        description: form.description,
+        plugged_in_notes: form.plugged_in_notes,
+        is_active: form.is_active,
+        ...(photoFile ? { photo: photoFile } : {}),
+      };
+      if (isEdit && id) {
+        await electricalCircuitsAPI.updateOutlet(id, payload);
+      } else {
+        await electricalCircuitsAPI.createOutlet(payload);
+      }
+      navigate('/facilities/electrical');
+    } catch (err: any) {
+      const data = err.response?.data;
+      const detail =
+        data?.detail ||
+        (typeof data === 'object' && data
+          ? Object.entries(data)
+              .map(([key, value]) => `${key}: ${Array.isArray(value) ? value.join(', ') : value}`)
+              .join('; ')
+          : null) ||
+        'Failed to save outlet';
+      setError(detail);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return <div>Loading outlet…</div>;
+
+  return (
+    <Stack gap="md">
+      <Title order={2}>{isEdit ? 'Edit outlet' : 'New outlet'}</Title>
+      {error && (
+        <Alert icon={<IconAlertCircle size={16} />} color="red" title="Error">
+          {error}
+        </Alert>
+      )}
+      <form onSubmit={handleSubmit}>
+        <Paper p="md" withBorder>
+          <Stack>
+            <Select
+              label="Location"
+              placeholder="Select location"
+              data={locationOptions}
+              value={form.location ? String(form.location) : null}
+              onChange={(value) =>
+                setForm((s) => ({ ...s, location: value ? Number(value) : null }))
+              }
+              required
+              searchable
+            />
+            <TextInput
+              label="Identifier"
+              placeholder="NW-bench-1"
+              value={form.identifier}
+              onChange={(e) => setForm((s) => ({ ...s, identifier: e.target.value }))}
+              required
+            />
+            <Select
+              label="Outlet type"
+              data={OUTLET_TYPE_OPTIONS}
+              value={form.outlet_type}
+              onChange={(value) =>
+                setForm((s) => ({ ...s, outlet_type: (value as OutletType) || 'standard' }))
+              }
+            />
+            <Select
+              label="Breaker (feeds this outlet)"
+              placeholder="Optional — select breaker"
+              data={breakerOptions}
+              value={form.breaker ? String(form.breaker) : null}
+              onChange={(value) =>
+                setForm((s) => ({ ...s, breaker: value ? Number(value) : null }))
+              }
+              clearable
+              searchable
+            />
+            <TextInput
+              label="Description"
+              value={form.description}
+              onChange={(e) => setForm((s) => ({ ...s, description: e.target.value }))}
+            />
+            <Textarea
+              label="What's plugged in"
+              description="Approximate description of currently connected equipment"
+              value={form.plugged_in_notes}
+              onChange={(e) =>
+                setForm((s) => ({ ...s, plugged_in_notes: e.target.value }))
+              }
+              rows={3}
+            />
+            <FileInput
+              label="Photo"
+              placeholder="Upload outlet photo"
+              accept="image/*"
+              leftSection={<IconPhoto size={16} />}
+              value={photoFile}
+              onChange={setPhotoFile}
+              clearable
+            />
+            {existingPhoto && !photoFile && (
+              <Image
+                src={existingPhoto}
+                alt="Existing outlet photo"
+                radius="md"
+                h={200}
+                fit="contain"
+              />
+            )}
+            <Switch
+              label="Active"
+              checked={form.is_active}
+              onChange={(e) =>
+                setForm((s) => ({ ...s, is_active: e.currentTarget.checked }))
+              }
+            />
+          </Stack>
+          <Group justify="flex-end" mt="xl">
+            <Button variant="subtle" onClick={() => navigate(-1)} type="button">
+              Cancel
+            </Button>
+            <Button type="submit" loading={saving}>
+              {isEdit ? 'Save changes' : 'Create outlet'}
+            </Button>
+          </Group>
+        </Paper>
+      </form>
+    </Stack>
+  );
+};
+
+export default OutletFormPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3,7 +3,7 @@
  */
 import * as Sentry from '@sentry/react';
 import axios from 'axios';
-import { ActiveMaintenanceRow, Asset, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, ItemSupplier, KioskPayload, Location, LocationProblem, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, NotificationPreferences, PendingReordersData, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
+import { ActiveMaintenanceRow, Asset, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
 
 /**
  * Resolves the API base URL based on environment.
@@ -1654,6 +1654,167 @@ export interface ThirdPartyWorkOrderDto {
   updated_at: string;
   closed_at: string | null;
 }
+
+// Electrical Circuits & Network Drops (oms-tt5 / oms-a5f)
+export interface BreakerListParams {
+  location?: number | string;
+  panel?: string;
+  is_active?: boolean;
+}
+export interface OutletListParams {
+  location?: number | string;
+  breaker?: number | string;
+  is_active?: boolean;
+}
+export interface LightSwitchListParams {
+  location?: number | string;
+  controls_location?: number | string;
+  is_active?: boolean;
+}
+export interface NetworkDropListParams {
+  location?: number | string;
+  drop_type?: NetworkDropType;
+  is_active?: boolean;
+}
+
+const electricalBase = '/electrical-circuits';
+
+const buildOutletFormData = (data: Omit<Partial<Outlet>, 'photo'> & { photo?: File | null }) => {
+  const form = new FormData();
+  Object.entries(data).forEach(([key, value]) => {
+    if (value === undefined) return;
+    if (key === 'photo') {
+      if (value instanceof File) form.append('photo', value);
+      // Ignore string URLs / null on update (keeps existing image)
+      return;
+    }
+    if (value === null) {
+      form.append(key, '');
+      return;
+    }
+    form.append(key, String(value));
+  });
+  return form;
+};
+
+const buildNetworkDropFormData = (data: Omit<Partial<NetworkDrop>, 'photo'> & { photo?: File | null }) => {
+  const form = new FormData();
+  Object.entries(data).forEach(([key, value]) => {
+    if (value === undefined) return;
+    if (key === 'photo') {
+      if (value instanceof File) form.append('photo', value);
+      return;
+    }
+    if (value === null) {
+      form.append(key, '');
+      return;
+    }
+    form.append(key, String(value));
+  });
+  return form;
+};
+
+export const electricalCircuitsAPI = {
+  // Breakers
+  listBreakers: (params?: BreakerListParams) =>
+    api.get<{ results: Breaker[] } | Breaker[]>(`${electricalBase}/breakers/`, { params })
+      .then((response) => ({ ...response, data: normalizeResults<Breaker>(response.data) })),
+  getBreaker: (id: number | string) =>
+    api.get<Breaker>(`${electricalBase}/breakers/${id}/`),
+  createBreaker: (data: Partial<Breaker>) =>
+    api.post<Breaker>(`${electricalBase}/breakers/`, data),
+  updateBreaker: (id: number | string, data: Partial<Breaker>) =>
+    api.patch<Breaker>(`${electricalBase}/breakers/${id}/`, data),
+  deleteBreaker: (id: number | string) =>
+    api.delete(`${electricalBase}/breakers/${id}/`),
+
+  // Outlets
+  listOutlets: (params?: OutletListParams) =>
+    api.get<{ results: Outlet[] } | Outlet[]>(`${electricalBase}/outlets/`, { params })
+      .then((response) => ({ ...response, data: normalizeResults<Outlet>(response.data) })),
+  getOutlet: (id: number | string) =>
+    api.get<Outlet>(`${electricalBase}/outlets/${id}/`),
+  createOutlet: (data: Omit<Partial<Outlet>, 'photo'> & { photo?: File | null }) => {
+    if (data.photo instanceof File) {
+      return api.post<Outlet>(`${electricalBase}/outlets/`, buildOutletFormData(data), {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+    }
+    return api.post<Outlet>(`${electricalBase}/outlets/`, data);
+  },
+  updateOutlet: (id: number | string, data: Omit<Partial<Outlet>, 'photo'> & { photo?: File | null }) => {
+    if (data.photo instanceof File) {
+      return api.patch<Outlet>(`${electricalBase}/outlets/${id}/`, buildOutletFormData(data), {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+    }
+    return api.patch<Outlet>(`${electricalBase}/outlets/${id}/`, data);
+  },
+  deleteOutlet: (id: number | string) =>
+    api.delete(`${electricalBase}/outlets/${id}/`),
+
+  // Light switches
+  listLightSwitches: (params?: LightSwitchListParams) =>
+    api.get<{ results: LightSwitch[] } | LightSwitch[]>(`${electricalBase}/light-switches/`, { params })
+      .then((response) => ({ ...response, data: normalizeResults<LightSwitch>(response.data) })),
+  getLightSwitch: (id: number | string) =>
+    api.get<LightSwitch>(`${electricalBase}/light-switches/${id}/`),
+  createLightSwitch: (data: Partial<LightSwitch>) =>
+    api.post<LightSwitch>(`${electricalBase}/light-switches/`, data),
+  updateLightSwitch: (id: number | string, data: Partial<LightSwitch>) =>
+    api.patch<LightSwitch>(`${electricalBase}/light-switches/${id}/`, data),
+  deleteLightSwitch: (id: number | string) =>
+    api.delete(`${electricalBase}/light-switches/${id}/`),
+
+  // Network drops
+  listNetworkDrops: (params?: NetworkDropListParams) =>
+    api.get<{ results: NetworkDrop[] } | NetworkDrop[]>(`${electricalBase}/network-drops/`, { params })
+      .then((response) => ({ ...response, data: normalizeResults<NetworkDrop>(response.data) })),
+  getNetworkDrop: (id: number | string) =>
+    api.get<NetworkDrop>(`${electricalBase}/network-drops/${id}/`),
+  createNetworkDrop: (data: Omit<Partial<NetworkDrop>, 'photo'> & { photo?: File | null }) => {
+    if (data.photo instanceof File) {
+      return api.post<NetworkDrop>(`${electricalBase}/network-drops/`, buildNetworkDropFormData(data), {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+    }
+    return api.post<NetworkDrop>(`${electricalBase}/network-drops/`, data);
+  },
+  updateNetworkDrop: (id: number | string, data: Omit<Partial<NetworkDrop>, 'photo'> & { photo?: File | null }) => {
+    if (data.photo instanceof File) {
+      return api.patch<NetworkDrop>(`${electricalBase}/network-drops/${id}/`, buildNetworkDropFormData(data), {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+    }
+    return api.patch<NetworkDrop>(`${electricalBase}/network-drops/${id}/`, data);
+  },
+  deleteNetworkDrop: (id: number | string) =>
+    api.delete(`${electricalBase}/network-drops/${id}/`),
+};
+
+export const OUTLET_TYPE_OPTIONS = [
+  { value: 'standard', label: 'Standard 120V' },
+  { value: '240v', label: '240V' },
+  { value: 'nema_5_15', label: 'NEMA 5-15 (120V 15A)' },
+  { value: 'nema_5_20', label: 'NEMA 5-20 (120V 20A)' },
+  { value: 'nema_6_15', label: 'NEMA 6-15 (240V 15A)' },
+  { value: 'nema_6_20', label: 'NEMA 6-20 (240V 20A)' },
+  { value: 'nema_l6_30', label: 'NEMA L6-30 (240V 30A locking)' },
+  { value: 'nema_14_30', label: 'NEMA 14-30 (240V 30A)' },
+  { value: 'nema_14_50', label: 'NEMA 14-50 (240V 50A)' },
+  { value: 'usb', label: 'USB charging' },
+  { value: 'other', label: 'Other' },
+];
+
+export const NETWORK_DROP_TYPE_OPTIONS = [
+  { value: 'data', label: 'Data jack' },
+  { value: 'voice', label: 'Voice / phone' },
+  { value: 'patch_panel', label: 'Patch panel termination' },
+  { value: 'ap', label: 'Wireless access point' },
+  { value: 'camera', label: 'Camera' },
+  { value: 'iot', label: 'IoT sensor' },
+  { value: 'other', label: 'Other' },
+];
 
 export const thirdPartyMaintenanceAPI = {
   getAssetWoStatus: (assetId: string, vendorId?: string) =>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1172,3 +1172,93 @@ export interface KioskPayload {
   weather_url?: string;
   generated_at: string;
 }
+
+// Electrical Circuits & Network Drops (oms-tt5 / oms-a5f)
+
+export type OutletType =
+  | 'standard'
+  | '240v'
+  | 'nema_5_15'
+  | 'nema_5_20'
+  | 'nema_6_15'
+  | 'nema_6_20'
+  | 'nema_l6_30'
+  | 'nema_14_30'
+  | 'nema_14_50'
+  | 'usb'
+  | 'other';
+
+export type NetworkDropType =
+  | 'data'
+  | 'voice'
+  | 'patch_panel'
+  | 'ap'
+  | 'camera'
+  | 'iot'
+  | 'other';
+
+export interface Breaker {
+  id: number;
+  location: number;
+  location_name: string;
+  panel: string;
+  breaker_number: string;
+  amperage: number;
+  voltage: number;
+  poles: number;
+  description: string;
+  notes: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Outlet {
+  id: number;
+  location: number;
+  location_name: string;
+  identifier: string;
+  breaker: number | null;
+  breaker_label: string | null;
+  outlet_type: OutletType;
+  description: string;
+  plugged_in_notes: string;
+  photo: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LightSwitch {
+  id: number;
+  location: number;
+  location_name: string;
+  identifier: string;
+  controls_location: number | null;
+  controls_location_name: string | null;
+  breaker: number | null;
+  breaker_label: string | null;
+  description: string;
+  notes: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface NetworkDrop {
+  id: number;
+  location: number;
+  location_name: string;
+  identifier: string;
+  drop_type: NetworkDropType;
+  patch_panel: string;
+  patch_port: string;
+  mac_address: string;
+  ip_address: string | null;
+  description: string;
+  notes: string;
+  photo: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- New frontend forms/pages for the electrical_circuits backend (landed earlier as oms-tt5): outlets, light switches, breakers, network drops
- Wires up to the API via `frontend/src/services/api.ts` (+163 LOC) and `types/index.ts` (+90 LOC)
- ~2.4k LOC across 13 files; closes the frontend follow-up filed in oms-tt5

## Test plan
- [x] Pre-verified by polecat

🤖 Generated with [Claude Code](https://claude.com/claude-code)