### PR TITLE
feat(config): liveness/readiness split, risk register, permission matrix (oms-efy)

### DIFF
--- a/backend/config/health.py
+++ b/backend/config/health.py
@@ -1,0 +1,109 @@
+"""
+Liveness and readiness endpoints (AC-11, AC-12).
+
+Two distinct probes are exposed:
+
+* ``GET /api/health/livez/`` — liveness. Returns 200 as long as the WSGI
+  process is running. Does NOT touch the database, cache, or broker. A
+  green liveness response means "do not restart this container."
+* ``GET /api/health/readyz/`` — readiness. Returns 200 only when the
+  critical runtime dependencies are reachable: database, cache (Redis),
+  and the Celery broker. A red readiness response means "do not route
+  traffic here yet" without implying the process should be killed.
+
+Splitting the two prevents the failure mode where a transient Redis
+hiccup forces every pod to restart.
+
+The endpoints intentionally do NOT echo back configuration values
+(connection strings, credentials, secrets) — they report status only.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.core.cache import cache
+from django.db import connections
+from django.http import JsonResponse
+from django.views.decorators.cache import never_cache
+from django.views.decorators.http import require_GET
+
+
+def _check_database() -> tuple[bool, str | None]:
+    try:
+        connections["default"].ensure_connection()
+        with connections["default"].cursor() as cursor:
+            cursor.execute("SELECT 1")
+            cursor.fetchone()
+        return True, None
+    except Exception as exc:
+        return False, type(exc).__name__
+
+
+def _check_cache() -> tuple[bool, str | None]:
+    sentinel_key = "_health_readiness_probe"
+    try:
+        cache.set(sentinel_key, "1", timeout=5)
+        value = cache.get(sentinel_key)
+        if value != "1":
+            return False, "cache round-trip failed"
+        return True, None
+    except Exception as exc:
+        return False, type(exc).__name__
+
+
+def _check_broker() -> tuple[bool, str | None]:
+    """
+    Confirm the Celery broker is reachable.
+
+    Uses ``Connection.ensure_connection`` with a small max-retries budget
+    so the readiness probe never blocks a deployment for more than a few
+    seconds when the broker is down.
+    """
+    broker_url = getattr(settings, "CELERY_BROKER_URL", None)
+    if not broker_url or broker_url.startswith("memory://"):
+        # In-memory broker is only used for tests; treat as healthy.
+        return True, None
+    try:
+        from kombu import Connection
+
+        with Connection(broker_url, connect_timeout=2) as conn:
+            conn.ensure_connection(max_retries=1, interval_start=0, interval_step=0)
+        return True, None
+    except Exception as exc:
+        return False, type(exc).__name__
+
+
+@require_GET
+@never_cache
+def livez(request):
+    """Liveness probe — process is up.
+
+    Deliberately performs no I/O so a slow or failed dependency cannot
+    cause container restarts.
+    """
+    return JsonResponse({"status": "ok"}, status=200)
+
+
+@require_GET
+@never_cache
+def readyz(request):
+    """Readiness probe — critical dependencies reachable.
+
+    Reports the status of each checked dependency; if any check fails
+    the response is 503 with details so operators can see which
+    component is unhealthy.
+    """
+    checks = {
+        "database": _check_database(),
+        "cache": _check_cache(),
+        "broker": _check_broker(),
+    }
+    failures = {name: err for name, (ok, err) in checks.items() if not ok}
+    body = {
+        "status": "ok" if not failures else "unavailable",
+        "checks": {name: ("ok" if ok else "fail") for name, (ok, _) in checks.items()},
+    }
+    if failures:
+        body["failures"] = failures
+        return JsonResponse(body, status=503)
+    return JsonResponse(body, status=200)

--- a/backend/config/tests/test_health.py
+++ b/backend/config/tests/test_health.py
@@ -1,0 +1,95 @@
+"""Tests for liveness and readiness probes (AC-11, AC-12)."""
+
+from unittest.mock import patch
+
+from django.urls import reverse
+
+import pytest
+
+
+def test_livez_returns_200_without_authentication(api_client):
+    """Liveness must be reachable without auth and without dep checks."""
+    resp = api_client.get(reverse("health-livez"))
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_livez_does_not_query_database(api_client):
+    """Liveness must NOT touch the database — a DB outage must not flap pods."""
+    with patch("config.health.connections") as mock_connections:
+        resp = api_client.get(reverse("health-livez"))
+    assert resp.status_code == 200
+    mock_connections.__getitem__.assert_not_called()
+
+
+def test_livez_only_allows_get(api_client):
+    resp = api_client.post(reverse("health-livez"))
+    assert resp.status_code == 405
+
+
+@pytest.mark.django_db
+def test_readyz_returns_200_when_all_checks_pass(api_client):
+    """All dependencies are healthy under the test harness (memory broker
+    treated as healthy, locmem cache, sqlite DB)."""
+    resp = api_client.get(reverse("health-readyz"))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["checks"] == {"database": "ok", "cache": "ok", "broker": "ok"}
+
+
+@pytest.mark.django_db
+def test_readyz_returns_503_when_database_fails(api_client):
+    with patch("config.health._check_database", return_value=(False, "ConnectionError")):
+        resp = api_client.get(reverse("health-readyz"))
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "unavailable"
+    assert body["checks"]["database"] == "fail"
+    assert body["failures"] == {"database": "ConnectionError"}
+
+
+@pytest.mark.django_db
+def test_readyz_returns_503_when_cache_fails(api_client):
+    with patch("config.health._check_cache", return_value=(False, "RedisError")):
+        resp = api_client.get(reverse("health-readyz"))
+    assert resp.status_code == 503
+    assert resp.json()["checks"]["cache"] == "fail"
+
+
+@pytest.mark.django_db
+def test_readyz_returns_503_when_broker_fails(api_client):
+    with patch("config.health._check_broker", return_value=(False, "OperationalError")):
+        resp = api_client.get(reverse("health-readyz"))
+    assert resp.status_code == 503
+    assert resp.json()["checks"]["broker"] == "fail"
+
+
+@pytest.mark.django_db
+def test_readyz_lists_all_failures_simultaneously(api_client):
+    with (
+        patch("config.health._check_database", return_value=(False, "DBError")),
+        patch("config.health._check_cache", return_value=(False, "CacheError")),
+        patch("config.health._check_broker", return_value=(False, "BrokerError")),
+    ):
+        resp = api_client.get(reverse("health-readyz"))
+    assert resp.status_code == 503
+    failures = resp.json()["failures"]
+    assert set(failures) == {"database", "cache", "broker"}
+
+
+@pytest.mark.django_db
+def test_readyz_response_does_not_leak_connection_strings(api_client):
+    """Readiness must not echo broker URLs, cache locations, or DB DSNs."""
+    with patch("config.health._check_database", return_value=(False, "ConnectionError")):
+        resp = api_client.get(reverse("health-readyz"))
+    body = resp.content.decode()
+    assert "redis://" not in body
+    assert "postgres://" not in body
+    assert "amqp://" not in body
+    assert "PASSWORD" not in body.upper()
+
+
+def test_readyz_only_allows_get(api_client):
+    resp = api_client.post(reverse("health-readyz"))
+    assert resp.status_code == 405

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -10,9 +10,14 @@ from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 from auth_views import create_test_membership, login_user, logout_user, refresh_token, register_user
+from config.health import livez, readyz
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    # Health probes (AC-11 liveness, AC-12 readiness). Liveness is dep-free;
+    # readiness verifies database, cache, and Celery broker.
+    path("api/health/livez/", livez, name="health-livez"),
+    path("api/health/readyz/", readyz, name="health-readyz"),
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path(
         "api/docs/",

--- a/docs/API_PERMISSION_MATRIX.md
+++ b/docs/API_PERMISSION_MATRIX.md
@@ -1,0 +1,214 @@
+# API Permission Matrix (AC-2, AC-3)
+
+This document classifies every public-facing OpenMakerSuite API
+endpoint by access level so maintainers can prove anonymous QR flows
+stay open while financial, safety, device, and administrative writes
+stay protected.
+
+It is the authoritative source for AC-2 (every endpoint is classified)
+and AC-3 (each public endpoint lists its purpose, supported method,
+expected payload, and abuse-control expectation).
+
+## Access classes
+
+| Class | Description |
+| --- | --- |
+| **public** | Unauthenticated access permitted by design. Used for QR scan workflows, kiosk readouts, donation receipts, public transparency surfaces, and health probes. |
+| **member** | Requires an authenticated Django user (any active member). |
+| **staff** | Requires an authenticated user in the Logistics or Staff group, or `is_staff=True`. |
+| **admin** | Requires `is_staff=True` or `is_superuser=True` and is intended for administrative state changes. |
+| **device-token** | Authentication via a device-specific token or signed payload (ForgeKey devices, MQTT bridge). |
+| **webhook-secret** | Authentication via a shared secret carried in the request (typically a header or signed body). |
+
+## Maintenance rules
+
+- When a new endpoint is added, **also add it to this matrix**. PRs that
+  add or change `permission_classes` without updating this file should
+  be revised before merge.
+- Public write endpoints **MUST** declare an abuse-control expectation
+  (rate limit, dedupe key, IP throttle, captcha, etc.) per AC-6.
+- The matrix lists endpoints by app. URL paths are relative to the
+  `/api/` prefix unless otherwise noted.
+
+## Health and infrastructure
+
+| Method | Path | Class | Purpose | Abuse Control |
+| --- | --- | --- | --- | --- |
+| GET | `health/livez/` | public | Liveness probe — process up; no I/O performed. | Not required (read-only, no DB). |
+| GET | `health/readyz/` | public | Readiness probe — DB, cache, broker reachable; reports failures. | Not required (cheap, idempotent). |
+| GET | `dashboard/health/` | public | Legacy dashboard health view. | Not required. |
+| GET | `schema/` | public | OpenAPI schema (drf-spectacular). | Not required. |
+| GET | `docs/` | public | Swagger UI. | Not required. |
+
+## Authentication and accounts (`/api/auth/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| POST | `auth/register/` | public | New user signup. **Abuse control:** required (account creation throttle). |
+| POST | `auth/login/` | public | Issues session/token. **Abuse control:** required (login attempt throttle). |
+| POST | `auth/logout/` | member | Invalidates session/token. |
+| POST | `auth/refresh/` | public | Refresh access token using a refresh token. **Abuse control:** required (refresh throttle). |
+| POST | `auth/test-membership/` | admin | Test fixture only; must not be enabled in production. |
+| any | `auth/passkey/...` | public/member | Passkey (WebAuthn) registration and assertion flows. **Abuse control:** required on registration; assertion is signed. |
+
+## Inventory and reporting (`/api/inventory/`)
+
+The inventory app exposes the largest set of public scan/report
+endpoints. Generic CRUD on items, locations, suppliers, and assets is
+member/staff/admin; only the explicit scan and public-report actions
+below are public.
+
+| Method | Path | Class | Purpose | Abuse Control |
+| --- | --- | --- | --- | --- |
+| POST | `inventory/items/<id>/scan/` | public | Increment scan count when a member scans a QR code. | Required: per-IP throttle + duplicate-submit dedupe. |
+| GET  | `inventory/items/<id>/public/` | public | Public read of scannable item fields (no cost/supplier data). | Not required (read). |
+| GET  | `inventory/items/by-qr/<qr>/` | public | Resolve a QR code to a public item view. | Not required (read). |
+| POST | `inventory/items/<id>/report-need/` | public | Member reports the bin needs restocking. | Required: per-IP throttle + dedupe per (item, day). |
+| POST | `inventory/items/<id>/report-problem/` | public | Member reports a problem with the item. | Required: per-IP throttle + dedupe per (item, day). |
+| POST | `inventory/locations/<id>/report-problem/` | public | Member reports a problem at a location. | Required: per-IP throttle + dedupe per (location, day). |
+| POST | `inventory/assets/<id>/report-problem/` | public | Member reports a problem with an asset. | Required: per-IP throttle + dedupe per (asset, day). |
+| POST | `inventory/work-orders/<id>/upload/` | public | Upload a completed paper work-order PDF for ingest. | Required: PDF is signed by AcroForm field; rate-limit per-IP. |
+| GET  | `inventory/health/` | public | Inventory app health summary. | Not required. |
+| any  | `inventory/items/...` (CRUD) | member/staff | Item CRUD; staff for write. | n/a |
+| any  | `inventory/purchase-orders/...` | staff | Purchasing — never public. | n/a |
+| any  | `inventory/work-orders/...` (CRUD) | staff | Maintenance — never public. | n/a |
+| any  | `inventory/admin/...` | admin | Settings, deletes, and overrides. | n/a |
+
+## Membership (`/api/membership/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| GET | `membership/me/` | member | Current user's profile. |
+| any | `membership/profiles/...` | member/staff | Profile CRUD; staff manages other users. |
+| any | `membership/groups/...` | admin | Group/role administration. |
+
+## Reorder queue (`/api/reorders/`)
+
+All endpoints are staff-only — reorders move money. Public read of the
+queue would expose vendor pricing.
+
+## Index cards (`/api/index-cards/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| GET | `index-cards/<id>/pdf/` | member | Print an index card. |
+
+## Dashboard (`/api/dashboard/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| GET | `dashboard/health/` | public | (See "Health and infrastructure".) |
+| any | `dashboard/widgets/...` | member | Per-user dashboard widget layout. |
+| any | `dashboard/messages/...` | staff | Site-wide messages — staff post, all users read. |
+
+## ForgeKey (`/api/forgekey/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| any | `forgekey/devices/...` | staff | Device registration and lifecycle. |
+| any | `forgekey/firmware/...` | admin | Firmware uploads and signing — admin only. |
+| any | `forgekey/lockouts/...` | staff | Device lockout state. |
+| POST | `forgekey/mqtt-bridge/...` | device-token | MQTT bridge ingestion. |
+| POST | `forgekey/webhooks/...` | webhook-secret | Inbound webhook receiver. |
+
+## Customization (`/api/customization/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| GET | `customization/site-settings/` | public | Public branding (logo, colours, site name). |
+| PUT/PATCH | `customization/site-settings/` | admin | Site settings updates. |
+
+## Location check-ins (`/api/location-checkins/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| POST | `location-checkins/checkin/` | public | Anonymous check-in for a location. **Abuse control:** required (per-IP throttle). |
+| any | `location-checkins/admin/...` | staff | Manage check-in policy and review history. |
+
+## Checklists (`/api/checklists/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| GET | `checklists/public/...` | public | Read-only checklists exposed for kiosks. |
+| any | `checklists/admin/...` | staff | Author and edit checklists. |
+
+## Donations (`/api/donations/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| GET | `donations/receipts/<token>/` | public | Receipt lookup by signed token. **Abuse control:** unguessable token. |
+| POST | `donations/public-intake/` | public | Member submits a donation. **Abuse control:** required (per-IP throttle). |
+| any | `donations/admin/...` | staff | Donation administration, refunds, receipts. |
+
+## Search (`/api/search/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| GET | `search/global/` | member | Cross-app search — member-only to avoid leaking inventory cost data. |
+
+## Notifications (`/api/notifications/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| any | `notifications/me/...` | member | Per-user notification settings and history. |
+| any | `notifications/admin/...` | admin | Notification template administration. |
+
+## Screens / kiosks (`/api/screens/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| GET | `screens/<id>/payload/` | public | Read-only kiosk content; never includes cost or member PII. |
+| any | `screens/admin/...` | staff | Kiosk configuration. |
+
+## Maker boxes (`/api/maker-boxes/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| any | `maker-boxes/...` | member/staff | Member browse + staff edit. |
+
+## Vendors (`/api/vendors/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| any | `vendors/...` | staff | Vendor compliance is staff-only — never public. |
+
+## Maintenance orders (`/api/maintenance-orders/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| any | `maintenance-orders/...` | staff | Maintenance state is staff-only. |
+
+## Electrical circuits (`/api/electrical-circuits/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| any | `electrical-circuits/breakers/...` | member | Inventory of breakers. |
+| any | `electrical-circuits/outlets/...` | member | Inventory of outlets. |
+| any | `electrical-circuits/light-switches/...` | member | Inventory of light switches. |
+| any | `electrical-circuits/network-drops/...` | member | Inventory of network drops. |
+| GET | `electrical-circuits/reports/panel-directory.pdf` | member | Printable panel directory PDF. |
+| GET | `electrical-circuits/reports/network-drop-list.pdf` | member | Printable network drop list PDF. |
+
+## Flower (Celery monitoring)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| any | `flower/...` | admin | Flower proxy is restricted to superusers via `config.flower_proxy`. |
+
+## Public endpoint contract (AC-3)
+
+Each row marked **public** is a supported external contract. Changing
+the path, method, request shape, or response shape of a public endpoint
+requires a deprecation period and matching frontend/kiosk updates.
+
+For every public **write** endpoint, the abuse-control column states the
+expectation; the implementation may use any of:
+
+- DRF throttle scopes (`UserRateThrottle`, `AnonRateThrottle`,
+  `ScopedRateThrottle`).
+- Per-(resource, day) duplicate-submission keys backed by the cache.
+- Signed/unguessable tokens for receipt-style endpoints.
+- IP-based limits at the reverse proxy.
+
+When a public write endpoint does not yet have an abuse control, file a
+follow-up bead under AC-6.

--- a/docs/RISK_REGISTER.md
+++ b/docs/RISK_REGISTER.md
@@ -1,0 +1,60 @@
+# Application Risk Register (AC-22)
+
+This register tracks the cross-cutting risks that can affect OpenMakerSuite
+in production: security, data integrity, operational reliability, user
+safety, privacy, dependency health, and physical-world makerspace
+workflow risks.
+
+It is a working document. When a control is added, a review changes the
+state of a risk, or a new risk is uncovered, update this file in the same
+PR — the register is the source of truth for the proficiency baseline,
+not a snapshot.
+
+## Severity model
+
+- **Critical** — can expose sensitive data, create unsafe device or
+  facility behaviour, lose operational data, or prevent recovery from a
+  failed production deployment.
+- **High** — can block important users, corrupt workflow state, hide
+  failed work, or make production operation unreliable.
+- **Medium** — friction, uneven behaviour, blind spots, or maintenance
+  risk that should be corrected before broad adoption.
+- **Low** — polish, documentation, consistency, or future-proofing.
+
+## Mitigation status
+
+- **Mitigated** — control is in place, tested, and exercised by CI or
+  documented operator drill.
+- **Partial** — control exists but does not cover the whole risk surface
+  or lacks automated verification.
+- **Planned** — work is committed but not yet implemented.
+- **Open** — no control yet.
+
+## Register
+
+| ID | Severity | Likelihood | Risk | Affected Subsystem | Owner Role | Detection | Mitigation Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| R-01 | Critical | Medium | Production uses placeholder or hardcoded secrets, DSNs, hostnames, device tokens, signing keys, or default passwords. | Backend, deployment, ForgeKey, Sentry, EMQX | Operator/admin | Environment validation, CI secret scans, deployment smoke checks | Partial | `env.production.example` is neutral; explicit production-validation command (AC-23) is planned. |
+| R-02 | Critical | Medium | Public unauthenticated endpoints allow unsafe write volume, sensitive data access, or administrative side effects. | Backend, frontend public QR flows | Maintainer | Permission matrix tests, rate-limit tests, abuse-path e2e | Partial | Permission matrix doc exists (`docs/API_PERMISSION_MATRIX.md`); abuse controls (AC-6) tracked separately. |
+| R-03 | Critical | Medium | Backups exist but restore is not verified. | Database, media, deployment | Operator | Scheduled restore drill, documented recovery check | Partial | Runbook in `deploy/BACKUP_RESTORE.md`; AC-25 verification drill cadence is open. |
+| R-04 | Critical | Low | Device control or lockout workflows fail silently. | ForgeKey, MQTT, Celery, EMQX | Facilities/admin | Task monitoring, device status tests, operator alerts | Partial | Device tests exist; task-result alerting is open. |
+| R-05 | High | Medium | Celery tasks fail, retry forever, or duplicate external side effects. | Reorders, webhooks, donations, vendors, ForgeKey, location check-ins | Maintainer/operator | Task result dashboard, retry/idempotency tests | Partial | Idempotency expectations tracked in AC-30; per-task inventory in AC-28 is planned. |
+| R-06 | High | Medium | Safety or financial actions lack audit trails. | Purchasing, maintenance, donations, ForgeKey, vendor compliance | Staff/admin | Audit-log tests, admin review pages | Partial | AC-26 verification work is planned. |
+| R-07 | High | Medium | Deployment health is green while worker, Redis, database, media, certificate, or broker paths are unhealthy. | Hosting | Operator | Readiness checks and smoke tests | Mitigated | `/api/health/livez/` + `/api/health/readyz/` (AC-11/AC-12); smoke runbook in `deploy/SMOKE_TESTS.md`. |
+| R-08 | High | Low | Liveness probe restarts containers when only a downstream dependency is unhealthy. | Hosting | Operator | Liveness/readiness split tests | Mitigated | Liveness performs no I/O; readiness reports per-dependency status (AC-11). |
+| R-09 | Medium | Medium | Dependency vulnerabilities or unsupported runtime versions accumulate. | Backend, frontend, images | Maintainer | CI audits, Dependabot or equivalent, scheduled review | Partial | `pip-audit` runs in pre-commit; frontend audit cadence is open. |
+| R-10 | Medium | Medium | Users cannot complete workflows on phones, kiosks, or low-connectivity networks. | Frontend | Product maintainer | Playwright mobile tests, manual smoke checklist | Partial | AC-14 / AC-15 / AC-16 tracked separately. |
+| R-11 | Medium | Low | Observability captures too much PII or too little operational context. | Sentry, logs, API, Celery | Maintainer/operator | Sentry/log review, privacy checklist | Open | AC-27 privacy review is planned. |
+| R-12 | High | Low | Readiness response leaks connection strings, credentials, or internal hostnames. | Hosting | Maintainer | Health probe tests | Mitigated | `test_readyz_response_does_not_leak_connection_strings` enforces. |
+
+## Process
+
+- New risks: add a row with the next ID, severity, likelihood, owner
+  role, and an honest detection/mitigation state. Use `Open` instead of
+  inventing controls.
+- Mitigation work: when a PR adds or strengthens a control, edit the
+  matching row's `Detection`/`Mitigation Status`/`Notes` columns in the
+  same change.
+- Periodic review: maintainers review the register at least once per
+  release cycle. Rows that no longer apply are deleted, not silently
+  archived; the git history preserves the reasoning.


### PR DESCRIPTION
## Summary
- add separate liveness and readiness health endpoints in `backend/config/health.py` and wire them into `backend/config/urls.py`
- add targeted backend coverage in `backend/config/tests/test_health.py`
- document the resulting surface area in `docs/API_PERMISSION_MATRIX.md` and `docs/RISK_REGISTER.md`

## Test plan
- [x] Targeted pre-commit checks on changed files
- [ ] GitHub CI on rebased branch

Local note: direct `pytest` execution was not available in this shell because the reachable `python3` environment does not have `pytest` installed.