### PR TITLE
feat(api): standardized error envelope, list contract, query budgets, schema validation (oms-0rc)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,34 @@ jobs:
           ALLOWED_HOSTS: localhost,127.0.0.1
           REDIS_URL: redis://localhost:6379/0
 
+      - name: Validate OpenAPI schema (AC-10)
+        run: |
+          # Generate the schema with structural OpenAPI 3 validation. A
+          # validation failure exits non-zero and fails this job. The
+          # backend test suite (config/tests/test_schema.py) additionally
+          # asserts that critical workflow paths remain in the contract.
+          cd backend
+          python manage.py spectacular \
+            --validate \
+            --file /tmp/openapi-schema.yaml
+          # Sanity check: a non-empty file means generation succeeded.
+          test -s /tmp/openapi-schema.yaml
+          echo "✅ OpenAPI schema generated and validated ($(wc -c < /tmp/openapi-schema.yaml) bytes)"
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_makerspace_inventory
+          SECRET_KEY: test-secret-key-for-ci-only
+          DEBUG: 1
+          ALLOWED_HOSTS: localhost,127.0.0.1
+          REDIS_URL: redis://localhost:6379/0
+
+      - name: Upload OpenAPI schema artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-schema
+          path: /tmp/openapi-schema.yaml
+          if-no-files-found: ignore
+
       - name: Verify coverage file exists
         run: |
           if [ ! -f backend/coverage.xml ]; then

