### PR TITLE
fix(forgekey): make provisioning token misconfig diagnosable from logs (oms-j96)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -44,6 +44,18 @@ SENTRY_DSN=
 SENTRY_ENVIRONMENT=production
 REACT_APP_SENTRY_DSN=
 
+# ForgeKey provisioning token — REQUIRED in production.
+# Shared secret ESP32 devices send in X-ForgeKey-Provisioning-Token at the
+# /api/forgekey/devices/register/ endpoint. The matching value is baked into
+# device firmware. Without this set, every device registration returns 401
+# `server_unconfigured`. Generate a strong random value (e.g.
+#   python -c 'import secrets; print(secrets.token_urlsafe(32))'
+# ) and never commit the real value. Rotate via:
+#   manage.py rotate_provisioning_token
+# (This file is the ONLY env file docker-compose.prod.yml loads — it must be
+# named `.env`, not `.env.prod`.)
+FORGEKEY_PROVISIONING_TOKEN=
+
 # ForgeKey firmware signing key — REQUIRED in production.
 # ECDSA(P-256) PEM private key, with literal "\n" sequences for newlines.
 # Generate with scripts/build/gen-firmware-signing-key.sh in the forgekey repo.

--- a/backend/forgekey/apps.py
+++ b/backend/forgekey/apps.py
@@ -1,4 +1,16 @@
+import hashlib
+import logging
+
 from django.apps import AppConfig
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _token_fingerprint(token: str) -> str:
+    if not token:
+        return ""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:8]
 
 
 class ForgekeyConfig(AppConfig):
@@ -9,3 +21,17 @@ class ForgekeyConfig(AppConfig):
     def ready(self) -> None:
         # Import for side-effect: registers system checks.
         from . import checks  # noqa: F401
+
+        token = (getattr(settings, "FORGEKEY_PROVISIONING_TOKEN", "") or "").strip()
+        if token:
+            logger.info(
+                "ForgeKey provisioning token configured (length=%d, fingerprint=%s)",
+                len(token),
+                _token_fingerprint(token),
+            )
+        else:
+            logger.warning(
+                "ForgeKey provisioning token NOT configured "
+                "(FORGEKEY_PROVISIONING_TOKEN is empty); device registration "
+                "will return 401 server_unconfigured for every request."
+            )

