### PR TITLE
fix(frontend): make Sentry init diagnosable from logs (oms-78t)

### DIFF
--- a/frontend/src/__tests__/utils/sentry.test.ts
+++ b/frontend/src/__tests__/utils/sentry.test.ts
@@ -1,0 +1,115 @@
+import { dsnFingerprint, initSentry, readSentryEnv } from '../../utils/sentry';
+
+describe('utils/sentry', () => {
+  describe('readSentryEnv', () => {
+    it('reads REACT_APP_* and NODE_ENV from process.env', () => {
+      const env = {
+        REACT_APP_SENTRY_DSN: 'https://abcd1234@sentry.example/42',
+        REACT_APP_SENTRY_ENVIRONMENT: 'production',
+        REACT_APP_GIT_HASH: 'deadbeef',
+        NODE_ENV: 'production',
+      } as unknown as NodeJS.ProcessEnv;
+
+      expect(readSentryEnv(env)).toEqual({
+        dsn: 'https://abcd1234@sentry.example/42',
+        environment: 'production',
+        release: 'deadbeef',
+        nodeEnv: 'production',
+      });
+    });
+  });
+
+  describe('initSentry', () => {
+    it('skips init and warns when DSN is missing', () => {
+      const init = jest.fn();
+      const logger = { info: jest.fn(), warn: jest.fn() };
+
+      const result = initSentry({ dsn: undefined, nodeEnv: 'production' }, init, logger);
+
+      expect(result).toBe(false);
+      expect(init).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[Sentry] DSN missing — exception reporting disabled',
+      );
+      expect(logger.info).not.toHaveBeenCalled();
+    });
+
+    it('skips init and warns when DSN is the empty string', () => {
+      const init = jest.fn();
+      const logger = { info: jest.fn(), warn: jest.fn() };
+
+      const result = initSentry({ dsn: '', nodeEnv: 'production' }, init, logger);
+
+      expect(result).toBe(false);
+      expect(init).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('initializes SDK with env config and logs INFO with release + dsn fingerprint', () => {
+      const init = jest.fn();
+      const logger = { info: jest.fn(), warn: jest.fn() };
+
+      const result = initSentry(
+        {
+          dsn: 'https://abcd1234efgh@sentry.example/42',
+          environment: 'production',
+          release: 'deadbeef',
+          nodeEnv: 'production',
+        },
+        init,
+        logger,
+      );
+
+      expect(result).toBe(true);
+      expect(init).toHaveBeenCalledTimes(1);
+      const callArg = init.mock.calls[0][0];
+      expect(callArg.dsn).toBe('https://abcd1234efgh@sentry.example/42');
+      expect(callArg.environment).toBe('production');
+      expect(callArg.release).toBe('deadbeef');
+      expect(callArg.tracesSampleRate).toBe(0.1);
+      expect(callArg.replaysOnErrorSampleRate).toBe(1.0);
+      expect(Array.isArray(callArg.integrations)).toBe(true);
+
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        '[Sentry] initialized (env=production, release=deadbeef, dsn-fingerprint=abcd1234)',
+      );
+    });
+
+    it('falls back to NODE_ENV when REACT_APP_SENTRY_ENVIRONMENT is unset', () => {
+      const init = jest.fn();
+      const logger = { info: jest.fn(), warn: jest.fn() };
+
+      initSentry(
+        { dsn: 'https://x@y/1', release: undefined, nodeEnv: 'development' },
+        init,
+        logger,
+      );
+
+      expect(init.mock.calls[0][0].environment).toBe('development');
+      expect(init.mock.calls[0][0].tracesSampleRate).toBe(1.0);
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('release=unknown'),
+      );
+    });
+
+    it('uses "development" when neither environment nor NODE_ENV is set', () => {
+      const init = jest.fn();
+      const logger = { info: jest.fn(), warn: jest.fn() };
+
+      initSentry({ dsn: 'https://x@y/1' }, init, logger);
+
+      expect(init.mock.calls[0][0].environment).toBe('development');
+    });
+  });
+
+  describe('dsnFingerprint', () => {
+    it('returns first 8 chars of the DSN public key', () => {
+      expect(dsnFingerprint('https://abcd1234efgh@sentry.example/42')).toBe('abcd1234');
+    });
+
+    it('falls back to the first 8 chars of the raw string for malformed DSNs', () => {
+      expect(dsnFingerprint('not-a-dsn-string')).toBe('not-a-ds');
+    });
+  });
+});

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,37 +5,14 @@ import '@mantine/dropzone/styles.css';
 import { ModalsProvider } from '@mantine/modals';
 import { Notifications } from '@mantine/notifications';
 import '@mantine/notifications/styles.css';
