### PR TITLE
build(frontend): add update-browserslist-db prebuild step (oms-xf4)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,10 @@ The `.github/workflows/ci.yml` workflow defines the required gates. Branch prote
 
 CI uses path filters: doc-only changes (`docs/**`, `*.md`, `.criteria/**`, README) skip the heavy jobs and `✅ CI Complete` still passes.
 
+### Frontend builds keep `caniuse-lite` fresh automatically
+
+`frontend/package.json` defines a `prebuild` script that runs `npx --yes update-browserslist-db@latest` before every `npm run build` (npm runs `prebuild` automatically as part of the `build` lifecycle). This refreshes the bundled browserslist database so webpack/react-scripts don't warn about a stale `caniuse-lite`. No manual action is required — local builds, CI, and Docker production builds all pick this up by invoking `npm run build`.
+
 ### Code Style
 
 **Python (Backend):**

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6495,12 +6495,15 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.7",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.7.tgz",
-      "integrity": "sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg==",
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/batch": {
@@ -6830,9 +6833,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001760",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001760.tgz",
-      "integrity": "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "prebuild": "npx --yes update-browserslist-db@latest",
     "build": "react-scripts build",
     "test": "TZ=America/Chicago react-scripts test --maxWorkers=4",
     "test:coverage": "TZ=America/Chicago react-scripts test --maxWorkers=4 --coverage --watchAll=false",


### PR DESCRIPTION
Fixes oms-xf4 — refreshes caniuse-lite via update-browserslist-db prebuild step. Single commit, 3 files (CONTRIBUTING.md, package.json, package-lock.json). MR oms-wisp-36y (P2).