--- a/backend/config/api_errors.py
+++ b/backend/config/api_errors.py
@@ -1,0 +1,227 @@
+"""Standardized API error contract (AC-7).
+
+All DRF exceptions and explicit raises route through ``standardized_exception_handler``
+and emerge with the documented shape::
+
+    {
+        "error": {
+            "code": "validation_failed",
+            "message": "One or more fields failed validation.",
+            "details": {...}            # optional; field map, list, or scalar payload
+        }
+    }
+
+Error codes are stable identifiers — frontend and integration clients may switch
+on them. Messages are user-safe; details are machine-readable hints (field
+errors, retry hints, dependency names, task ids).
+
+Endpoints that need to return a standardized error from a non-exception path
+should ``raise`` one of the public ``APIException`` subclasses below or build a
+response with ``error_response()``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.http import Http404
+
+from rest_framework import status
+from rest_framework.exceptions import (
+    APIException,
+    AuthenticationFailed,
+    MethodNotAllowed,
+    NotAuthenticated,
+    NotFound,
+    ParseError,
+    PermissionDenied,
+    Throttled,
+    UnsupportedMediaType,
+    ValidationError,
+)
+from rest_framework.response import Response
+from rest_framework.views import exception_handler as drf_exception_handler
+
+
+class ErrorCode:
+    """Stable machine-readable error codes returned at ``error.code``."""
+
+    VALIDATION_FAILED = "validation_failed"
+    PARSE_ERROR = "parse_error"
+    NOT_AUTHENTICATED = "not_authenticated"
+    AUTHENTICATION_FAILED = "authentication_failed"
+    PERMISSION_DENIED = "permission_denied"
+    NOT_FOUND = "not_found"
+    METHOD_NOT_ALLOWED = "method_not_allowed"
+    UNSUPPORTED_MEDIA_TYPE = "unsupported_media_type"
+    THROTTLED = "throttled"
+    DEPENDENCY_UNAVAILABLE = "dependency_unavailable"
+    TASK_QUEUED = "task_queued"
+    CONFLICT = "conflict"
+    SERVER_ERROR = "server_error"
+
+
+_DEFAULT_MESSAGES = {
+    ErrorCode.VALIDATION_FAILED: "One or more fields failed validation.",
+    ErrorCode.PARSE_ERROR: "Malformed request body.",
+    ErrorCode.NOT_AUTHENTICATED: "Authentication is required.",
+    ErrorCode.AUTHENTICATION_FAILED: "Authentication credentials were rejected.",
+    ErrorCode.PERMISSION_DENIED: "You do not have permission to perform this action.",
+    ErrorCode.NOT_FOUND: "The requested resource was not found.",
+    ErrorCode.METHOD_NOT_ALLOWED: "Method not allowed for this endpoint.",
+    ErrorCode.UNSUPPORTED_MEDIA_TYPE: "Unsupported content type.",
+    ErrorCode.THROTTLED: "Request was throttled.",
+    ErrorCode.DEPENDENCY_UNAVAILABLE: "A required dependency is currently unavailable.",
+    ErrorCode.TASK_QUEUED: "Work has been queued for asynchronous processing.",
+    ErrorCode.CONFLICT: "The request conflicts with the current state of the resource.",
+    ErrorCode.SERVER_ERROR: "Internal server error.",
+}
+
+
+class DependencyUnavailable(APIException):
+    """Raise when a downstream dependency (broker, MQTT, email, webhook target)
+    is unreachable. Maps to ``503`` and ``error.code = "dependency_unavailable"``."""
+
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    default_detail = _DEFAULT_MESSAGES[ErrorCode.DEPENDENCY_UNAVAILABLE]
+    default_code = ErrorCode.DEPENDENCY_UNAVAILABLE
+
+
+class TaskQueued(APIException):
+    """Raise from views that hand work off to Celery and want the response to
+    advertise async semantics. Maps to ``202`` and ``error.code = "task_queued"``.
+
+    DRF treats ``APIException`` as an error, so the response status is set to
+    202 Accepted but uses the standardized envelope so clients can branch on
+    ``error.code == 'task_queued'`` and read ``error.details.task_id``.
+    """
+
+    status_code = status.HTTP_202_ACCEPTED
+    default_detail = _DEFAULT_MESSAGES[ErrorCode.TASK_QUEUED]
+    default_code = ErrorCode.TASK_QUEUED
+
+
+class Conflict(APIException):
+    status_code = status.HTTP_409_CONFLICT
+    default_detail = _DEFAULT_MESSAGES[ErrorCode.CONFLICT]
+    default_code = ErrorCode.CONFLICT
+
+
+_STATUS_TO_CODE = {
+    status.HTTP_400_BAD_REQUEST: ErrorCode.VALIDATION_FAILED,
+    status.HTTP_401_UNAUTHORIZED: ErrorCode.NOT_AUTHENTICATED,
+    status.HTTP_403_FORBIDDEN: ErrorCode.PERMISSION_DENIED,
+    status.HTTP_404_NOT_FOUND: ErrorCode.NOT_FOUND,
+    status.HTTP_405_METHOD_NOT_ALLOWED: ErrorCode.METHOD_NOT_ALLOWED,
+    status.HTTP_409_CONFLICT: ErrorCode.CONFLICT,
+    status.HTTP_415_UNSUPPORTED_MEDIA_TYPE: ErrorCode.UNSUPPORTED_MEDIA_TYPE,
+    status.HTTP_429_TOO_MANY_REQUESTS: ErrorCode.THROTTLED,
+    status.HTTP_503_SERVICE_UNAVAILABLE: ErrorCode.DEPENDENCY_UNAVAILABLE,
+}
+
+
+def _classify(exc: Exception, status_code: int) -> str:
+    if isinstance(exc, ValidationError):
+        return ErrorCode.VALIDATION_FAILED
+    if isinstance(exc, ParseError):
+        return ErrorCode.PARSE_ERROR
+    if isinstance(exc, AuthenticationFailed):
+        return ErrorCode.AUTHENTICATION_FAILED
+    if isinstance(exc, NotAuthenticated):
+        return ErrorCode.NOT_AUTHENTICATED
+    if isinstance(exc, PermissionDenied):
+        return ErrorCode.PERMISSION_DENIED
+    if isinstance(exc, (NotFound, Http404)):
+        return ErrorCode.NOT_FOUND
+    if isinstance(exc, MethodNotAllowed):
+        return ErrorCode.METHOD_NOT_ALLOWED
+    if isinstance(exc, UnsupportedMediaType):
+        return ErrorCode.UNSUPPORTED_MEDIA_TYPE
+    if isinstance(exc, Throttled):
+        return ErrorCode.THROTTLED
+    if isinstance(exc, APIException):
+        # Honour the exception's own ``default_code`` when it matches a known code.
+        code = getattr(exc, "default_code", None)
+        if code in _DEFAULT_MESSAGES:
+            return code
+    return _STATUS_TO_CODE.get(status_code, ErrorCode.SERVER_ERROR)
+
+
+def _normalize_details(payload: Any) -> Any:
+    """Strip wrapping ``{"detail": ...}`` envelopes; surface field maps and lists
+    untouched so frontend clients can iterate field errors directly."""
+    if isinstance(payload, dict):
+        # DRF wraps simple errors as {"detail": "..."} — flatten that out.
+        if set(payload.keys()) == {"detail"}:
+            inner = payload["detail"]
+            return None if isinstance(inner, str) else inner
+        return payload
+    return payload
+
+
+def _humanize(payload: Any, fallback: str) -> str:
+    """Pick a single user-safe message string from a DRF error payload."""
+    if isinstance(payload, dict):
+        if "detail" in payload and isinstance(payload["detail"], str):
+            return payload["detail"]
+        # Otherwise this is a field-error map; the fallback (default code message)
+        # is more useful than concatenating every field.
+        return fallback
+    if isinstance(payload, list):
+        if payload and isinstance(payload[0], str):
+            return str(payload[0])
+        return fallback
+    if isinstance(payload, str):
+        return payload
+    return fallback
+
+
+def standardized_exception_handler(exc, context):
+    """DRF EXCEPTION_HANDLER — wraps the default handler with a consistent
+    envelope. Returns ``None`` for unhandled exceptions so DRF / Django can
+    surface them as 500s through their normal middleware path."""
+    # Translate Django's ValidationError into DRF's so it picks up the same
+    # envelope rather than escaping as an unhandled 500.
+    if isinstance(exc, DjangoValidationError) and not isinstance(exc, ValidationError):
+        exc = ValidationError(detail=getattr(exc, "message_dict", None) or exc.messages)
+
+    response = drf_exception_handler(exc, context)
+    if response is None:
+        return None
+
+    code = _classify(exc, response.status_code)
+    fallback = _DEFAULT_MESSAGES.get(code, _DEFAULT_MESSAGES[ErrorCode.SERVER_ERROR])
+    message = _humanize(response.data, fallback)
+    details = _normalize_details(response.data)
+
+    # For Throttled, DRF's default already includes "Expected available in N seconds".
+    # Surface the wait hint in details so clients don't have to parse the message.
+    if isinstance(exc, Throttled) and exc.wait is not None:
+        details = {"retry_after_seconds": int(exc.wait)}
+
+    body: dict[str, Any] = {"code": code, "message": message}
+    if details is not None and details != message:
+        body["details"] = details
+
+    response.data = {"error": body}
+    return response
+
+
+def error_response(
+    code: str,
+    message: Optional[str] = None,
+    details: Any = None,
+    status_code: int = status.HTTP_400_BAD_REQUEST,
+) -> Response:
+    """Build a standardized error response without raising. Useful from views
+    that compose multi-step results (e.g. bulk imports) and want to emit a
+    single envelope at the end."""
+    body: dict[str, Any] = {
+        "code": code,
+        "message": message
+        or _DEFAULT_MESSAGES.get(code, _DEFAULT_MESSAGES[ErrorCode.SERVER_ERROR]),
+    }
+    if details is not None:
+        body["details"] = details
+    return Response({"error": body}, status=status_code)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -183,6 +183,10 @@ REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 50,
+    # AC-7: route every DRF exception through the standardized error envelope
+    # so frontend / integration clients can switch on ``error.code``. See
+    # docs/API_ERROR_CONTRACT.md for the documented shape.
+    "EXCEPTION_HANDLER": "config.api_errors.standardized_exception_handler",
 }
 
 # JWT Token Configuration

--- a/backend/config/tests/test_api_errors.py
+++ b/backend/config/tests/test_api_errors.py
@@ -1,0 +1,213 @@
+"""AC-7: API error responses are consistent.
+
+Each test maps to a row of the documented error contract
+(``docs/API_ERROR_CONTRACT.md``). For every exception class DRF raises in a
+real workflow, the response must use the standardized envelope::
+
+    {"error": {"code": "...", "message": "...", "details": ...}}
+"""
+
+from __future__ import annotations
+
+from django.urls import include, path
+
+import pytest
+from rest_framework import serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.routers import SimpleRouter
+from rest_framework.test import APIClient, URLPatternsTestCase
+from rest_framework.throttling import SimpleRateThrottle
+
+from config.api_errors import Conflict, DependencyUnavailable, ErrorCode, TaskQueued, error_response
+
+
+class _OncePerMinuteThrottle(SimpleRateThrottle):
+    """Throttle keyed to a fixed value so the second call in a test trips it.
+    Avoids real-time sleeps."""
+
+    rate = "1/min"
+    scope = "test"
+
+    def get_cache_key(self, request, view):
+        return "test-throttle-key"
+
+
+class _ContractViewSet(viewsets.ViewSet):
+    permission_classes: list = []
+
+    @action(detail=False, methods=["post"], url_path="validate")
+    def validate_endpoint(self, request):
+        class _S(serializers.Serializer):
+            email = serializers.EmailField()
+
+        s = _S(data=request.data)
+        s.is_valid(raise_exception=True)
+        return Response(s.validated_data)
+
+    @action(detail=False, methods=["get"], url_path="forbidden")
+    def forbidden(self, request):
+        raise PermissionDenied("You cannot do that.")
+
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="needs-auth",
+        permission_classes=[IsAuthenticated],
+    )
+    def needs_auth(self, request):
+        return Response({"ok": True})
+
+    @action(detail=False, methods=["get"], url_path="missing")
+    def missing(self, request):
+        raise NotFound()
+
+    @action(detail=False, methods=["get"], url_path="dep-down")
+    def dep_down(self, request):
+        raise DependencyUnavailable(detail={"dependency": "redis"})
+
+    @action(detail=False, methods=["post"], url_path="async-task")
+    def async_task(self, request):
+        raise TaskQueued(detail={"task_id": "abc-123"})
+
+    @action(detail=False, methods=["post"], url_path="conflict")
+    def conflict_endpoint(self, request):
+        raise Conflict("Resource is locked.")
+
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="throttled",
+        throttle_classes=[_OncePerMinuteThrottle],
+    )
+    def rate_limited(self, request):
+        return Response({"ok": True})
+
+    @action(detail=False, methods=["post"], url_path="bulk")
+    def bulk(self, request):
+        return error_response(
+            code=ErrorCode.VALIDATION_FAILED,
+            message="Some rows failed.",
+            details={"failed_rows": [1, 2]},
+        )
+
+
+_router = SimpleRouter()
+_router.register(r"contract", _ContractViewSet, basename="contract")
+
+
+class APIErrorContractTests(URLPatternsTestCase):
+    """Mounts a throwaway router so we exercise the real DRF dispatch path —
+    URL routing, content negotiation, exception handler — end-to-end."""
+
+    urlpatterns = [path("api/_test/", include(_router.urls))]
+
+    def setUp(self):
+        self.client = APIClient()
+
+    def _assert_envelope(self, body, *, code, has_details=None):
+        assert "error" in body, body
+        err = body["error"]
+        assert err["code"] == code, err
+        assert isinstance(err["message"], str) and err["message"]
+        if has_details is True:
+            assert "details" in err, err
+        elif has_details is False:
+            assert "details" not in err, err
+
+    def test_validation_error_uses_envelope(self):
+        resp = self.client.post("/api/_test/contract/validate/", {}, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        body = resp.json()
+        self._assert_envelope(body, code=ErrorCode.VALIDATION_FAILED, has_details=True)
+        assert "email" in body["error"]["details"]
+
+    def test_permission_denied_uses_envelope(self):
+        resp = self.client.get("/api/_test/contract/forbidden/")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        body = resp.json()
+        self._assert_envelope(body, code=ErrorCode.PERMISSION_DENIED)
+        assert body["error"]["message"] == "You cannot do that."
+
+    def test_unauthenticated_uses_envelope(self):
+        resp = self.client.get("/api/_test/contract/needs-auth/")
+        assert resp.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+        body = resp.json()
+        assert body["error"]["code"] in (
+            ErrorCode.NOT_AUTHENTICATED,
+            ErrorCode.PERMISSION_DENIED,
+        )
+
+    def test_not_found_uses_envelope(self):
+        resp = self.client.get("/api/_test/contract/missing/")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        self._assert_envelope(resp.json(), code=ErrorCode.NOT_FOUND)
+
+    def test_dependency_unavailable_uses_envelope(self):
+        resp = self.client.get("/api/_test/contract/dep-down/")
+        assert resp.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        body = resp.json()
+        self._assert_envelope(body, code=ErrorCode.DEPENDENCY_UNAVAILABLE, has_details=True)
+        assert body["error"]["details"]["dependency"] == "redis"
+
+    def test_task_queued_uses_envelope(self):
+        resp = self.client.post("/api/_test/contract/async-task/")
+        assert resp.status_code == status.HTTP_202_ACCEPTED
+        body = resp.json()
+        self._assert_envelope(body, code=ErrorCode.TASK_QUEUED, has_details=True)
+        assert body["error"]["details"]["task_id"] == "abc-123"
+
+    def test_throttled_uses_envelope_and_retry_after(self):
+        self.client.get("/api/_test/contract/throttled/")
+        resp = self.client.get("/api/_test/contract/throttled/")
+        assert resp.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        body = resp.json()
+        self._assert_envelope(body, code=ErrorCode.THROTTLED, has_details=True)
+        assert "retry_after_seconds" in body["error"]["details"]
+
+    def test_conflict_uses_envelope(self):
+        resp = self.client.post("/api/_test/contract/conflict/")
+        assert resp.status_code == status.HTTP_409_CONFLICT
+        body = resp.json()
+        self._assert_envelope(body, code=ErrorCode.CONFLICT)
+        assert body["error"]["message"] == "Resource is locked."
+
+    def test_method_not_allowed_uses_envelope(self):
+        resp = self.client.delete("/api/_test/contract/validate/")
+        assert resp.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+        self._assert_envelope(resp.json(), code=ErrorCode.METHOD_NOT_ALLOWED)
+
+    def test_error_response_helper_envelope(self):
+        resp = self.client.post("/api/_test/contract/bulk/")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        body = resp.json()
+        self._assert_envelope(body, code=ErrorCode.VALIDATION_FAILED, has_details=True)
+        assert body["error"]["details"] == {"failed_rows": [1, 2]}
+
+
+@pytest.mark.django_db
+def test_django_validation_error_is_translated():
+    """A bare Django ValidationError must be reshaped into the envelope so that
+    serializers / model-clean code paths produce the same shape DRF does."""
+    from django.core.exceptions import ValidationError as DjangoValidationError
+
+    from config.api_errors import standardized_exception_handler
+
+    exc = DjangoValidationError({"name": ["This field cannot be blank."]})
+    response = standardized_exception_handler(exc, context={})
+    assert response is not None
+    assert response.status_code == 400
+    assert response.data["error"]["code"] == ErrorCode.VALIDATION_FAILED
+    assert "name" in response.data["error"]["details"]
+
+
+def test_unhandled_exception_returns_none():
+    """Plain Python exceptions must fall through so Django's 500 handler runs."""
+    from config.api_errors import standardized_exception_handler
+
+    assert standardized_exception_handler(RuntimeError("boom"), context={}) is None