-import * as Sentry from '@sentry/react';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { NotificationProvider } from './contexts/NotificationContext';
 import './styles/index.css';
+import { initSentry } from './utils/sentry';
 
-// Initialize Sentry
-const sentryDsn = process.env.REACT_APP_SENTRY_DSN;
-if (sentryDsn) {
-  Sentry.init({
-    dsn: sentryDsn,
-    environment: process.env.REACT_APP_SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'development',
-    release: process.env.REACT_APP_GIT_HASH || undefined,
-    integrations: [
-      new Sentry.BrowserTracing({
-        // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
-        // We recommend adjusting this value in production
-      }),
-      new Sentry.Replay({
-        maskAllText: false,
-        blockAllMedia: false,
-      }),
-    ],
-    // Performance Monitoring
-    tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
-    // Session Replay
-    replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-    replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
-  });
-}
+initSentry();
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/frontend/src/utils/sentry.ts
+++ b/frontend/src/utils/sentry.ts
@@ -1,0 +1,70 @@
+import * as Sentry from '@sentry/react';
+
+export interface SentryEnvConfig {
+  dsn?: string;
+  environment?: string;
+  release?: string;
+  nodeEnv?: string;
+}
+
+export interface SentryLogger {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+}
+
+export function readSentryEnv(env: NodeJS.ProcessEnv = process.env): SentryEnvConfig {
+  return {
+    dsn: env.REACT_APP_SENTRY_DSN,
+    environment: env.REACT_APP_SENTRY_ENVIRONMENT,
+    release: env.REACT_APP_GIT_HASH,
+    nodeEnv: env.NODE_ENV,
+  };
+}
+
+// Initialize Sentry from env config. Returns true if initialized, false if
+// skipped (DSN missing). Always emits a single INFO or WARN log so a missing
+// or misconfigured DSN is diagnosable from a deployed build's console.
+export function initSentry(
+  config: SentryEnvConfig = readSentryEnv(),
+  init: typeof Sentry.init = Sentry.init,
+  logger: SentryLogger = console,
+): boolean {
+  const { dsn, environment, release, nodeEnv } = config;
+
+  if (!dsn) {
+    logger.warn('[Sentry] DSN missing — exception reporting disabled');
+    return false;
+  }
+
+  const env = environment || nodeEnv || 'development';
+
+  init({
+    dsn,
+    environment: env,
+    release: release || undefined,
+    integrations: [
+      new Sentry.BrowserTracing(),
+      new Sentry.Replay({
+        maskAllText: false,
+        blockAllMedia: false,
+      }),
+    ],
+    tracesSampleRate: nodeEnv === 'production' ? 0.1 : 1.0,
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
+  });
+
+  logger.info(
+    `[Sentry] initialized (env=${env}, release=${release || 'unknown'}, dsn-fingerprint=${dsnFingerprint(dsn)})`,
+  );
+  return true;
+}
+
+// First 8 chars of the DSN's public key. The public key is the segment between
+// `://` and `@` in `https://<publicKey>@host/projectId`. Falls back to first 8
+// chars of the raw DSN if the format is unrecognized.
+export function dsnFingerprint(dsn: string): string {
+  const match = dsn.match(/:\/\/([^@]+)@/);
+  const key = match ? match[1] : dsn;
+  return key.slice(0, 8);
+}


### PR DESCRIPTION
Fixes oms-78t / gh #301 — frontend Sentry not reporting. Extracts Sentry setup into utils/sentry.ts with init log diagnostics + tests.

Single commit, 3 files (utils/sentry.ts, index.tsx, tests/sentry.test.ts). MR oms-wisp-xer (P2).