### PR TITLE
fix(forgekey): differentiate provisioning auth failure modes (oms-xoh)

### DIFF
--- a/backend/forgekey/tests/test_provisioning_and_photo.py
+++ b/backend/forgekey/tests/test_provisioning_and_photo.py
@@ -151,6 +151,13 @@ class TestRegister:
             format="multipart",
         )
         assert resp.status_code == 401
+        body = resp.json()
+        assert body["code"] == "token_mismatch"
+        # Fingerprints must differ and neither must contain the actual token.
+        assert body["expected_token_fingerprint"]
+        assert body["supplied_token_fingerprint"]
+        assert body["expected_token_fingerprint"] != body["supplied_token_fingerprint"]
+        assert PROVISIONING_TOKEN not in resp.content.decode()
         assert ESP32Device.objects.filter(mac_address="AA:BB:CC:DD:EE:02").exists() is False
 
     def test_register_placeholder_token_returns_401(
@@ -167,6 +174,7 @@ class TestRegister:
             format="multipart",
         )
         assert resp.status_code == 401
+        assert resp.json()["code"] == "token_placeholder"
         assert ESP32Device.objects.filter(mac_address="AA:BB:CC:DD:EE:03").exists() is False
 
     def test_register_missing_token_returns_401(
@@ -182,6 +190,85 @@ class TestRegister:
             format="multipart",
         )
         assert resp.status_code == 401