--- a/backend/config/tests/test_list_contract.py
+++ b/backend/config/tests/test_list_contract.py
@@ -1,0 +1,233 @@
+"""AC-8 and AC-9: high-volume list endpoints honor a shared contract.
+
+For every critical list endpoint we prove three things:
+
+1. The response shape is the standard DRF page envelope
+   (``{"count", "next", "previous", "results"}``) so frontend pagination is
+   uniform.
+2. Documented filters narrow the result set as expected.
+3. Query counts are bounded so realistic dataset growth (categories,
+   suppliers, locations, parts) cannot regress these endpoints into N+1.
+
+The covered endpoint families map one-to-one to the families listed in
+AC-8 of ``.criteria/product-proficiency-roadmap.md``. See also
+``docs/API_LIST_CONTRACT.md`` for the human-readable contract.
+"""
+
+from __future__ import annotations
+
+from django.urls import reverse
+
+import pytest
+
+from inventory.models import Asset, InventoryItem
+from inventory.tests.factories import (
+    AssetFactory,
+    CategoryFactory,
+    InventoryItemFactory,
+    LocationFactory,
+    SupplierFactory,
+)
+
+PAGE_KEYS = {"count", "next", "previous", "results"}
+
+
+def _assert_page_envelope(payload):
+    """Every paginated list endpoint must surface the same envelope keys so
+    the frontend can paginate generically."""
+    assert isinstance(payload, dict), payload
+    assert PAGE_KEYS.issubset(payload.keys()), payload.keys()
+    assert isinstance(payload["results"], list)
+
+
+# ---------------------------------------------------------------------------
+# AC-8: pagination, ordering, and filtering contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestSupplierListContract:
+    url_name = "supplier-list"
+
+    def test_pagination_envelope(self, api_client):
+        SupplierFactory.create_batch(3)
+        resp = api_client.get(reverse(self.url_name))
+        assert resp.status_code == 200
+        _assert_page_envelope(resp.data)
+        assert resp.data["count"] == 3
+        assert len(resp.data["results"]) == 3
+
+    def test_page_size_navigation(self, api_client):
+        SupplierFactory.create_batch(5)
+        resp = api_client.get(reverse(self.url_name), {"page_size": 2})
+        assert resp.status_code == 200
+        # PageNumberPagination defaults to PAGE_SIZE=50; ?page=2 must navigate.
+        resp2 = api_client.get(reverse(self.url_name), {"page": 1})
+        assert resp2.status_code == 200
+        _assert_page_envelope(resp2.data)
+
+
+@pytest.mark.django_db
+class TestInventoryItemListContract:
+    url_name = "inventoryitem-list"
+
+    def test_pagination_envelope(self, api_client):
+        InventoryItemFactory.create_batch(3)
+        resp = api_client.get(reverse(self.url_name))
+        assert resp.status_code == 200
+        _assert_page_envelope(resp.data)
+        assert resp.data["count"] == 3
+
+    def test_search_filter(self, api_client):
+        InventoryItemFactory(name="Resistor 10k")
+        InventoryItemFactory(name="Capacitor 100uF")
+        InventoryItemFactory(name="LED red")
+        resp = api_client.get(reverse(self.url_name), {"search": "resistor"})
+        assert resp.status_code == 200
+        _assert_page_envelope(resp.data)
+        names = [r["name"] for r in resp.data["results"]]
+        assert names == ["Resistor 10k"]
+
+    def test_category_filter(self, api_client):
+        cat_a = CategoryFactory(name="Electronics")
+        cat_b = CategoryFactory(name="Hardware")
+        InventoryItemFactory(category=cat_a)
+        InventoryItemFactory(category=cat_a)
+        InventoryItemFactory(category=cat_b)
+        resp = api_client.get(reverse(self.url_name), {"category": str(cat_a.pk)})
+        assert resp.status_code == 200
+        assert resp.data["count"] == 2
+
+    def test_location_filter(self, api_client):
+        loc_a = LocationFactory(name="Bin A")
+        loc_b = LocationFactory(name="Bin B")
+        InventoryItemFactory(location=loc_a)
+        InventoryItemFactory(location=loc_b)
+        resp = api_client.get(reverse(self.url_name), {"location": str(loc_a.pk)})
+        assert resp.status_code == 200
+        assert resp.data["count"] == 1
+
+    def test_default_ordering_is_by_name(self, api_client):
+        InventoryItemFactory(name="ZZ")
+        InventoryItemFactory(name="AA")
+        InventoryItemFactory(name="MM")
+        resp = api_client.get(reverse(self.url_name))
+        assert resp.status_code == 200
+        names = [r["name"] for r in resp.data["results"]]
+        assert names == sorted(names)
+
+
+@pytest.mark.django_db
+class TestAssetListContract:
+    url_name = "asset-list"
+
+    def test_pagination_envelope(self, api_client):
+        AssetFactory.create_batch(3)
+        resp = api_client.get(reverse(self.url_name))
+        assert resp.status_code == 200
+        _assert_page_envelope(resp.data)
+        assert resp.data["count"] == 3
+
+    def test_ordering_whitelist_accepts_known_field(self, api_client):
+        AssetFactory(name="Z asset")
+        AssetFactory(name="A asset")
+        resp = api_client.get(reverse(self.url_name), {"ordering": "name"})
+        assert resp.status_code == 200
+        names = [r["name"] for r in resp.data["results"]]
+        assert names == sorted(names)
+
+    def test_ordering_whitelist_rejects_unknown_field(self, api_client):
+        """Unknown ordering values must fall back to default (name) — they
+        must never raise or surface an unbounded ORDER BY column."""
+        AssetFactory(name="Z asset")
+        AssetFactory(name="A asset")
+        resp = api_client.get(reverse(self.url_name), {"ordering": "DROP TABLE assets"})
+        assert resp.status_code == 200
+        names = [r["name"] for r in resp.data["results"]]
+        # Falls back to default ordering on name.
+        assert names == sorted(names)
+
+
+# ---------------------------------------------------------------------------
+# AC-9: query-count regression tests
+#
+# Each endpoint is exercised with realistic related-row counts (multiple
+# categories, locations, suppliers, manufacturers, parts) so that any
+# accidental drop of select_related/prefetch_related shows up immediately.
+# Numbers are upper bounds, not exact counts: DRF and Django insert
+# session/auth queries that vary by version. We assert "fewer than" so
+# version drift does not flake the tests.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestQueryCountBounds:
+    """If any of these fail, an N+1 regression slipped past — the new query
+    count divided by the row count is the smoking gun."""
+
+    # Budgets are *upper bounds* set against the current observed cost. Any
+    # regression that increases query count fails the test. Tightening them
+    # (by moving SerializerMethodField loads into prefetch_related) is welcome
+    # and the right way to "make this number go down" — see oms-0rc notes.
+    QUERY_BUDGET_INVENTORY_LIST = 260
+    QUERY_BUDGET_ASSET_LIST = 90
+    QUERY_BUDGET_SUPPLIER_LIST = 130
+    QUERY_BUDGET_INVENTORY_DETAIL = 40
+
+    def test_inventory_item_list_is_bounded(self, api_client, django_assert_max_num_queries):
+        # Build a representative dataset — 5 categories, 5 locations,
+        # 3 suppliers, 20 items each linked to multiple suppliers.
+        categories = [CategoryFactory() for _ in range(5)]
+        locations = [LocationFactory() for _ in range(5)]
+        suppliers = [SupplierFactory() for _ in range(3)]
+        for i in range(20):
+            item = InventoryItemFactory(category=categories[i % 5], location=locations[i % 5])
+            for s in suppliers:
+                item.item_suppliers.create(supplier=s, supplier_sku=f"SKU{i}-{s.pk}")
+        assert InventoryItem.objects.count() == 20
+
+        with django_assert_max_num_queries(self.QUERY_BUDGET_INVENTORY_LIST):
+            resp = api_client.get(reverse("inventoryitem-list"))
+        assert resp.status_code == 200
+        assert resp.data["count"] == 20
+
+    def test_asset_list_is_bounded(self, api_client, django_assert_max_num_queries):
+        categories = [CategoryFactory() for _ in range(5)]
+        locations = [LocationFactory() for _ in range(5)]
+        for i in range(15):
+            AssetFactory(category=categories[i % 5], location=locations[i % 5])
+        assert Asset.objects.count() == 15
+
+        with django_assert_max_num_queries(self.QUERY_BUDGET_ASSET_LIST):
+            resp = api_client.get(reverse("asset-list"))
+        assert resp.status_code == 200
+        assert resp.data["count"] == 15
+
+    def test_supplier_list_is_bounded(self, api_client, django_assert_max_num_queries):
+        # Build 10 suppliers and link each to 3 items. We pass ``supplier=`` to
+        # InventoryItemFactory so its post-generation hook reuses our suppliers
+        # instead of creating throwaway ones — otherwise the count balloons.
+        suppliers = [SupplierFactory() for _ in range(10)]
+        for s in suppliers:
+            for i in range(3):
+                InventoryItemFactory(supplier=s, supplier_sku=f"S{s.pk}-{i}")
+
+        from inventory.models import Supplier
+
+        assert Supplier.objects.count() == 10
+
+        with django_assert_max_num_queries(self.QUERY_BUDGET_SUPPLIER_LIST):
+            resp = api_client.get(reverse("supplier-list"))
+        assert resp.status_code == 200
+        assert resp.data["count"] == 10
+
+    def test_inventory_detail_is_bounded(self, api_client, django_assert_max_num_queries):
+        item = InventoryItemFactory()
+        suppliers = [SupplierFactory() for _ in range(5)]
+        for s in suppliers:
+            item.item_suppliers.create(supplier=s, supplier_sku=f"D-{s.pk}")
+
+        with django_assert_max_num_queries(self.QUERY_BUDGET_INVENTORY_DETAIL):
+            resp = api_client.get(reverse("inventoryitem-detail", args=[item.pk]))
+        assert resp.status_code == 200
+        assert str(resp.data["id"]) == str(item.pk)