--- a/backend/forgekey/tests/test_provisioning_token_loading.py
+++ b/backend/forgekey/tests/test_provisioning_token_loading.py
@@ -1,0 +1,120 @@
+"""Regression tests for FORGEKEY_PROVISIONING_TOKEN env-var loading (oms-j96).
+
+The original bug (gh #296) was that the backend reported
+``expected_token_length: 0`` despite the operator having ``FORGEKEY_PROVISIONING_TOKEN``
+in their ``.env`` files. These tests pin:
+
+  * the env-var → settings binding so future loader swaps don't silently
+    default the token to empty (AC-4)
+  * the ``ForgekeyConfig.ready()`` startup log line that lets operators
+    verify token configuration from process logs without firing a
+    registration request (AC-3)
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+def test_decouple_config_reads_env_var(monkeypatch):
+    """AC-4: when ``FORGEKEY_PROVISIONING_TOKEN`` is in ``os.environ``,
+    ``decouple.config`` must return that value, not the empty default.
+
+    settings.py binds the setting via
+    ``FORGEKEY_PROVISIONING_TOKEN = config("FORGEKEY_PROVISIONING_TOKEN", default="")``;
+    this pins that loader against future swaps that could regress to a
+    pure ``os.environ.get(..., "")`` (which would be fine) or — the
+    original failure mode — silently default to empty when the env var
+    is set."""
+    from decouple import AutoConfig
+
+    monkeypatch.setenv("FORGEKEY_PROVISIONING_TOKEN", "value-from-env-abcdef")
+    cfg = AutoConfig()
+    assert cfg("FORGEKEY_PROVISIONING_TOKEN", default="") == "value-from-env-abcdef"
+
+
+def test_settings_attribute_non_empty_when_overridden(settings):
+    """AC-4: ``settings.FORGEKEY_PROVISIONING_TOKEN`` is honored when set —
+    code paths that call ``getattr(settings, "FORGEKEY_PROVISIONING_TOKEN", "")``
+    see the configured value, not the empty default."""
+    settings.FORGEKEY_PROVISIONING_TOKEN = "configured-token-1234"
+    from django.conf import settings as django_settings
+
+    assert django_settings.FORGEKEY_PROVISIONING_TOKEN == "configured-token-1234"
+    assert getattr(django_settings, "FORGEKEY_PROVISIONING_TOKEN", "")
+
+
+class TestStartupLogLine:
+    """AC-3: ``ForgekeyConfig.ready()`` emits an INFO line carrying token
+    length and fingerprint when configured, and a WARNING when not.
+    Operators diagnose misconfiguration by grepping logs at boot — no
+    device registration request needed."""
+
+    def _run_ready(self):
+        from django.apps import apps
+
+        apps.get_app_config("forgekey").ready()
+
+    def test_info_log_when_token_configured(self, settings, caplog):
+        settings.FORGEKEY_PROVISIONING_TOKEN = "actual-secret-token-xyz"  # 23 chars
+
+        with caplog.at_level(logging.INFO, logger="forgekey.apps"):
+            self._run_ready()
+
+        infos = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.INFO and "provisioning token configured" in r.getMessage()
+        ]
+        assert infos, (
+            "expected INFO log with token diagnostics; "
+            f"got {[r.getMessage() for r in caplog.records]}"
+        )
+        msg = infos[-1].getMessage()
+        assert "length=23" in msg
+        assert "fingerprint=" in msg
+        # Never log the raw token.
+        assert "actual-secret-token-xyz" not in msg
+
+    def test_warning_log_when_token_missing(self, settings, caplog):
+        settings.FORGEKEY_PROVISIONING_TOKEN = ""
+
+        with caplog.at_level(logging.WARNING, logger="forgekey.apps"):
+            self._run_ready()
+
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "NOT configured" in r.getMessage()
+        ]
+        assert warnings, "expected WARNING log when provisioning token is empty"
+
+    def test_whitespace_only_token_is_treated_as_missing(self, settings, caplog):
+        settings.FORGEKEY_PROVISIONING_TOKEN = "   \n\t  "
+
+        with caplog.at_level(logging.WARNING, logger="forgekey.apps"):
+            self._run_ready()
+
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "NOT configured" in r.getMessage()
+        ]
+        assert warnings
+
+    def test_length_uses_stripped_value(self, settings, caplog):
+        """The reported length matches what ``_classify_provisioning_token``
+        measures (post-strip), so the boot-log fingerprint/length lines up
+        with the diagnostics returned in the 401 response body."""
+        settings.FORGEKEY_PROVISIONING_TOKEN = "  padded-token-xyz  "  # 16 stripped
+
+        with caplog.at_level(logging.INFO, logger="forgekey.apps"):
+            self._run_ready()
+
+        infos = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.INFO and "provisioning token configured" in r.getMessage()
+        ]
+        assert infos
+        assert "length=16" in infos[-1].getMessage()

--- a/docs/forgekey-integration.md
+++ b/docs/forgekey-integration.md
@@ -185,7 +185,9 @@ selected releases.
 
 ## Required environment variables
 
-Set these in `.env` (development) and `.env.prod` (production):
+Set these in `.env` (both development and production — `docker-compose.prod.yml`
+loads the production stack from `.env`, not `.env.prod`. The `.env.prod.example`
+template is copied to `.env` during initial setup, despite the name).
 
 | Variable                          | Description                                                                                    |
 | --------------------------------- | ---------------------------------------------------------------------------------------------- |
@@ -235,13 +237,13 @@ TLS); the dashboard is reachable on port `18083`.
 
 ### First-deploy checklist
 
-1. Set `EMQX_DASHBOARD_PASSWORD` in `.env.prod` to a strong value before
+1. Set `EMQX_DASHBOARD_PASSWORD` in `.env` to a strong value before
    `docker compose up -d`. EMQX bakes this into the dashboard's default
    `admin` user on first boot.
 2. Open `https://<host>:18083` and log in as `admin`. Rotate the password
    immediately if you reused a placeholder.
 3. Generate an API key under **System → API Keys**. Copy the key and
-   secret into `EMQX_API_KEY` / `EMQX_API_SECRET` in `.env.prod` and
+   secret into `EMQX_API_KEY` / `EMQX_API_SECRET` in `.env` and
    restart the `backend` service so it picks up the new values.
 4. (Optional) Create a dedicated MQTT user under **Access Control →
    Authentication** and set `MQTT_BROKER_USERNAME` /

--- a/scripts/validate-prod-env.sh
+++ b/scripts/validate-prod-env.sh
@@ -14,6 +14,7 @@
 #   - REDIS_URL, CELERY_BROKER_URL (must be set)
 #   - EMQX_DASHBOARD_PASSWORD (8+ chars, mixed case, digit, non-placeholder)
 #   - ForgeKey: FORGEKEY_FIRMWARE_SIGNING_KEY (if set, must look like PEM)
+#   - ForgeKey: FORGEKEY_PROVISIONING_TOKEN (warned if empty/placeholder)
 #   - Webhook tokens: POSTMARK_INBOUND_TOKEN, LOCATION_PING_TOKEN (warned if empty)
 #   - Email: EMAIL_BACKEND must not be the console backend in prod
 #   - Sentry: if SENTRY_DSN set, must look like a DSN URL
@@ -195,6 +196,15 @@ if [ -n "${FORGEKEY_FIRMWARE_SIGNING_KEY:-}" ]; then
         *"-----BEGIN "*"PRIVATE KEY-----"*) ;;
         *) err "FORGEKEY_FIRMWARE_SIGNING_KEY does not look like a PEM private key (no '-----BEGIN ... PRIVATE KEY-----' header)." ;;
     esac
+fi
+
+# --- 8a. ForgeKey provisioning token ----------------------------------------
+# Without this set, every ESP32 device-registration request returns 401
+# server_unconfigured. Warned (not errored) to keep deployments without the
+# ForgeKey integration from being blocked.
+
+if [ -z "${FORGEKEY_PROVISIONING_TOKEN:-}" ] || is_placeholder "${FORGEKEY_PROVISIONING_TOKEN:-}" || [ "${FORGEKEY_PROVISIONING_TOKEN:-}" = "REPLACE_ME_PROVISIONING_TOKEN" ]; then
+    warn "FORGEKEY_PROVISIONING_TOKEN is empty or a placeholder — ESP32 device registration will return 401 server_unconfigured. Generate with: python -c 'import secrets; print(secrets.token_urlsafe(32))'"
 fi
 
 # --- 9. Email ---------------------------------------------------------------


### PR DESCRIPTION
Fixes oms-j96 / gh #296. Diagnoses FORGEKEY_PROVISIONING_TOKEN not being picked up from .env via boot-time logging + validate-prod-env warnings.

Single commit, 5 files: .env.prod.example, forgekey/apps.py, tests, docs/forgekey-integration.md, scripts/validate-prod-env.sh. MR oms-wisp-7j2 (P1).