+        body = resp.json()
+        assert body["code"] == "token_missing"
+        assert body["supplied_token_length"] == 0
+
+    def test_register_server_unconfigured_returns_distinct_code(
+        self, api_client, settings, people_counter_type, register_url
+    ):
+        """When the server has no token configured, the response distinguishes
+        that from a client-side header problem so operators see the real cause."""
+        settings.FORGEKEY_PROVISIONING_TOKEN = ""
+        meta = {
+            "mac_address": "AA:BB:CC:DD:EE:05",
+            "device_type": DeviceType.TYPE_PEOPLE_COUNTER,
+        }
+        resp = api_client.post(
+            register_url,
+            data={"photo": _jpeg(), "metadata": json.dumps(meta)},
+            HTTP_X_FORGEKEY_PROVISIONING_TOKEN="anything-here",
+            format="multipart",
+        )
+        assert resp.status_code == 401
+        body = resp.json()
+        assert body["code"] == "server_unconfigured"
+        assert body["expected_token_length"] == 0
+
+    def test_register_server_placeholder_token_returns_unconfigured(
+        self, api_client, settings, people_counter_type, register_url
+    ):
+        settings.FORGEKEY_PROVISIONING_TOKEN = "REPLACE_ME_PROVISIONING_TOKEN"
+        meta = {
+            "mac_address": "AA:BB:CC:DD:EE:06",
+            "device_type": DeviceType.TYPE_PEOPLE_COUNTER,
+        }
+        resp = api_client.post(
+            register_url,
+            data={"photo": _jpeg(), "metadata": json.dumps(meta)},
+            HTTP_X_FORGEKEY_PROVISIONING_TOKEN="REPLACE_ME_PROVISIONING_TOKEN",
+            format="multipart",
+        )
+        assert resp.status_code == 401
+        # Server unconfigured takes precedence over token_placeholder so
+        # operators are pointed at the backend, not the device.
+        assert resp.json()["code"] == "server_unconfigured"
+
+    def test_register_strips_whitespace_around_token(
+        self, api_client, settings, people_counter_type, register_url
+    ):
+        """A trailing newline in the env var or device-side string must not
+        cause a spurious 401 — the most common copy/paste failure mode."""
+        settings.FORGEKEY_PROVISIONING_TOKEN = PROVISIONING_TOKEN + "\n"
+        meta = {
+            "mac_address": "AA:BB:CC:DD:EE:07",
+            "device_type": DeviceType.TYPE_PEOPLE_COUNTER,
+        }
+        resp = api_client.post(
+            register_url,
+            data={"photo": _jpeg(), "metadata": json.dumps(meta)},
+            HTTP_X_FORGEKEY_PROVISIONING_TOKEN=f"  {PROVISIONING_TOKEN}  ",
+            format="multipart",
+        )
+        assert resp.status_code == 201, resp.content
+
+    def test_register_mismatch_response_does_not_leak_token(
+        self, api_client, people_counter_type, register_url
+    ):
+        meta = {
+            "mac_address": "AA:BB:CC:DD:EE:08",
+            "device_type": DeviceType.TYPE_PEOPLE_COUNTER,
+        }
+        resp = api_client.post(
+            register_url,
+            data={"photo": _jpeg(), "metadata": json.dumps(meta)},
+            HTTP_X_FORGEKEY_PROVISIONING_TOKEN="completely-wrong",
+            format="multipart",
+        )
+        assert resp.status_code == 401
+        body_text = resp.content.decode()
+        assert PROVISIONING_TOKEN not in body_text
+        assert "completely-wrong" not in body_text
 
     def test_register_firmware_contract_payload(
         self, api_client, people_counter_type, register_url

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -63,9 +63,9 @@ PLACEHOLDER_PROVISIONING_TOKEN = "REPLACE_ME_PROVISIONING_TOKEN"  # nosec B105
 # diagnostic instead of a generic 401. Safe to expose: they identify the
 # failure mode without revealing any part of the configured secret.
 AUTH_ERR_SERVER_UNCONFIGURED = "server_unconfigured"
-AUTH_ERR_TOKEN_MISSING = "token_missing"
-AUTH_ERR_TOKEN_PLACEHOLDER = "token_placeholder"
-AUTH_ERR_TOKEN_MISMATCH = "token_mismatch"
+AUTH_ERR_TOKEN_MISSING = "token_missing"  # nosec B105 — error code, not a password
+AUTH_ERR_TOKEN_PLACEHOLDER = "token_placeholder"  # nosec B105 — error code, not a password
+AUTH_ERR_TOKEN_MISMATCH = "token_mismatch"  # nosec B105 — error code, not a password
 
 
 def _token_fingerprint(token: str) -> str:

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -2,6 +2,8 @@
 Views for ForgeKey API.
 """
 
+import hashlib
+import hmac
 import json
 import logging
 
@@ -57,15 +59,93 @@ logger = logging.getLogger(__name__)
 JPEG_MAGIC = b"\xff\xd8\xff"
 PLACEHOLDER_PROVISIONING_TOKEN = "REPLACE_ME_PROVISIONING_TOKEN"  # nosec B105
 
+# Stable error codes returned to the device so firmware can log a meaningful
+# diagnostic instead of a generic 401. Safe to expose: they identify the
+# failure mode without revealing any part of the configured secret.
+AUTH_ERR_SERVER_UNCONFIGURED = "server_unconfigured"
+AUTH_ERR_TOKEN_MISSING = "token_missing"
+AUTH_ERR_TOKEN_PLACEHOLDER = "token_placeholder"
+AUTH_ERR_TOKEN_MISMATCH = "token_mismatch"
+
+
+def _token_fingerprint(token: str) -> str:
+    """Short, non-reversible fingerprint of a token for operator diagnosis.
+
+    Returns the first 8 hex chars of SHA-256(token). High-entropy tokens are
+    not recoverable from this prefix, so it is safe to log/return; operators
+    can compare fingerprints across the device, the OMS env, and the rotate
+    command without exposing the secret itself.
+    """
+    if not token:
+        return ""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:8]
+
+
+def _classify_provisioning_token(request) -> tuple[bool, str | None, dict]:
+    """Validate the provisioning token and classify any failure.
+
+    Returns ``(ok, error_code, diagnostics)``. ``diagnostics`` contains
+    non-secret fields suitable for the response body and server logs:
+    ``expected_fp``, ``supplied_fp``, ``expected_len``, ``supplied_len``.
+    """
+    raw_expected = getattr(settings, "FORGEKEY_PROVISIONING_TOKEN", "") or ""
+    expected = raw_expected.strip()
+    raw_supplied = request.headers.get("x-forgekey-provisioning-token", "") or ""
+    supplied = raw_supplied.strip()
+
+    diagnostics = {
+        "expected_fp": _token_fingerprint(expected),
+        "supplied_fp": _token_fingerprint(supplied),
+        "expected_len": len(expected),
+        "supplied_len": len(supplied),
+    }
+
+    if not expected or expected == PLACEHOLDER_PROVISIONING_TOKEN:
+        return False, AUTH_ERR_SERVER_UNCONFIGURED, diagnostics
+    if not supplied:
+        return False, AUTH_ERR_TOKEN_MISSING, diagnostics
+    if supplied == PLACEHOLDER_PROVISIONING_TOKEN:
+        return False, AUTH_ERR_TOKEN_PLACEHOLDER, diagnostics
+    if not hmac.compare_digest(supplied, expected):
+        return False, AUTH_ERR_TOKEN_MISMATCH, diagnostics
+    return True, None, diagnostics
+
+
+# Human-readable hints paired with each error code. Kept short so they fit
+# inside ESP32 serial logs.
+_AUTH_ERR_DETAILS = {
+    AUTH_ERR_SERVER_UNCONFIGURED: (
+        "Server has no provisioning token configured. "
+        "Set FORGEKEY_PROVISIONING_TOKEN on the backend."
+    ),
+    AUTH_ERR_TOKEN_MISSING: ("Request is missing the X-ForgeKey-Provisioning-Token header."),
+    AUTH_ERR_TOKEN_PLACEHOLDER: (
+        "Device sent the placeholder provisioning token; "
+        "publish the real token via rotate_provisioning_token."
+    ),
+    AUTH_ERR_TOKEN_MISMATCH: (
+        "Provisioning token does not match the server's configured value. "
+        "Compare token fingerprints to identify the drift."
+    ),
+}
+
+
+def _provisioning_auth_error_response(error_code: str, diagnostics: dict) -> Response:
+    """Build a 401 response that distinguishes the failure mode."""
+    payload = {
+        "detail": _AUTH_ERR_DETAILS.get(error_code, "Provisioning auth failed."),
+        "code": error_code,
+        "expected_token_fingerprint": diagnostics["expected_fp"],
+        "supplied_token_fingerprint": diagnostics["supplied_fp"],
+        "expected_token_length": diagnostics["expected_len"],
+        "supplied_token_length": diagnostics["supplied_len"],
+    }
+    return Response(payload, status=status.HTTP_401_UNAUTHORIZED)
+
 
 def _provisioning_token_valid(request) -> bool:
-    expected = getattr(settings, "FORGEKEY_PROVISIONING_TOKEN", "")
-    if not expected or expected == PLACEHOLDER_PROVISIONING_TOKEN:
-        return False
-    supplied = request.headers.get("x-forgekey-provisioning-token", "")
-    if not supplied or supplied == PLACEHOLDER_PROVISIONING_TOKEN:
-        return False
-    return supplied == expected
+    ok, _err, _diag = _classify_provisioning_token(request)
+    return ok
 
 
 class ForgeKeyDeviceRegisterView(APIView):
@@ -85,11 +165,20 @@ class ForgeKeyDeviceRegisterView(APIView):
     parser_classes = [MultiPartParser, FormParser, JSONParser]
 
     def post(self, request):
-        if not _provisioning_token_valid(request):
-            return Response(
-                {"detail": "Invalid or missing provisioning token."},
-                status=status.HTTP_401_UNAUTHORIZED,
+        ok, error_code, diagnostics = _classify_provisioning_token(request)
+        if not ok:
+            logger.warning(
+                "ForgeKey register: provisioning auth failed code=%s "
+                "expected_fp=%s expected_len=%d supplied_fp=%s supplied_len=%d "
+                "remote=%s",
+                error_code,
+                diagnostics["expected_fp"] or "<empty>",
+                diagnostics["expected_len"],
+                diagnostics["supplied_fp"] or "<empty>",
+                diagnostics["supplied_len"],
+                request.META.get("REMOTE_ADDR", "?"),
             )
+            return _provisioning_auth_error_response(error_code, diagnostics)
 
         # Metadata may arrive either as top-level multipart fields or as a
         # JSON blob under the "metadata" field — accept both shapes.


### PR DESCRIPTION
Fixes oms-xoh — ForgeKey device provisioning failing.

Single commit. Modifies forgekey/views.py (+100 LOC) and adds tests in forgekey/tests/test_provisioning_and_photo.py (+87 LOC). MR oms-wisp-lhz (P1).