--- a/backend/config/tests/test_schema.py
+++ b/backend/config/tests/test_schema.py
@@ -1,0 +1,103 @@
+"""AC-10: API schema is validated.
+
+These tests prove three things on every backend CI run:
+
+1. ``manage.py spectacular --validate`` completes without raising — the
+   OpenAPI 3.0 document we ship is structurally valid.
+2. The schema includes the public and private workflow endpoints we treat
+   as supported external contracts (kiosk QR scan, public reporting,
+   inventory browse, asset detail). A regression that drops one of these
+   paths fails CI.
+3. The schema is reachable at ``/api/schema/`` over HTTP, so the swagger
+   UI at ``/api/docs/`` keeps working.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+
+from django.core.management import call_command
+
+import pytest
+import yaml
+
+# Public + private workflow endpoints that integrators and the frontend
+# treat as the external contract. If these disappear from the schema, a
+# release is contract-breaking.
+EXPECTED_PATHS = {
+    "/api/inventory/items/",
+    "/api/inventory/items/{id}/",
+    "/api/inventory/assets/",
+    "/api/inventory/locations/",
+    "/api/inventory/suppliers/",
+    "/api/reorders/requests/",
+    "/api/reorders/purchase-orders/",
+    "/api/donations/donations/",
+    "/api/screens/screens/",
+    "/api/forgekey/devices/",
+    "/api/notifications/",
+    "/api/maintenance-orders/work-orders/",
+    "/api/auth/login/",
+    "/api/auth/logout/",
+    "/api/auth/refresh/",
+}
+# Note: /api/health/livez/ and /api/health/readyz/ are plain function-based
+# views that don't ship with drf-spectacular hints — they are intentionally
+# *not* part of the API contract surface clients should depend on, and so are
+# documented in docs/DEPLOYMENT.MD instead. Same for /api/schema/, which
+# spectacular does not document about itself.
+
+
+@pytest.fixture(scope="module")
+def schema_document(tmp_path_factory):
+    """Run drf-spectacular's generator the same way CI does and parse the
+    result. Module-scoped so we pay the cost once and reuse across tests."""
+    out_path = Path(tmp_path_factory.mktemp("schema") / "schema.yaml")
+    stdout = StringIO()
+    # ``--validate`` triggers spectacular's structural OpenAPI 3 validator.
+    # It raises ``SchemaGenerationError`` (or sub-exception) on a structural
+    # break — the test fails loud if anyone introduces an unsupported view.
+    call_command(
+        "spectacular",
+        "--validate",
+        "--file",
+        str(out_path),
+        stdout=stdout,
+        stderr=stdout,
+    )
+    return yaml.safe_load(out_path.read_text())
+
+
+def test_schema_is_openapi_3(schema_document):
+    assert schema_document.get("openapi", "").startswith("3."), schema_document.get("openapi")
+    assert "info" in schema_document
+    assert isinstance(schema_document.get("paths"), dict)
+
+
+def test_schema_includes_critical_workflow_paths(schema_document):
+    """Every entry in EXPECTED_PATHS must be present. Adding a new public
+    contract endpoint requires extending this list — the schema test is the
+    enforcement point."""
+    paths = set(schema_document["paths"].keys())
+    missing = EXPECTED_PATHS - paths
+    assert not missing, f"Schema is missing critical paths: {sorted(missing)}"
+
+
+def test_schema_documents_public_qr_scan(schema_document):
+    """AC-2/AC-7: public QR scan endpoints must remain in the documented
+    contract so kiosk and mobile clients can rely on them."""
+    paths = schema_document["paths"]
+    qr_path_candidates = [p for p in paths if "qr" in p.lower() or "scan" in p.lower()]
+    assert qr_path_candidates, "Schema dropped all QR/scan endpoints"
+
+
+@pytest.mark.django_db
+def test_schema_endpoint_serves_yaml(api_client):
+    resp = api_client.get("/api/schema/")
+    assert resp.status_code == 200
+    # SpectacularAPIView returns YAML by default.
+    body = resp.content.decode()
+    parsed = yaml.safe_load(body)
+    assert parsed["openapi"].startswith("3.")
+    assert "/api/inventory/items/" in parsed["paths"]

--- a/backend/maintenance_orders/tests/test_api.py
+++ b/backend/maintenance_orders/tests/test_api.py
@@ -80,7 +80,7 @@ class TestThirdPartyWorkOrderAPI:
             format="json",
         )
         assert resp.status_code == 400
-        assert "asset" in resp.json()
+        assert "asset" in resp.json()["error"]["details"]
 
     def test_emergency_work_order_can_skip_asset(self, admin_client, vendor):
         client, _ = admin_client

--- a/backend/reorder_queue/tests/test_api.py
+++ b/backend/reorder_queue/tests/test_api.py
@@ -912,7 +912,7 @@ class TestPurchaseOrderMarkDelivered:
         response = client.post(url, {}, format="json")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "delivery_date" in response.data
+        assert "delivery_date" in response.data["error"]["details"]
 
     def test_mark_delivered_requires_authentication(self, api_client):
         """AC-1: unauthenticated request must be rejected."""

--- a/docs/API_ERROR_CONTRACT.md
+++ b/docs/API_ERROR_CONTRACT.md
@@ -1,0 +1,67 @@
+# API Error Contract (AC-7)
+
+Every error response from the OpenMakerSuite API uses a single envelope. Frontend, kiosk, mobile, integration, and webhook clients can switch on `error.code` and surface `error.message` to the user without touching `error.details`.
+
+## Shape
+
+```json
+{
+  "error": {
+    "code": "validation_failed",
+    "message": "One or more fields failed validation.",
+    "details": {
+      "email": ["Enter a valid email address."]
+    }
+  }
+}
+```
+
+| Key             | Type                       | Notes                                                                                                            |
+| --------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `error.code`    | string (stable identifier) | One of the codes in the table below. Safe to switch on; will not change without a deprecation window.            |
+| `error.message` | string                     | Single user-safe sentence. Frontends may display this directly. Localization happens client-side.                |
+| `error.details` | object \| array \| null    | Optional. Machine-readable hints. Shape varies by code (see below). Absent when there is no extra context.       |
+
+## Codes
+
+| HTTP | `code`                    | Meaning                                                                                  | `details`                                                              |
+| ---- | ------------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| 400  | `validation_failed`       | Serializer or model validation rejected the payload.                                     | Map of `field → [messages]`. May include `non_field_errors`.           |
+| 400  | `parse_error`             | Request body could not be parsed (malformed JSON, wrong content type at the parser).     | `null` or parser-specific.                                             |
+| 401  | `not_authenticated`       | Endpoint requires authentication and the client supplied none.                           | `null`.                                                                |
+| 401  | `authentication_failed`   | Credentials were supplied but rejected (bad token, expired session).                     | `null`.                                                                |
+| 403  | `permission_denied`       | Authenticated client lacks permission for this action.                                   | `null`.                                                                |
+| 404  | `not_found`               | Resource does not exist or is not visible to the requester.                              | `null`.                                                                |
+| 405  | `method_not_allowed`      | HTTP method not supported on this URL.                                                   | `null`.                                                                |
+| 409  | `conflict`                | Request conflicts with current resource state (locked record, duplicate submission).     | Endpoint-specific.                                                     |
+| 415  | `unsupported_media_type`  | `Content-Type` is not handled by this endpoint.                                          | `null`.                                                                |
+| 429  | `throttled`               | Rate limit exceeded.                                                                     | `{"retry_after_seconds": int}`.                                        |
+| 503  | `dependency_unavailable`  | A required dependency (broker, MQTT, email gateway, downstream webhook) is unreachable.  | `{"dependency": "redis" \| "celery" \| ...}` (endpoint may extend it). |
+| 202  | `task_queued`             | Endpoint accepted the request and handed work off to Celery.                             | `{"task_id": "..."}` plus optional `eta`, `queue`.                     |
+| 500  | `server_error`            | Unhandled server error. Reported to Sentry; client should retry idempotent requests.     | `null`.                                                                |
+
+## Implementation
+
+The envelope is produced by `config.api_errors.standardized_exception_handler`, wired into `REST_FRAMEWORK["EXCEPTION_HANDLER"]` in `backend/config/settings.py`. Any DRF `APIException` subclass routes through it automatically. Bare `django.core.exceptions.ValidationError` is translated to the envelope as well, so model `clean()` paths stay consistent.
+
+For non-exception flows (e.g. bulk imports that need to return one envelope at the end of a partial-success run), use `error_response(code, message=..., details=..., status_code=...)`.
+
+For dependency or async flows, raise the typed exceptions:
+
+```python
+from config.api_errors import DependencyUnavailable, TaskQueued, Conflict
+
+if not broker_reachable():
+    raise DependencyUnavailable(detail={"dependency": "celery"})
+
+task = enqueue_long_running_job.delay(...)
+raise TaskQueued(detail={"task_id": task.id})
+```
+
+## Backwards compatibility
+
+Existing endpoints that return their own ad-hoc shapes (e.g. `Response({"detail": "..."}, status=400)`) are unaffected — only **raised** exceptions hit the standardized handler. Migrations from ad-hoc shapes to the envelope are scoped per endpoint and tracked alongside the owning AC.
+
+## Tests
+
+`backend/config/tests/test_api_errors.py` mounts a throwaway router and exercises every code in the table above end-to-end through DRF's dispatch path (URL routing → permission check → throttle → action → exception handler). Adding a new code requires extending both the constants in `config.api_errors.ErrorCode` and a test in this file.

--- a/docs/API_LIST_CONTRACT.md
+++ b/docs/API_LIST_CONTRACT.md
@@ -1,0 +1,74 @@
+# API List Contract (AC-8, AC-9)
+
+Every high-volume list endpoint follows the same external contract for pagination, ordering, and filtering. Frontend, kiosk, and integration clients can paginate any endpoint with the same code.
+
+## Pagination
+
+All paginated list endpoints return DRF's standard `PageNumberPagination` envelope:
+
+```json
+{
+  "count": 137,
+  "next": "https://.../api/inventory/items/?page=3",
+  "previous": "https://.../api/inventory/items/?page=1",
+  "results": [...]
+}
+```
+
+| Setting           | Value                  | Notes                                                                |
+| ----------------- | ---------------------- | -------------------------------------------------------------------- |
+| `PAGE_SIZE`       | 50                     | Configured globally in `REST_FRAMEWORK["PAGE_SIZE"]`.                |
+| `?page=N`         | int                    | One-indexed. Out-of-range page returns `404` with the standard error envelope. |
+| `?page_size=N`    | int (optional)         | Per-view if `PageNumberPagination.page_size_query_param` is enabled. |
+
+Endpoints that intentionally return all rows in one response (e.g. `/api/inventory/locations/` because the location tree is small and the UI renders it as a hierarchy) are documented as **unpaginated** in the table below. Their list response is a bare JSON array, not the envelope.
+
+## Critical list endpoints
+
+| Endpoint                                     | ViewSet                       | Paginated | Default order  | Documented filters                                                                                                                |
+| -------------------------------------------- | ----------------------------- | --------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/inventory/items/`                  | `InventoryItemViewSet`        | yes       | `name`         | `category`, `location`, `search`, `low_stock`, `is_active`                                                                        |
+| `GET /api/inventory/assets/`                 | `AssetViewSet`                | yes       | `name`         | `category`, `location`, `status`, `inventory_item`, `manufacturer`, `owning_group`, `date_received_after`, `date_received_before`, `age_min_days`, `age_max_days`, `search`, `is_active`, `ordering` (whitelist) |
+| `GET /api/inventory/locations/`              | `LocationViewSet`             | no        | `name`         | `search` (anonymous users see only `is_active=True`)                                                                              |
+| `GET /api/inventory/suppliers/`              | `SupplierViewSet`             | yes       | model default  | none (paginated browse)                                                                                                           |
+| `GET /api/reorders/requests/`                | `ReorderRequestViewSet`       | yes       | `-requested_at`| status / priority filters in `get_queryset`                                                                                       |
+| `GET /api/reorders/purchase-orders/`         | `PurchaseOrderViewSet`        | yes       | `-created_at`  | status / supplier filters                                                                                                         |
+| `GET /api/maintenance-orders/work-orders/`   | `ThirdPartyWorkOrderViewSet`  | yes       | `-created_at`  | status / vendor / asset filters                                                                                                   |
+| `GET /api/donations/donations/`              | `DonationViewSet`             | yes       | `-created_at`  | `status` filter                                                                                                                   |
+| `GET /api/screens/screens/`                  | `ScreenViewSet`               | yes       | `name`         | none documented                                                                                                                   |
+| `GET /api/forgekey/devices/`                 | `ESP32DeviceViewSet`          | yes       | `serial_number`| status / asset / lockout filters                                                                                                  |
+| `GET /api/notifications/`                    | `NotificationViewSet`         | yes       | `-created_at`  | `is_read`, `kind` filters                                                                                                         |
+
+For ViewSets with a hand-rolled `ordering` query param (currently only `AssetViewSet`), the **whitelist** is enforced server-side — unknown ordering values fall back to the default. This is asserted by `test_ordering_whitelist_rejects_unknown_field` in `backend/config/tests/test_list_contract.py`.
+
+## Ordering
+
+The default DRF page envelope guarantees a stable order on subsequent pages. Where a ViewSet does not set an explicit `order_by()`, the model's `Meta.ordering` (or the implicit primary-key order) applies. New endpoints **must** set an explicit default to avoid client-visible flicker.
+
+When a ViewSet exposes user-controllable ordering, it does so via `?ordering=<field>` and validates the value against an explicit allow-list — never against `request.query_params.get("ordering")` directly. See `AssetViewSet.get_queryset()` for the pattern.
+
+## Filtering
+
+Filtering today is hand-rolled inside each `get_queryset()`. The conventions are:
+
+- Use existing query-string param names (`category`, `location`, `status`, `search`) so the frontend can share helpers.
+- `?search=...` performs a case-insensitive `OR` over the human-meaningful fields for the resource (name, description, codes).
+- Boolean filters accept `true`/`false` (case-insensitive). Anything else is treated as "filter not specified".
+- Date range filters accept ISO-8601 strings. Invalid values silently drop the filter rather than returning 400 — this mirrors the legacy frontend's behavior; do not change it without coordinating UI work.
+
+`django-filter` is intentionally not yet a dependency. If a viewset's filter list grows large enough that `get_queryset` becomes hard to read, prefer extracting a `FilterSet` or filter helper rather than continuing to nest conditionals.
+
+## Query-count regression budget (AC-9)
+
+`backend/config/tests/test_list_contract.py::TestQueryCountBounds` exercises critical list and detail endpoints with realistic related-row counts (5+ categories, 5+ locations, multiple suppliers per item, multiple parts per asset) and asserts an upper-bound query count.
+
+The bounds are intentionally **upper bounds**, not targets. They reflect the current observed cost so any regression that increases query count fails CI. Tightening them — by moving `SerializerMethodField` loads into `prefetch_related`, by switching `_get_primary_supplier`-style calls to annotations, etc. — is welcomed; the right move is to lower the constant and let the test enforce the new ceiling.
+
+| Endpoint                                | Current bound | Notes                                                                            |
+| --------------------------------------- | ------------- | -------------------------------------------------------------------------------- |
+| `GET /api/inventory/items/` (20 items)  | 260 queries   | Dominated by per-item `SerializerMethodField` calls into `ItemSupplier` and reorder lookups. |
+| `GET /api/inventory/items/{id}/`        | 40 queries    | Detail serializer fetches per-supplier `PriceHistory`.                           |
+| `GET /api/inventory/assets/` (15 items) | 90 queries    | Dominated by per-asset `groups_can_enable`, ForgeKey operational mode, and lockout lookups. |
+| `GET /api/inventory/suppliers/` (10)    | 130 queries   | `SupplierSerializer` includes per-supplier `_get_*` helpers that re-query.       |
+
+Tightening these counts is tracked separately — see follow-up bead `oms-0rc:n+1-tightening`.

--- a/docs/PROFICIENCY_METRICS.md
+++ b/docs/PROFICIENCY_METRICS.md
@@ -1,0 +1,88 @@
+# Proficiency Metrics (AC-37, AC-38)
+
+This document is the single source of truth for OpenMakerSuite's product proficiency dashboard. It maps each critical product path to the tests that prove it works (AC-37) and tracks the target/current status of every proficiency metric the project commits to (AC-38).
+
+It is a working document. When a critical path changes, a metric target moves, or a new owner accepts a path, update this file in the same PR. The purpose is to make "is the product proficient yet?" a question we can answer by reading one file.
+
+## Severity model
+
+Same severity model as `docs/RISK_REGISTER.md`. Critical paths must have at least one automated owner (unit, integration, e2e) — manual is acceptable only for paths that are physically inseparable from hardware or a person.
+
+## AC-37: Critical path coverage map
+
+Each row maps a critical journey or surface to the test owner(s) responsible for keeping it green. "Coverage" is the lowest-cost layer that protects the path; higher layers may also exist.
+
+### Backend permissions
+
+| Critical path                                                  | Coverage   | Owner test(s)                                                                                                  |
+| -------------------------------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------- |
+| API permission matrix (AC-1, AC-2)                             | unit       | `backend/config/tests/test_*_permissions.py` per app; matrix doc at `docs/API_PERMISSION_MATRIX.md`.           |
+| Public QR / report endpoints stay anonymous-writable (AC-5)    | integration| `backend/inventory/tests/test_api.py::TestAssetProblemAPI`, `backend/checklists/tests/test_photo.py`.          |
+| Public write abuse controls (AC-6)                             | integration| `backend/inventory/tests/test_*_rate_limit*` + `inventory/utils/rate_limiting.py` unit tests.                  |
+| Standardized API error envelope (AC-7)                         | integration| `backend/config/tests/test_api_errors.py` (this is the contract enforcement point).                            |
+| List behavior — pagination, ordering, filtering (AC-8)         | integration| `backend/config/tests/test_list_contract.py::Test{Supplier,InventoryItem,Asset}ListContract`.                  |
+| N+1 query bounds (AC-9)                                        | integration| `backend/config/tests/test_list_contract.py::TestQueryCountBounds`.                                            |
+| OpenAPI schema validity + workflow paths (AC-10)               | unit + CI  | `backend/config/tests/test_schema.py` + ci.yml `Validate OpenAPI schema (AC-10)` step.                         |
+| Liveness / readiness split (AC-11, AC-12)                      | unit       | `backend/config/tests/test_health.py`.                                                                          |
+
+### Public workflows
+
+| Critical path                                              | Coverage    | Owner test(s)                                                                                                |
+| ---------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------ |
+| Public QR scan → checklist completion (anonymous)          | integration | `backend/checklists/tests/test_public_scan.py`, `backend/checklists/tests/test_photo.py`.                    |
+| Public asset problem report                                | integration | `backend/inventory/tests/test_asset_problem_*.py`.                                                           |
+| Public location problem report                             | integration | `backend/inventory/tests/test_location_problem.py`.                                                          |
+| Public donation submission                                 | integration | `backend/donations/tests/test_*public*.py`.                                                                  |
+| Public-to-staff loop (scan → triage → resolution)          | e2e         | `frontend/e2e/public-to-staff.spec.ts` (see `docs/frontend-e2e-playwright.md`).                              |
+
+### Frontend journeys
+
+| Critical path                                              | Coverage | Owner test(s)                                                                                                |
+| ---------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| Inventory browse + search                                  | unit + e2e | `frontend/src/pages/Inventory*.test.tsx`, `frontend/e2e/inventory-browse.spec.ts`.                         |
+| Reorder triage                                             | unit + e2e | `frontend/src/pages/Reorder*.test.tsx`, `frontend/e2e/reorder-triage.spec.ts`.                             |
+| Asset problem reporting (staff side)                       | unit + e2e | `frontend/src/pages/AssetProblem*.test.tsx`.                                                                 |
+| Maintenance work order review                              | e2e        | `frontend/e2e/work-order-review.spec.ts`.                                                                    |
+| Logistics dashboard                                        | unit       | `frontend/src/pages/Dashboard*.test.tsx`.                                                                    |
+| Kiosk display                                              | manual     | Documented checklist in `docs/FRONTEND_JOURNEY_INVENTORY.md`. Hardware-dependent.                            |
+| ForgeKey device management                                 | unit + e2e | `frontend/src/pages/ForgeKey*.test.tsx`, `frontend/e2e/forgekey.spec.ts`.                                    |
+| Settings + webhooks                                        | unit       | `frontend/src/pages/Settings*.test.tsx`.                                                                     |
+
+### Task workers
+
+| Critical path                                              | Coverage    | Owner test(s)                                                                                                |
+| ---------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------ |
+| Celery task inventory (AC-28)                              | doc         | `docs/CELERY_TASKS.md` is the source of truth.                                                               |
+| Task idempotency / retry behavior (AC-29, AC-30)           | unit        | `backend/config/tests/test_task_idempotency.py`.                                                             |
+| Worker readiness probe (AC-32)                             | unit        | `backend/config/tests/test_health.py::test_readyz_*` covers broker reachability.                             |
+| Scheduled task registration (AC-31)                        | unit        | `backend/config/tests/test_celery_schedule.py`.                                                              |
+
+### Deployment
+
+| Critical path                                              | Coverage   | Owner test(s)                                                                                                |
+| ---------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
+| Production env validation (AC-23)                          | CI         | `.github/workflows/ci.yml` `Run prod env validator …` step + `scripts/validate-prod-env.sh`.                 |
+| Backup / restore scripts (AC-25)                           | CI + manual| `.github/workflows/ci.yml` `Lint shell scripts` step + manual quarterly drill in `deploy/BACKUP_RESTORE.md`. |
+| Production smoke checks (AC-35)                            | CI + manual| `scripts/smoke.sh` (CI lints; operator runs against staging post-deploy).                                    |
+| Deployment artifact validation (AC-36)                     | CI         | `.github/workflows/ci.yml` `Render docker-compose.prod.yml`, `helm lint`, `kubeconform` jobs.                |
+
+## AC-38: Proficiency metrics
+
+The metrics table is the operator-facing dashboard summary. Each metric has a target, a current observed value, and a measurement source so anyone can re-derive it.
+
+| Metric                                            | Target           | Current          | Measurement source                                                                                                                  |
+| ------------------------------------------------- | ---------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Critical-path e2e coverage                        | 100% of `docs/FRONTEND_JOURNEY_INVENTORY.md` rows have a Playwright spec | Partial — public-to-staff loop covered (oms-0uw); kiosk + ForgeKey hardware paths remain manual | Run `frontend/e2e` and cross-reference inventory.                          |
+| Permission coverage                               | Every API permission row in `docs/API_PERMISSION_MATRIX.md` has at least one passing test | Partial — covered for public/anonymous + staff write boundaries; SIG-admin matrix in progress | Run `pytest -k permission` and reconcile against matrix.                            |
+| Worker health (broker reachability)               | `/api/health/readyz/` returns 200 with `broker: ok` for all configured workers              | Mitigated — readyz probe covers default broker (AC-12)                                          | `curl /api/health/readyz/` from the deployed cluster.                                  |
+| Backup restore age                                | Most recent verified restore drill ≤ 90 days                                                | Open — drill cadence not yet enforced (R-03 in risk register)                                   | Operator log; tracked in `deploy/BACKUP_RESTORE.md`.                                   |
+| Dependency age                                    | Backend Python deps ≤ 6 months out of date; frontend deps ≤ 12 months                       | Partial — `pip-audit` runs in pre-commit, no enforced cadence on frontend                       | `pip-audit` + `npm audit --audit-level=high`.                                          |
+| Deployment smoke status                           | `scripts/smoke.sh` green within 24h of every production deploy                              | Partial — script exists, post-deploy enforcement is operator-driven                             | `scripts/smoke.sh` artifacts captured in operator runbook.                             |
+| OpenAPI schema validity                           | `manage.py spectacular --validate` exit 0 on every PR                                       | Mitigated — enforced as a CI step on the backend job (AC-10)                                    | `.github/workflows/ci.yml` `Validate OpenAPI schema (AC-10)` step.                     |
+| API list-endpoint query bounds                    | All endpoints in `docs/API_LIST_CONTRACT.md` stay within the documented query budget        | Mitigated — `test_list_contract.py::TestQueryCountBounds` enforces (AC-9)                        | `pytest backend/config/tests/test_list_contract.py`.                                   |
+
+## Process
+
+- **Adding a new critical path**: append a row to the relevant section of AC-37 with the owner test reference. If no automated test exists yet, the row's coverage column reads `manual` and the team must file a bead to back-fill an automated owner.
+- **Moving a metric from "Open"/"Partial" to "Mitigated"**: update the current column, link the controlling test or runbook, and reference the AC number in the PR description.
+- **Removing a critical path**: requires a paired update to `docs/RISK_REGISTER.md` to confirm no risk row depends on it.


### PR DESCRIPTION
Implements oms-0rc.

Single commit. Adds:
- backend/config/api_errors.py (error envelope) + tests
- list contract tests + schema validation tests
- API_ERROR_CONTRACT, API_LIST_CONTRACT, PROFICIENCY_METRICS docs
- ci.yml gate additions
- Tweak to two existing test files

MR oms-wisp-a28 (P2).