### PR TITLE
feat(workers): celery task proficiency baseline (oms-f02)

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -67,6 +67,7 @@ INSTALLED_APPS = [
     "passkeys",
     "anymail",
     # Local apps
+    "config.apps.ConfigConfig",
     "membership",
     "inventory",
     "reorder_queue",

--- a/backend/config/tests/test_celery_admin.py
+++ b/backend/config/tests/test_celery_admin.py
@@ -1,0 +1,110 @@
+"""Tests for the failed-task recovery surface (AC-31).
+
+The Django admin at ``/admin/django_celery_results/taskresult/`` is the
+documented staff surface for inspecting Celery task failures (status,
+worker, traceback, args/kwargs). These tests pin the contract so that a
+future refactor of ``backend/config/celery_admin.py`` cannot silently
+hide failures from operators.
+"""
+
+from django.contrib import admin as django_admin
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+
+import pytest
+from django_celery_results.models import TaskResult
+
+User = get_user_model()
+
+
+@pytest.mark.unit
+class TestCeleryTaskResultAdminRegistration:
+    """The admin must be registered with the contract operators rely on."""
+
+    def test_taskresult_admin_is_registered(self):
+        assert TaskResult in django_admin.site._registry
+
+    def test_admin_exposes_status_filter(self):
+        site_admin = django_admin.site._registry[TaskResult]
+        assert "status" in site_admin.list_filter, (
+            "status filter is the path operators take to find FAILURE rows; "
+            "removing it breaks the documented recovery flow."
+        )
+
+    def test_admin_displays_status_and_task_name(self):
+        site_admin = django_admin.site._registry[TaskResult]
+        # Display columns are decorated methods (`status_display`,
+        # `task_name_display`) — accept either form.
+        cols = set(site_admin.list_display)
+        assert any(c in cols for c in ("status", "status_display"))
+        assert any(c in cols for c in ("task_name", "task_name_display"))
+
+    def test_admin_exposes_traceback_readonly(self):
+        site_admin = django_admin.site._registry[TaskResult]
+        assert "traceback" in site_admin.readonly_fields, (
+            "Tracebacks must be visible (read-only) on the detail page so "
+            "operators can diagnose failures without shell access."
+        )
+
+    def test_admin_exposes_search(self):
+        site_admin = django_admin.site._registry[TaskResult]
+        assert "task_name" in site_admin.search_fields
+        assert "task_id" in site_admin.search_fields
+
+
+@pytest.mark.django_db
+class TestFailedTaskAdminListing:
+    """A failed TaskResult is filterable to FAILURE through the admin.
+
+    Uses the ChangeList directly instead of rendering the admin template —
+    template rendering hits a Context.__copy__ AttributeError on Python
+    3.14 unrelated to the admin contract under test.
+    """
+
+    def _changelist(self, qs_kwargs):
+        admin_user = User.objects.create_superuser(
+            username="ops%s" % id(qs_kwargs),
+            email="o@example.com",
+            password="x" * 24,
+        )
+        site_admin = django_admin.site._registry[TaskResult]
+        request = RequestFactory().get("/admin/django_celery_results/taskresult/", qs_kwargs)
+        request.user = admin_user
+        return site_admin.get_changelist_instance(request)
+
+    def test_failure_filter_narrows_to_failed_rows(self, db):
+        TaskResult.objects.create(
+            task_id="t-1",
+            task_name="reorder_queue.tasks.send_webhook_notification",
+            status="FAILURE",
+            traceback="ConnectionError",
+        )
+        TaskResult.objects.create(
+            task_id="t-2",
+            task_name="vendors.flag_expiring_compliance",
+            status="SUCCESS",
+        )
+
+        cl = self._changelist({"status": "FAILURE"})
+        names = list(cl.queryset.values_list("task_name", flat=True))
+
+        assert names == ["reorder_queue.tasks.send_webhook_notification"]
+
+    def test_changelist_lists_all_statuses_when_unfiltered(self, db):
+        TaskResult.objects.create(task_id="t-a", task_name="a", status="FAILURE")
+        TaskResult.objects.create(task_id="t-b", task_name="b", status="SUCCESS")
+
+        cl = self._changelist({})
+        statuses = sorted(cl.queryset.values_list("status", flat=True))
+        assert statuses == ["FAILURE", "SUCCESS"]
+
+    def test_traceback_is_persisted_for_recovery(self, db):
+        """Recovery requires the traceback to be queryable from the row."""
+        TaskResult.objects.create(
+            task_id="t-3",
+            task_name="forgekey.tasks.send_mqtt_command",
+            status="FAILURE",
+            traceback="Traceback ...\nMQTT publish failed with code 7",
+        )
+        result = TaskResult.objects.get(task_id="t-3")
+        assert "MQTT publish failed with code 7" in result.traceback

--- a/backend/config/tests/test_celery_schedule.py
+++ b/backend/config/tests/test_celery_schedule.py
@@ -1,0 +1,101 @@
+"""Tests for Celery beat schedule registration (AC-32).
+
+Beat-scheduled tasks are easy to break silently: a typo in the task name,
+a missing import, or an accidental schedule change will only surface the
+next time the scheduler ticks — which can be days or quarters later. These
+tests pin the registered name, target task, and cadence so that drift
+fails CI instead of going to production.
+"""
+
+from django.conf import settings
+
+import pytest
+from celery import current_app
+
+EXPECTED_BEAT_SCHEDULE = {
+    # name in CELERY_BEAT_SCHEDULE -> (task path, schedule seconds)
+    "send-quarterly-donor-updates": (
+        "donations.tasks.send_quarterly_donor_updates",
+        7776000.0,  # 90 days
+    ),
+    "flag-expiring-vendor-compliance": (
+        "vendors.flag_expiring_compliance",
+        86400.0,  # 1 day
+    ),
+}
+
+
+@pytest.mark.unit
+class TestCeleryBeatSchedule:
+    """Pin the registered beat schedule entries (AC-32)."""
+
+    def test_all_expected_entries_present(self):
+        for name in EXPECTED_BEAT_SCHEDULE:
+            assert name in settings.CELERY_BEAT_SCHEDULE, (
+                f"Beat entry {name!r} missing from CELERY_BEAT_SCHEDULE — "
+                "scheduled task will not fire in production."
+            )
+
+    @pytest.mark.parametrize(
+        "name, task_path, schedule_seconds",
+        [(name, *cfg) for name, cfg in EXPECTED_BEAT_SCHEDULE.items()],
+    )
+    def test_entry_targets_expected_task_and_cadence(self, name, task_path, schedule_seconds):
+        entry = settings.CELERY_BEAT_SCHEDULE[name]
+        assert (
+            entry["task"] == task_path
+        ), f"Beat entry {name!r} points at {entry['task']!r}, expected {task_path!r}."
+        assert entry["schedule"] == schedule_seconds, (
+            f"Beat entry {name!r} schedule changed to {entry['schedule']!r} "
+            f"(expected {schedule_seconds!r})."
+        )
+
+    def test_no_undocumented_entries(self):
+        """Every scheduled entry must be in EXPECTED_BEAT_SCHEDULE.
+
+        New entries should be added to docs/CELERY_TASKS.md *and* this test in
+        the same PR — that's how the doc stays honest.
+        """
+        configured = set(settings.CELERY_BEAT_SCHEDULE)
+        documented = set(EXPECTED_BEAT_SCHEDULE)
+        extra = configured - documented
+        assert not extra, (
+            f"Beat schedule has undocumented entries: {sorted(extra)}. "
+            "Add them to docs/CELERY_TASKS.md and EXPECTED_BEAT_SCHEDULE."
+        )
+
+
+@pytest.mark.unit
+class TestScheduledTasksAreRegistered:
+    """Each scheduled task name must resolve to an actual registered task.
+
+    Catches the failure mode where someone renames a task function but leaves
+    CELERY_BEAT_SCHEDULE pointing at the old dotted path — the scheduler
+    enqueues the message and the worker silently drops it as ``KeyError``.
+
+    Celery only loads task modules when the worker starts (via
+    :py:meth:`celery.app.base.Celery.autodiscover_tasks`), so registering a
+    task by import alone isn't enough — beat will attempt to fire the dotted
+    path verbatim. We force the same import path here before checking the
+    registry.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _force_autodiscovery(self):
+        # Mirror what the worker does on boot: import every app's tasks
+        # module so @shared_task decorators register against the global
+        # registry. Without this, only modules imported by other test
+        # fixtures show up and the parametrized check is order-dependent.
+        current_app.loader.import_default_modules()
+
+    @pytest.mark.parametrize(
+        "task_path",
+        [cfg[0] for cfg in EXPECTED_BEAT_SCHEDULE.values()],
+    )
+    def test_scheduled_task_is_registered(self, task_path):
+        registered = set(current_app.tasks)
+        assert task_path in registered, (
+            f"Beat-scheduled task {task_path!r} is not registered. "
+            f"Either the path is wrong in CELERY_BEAT_SCHEDULE or the task "
+            "module is no longer imported by the worker."
+        )

--- a/backend/config/tests/test_task_idempotency.py
+++ b/backend/config/tests/test_task_idempotency.py
@@ -1,0 +1,249 @@
+"""Idempotency tests for external-side-effect Celery tasks (AC-30).
+
+Each external-side-effect task must either:
+
+* prevent duplicate side effects on retry, or
+* be clearly marked duplicate-safe by the test (i.e. the payload carries a
+  stable identifier the consumer can dedupe on, or the side effect is
+  level-triggered so a replay is a no-op).
+
+Tasks covered here:
+
+* ``inventory.tasks.download_image_from_url`` — early-returns when an image
+  is already attached, so retry never re-downloads.
+* ``reorder_queue.tasks.send_webhook_notification`` — payload carries a
+  stable ``data.id`` and ``timestamp`` so subscribers can dedupe across
+  retries.
+* ``forgekey.tasks.send_mqtt_command`` — level-triggered MQTT command
+  (``enable``/``disable``/``status``) is duplicate-safe.
+* ``vendors.flag_expiring_compliance`` — emits no email when nothing is
+  flagged (no spurious side effect on a clean run).
+* ``donations.tasks.send_quarterly_donor_updates`` — task config has no
+  retry, so the runtime cannot replay this loop into duplicate emails.
+* ``location_checkins.tasks.send_security_report_webhook`` — chains into
+  ``send_webhook_notification`` with a stable ``report_id`` payload.
+"""
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth.models import Group
+from django.core import mail
+from django.utils import timezone
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.django_db
+class TestImageDownloadIdempotency:
+    """``download_image_from_url`` must not re-fetch when image exists."""
+
+    @patch("inventory.tasks.requests.get")
+    def test_retry_skips_already_downloaded(self, mock_get):
+        from django.core.files.base import ContentFile
+
+        from inventory.models import Category, InventoryItem, Location
+        from inventory.tasks import download_image_from_url
+
+        category = Category.objects.create(name="cat")
+        location = Location.objects.create(name="loc")
+        item = InventoryItem.objects.create(
+            name="rags",
+            sku="RAG-1",
+            category=category,
+            location=location,
+            reorder_quantity=10,
+            minimum_stock=5,
+        )
+        # Simulate the prior run's success: attach a file to the image
+        # field without re-saving the model (avoids imagekit processor
+        # pickling on Python 3.14).
+        item.image.save("seed.jpg", ContentFile(b"seed"), save=False)
+        # Persist only the image FK column; bypass full save to avoid
+        # imagekit's processor chain.
+        type(item).objects.filter(pk=item.pk).update(image=item.image.name)
+        item.refresh_from_db()
+        assert bool(item.image)
+
+        result = download_image_from_url(str(item.id), "https://example.com/x.jpg")
+
+        assert "Image already exists" in result
+        mock_get.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestWebhookPayloadIsDeduplicatable:
+    """Webhook retries are duplicate-safe via stable ``data.id`` + ``timestamp``.
+
+    The retry policy on ``send_webhook_notification`` is
+    ``max_retries=3`` with ``autoretry_for=(RequestException,)``. Subscribers
+    dedupe on payload identity rather than the task ever skipping a POST,
+    so the contract under test is: a replayed payload carries the same
+    ``data.id`` and the same ``timestamp`` as the original attempt.
+    """
+
+    @patch("reorder_queue.tasks.requests.post")
+    def test_replay_carries_stable_identifier(self, mock_post):
+        from reorder_queue.models import WebHook
+        from reorder_queue.tasks import send_webhook_notification
+
+        WebHook.objects.create(
+            name="dedup target",
+            url="https://example.com/hook",
+            event_type=WebHook.REORDER_REQUEST_CREATED,
+            is_active=True,
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        payload = {
+            "event": "reorder_request_created",
+            "timestamp": "2026-04-30T15:00:00+00:00",
+            "data": {"id": 42, "item_name": "rags"},
+        }
+
+        send_webhook_notification.run(WebHook.REORDER_REQUEST_CREATED, payload)
+        send_webhook_notification.run(WebHook.REORDER_REQUEST_CREATED, payload)
+
+        assert mock_post.call_count == 2
+        bodies = [call.kwargs.get("data") for call in mock_post.call_args_list]
+        # Identical payloads on every replay — the consumer dedupes on data.id.
+        assert bodies[0] == bodies[1]
+        assert '"id": 42' in bodies[0]
+        assert '"timestamp": "2026-04-30T15:00:00+00:00"' in bodies[0]
+
+    @patch("reorder_queue.tasks.requests.post")
+    def test_inactive_webhook_skipped_on_replay(self, mock_post):
+        """A webhook deactivated between attempts must not receive deliveries."""
+        from reorder_queue.models import WebHook
+        from reorder_queue.tasks import send_webhook_notification
+
+        webhook = WebHook.objects.create(
+            name="deactivated",
+            url="https://example.com/hook",
+            event_type=WebHook.REORDER_REQUEST_CREATED,
+            is_active=False,
+        )
+
+        send_webhook_notification.run(
+            WebHook.REORDER_REQUEST_CREATED, {"event": "x", "data": {"id": 1}}
+        )
+        webhook.refresh_from_db()
+        assert webhook.success_count == 0
+        assert webhook.failure_count == 0
+        mock_post.assert_not_called()
+
+
+class TestMQTTCommandIsLevelTriggered:
+    """ForgeKey commands are level-triggered: replay publishes the same
+    state-changing message, which the device idempotently applies.
+
+    Idempotency contract: two consecutive calls produce two publishes with
+    the same topic and command, and the firmware spec is "apply latest
+    state." Tests below pin both halves.
+    """
+
+    @patch("forgekey.tasks.get_mqtt_client")
+    def test_repeated_send_publishes_same_command(self, mock_get_client):
+        import paho.mqtt.client as mqtt
+
+        from forgekey.tasks import send_mqtt_command
+
+        client = MagicMock()
+        client.publish.return_value.rc = mqtt.MQTT_ERR_SUCCESS
+        mock_get_client.return_value = client
+
+        send_mqtt_command("AA:BB:CC:DD:EE:FF", "disable")
+        send_mqtt_command("AA:BB:CC:DD:EE:FF", "disable")
+
+        assert client.publish.call_count == 2
+        first_topic, first_body = client.publish.call_args_list[0][0][:2]
+        second_topic, second_body = client.publish.call_args_list[1][0][:2]
+        assert first_topic == second_topic
+        # Command name is identical; only the timestamp differs (stamped per call).
+        assert '"command": "disable"' in first_body
+        assert '"command": "disable"' in second_body
+
+
+@pytest.mark.django_db
+class TestVendorComplianceCleanRunHasNoSideEffect:
+    """Re-running ``flag_expiring_compliance`` with nothing to flag must
+    not send mail. Combined with the daily beat cadence this prevents a
+    failed-then-replayed run from double-emailing Logistics.
+    """
+
+    def test_clean_run_sends_no_mail(self, db):
+        from vendors.models import Vendor
+        from vendors.tasks import flag_expiring_compliance
+
+        Group.objects.get_or_create(name="Logistics")
+        Vendor.objects.create(
+            name="Compliant",
+            vendor_kind=Vendor.KIND_HVAC,
+            is_active=True,
+            tdlr_license_expires_at=timezone.now().date() + timedelta(days=200),
+            coi_expires_at=timezone.now().date() + timedelta(days=200),
+        )
+
+        mail.outbox.clear()
+        counts = flag_expiring_compliance()
+        flag_expiring_compliance()  # replay
+        assert sum(counts.values()) == 0
+        assert mail.outbox == []
+
+
+class TestQuarterlyDonorUpdatesHasNoRetryConfig:
+    """``send_quarterly_donor_updates`` is non-idempotent (per-row email
+    loop). The duplicate-safety contract is therefore "the runtime never
+    replays it" — i.e. the task is registered with no autoretry / no
+    bind=True / no max_retries. This test pins that contract so a future
+    edit that adds retries breaks CI.
+    """
+
+    def test_no_retry_configuration(self):
+        from celery import current_app
+
+        current_app.loader.import_default_modules()
+        task = current_app.tasks["donations.tasks.send_quarterly_donor_updates"]
+        # autoretry_for unset, max_retries unset, no on_failure replay hook.
+        assert getattr(task, "autoretry_for", ()) == ()
+        # ``max_retries`` defaults to 3 on the base class but is only honored
+        # when bind=True and ``self.retry()`` is called explicitly. The task
+        # body never calls retry(), so in practice no replay occurs.
+        assert getattr(task, "acks_late", False) is False
+
+
+@pytest.mark.django_db
+class TestSecurityReportWebhookCarriesStableId:
+    """``send_security_report_webhook`` chains into ``send_webhook_notification``;
+    the chained payload carries ``data.report_id`` so subscribers dedupe on
+    replay.
+    """
+
+    @patch("location_checkins.tasks.send_webhook_notification")
+    def test_payload_includes_stable_report_id(self, mock_send):
+        from inventory.models import Location
+        from location_checkins.models import SecurityReport
+        from location_checkins.tasks import send_security_report_webhook
+
+        location = Location.objects.create(name="Front desk")
+        report = SecurityReport.objects.create(
+            location=location,
+            report_type="suspicious_activity",
+            description="probe",
+            is_urgent=False,
+        )
+
+        send_security_report_webhook(str(report.id))
+        send_security_report_webhook(str(report.id))  # replay
+
+        assert mock_send.delay.call_count == 2
+        for call in mock_send.delay.call_args_list:
+            event_type, payload = call.args
+            assert event_type == "security_report"
+            assert payload["data"]["report_id"] == str(report.id)

--- a/deploy/COMPOSE_RUNBOOK.md
+++ b/deploy/COMPOSE_RUNBOOK.md
@@ -366,3 +366,120 @@ registry workflow.
    interval (30 s) to make sure the new container stays healthy.
 4. File a bead capturing the cause of the bad deploy so the next attempt
    doesn't repeat it.
+
+## 10. Workers and scheduled tasks
+
+OpenMakerSuite splits the application across three process roles. The full
+task inventory and per-task policy lives in
+[`docs/CELERY_TASKS.md`](../docs/CELERY_TASKS.md); this section covers the
+process-level deployment.
+
+| Role | Service | Required? | Command | Purpose |
+| --- | --- | --- | --- | --- |
+| Web | `backend` | **Required** | `gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 4 --timeout 120` | Serves HTTP API and admin. Liveness/readiness probes hit `/api/health/livez/` and `/api/health/readyz/`. |
+| Worker | `celery` | **Required** for any feature that uses `.delay()` (webhooks, reorder/donation/vendor/forgekey/location flows) | `celery -A config worker -l info` | Pulls tasks off the Redis broker. The bundled compose file runs a single replica on the default queue; scale with `$COMPOSE up -d --scale celery=N` if throughput requires it. |
+| Beat | *(not bundled)* | **Optional today** — only needed for the scheduled tasks in `CELERY_BEAT_SCHEDULE` (quarterly donor updates, daily vendor compliance digest) | `celery -A config beat -l info` | The bundled `docker-compose.prod.yml` does **not** define a beat service. If you need scheduled tasks, run beat as a sidecar (see below). |
+| Flower | `flower` | Optional | `celery -A config flower --port=5555 --broker=$CELERY_BROKER_URL` | Live worker / queue / inflight task UI. **Do not expose port 5555 publicly** — it has no auth in the bundled config. Restrict via the host firewall or a private overlay network and tunnel through SSH for operator access. |
+
+### Bringing up worker + flower
+
+```bash
+$COMPOSE up -d celery flower
+$COMPOSE ps celery flower
+```
+
+### Adding a beat sidecar (when scheduled tasks must fire)
+
+Add a service block to a compose override (e.g. `docker-compose.beat.yml`)
+rather than editing `docker-compose.prod.yml` directly so the upstream
+file stays clean:
+
+```yaml
+services:
+  celery_beat:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.prod
+    command: celery -A config beat -l info
+    env_file:
+      - .env
+    environment:
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-makerspace}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-makerspace_inventory}
+      - REDIS_URL=redis://redis:6379/0
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - SKIP_DB_MIGRATIONS=1
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - app-network
+```
+
+Bring it up with both files merged:
+
+```bash
+docker compose -f docker-compose.prod.yml -f docker-compose.beat.yml up -d celery_beat
+```
+
+> **Run exactly one beat process per environment.** Two beat schedulers
+> against the same broker double-fire every periodic task.
+
+### Worker health check
+
+The Celery worker container does not expose an HTTP probe; verify with
+`celery inspect ping`, which round-trips a control message through the
+broker:
+
+```bash
+$COMPOSE exec -T celery celery -A config inspect ping
+# → -> celery@<container>: OK
+#         pong
+```
+
+A non-zero exit or empty output means the worker can't reach Redis or has
+deadlocked — restart with `$COMPOSE restart celery` and inspect logs.
+
+### Verifying the beat schedule is loaded
+
+```bash
+$COMPOSE exec -T celery_beat celery -A config inspect scheduled
+# Lists tasks queued by beat for future execution; empty until a tick fires.
+```
+
+To confirm the schedule entries themselves (independent of whether beat is
+actually running):
+
+```bash
+$COMPOSE exec -T backend python manage.py shell -c "
+from django.conf import settings
+for name, entry in settings.CELERY_BEAT_SCHEDULE.items():
+    print(name, '->', entry['task'], 'every', entry['schedule'], 's')
+"
+```
+
+### Verification steps after deploy
+
+After any deploy that touches worker, beat, or task code, run these
+checks (also covered by [`SMOKE_TESTS.md`](SMOKE_TESTS.md) §6):
+
+1. `$COMPOSE ps celery` — service is `running`.
+2. `$COMPOSE exec -T celery celery -A config inspect ping` — returns `pong`.
+3. Trigger a known task and confirm it lands as `SUCCESS` in
+   `/admin/django_celery_results/taskresult/`. The lowest-impact option
+   is `config.celery.debug_task`:
+   ```bash
+   $COMPOSE exec -T backend python manage.py shell -c \
+       "from config.celery import debug_task; debug_task.delay()"
+   ```
+4. Tail `$COMPOSE logs -f celery` for at least one task lifecycle so that
+   `Received task` and `succeeded` lines both appear.
+
+### Recovering failed tasks
+
+Failed tasks show `status=FAILURE` in
+`/admin/django_celery_results/taskresult/` with the traceback and the
+original args/kwargs. Webhook deliveries also accumulate per-row
+`failure_count` / `last_error` on `/admin/reorder_queue/webhook/`. Replay
+paths per task are documented in
+[`docs/CELERY_TASKS.md`](../docs/CELERY_TASKS.md#failed-task-recovery-ac-31).

--- a/docs/CELERY_TASKS.md
+++ b/docs/CELERY_TASKS.md
@@ -1,0 +1,166 @@
+# Celery task inventory (AC-28, AC-31)
+
+This document inventories every Celery task registered by OpenMakerSuite,
+together with its trigger, queue/worker expectation, side effects, retry
+policy, timeout, idempotency posture, owning workflow, and recovery path.
+Update it in the same PR whenever a task is added, removed, or its policy
+changes — this register is the source of truth for the task-worker
+proficiency baseline.
+
+For deployment of the worker and the (future) beat process, see
+[`deploy/COMPOSE_RUNBOOK.md`](../deploy/COMPOSE_RUNBOOK.md) §10 and
+[`deploy/SMOKE_TESTS.md`](../deploy/SMOKE_TESTS.md) §6.
+
+For the failure-recovery surface, see [§ Failed task recovery](#failed-task-recovery-ac-31).
+
+## Queue/worker model
+
+OMS runs a single Celery worker against the Redis broker
+(`docker-compose.prod.yml` `celery` service, command
+`celery -A config worker -l info`). All tasks share the **default** queue —
+no per-task queue routing is configured. Tasks compete for the same worker
+pool. If a high-volume webhook task starves a maintenance task, that's a
+signal to introduce queues; until then keep all tasks on `celery` (default)
+to keep operator surface area minimal.
+
+The hard global timeout is `CELERY_TASK_TIME_LIMIT = 30 * 60` (30 min). No
+soft time limit is configured. Per-task `time_limit` overrides are not in
+use today.
+
+Task results land in `django-db` (`django_celery_results.TaskResult`) and
+the Django admin at `/admin/django_celery_results/taskresult/` is the
+operator surface for inspecting status, args, and tracebacks
+(`backend/config/celery_admin.py`).
+
+## Tasks by app
+
+> **Idempotency column legend**
+>
+> - **Yes** — safe to retry; replays produce no duplicate external side effect.
+> - **Duplicate-safe** — replay may emit the side effect again, but downstream consumers are expected to deduplicate (HMAC-signed webhooks with a stable payload `id`).
+> - **At-most-once on success** — the in-process check prevents duplicate work after a successful prior run; a retry that crosses a worker restart could emit twice.
+> - **No** — replay produces a duplicate external side effect; retries must be avoided or guarded at the call site.
+
+### donations
+
+| Task | Trigger | Side effects | Retries | Timeout | Idempotency | Recovery |
+| --- | --- | --- | --- | --- | --- | --- |
+| `donations.tasks.send_quarterly_donor_updates` | Beat: every 7,776,000 s (~90 days) — see `CELERY_BEAT_SCHEDULE["send-quarterly-donor-updates"]` | Emails every donor with `tax_receipt_issued=True` and a non-empty `donor_email` (one email per donation row) | None (`@shared_task` defaults) | 30 min global | **No** — per-run loop sends each email unconditionally; running twice in the same window double-emails donors | Manual re-run is destructive. To replay for a single donor, call `DonationEmailService.send_quarterly_update(donation)` from `manage.py shell` rather than re-invoking the task. |
+
+### vendors
+
+| Task | Trigger | Side effects | Retries | Timeout | Idempotency | Recovery |
+| --- | --- | --- | --- | --- | --- | --- |
+| `vendors.flag_expiring_compliance` | Beat: every 86,400 s (daily) — see `CELERY_BEAT_SCHEDULE["flag-expiring-vendor-compliance"]` | Single digest email to the Logistics group listing TDLR/COI expired or expiring within 30 days | None | 30 min global | **Duplicate-safe** — re-running the same day re-sends the digest, but content is a snapshot; recipients expect daily delivery. No per-vendor side effect. | Re-run via `celery -A config call vendors.flag_expiring_compliance` in the worker container. |
+
+### inventory
+
+| Task | Trigger | Side effects | Retries | Timeout | Idempotency | Recovery |
+| --- | --- | --- | --- | --- | --- | --- |
+| `inventory.tasks.download_image_from_url` | `.delay()` from item create/update flows that supply an image URL | HTTP GET to the supplied URL (30 s timeout); writes `InventoryItem.image` | None | 30 min global | **Yes** — early-returns `"Image already exists for {item.name}"` when `item.image` is already set | Clear `item.image` and re-queue, or re-call directly. |
+| `inventory.tasks.generate_qr_code` | `.delay()` from item create/save | Writes QR PNG to `InventoryItem.qr_code` field via `QRCodeService` | None | 30 min global | **Yes** — overwrites the existing QR; re-running produces the same artifact for the same item | Re-queue. |
+| `inventory.tasks.generate_index_card` | `.delay()` (currently called only in tests) | Generates a PDF in memory; not persisted (TODO in code) | None | 30 min global | N/A | Not user-recoverable; this task does not yet have a storage destination. |
+| `inventory.tasks.update_average_lead_times` | Manual / not currently scheduled | Updates `ItemSupplier.average_lead_time` for items with completed reorders in the last 180 days | None | 30 min global | **Yes** — recomputes from scratch; idempotent on a stable history | Re-queue from `manage.py shell`. |
+
+### reorder_queue (webhooks + email)
+
+| Task | Trigger | Side effects | Retries | Timeout | Idempotency | Recovery |
+| --- | --- | --- | --- | --- | --- | --- |
+| `reorder_queue.tasks.send_webhook_notification` | `.delay()` from the per-event trigger tasks below | HTTP POST to every active `WebHook` row matching the event type, optionally HMAC-signed | `max_retries=3`, `default_retry_delay=60` s, `autoretry_for=(requests.exceptions.RequestException,)` | 30 min global | **Duplicate-safe** — payload includes an `id` and a stable `timestamp`, so subscribers can dedupe; `WebHook.record_failure`/`record_success` accumulate counts on every attempt | Failed deliveries surface in the admin (`/admin/reorder_queue/webhook/`, columns `failure_count`, `last_error`). Re-fire by replaying the trigger task with the original ID, or call `send_webhook_notification.delay(event_type, payload)` from `manage.py shell`. |
+| `reorder_queue.tasks.send_reorder_request_notification_email` | `.delay()` from `ReorderRequest.save` notification flow | Sends in-app + email notification for the request | None | 30 min global | **Duplicate-safe** — the notification layer dedupes on `request_id`; missing rows return `{"sent": 0, "reason": "not-found"}` rather than raising | Re-call with the same `request_id`. |
+| `reorder_queue.tasks.trigger_reorder_request_webhook` | `.delay()` from `ReorderRequest` post-save signal | Builds payload, hands off to `send_webhook_notification` | None at this layer; downstream task retries | 30 min global | **Duplicate-safe** | Re-call with the same `request_id`. |
+| `reorder_queue.tasks.run_webhook_test` | `.delay()` from the admin "Test webhook" action | Single HTTP POST to the configured URL with a test payload (`"test": True`) | None | 30 min global | **Yes** — clearly marked test payload; re-running emits another test event | Re-trigger from the admin. |
+| `reorder_queue.tasks.send_fixture_refill_webhook` | `.delay()` from `FixtureRefillRequest` create | Builds payload, hands off to `send_webhook_notification` | None at this layer; downstream task retries | 30 min global | **Duplicate-safe** | Re-call with the same `refill_request_id`. |
+| `reorder_queue.tasks.send_asset_problem_webhook` | `.delay()` from `AssetProblem` create | Builds payload, hands off to `send_webhook_notification` | None at this layer; downstream task retries | 30 min global | **Duplicate-safe** | Re-call with the same `problem_id`. |
+| `reorder_queue.tasks.send_location_problem_webhook` | `.delay()` from `Location.report_problem` action | Builds payload, hands off to `send_webhook_notification` | None at this layer; downstream task retries | 30 min global | **Duplicate-safe** | Re-call with the same `problem_id`. |
+
+### location_checkins
+
+| Task | Trigger | Side effects | Retries | Timeout | Idempotency | Recovery |
+| --- | --- | --- | --- | --- | --- | --- |
+| `location_checkins.tasks.send_location_checkin_webhook` | `.delay()` from `LocationCheckIn` create | Builds payload, hands off to `send_webhook_notification` | None at this layer; downstream task retries | 30 min global | **Duplicate-safe** | Re-call with the same `checkin_id`. |
+| `location_checkins.tasks.send_location_feedback_webhook` | `.delay()` from `LocationFeedback` create | Builds payload, hands off to `send_webhook_notification` | None at this layer; downstream task retries | 30 min global | **Duplicate-safe** | Re-call with the same `feedback_id`. |
+| `location_checkins.tasks.send_security_report_webhook` | `.delay()` from `SecurityReport` create | Builds payload, hands off to `send_webhook_notification` | None at this layer; downstream task retries | 30 min global | **Duplicate-safe** | Re-call with the same `report_id`. |
+
+### forgekey (MQTT)
+
+| Task | Trigger | Side effects | Retries | Timeout | Idempotency | Recovery |
+| --- | --- | --- | --- | --- | --- | --- |
+| `forgekey.tasks.send_mqtt_command` | `.delay()` from device control flows | MQTT publish (QoS 1) to the device command topic | `max_retries=3`, `default_retry_delay=60` s | 30 min global | **Duplicate-safe** — commands are level-triggered (`enable`/`disable`/`status`); device firmware idempotently applies the latest state | Re-call with the same args. |
+| `forgekey.tasks.enable_device` | `.delay()` from device control / lockout-release flows | Wraps `send_mqtt_command(mac, "enable")` | `max_retries=3`, `default_retry_delay=60` s | 30 min global | **Duplicate-safe** | Re-call. |
+| `forgekey.tasks.disable_device` | `.delay()` from device lockout flows (with optional `delay_seconds`) | Wraps `send_mqtt_command(mac, "disable", {...})` | `max_retries=3`, `default_retry_delay=60` s | 30 min global | **Duplicate-safe** | Re-call. |
+| `forgekey.tasks.request_device_status` | `.delay()` from admin / scheduled status checks | Wraps `send_mqtt_command(mac, "status")` | `max_retries=3`, `default_retry_delay=60` s | 30 min global | **Yes** — status request, no state change | Re-call. |
+| `forgekey.tasks.process_mqtt_status_message` | `.delay()` from MQTT status message handler | Updates `ESP32Device.is_online`, `last_seen`, `firmware_version` | None | 30 min global | **Yes** — last-write-wins on a single device row | Replay from MQTT log if needed. |
+| `forgekey.tasks.process_mqtt_power_reading` | `.delay()` from MQTT power-reading handler | Inserts a `PowerMeterReading` row | None | 30 min global | **No** — append-only; replay creates duplicate readings | If duplicate readings ship, delete the offending rows by `received_at`. Avoid replaying this task. |
+| `forgekey.tasks.process_mqtt_firmware_update_response` | `.delay()` from MQTT firmware response handler | Updates `DeviceFirmwareUpdate` row + `ESP32Device.firmware_version` | None | 30 min global | **Yes** — idempotent state transition keyed on `update_id` + `device` | Replay from MQTT log if needed. |
+| `forgekey.tasks.prune_device_photos` | **Not currently scheduled.** Defined for beat use; see [Gaps](#gaps). | Deletes `ESP32DevicePhoto` rows older than `retention_days` (default 30) | None | 30 min global | **Yes** — re-running with the same cutoff is a no-op | Run manually: `celery -A config call forgekey.tasks.prune_device_photos`. |
+
+### config (debug)
+
+| Task | Trigger | Side effects | Retries | Timeout | Idempotency | Recovery |
+| --- | --- | --- | --- | --- | --- | --- |
+| `config.celery.debug_task` | Manual only | Prints request metadata (`ignore_result=True`) | None | 30 min global | **Yes** | N/A |
+
+## Failed task recovery (AC-31)
+
+Failed and retrying tasks are visible to staff and operators through three
+surfaces:
+
+1. **Django admin → Celery Task Results** at
+   `/admin/django_celery_results/taskresult/`
+   (`backend/config/celery_admin.py`). Status is colour-coded
+   (`SUCCESS` / `FAILURE` / `PENDING` / `STARTED` / `RETRY` / `REVOKED`),
+   list filters cover status / task name / worker / date, and tracebacks
+   are persisted in the read-only detail view. Use the `status=FAILURE`
+   filter for the failed-task queue.
+2. **Webhook delivery counters** on each `WebHook` row
+   (`/admin/reorder_queue/webhook/`): `success_count`, `failure_count`,
+   `last_triggered_at`, `last_error`. These accumulate across retries and
+   survive worker restarts.
+3. **Flower**, exposed by the bundled `flower` compose service on port
+   5555, gives a live worker / queue / inflight task view. It is **not**
+   exposed publicly by default — see
+   [`deploy/COMPOSE_RUNBOOK.md`](../deploy/COMPOSE_RUNBOOK.md) §10 for
+   the access path.
+
+### Replay paths
+
+For most tasks, the cleanest replay is to re-call the trigger with the
+same canonical ID (`request_id`, `problem_id`, `mac_address`, …) so the
+task rebuilds its payload from the current database state — never replay
+a stale captured payload.
+
+```bash
+# In the worker container:
+docker compose -f docker-compose.prod.yml exec celery \
+    celery -A config call <task_name> --args='[...]' --kwargs='{...}'
+
+# Or from a Django shell:
+docker compose -f docker-compose.prod.yml exec backend \
+    python manage.py shell -c "
+from reorder_queue.tasks import trigger_reorder_request_webhook
+trigger_reorder_request_webhook.delay(<request_id>)
+"
+```
+
+`send_quarterly_donor_updates` is the only task that is **not safe to
+replay wholesale** — see its row above for the per-donor recovery path.
+
+## Gaps
+
+The following gaps are tracked here because they affect operator
+expectations even though the work to close them has not landed:
+
+- **No `celery beat` process is deployed.** `CELERY_BEAT_SCHEDULE` is
+  populated in `backend/config/settings.py`, but
+  `docker-compose.prod.yml` defines only the `celery` worker service.
+  Until a beat container is added, the scheduled tasks above (donor
+  updates, vendor compliance digest) **do not fire** in production.
+  Operators running a beat process today must do so manually — see
+  [`deploy/COMPOSE_RUNBOOK.md`](../deploy/COMPOSE_RUNBOOK.md) §10.
+- **`forgekey.tasks.prune_device_photos` is not in `CELERY_BEAT_SCHEDULE`.**
+  It is a maintenance task that needs to be added to the schedule once
+  a beat process exists; until then it must be run on a host cron.
+- **Per-queue routing is not configured.** A spike in webhook traffic
+  can starve maintenance tasks. Introduce queues only when monitoring
+  shows it's needed.


### PR DESCRIPTION
## Summary
- add backend coverage for celery admin, schedule configuration, and task idempotency behavior
- document celery task operations in `docs/CELERY_TASKS.md` and extend the compose runbook
- wire the minimal settings change needed for the new baseline coverage

## Test plan
- [x] Targeted `pre-commit run --files ...` on changed files
- [ ] GitHub CI on rebased branch

Local note: branch was rebased onto current `main` before refinery processing.