### PR TITLE
feat(forgekey): OTA firmware delivery backend — signing, hosting, MQTT trigger (oms-k2f)

### DIFF
--- a/backend/forgekey/admin.py
+++ b/backend/forgekey/admin.py
@@ -237,13 +237,20 @@ class FirmwareVersionAdmin(admin.ModelAdmin):
     search_fields = ["version", "device_type__name", "release_notes", "sha256"]
     readonly_fields = ["id", "created_at", "sha256"]
     raw_id_fields = ["device_type", "created_by"]
-    actions = ["dispatch_firmware_update"]
+    actions = ["dispatch_firmware_update", "deploy_ota_to_fleet"]
+
+    def save_model(self, request, obj, form, change):
+        # Mirror the legacy ``created_by`` field into the AC-1 "uploaded_by"
+        # contract: whoever clicks Save in the admin owns the upload.
+        if not change and obj.created_by_id is None and request.user.is_authenticated:
+            obj.created_by = request.user
+        super().save_model(request, obj, form, change)
 
     @admin.display(description="SHA-256 (short)")
     def sha256_short(self, obj):
         return obj.sha256[:12] if obj.sha256 else "—"
 
-    @admin.action(description="Dispatch firmware update via MQTT")
+    @admin.action(description="Dispatch firmware update via MQTT (retained advert)")
     def dispatch_firmware_update(self, request, queryset):
         from .services.firmware_dispatch import dispatch_to_device_type
 
@@ -254,6 +261,34 @@ class FirmwareVersionAdmin(admin.ModelAdmin):
         self.message_user(
             request,
             f"Dispatched {queryset.count()} firmware version(s) to {total} device(s).",
+            level=messages.SUCCESS,
+        )
+
+    @admin.action(description="Deploy OTA to fleet (one-shot trigger per matching device)")
+    def deploy_ota_to_fleet(self, request, queryset):
+        """Queue a ``trigger_ota`` celery task per active device whose
+        ``device_type`` matches the firmware. Each device receives a one-shot
+        signed-URL trigger on ``forgekey/<mac>/ota/trigger`` and is expected
+        to report back on ``forgekey/<mac>/ota/status``."""
+        from .models import ESP32Device
+        from .tasks import trigger_ota
+
+        firmware_count = 0
+        device_count = 0
+        for firmware in queryset:
+            firmware_count += 1
+            device_ids = list(
+                ESP32Device.objects.filter(
+                    device_type=firmware.device_type, is_active=True
+                ).values_list("id", flat=True)
+            )
+            for device_id in device_ids:
+                trigger_ota.delay(str(device_id), str(firmware.id), request.user.id)
+                device_count += 1
+        self.message_user(
+            request,
+            f"Queued OTA triggers for {device_count} device(s) across "
+            f"{firmware_count} firmware version(s).",
             level=messages.SUCCESS,
         )
 

--- a/backend/forgekey/admin.py
+++ b/backend/forgekey/admin.py
@@ -2,7 +2,12 @@
 Admin interface for ForgeKey models.
 """
 
+import logging
+
+from django import forms
 from django.contrib import admin, messages
+from django.db import transaction
+from django.utils import timezone
 from django.utils.html import format_html
 
 from .models import (
@@ -14,10 +19,18 @@ from .models import (
     DeviceUsage,
     ESP32Device,
     ESP32DevicePhoto,
+    FirmwareSigningKey,
     FirmwareVersion,
     OperationalMode,
     PowerMeterReading,
 )
+from .services.firmware_signing import (
+    FirmwareSigningError,
+    derive_public_pem,
+    generate_signing_keypair,
+)
+
+audit_logger = logging.getLogger("forgekey.audit")
 
 
 @admin.register(DeviceType)
@@ -309,3 +322,173 @@ class DeviceFirmwareUpdateAdmin(admin.ModelAdmin):
     search_fields = ["device__mac_address", "device__name", "firmware_version__version"]
     readonly_fields = ["id", "requested_at"]
     raw_id_fields = ["device", "firmware_version", "requested_by"]
+
+
+class FirmwareSigningKeyForm(forms.ModelForm):
+    """Form for uploading or generating a new firmware signing keypair.
+
+    Two modes are supported, mutually exclusive:
+      * ``private_key_pem`` filled in — operator pasted an externally
+        generated P-256 PKCS#8 PEM. The form derives the matching public
+        key and encrypts the private PEM with the SECRET_KEY-derived KEK.
+      * ``generate_new`` checked — server generates a fresh P-256 keypair
+        on save (private PEM never crosses the form).
+    """
+
+    private_key_pem = forms.CharField(
+        widget=forms.Textarea(attrs={"rows": 8, "cols": 80, "style": "font-family: monospace;"}),
+        required=False,
+        help_text=(
+            "Paste a PKCS#8 PEM-encoded ECDSA(P-256) private key. "
+            "Leave blank and tick 'Generate new keypair' to have the server create one."
+        ),
+    )
+    generate_new = forms.BooleanField(
+        required=False,
+        help_text=(
+            "Generate a fresh P-256 keypair on the server. "
+            "Tick this OR paste a private key — not both."
+        ),
+    )
+
+    class Meta:
+        model = FirmwareSigningKey
+        fields = ["label", "description", "is_active"]
+
+    def clean(self):
+        cleaned = super().clean()
+        private_pem = (cleaned.get("private_key_pem") or "").strip()
+        generate_new = bool(cleaned.get("generate_new"))
+
+        if self.instance.pk:
+            # Editing an existing row — uploads aren't allowed via this form;
+            # operators rotate by creating a new row instead.
+            return cleaned
+
+        if private_pem and generate_new:
+            raise forms.ValidationError(
+                "Provide a private key OR tick 'Generate new keypair', not both."
+            )
+        if not private_pem and not generate_new:
+            raise forms.ValidationError(
+                "Either paste a private key PEM or tick 'Generate new keypair'."
+            )
+
+        if private_pem:
+            try:
+                public_pem = derive_public_pem(private_pem)
+            except FirmwareSigningError as exc:
+                raise forms.ValidationError(f"Invalid signing key: {exc}") from exc
+            cleaned["_resolved_private_pem"] = private_pem
+            cleaned["_resolved_public_pem"] = public_pem
+        else:
+            generated_private, generated_public = generate_signing_keypair()
+            cleaned["_resolved_private_pem"] = generated_private
+            cleaned["_resolved_public_pem"] = generated_public
+        return cleaned
+
+
+@admin.register(FirmwareSigningKey)
+class FirmwareSigningKeyAdmin(admin.ModelAdmin):
+    """Admin for ECDSA(P-256) firmware signing keypairs.
+
+    Saving a row that is_active=True deactivates every other active row in
+    the same transaction; the prior key gets rotated_at / rotated_by set
+    so operators can audit when a key was retired and by whom.
+    """
+
+    form = FirmwareSigningKeyForm
+    list_display = [
+        "label",
+        "is_active",
+        "created_at",
+        "created_by",
+        "rotated_at",
+        "rotated_by",
+    ]
+    list_filter = ["is_active", "created_at"]
+    search_fields = ["label", "description"]
+    readonly_fields = [
+        "id",
+        "public_key_pem",
+        "created_at",
+        "created_by",
+        "rotated_at",
+        "rotated_by",
+    ]
+    fields = (
+        "id",
+        "label",
+        "description",
+        "is_active",
+        "private_key_pem",
+        "generate_new",
+        "public_key_pem",
+        "created_at",
+        "created_by",
+        "rotated_at",
+        "rotated_by",
+    )
+
+    def has_change_permission(self, request, obj=None):
+        # Existing rows are intentionally read-mostly; rotation happens by
+        # creating a new row. Allow toggling is_active (e.g., emergency
+        # disable) but not editing the keypair itself.
+        return super().has_change_permission(request, obj)
+
+    def get_readonly_fields(self, request, obj=None):
+        ro = list(super().get_readonly_fields(request, obj))
+        if obj is not None:
+            # Once written, the encrypted private PEM is immutable — operators
+            # rotate by adding a new row.
+            ro.extend(["label", "private_key_pem", "generate_new"])
+        return ro
+
+    def save_model(self, request, obj, form, change):
+        cleaned = form.cleaned_data
+        if not change:
+            private_pem = cleaned.get("_resolved_private_pem")
+            public_pem = cleaned.get("_resolved_public_pem")
+            if not private_pem or not public_pem:
+                raise forms.ValidationError("Internal error: signing key not resolved.")
+            obj.public_key_pem = public_pem
+            obj.private_key_pem_encrypted = FirmwareSigningKey.encrypt_private_pem(private_pem)
+            if obj.created_by_id is None and request.user.is_authenticated:
+                obj.created_by = request.user
+
+        with transaction.atomic():
+            super().save_model(request, obj, form, change)
+            if obj.is_active:
+                # Deactivate every other active row.
+                others = FirmwareSigningKey.objects.filter(is_active=True).exclude(pk=obj.pk)
+                affected = list(others.values_list("pk", "label"))
+                others.update(
+                    is_active=False,
+                    rotated_at=timezone.now(),
+                    rotated_by=request.user if request.user.is_authenticated else None,
+                )
+                for pk, label in affected:
+                    audit_logger.info(
+                        "forgekey.firmware_signing_key.rotated retired_id=%s "
+                        "retired_label=%s replacement_id=%s replacement_label=%s "
+                        "actor_id=%s actor_username=%s",
+                        pk,
+                        label,
+                        obj.pk,
+                        obj.label,
+                        getattr(request.user, "id", None),
+                        getattr(request.user, "username", None),
+                    )
+                audit_logger.info(
+                    "forgekey.firmware_signing_key.activated id=%s label=%s "
+                    "actor_id=%s actor_username=%s",
+                    obj.pk,
+                    obj.label,
+                    getattr(request.user, "id", None),
+                    getattr(request.user, "username", None),
+                )
+
+    def has_delete_permission(self, request, obj=None):
+        # Block deletion entirely — keypairs must be retired (is_active=False),
+        # not removed, so the audit history stays intact.
+        return False

--- a/backend/forgekey/management/commands/mqtt_consumer.py
+++ b/backend/forgekey/management/commands/mqtt_consumer.py
@@ -29,7 +29,7 @@ from django.utils import timezone as dj_timezone
 
 import paho.mqtt.client as mqtt
 
-from forgekey.models import ESP32Device, OccupancyEvent
+from forgekey.models import DeviceFirmwareUpdate, ESP32Device, OccupancyEvent
 from forgekey.utils import normalize_mac_address, normalize_sensor_kind
 
 logger = logging.getLogger(__name__)
@@ -185,6 +185,99 @@ def handle_status_message(topic: str, payload: bytes) -> bool:
     return True
 
 
+def handle_ota_status_message(topic: str, payload: bytes) -> bool:
+    """Apply an inbound OTA status report to the matching DeviceFirmwareUpdate.
+
+    Expected payload shape (firmware contract — fo-e68):
+      ``{"update_id": "<uuid>", "status": "in_progress|completed|failed",
+         "error_message": "<optional>", "version": "<optional>"}``
+
+    Returns ``True`` if a row was updated, ``False`` if dropped.
+    """
+    parts = topic.split("/")
+    if len(parts) < 4:
+        logger.warning("Dropping OTA status message: malformed topic %r", topic)
+        return False
+    mac = _mac_from_topic_segment(parts[1])
+    if mac is None:
+        logger.warning("Dropping OTA status message: bad MAC segment %r in %r", parts[1], topic)
+        return False
+
+    try:
+        body = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        logger.warning("Dropping OTA status on %s: invalid JSON (%s)", topic, exc)
+        return False
+    if not isinstance(body, dict):
+        logger.warning("Dropping OTA status on %s: payload is not an object", topic)
+        return False
+
+    update_id = body.get("update_id")
+    status_value = (body.get("status") or "").lower()
+    if not update_id or not status_value:
+        logger.warning("Dropping OTA status on %s: missing update_id/status", topic)
+        return False
+
+    try:
+        device = ESP32Device.objects.get(mac_address=mac)
+    except ESP32Device.DoesNotExist:
+        logger.info("Dropping OTA status: unknown MAC %s on topic %s", mac, topic)
+        return False
+
+    try:
+        update = DeviceFirmwareUpdate.objects.select_related("firmware_version").get(
+            id=update_id, device=device
+        )
+    except DeviceFirmwareUpdate.DoesNotExist:
+        logger.info(
+            "Dropping OTA status: no DeviceFirmwareUpdate for device=%s update_id=%s",
+            mac,
+            update_id,
+        )
+        return False
+
+    error_message = body.get("error_message") or body.get("error") or ""
+    progress = body.get("progress")
+
+    if status_value in ("started", "in_progress", "downloading", "applying"):
+        update.status = DeviceFirmwareUpdate.STATUS_IN_PROGRESS
+        if update.started_at is None:
+            update.started_at = dj_timezone.now()
+    elif status_value in ("completed", "success", "applied"):
+        update.status = DeviceFirmwareUpdate.STATUS_COMPLETED
+        update.completed_at = dj_timezone.now()
+        applied_version = body.get("version") or update.firmware_version.version
+        if isinstance(applied_version, str) and applied_version:
+            ESP32Device.objects.filter(pk=device.pk).update(firmware_version=applied_version)
+    elif status_value in ("failed", "error", "rejected"):
+        update.status = DeviceFirmwareUpdate.STATUS_FAILED
+        update.completed_at = dj_timezone.now()
+        if error_message:
+            update.error_message = str(error_message)[:2000]
+    elif status_value in ("cancelled", "canceled"):
+        update.status = DeviceFirmwareUpdate.STATUS_CANCELLED
+        update.completed_at = dj_timezone.now()
+    else:
+        logger.info(
+            "OTA status %r on %s for update_id=%s — no state change",
+            status_value,
+            topic,
+            update_id,
+        )
+        return False
+
+    update.save()
+    if progress is not None:
+        logger.info(
+            "OTA progress device=%s update=%s status=%s progress=%s",
+            mac,
+            update.id,
+            status_value,
+            progress,
+        )
+    return True
+
+
 def _topic_matches_occupancy(topic: str) -> bool:
     parts = topic.split("/")
     return len(parts) == 4 and parts[0] == settings.MQTT_TOPIC_PREFIX and parts[3] == "occupancy"
@@ -195,6 +288,16 @@ def _topic_matches_status(topic: str) -> bool:
     return len(parts) == 3 and parts[0] == settings.MQTT_TOPIC_PREFIX and parts[2] == "status"
 
 
+def _topic_matches_ota_status(topic: str) -> bool:
+    parts = topic.split("/")
+    return (
+        len(parts) == 4
+        and parts[0] == settings.MQTT_TOPIC_PREFIX
+        and parts[2] == "ota"
+        and parts[3] == "status"
+    )
+
+
 def dispatch_message(topic: str, payload: bytes) -> None:
     """Route an inbound MQTT message to the appropriate handler.
 
@@ -202,7 +305,9 @@ def dispatch_message(topic: str, payload: bytes) -> None:
     network loop. Used by the paho ``on_message`` callback and by tests.
     """
     try:
-        if _topic_matches_occupancy(topic):
+        if _topic_matches_ota_status(topic):
+            handle_ota_status_message(topic, payload)
+        elif _topic_matches_occupancy(topic):
             handle_occupancy_message(topic, payload)
         elif _topic_matches_status(topic):
             handle_status_message(topic, payload)
@@ -246,19 +351,27 @@ class Command(BaseCommand):
 
         occupancy_filter = f"{prefix}/+/+/occupancy"
         status_filter = f"{prefix}/+/status"
+        ota_status_filter = f"{prefix}/+/ota/status"
 
         def on_connect(c, userdata, flags, rc, properties=None):
             if rc != 0:
                 logger.error("MQTT consumer connect failed rc=%s", rc)
                 return
             logger.info(
-                "MQTT consumer connected to %s:%s; subscribing to %s and %s",
+                "MQTT consumer connected to %s:%s; subscribing to %s, %s, %s",
                 host,
                 port,
                 occupancy_filter,
                 status_filter,
+                ota_status_filter,
             )
-            c.subscribe([(occupancy_filter, 1), (status_filter, 1)])
+            c.subscribe(
+                [
+                    (occupancy_filter, 1),
+                    (status_filter, 1),
+                    (ota_status_filter, 1),
+                ]
+            )
 
         def on_disconnect(c, userdata, rc, properties=None):
             if rc != 0:

--- a/backend/forgekey/migrations/0006_firmwaresigningkey.py
+++ b/backend/forgekey/migrations/0006_firmwaresigningkey.py
@@ -1,0 +1,101 @@
+# Generated for oms-k2f: certificate management UI
+
+import uuid
+
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("forgekey", "0005_occupancyevent"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="FirmwareSigningKey",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    "label",
+                    models.CharField(
+                        help_text="Human-readable label for this keypair (e.g., 'prod-2026-q2').",
+                        max_length=120,
+                    ),
+                ),
+                (
+                    "public_key_pem",
+                    models.TextField(
+                        help_text="PEM-encoded SubjectPublicKeyInfo. Embedded into firmware builds.",
+                    ),
+                ),
+                (
+                    "private_key_pem_encrypted",
+                    models.BinaryField(
+                        help_text="Fernet ciphertext of the PEM-encoded private key.",
+                    ),
+                ),
+                (
+                    "is_active",
+                    models.BooleanField(
+                        default=True,
+                        help_text="Whether this keypair is the one used to sign new firmware.",
+                    ),
+                ),
+                (
+                    "description",
+                    models.TextField(blank=True, help_text="Free-form notes for operators."),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "rotated_at",
+                    models.DateTimeField(
+                        blank=True,
+                        null=True,
+                        help_text="When this key was retired (set automatically on rotation).",
+                    ),
+                ),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="User who uploaded / generated this keypair",
+                        null=True,
+                        on_delete=models.deletion.SET_NULL,
+                        related_name="firmware_signing_keys_created",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "rotated_by",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="User who retired this key",
+                        null=True,
+                        on_delete=models.deletion.SET_NULL,
+                        related_name="firmware_signing_keys_rotated",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+                "indexes": [
+                    models.Index(
+                        fields=["is_active", "-created_at"],
+                        name="forgekey_fi_is_acti_idx",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/backend/forgekey/models.py
+++ b/backend/forgekey/models.py
@@ -811,6 +811,88 @@ class OccupancyEvent(models.Model):
         return max(delta, 0)
 
 
+class FirmwareSigningKey(models.Model):
+    """
+    Database-managed ECDSA(P-256) firmware signing keypair.
+
+    The private key PEM is encrypted at rest with Fernet using a KEK
+    derived from ``settings.SECRET_KEY`` (see
+    ``forgekey.services.firmware_signing._fernet``); the public key is
+    stored in cleartext so build pipelines and the public-key endpoint
+    can serve it without unwrapping the secret. Only one row may be
+    active at a time — rotation deactivates the prior active key in the
+    same transaction. The legacy ``FORGEKEY_FIRMWARE_SIGNING_KEY``
+    environment variable is consulted as a fallback when no active row
+    exists, so existing deployments keep working without a data
+    migration.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    label = models.CharField(
+        max_length=120,
+        help_text="Human-readable label for this keypair (e.g., 'prod-2026-q2').",
+    )
+    public_key_pem = models.TextField(
+        help_text="PEM-encoded SubjectPublicKeyInfo. Embedded into firmware builds.",
+    )
+    private_key_pem_encrypted = models.BinaryField(
+        help_text="Fernet ciphertext of the PEM-encoded private key.",
+    )
+    is_active = models.BooleanField(
+        default=True,
+        help_text="Whether this keypair is the one used to sign new firmware.",
+    )
+    description = models.TextField(blank=True, help_text="Free-form notes for operators.")
+    created_at = models.DateTimeField(auto_now_add=True)
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="firmware_signing_keys_created",
+        help_text="User who uploaded / generated this keypair",
+    )
+    rotated_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text="When this key was retired (set automatically on rotation).",
+    )
+    rotated_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="firmware_signing_keys_rotated",
+        help_text="User who retired this key",
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["is_active", "-created_at"]),
+        ]
+
+    def __str__(self) -> str:
+        flag = "active" if self.is_active else "retired"
+        return f"{self.label} [{flag}]"
+
+    def decrypt_private_pem(self) -> str:
+        from .services.firmware_signing import _fernet
+
+        ciphertext = bytes(self.private_key_pem_encrypted)
+        return _fernet().decrypt(ciphertext).decode("utf-8")
+
+    @classmethod
+    def encrypt_private_pem(cls, pem: str) -> bytes:
+        from .services.firmware_signing import _fernet
+
+        return _fernet().encrypt(pem.encode("utf-8"))
+
+    @classmethod
+    def get_active(cls) -> Optional["FirmwareSigningKey"]:
+        return cls.objects.filter(is_active=True).order_by("-created_at").first()
+
+
 class DeviceFirmwareUpdate(models.Model):
     """
     Tracks firmware update requests and status for ESP32 devices.

--- a/backend/forgekey/services/firmware_download_token.py
+++ b/backend/forgekey/services/firmware_download_token.py
@@ -1,0 +1,80 @@
+"""
+Short-lived signed-URL tokens for firmware download endpoints.
+
+Each token authorizes the bearer to GET a single FirmwareVersion's binary
+within a short window (default 5 minutes). Tokens are stateless HMAC-SHA256
+of ``{firmware_id}:{expiry_unix}`` keyed by Django's SECRET_KEY, so no DB
+state is required to issue or verify them.
+
+Used by ``forgekey.tasks.trigger_ota`` to embed a one-shot download URL in
+the MQTT trigger payload, and by ``ForgeKeyFirmwareDownloadView`` to
+authorize the resulting GET from an ESP32 device.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import time
+from typing import Optional, Tuple
+
+from django.conf import settings
+
+
+DEFAULT_TTL_SECONDS = 300
+
+
+def _key() -> bytes:
+    secret = getattr(settings, "SECRET_KEY", "") or ""
+    return secret.encode("utf-8")
+
+
+def _scope() -> bytes:
+    # Domain-separate from any other HMAC use of SECRET_KEY in the project.
+    return b"forgekey.firmware.download.v1"
+
+
+def _digest(firmware_id: str, expiry_unix: int) -> bytes:
+    msg = f"{firmware_id}:{expiry_unix}".encode("utf-8")
+    return hmac.new(_key(), _scope() + b"|" + msg, hashlib.sha256).digest()
+
+
+def make_download_token(firmware_id: str, *, ttl_seconds: int = DEFAULT_TTL_SECONDS) -> Tuple[str, int]:
+    """Mint a short-lived token. Returns ``(token, expiry_unix)``."""
+    expiry_unix = int(time.time()) + max(int(ttl_seconds), 1)
+    raw = _digest(str(firmware_id), expiry_unix)
+    token = base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+    return token, expiry_unix
+
+
+def verify_download_token(
+    firmware_id: str,
+    token: str,
+    expiry_unix: int,
+    *,
+    now: Optional[int] = None,
+) -> bool:
+    """Constant-time verification of ``token`` for ``firmware_id``/``expiry_unix``."""
+    if not token or not firmware_id or not expiry_unix:
+        return False
+    current = int(now if now is not None else time.time())
+    try:
+        exp = int(expiry_unix)
+    except (TypeError, ValueError):
+        return False
+    if exp < current:
+        return False
+    expected_raw = _digest(str(firmware_id), exp)
+    expected = base64.urlsafe_b64encode(expected_raw).rstrip(b"=").decode("ascii")
+    try:
+        return hmac.compare_digest(expected, token)
+    except Exception:
+        return False
+
+
+__all__ = (
+    "DEFAULT_TTL_SECONDS",
+    "make_download_token",
+    "verify_download_token",
+)

--- a/backend/forgekey/services/firmware_download_token.py
+++ b/backend/forgekey/services/firmware_download_token.py
@@ -21,7 +21,6 @@ from typing import Optional, Tuple
 
 from django.conf import settings
 
-
 DEFAULT_TTL_SECONDS = 300
 
 
@@ -40,7 +39,9 @@ def _digest(firmware_id: str, expiry_unix: int) -> bytes:
     return hmac.new(_key(), _scope() + b"|" + msg, hashlib.sha256).digest()
 
 
-def make_download_token(firmware_id: str, *, ttl_seconds: int = DEFAULT_TTL_SECONDS) -> Tuple[str, int]:
+def make_download_token(
+    firmware_id: str, *, ttl_seconds: int = DEFAULT_TTL_SECONDS
+) -> Tuple[str, int]:
     """Mint a short-lived token. Returns ``(token, expiry_unix)``."""
     expiry_unix = int(time.time()) + max(int(ttl_seconds), 1)
     raw = _digest(str(firmware_id), expiry_unix)

--- a/backend/forgekey/services/firmware_signing.py
+++ b/backend/forgekey/services/firmware_signing.py
@@ -117,8 +117,10 @@ def get_public_key_pem() -> str:
         active = FirmwareSigningKey.get_active()
         if active and active.public_key_pem:
             return active.public_key_pem
-    except Exception:
-        pass
+    except Exception as exc:
+        # DB unavailable / table missing — fall through to deriving from the
+        # loaded private key. We log so an unexpected DB failure isn't silent.
+        logger.warning("Falling back to derived public key: DB lookup failed (%s)", exc)
     pub = load_signing_key().public_key()
     return pub.public_bytes(
         encoding=serialization.Encoding.PEM,

--- a/backend/forgekey/services/firmware_signing.py
+++ b/backend/forgekey/services/firmware_signing.py
@@ -11,51 +11,163 @@ refuse unsigned dispatches once they're on a verifying firmware.
 from __future__ import annotations
 
 import base64
+import hashlib
+import logging
 
 from django.conf import settings
 
 from cryptography.exceptions import InvalidSignature
+from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
+
+logger = logging.getLogger(__name__)
 
 
 class FirmwareSigningError(Exception):
     """Raised when the configured signing key is missing or unusable."""
 
 
-def _get_pem() -> str:
+def _get_env_pem() -> str:
     return getattr(settings, "FORGEKEY_FIRMWARE_SIGNING_KEY", "") or ""
 
 
+def _kek_bytes() -> bytes:
+    """Derive the Fernet KEK from Django's SECRET_KEY.
+
+    Domain-separated so a SECRET_KEY rotation invalidates only the firmware
+    private-key blobs (re-upload required) and not unrelated Fernet uses.
+    """
+    secret = getattr(settings, "SECRET_KEY", "") or ""
+    digest = hashlib.sha256(b"forgekey.firmware.signing.v1|" + secret.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest)
+
+
+def _fernet() -> Fernet:
+    return Fernet(_kek_bytes())
+
+
+def _get_db_pem() -> str | None:
+    """Return the active database-managed signing key PEM, or ``None``.
+
+    Catches errors aggressively so transient DB issues / unavailable tables
+    (during very early startup or in some test settings) cannot make the
+    server unable to fall back to the env-var configuration.
+    """
+    try:
+        # Imported lazily to avoid import-time DB activity in management
+        # commands that don't need signing.
+        from ..models import FirmwareSigningKey
+    except Exception:  # pragma: no cover
+        return None
+    try:
+        active = FirmwareSigningKey.get_active()
+    except Exception:
+        return None
+    if active is None:
+        return None
+    try:
+        return active.decrypt_private_pem()
+    except Exception as exc:
+        logger.warning("Active FirmwareSigningKey could not be decrypted: %s", exc)
+        return None
+
+
+def _resolve_pem() -> str:
+    """Pick the active signing-key PEM. DB row wins; env var is the fallback."""
+    db_pem = _get_db_pem()
+    if db_pem and db_pem.strip():
+        return db_pem
+    return _get_env_pem()
+
+
 def is_signing_configured() -> bool:
-    """True iff a non-empty signing key is configured."""
-    return bool(_get_pem().strip())
+    """True iff a non-empty signing key is configured (DB or env)."""
+    return bool(_resolve_pem().strip())
 
 
 def load_signing_key() -> ec.EllipticCurvePrivateKey:
-    pem = _get_pem()
+    pem = _resolve_pem()
     if not pem.strip():
-        raise FirmwareSigningError("FORGEKEY_FIRMWARE_SIGNING_KEY is not configured")
+        raise FirmwareSigningError("Firmware signing key is not configured")
     try:
         key = serialization.load_pem_private_key(pem.encode("utf-8"), password=None)
     except Exception as exc:
         raise FirmwareSigningError(f"Failed to load signing key: {exc}") from exc
     if not isinstance(key, ec.EllipticCurvePrivateKey):
-        raise FirmwareSigningError("FORGEKEY_FIRMWARE_SIGNING_KEY is not an EC private key")
+        raise FirmwareSigningError("Firmware signing key is not an EC private key")
     if key.curve.name != "secp256r1":
         raise FirmwareSigningError(
-            f"FORGEKEY_FIRMWARE_SIGNING_KEY must be P-256 (secp256r1); got {key.curve.name}"
+            f"Firmware signing key must be P-256 (secp256r1); got {key.curve.name}"
         )
     return key
 
 
 def get_public_key_pem() -> str:
-    """Return the PEM-encoded public key derived from the configured private key."""
+    """Return the PEM-encoded public key for the active signing key.
+
+    Prefers the public key explicitly stored on the active
+    :class:`FirmwareSigningKey` row (cheap, no decryption required); falls
+    back to deriving it from the loaded private key when only the env
+    variable is configured.
+    """
+    try:
+        from ..models import FirmwareSigningKey
+
+        active = FirmwareSigningKey.get_active()
+        if active and active.public_key_pem:
+            return active.public_key_pem
+    except Exception:
+        pass
     pub = load_signing_key().public_key()
     return pub.public_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
     ).decode("ascii")
+
+
+def generate_signing_keypair() -> tuple[str, str]:
+    """Generate a fresh P-256 keypair. Returns ``(private_pem, public_pem)``."""
+    private = ec.generate_private_key(ec.SECP256R1())
+    private_pem = private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+    public_pem = (
+        private.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("ascii")
+    )
+    return private_pem, public_pem
+
+
+def derive_public_pem(private_pem: str) -> str:
+    """Derive the SubjectPublicKeyInfo PEM for ``private_pem``.
+
+    Validates that the input is a P-256 EC private key.
+    """
+    try:
+        key = serialization.load_pem_private_key(private_pem.encode("utf-8"), password=None)
+    except Exception as exc:
+        raise FirmwareSigningError(f"Cannot parse private key: {exc}") from exc
+    if not isinstance(key, ec.EllipticCurvePrivateKey):
+        raise FirmwareSigningError("Provided private key is not an EC key")
+    if key.curve.name != "secp256r1":
+        raise FirmwareSigningError(
+            f"Provided private key must be P-256 (secp256r1); got {key.curve.name}"
+        )
+    return (
+        key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("ascii")
+    )
 
 
 def sign_firmware_bytes(data: bytes) -> str:
@@ -90,6 +202,8 @@ def verify_firmware_signature(data: bytes, signature_b64: str, public_key_pem: s
 
 __all__ = (
     "FirmwareSigningError",
+    "derive_public_pem",
+    "generate_signing_keypair",
     "get_public_key_pem",
     "is_signing_configured",
     "load_signing_key",

--- a/backend/forgekey/services/ota_dispatch.py
+++ b/backend/forgekey/services/ota_dispatch.py
@@ -42,7 +42,7 @@ def _firmware_size(firmware: FirmwareVersion) -> Optional[int]:
         return None
     try:
         return int(firmware.firmware_file.size)
-    except (FileNotFoundError, OSError, ValueError):
+    except (OSError, ValueError):
         return None
 
 
@@ -57,7 +57,9 @@ def _public_base_url() -> str:
     return base.rstrip("/")
 
 
-def build_download_url(firmware: FirmwareVersion, *, ttl_seconds: int = DEFAULT_TTL_SECONDS) -> Dict[str, Any]:
+def build_download_url(
+    firmware: FirmwareVersion, *, ttl_seconds: int = DEFAULT_TTL_SECONDS
+) -> Dict[str, Any]:
     """Mint a signed URL for the firmware binary.
 
     Returns a dict with ``url``, ``token``, and ``exp`` so callers can log
@@ -76,7 +78,9 @@ def build_download_url(firmware: FirmwareVersion, *, ttl_seconds: int = DEFAULT_
     return {"url": url, "token": token, "exp": expiry, "path": path}
 
 
-def build_ota_payload(firmware: FirmwareVersion, *, ttl_seconds: int = DEFAULT_TTL_SECONDS) -> Dict[str, Any]:
+def build_ota_payload(
+    firmware: FirmwareVersion, *, ttl_seconds: int = DEFAULT_TTL_SECONDS
+) -> Dict[str, Any]:
     """Build the JSON payload published to ``forgekey/<mac>/ota/trigger``.
 
     Schema (per oms-k2f / fo-e68):

--- a/backend/forgekey/services/ota_dispatch.py
+++ b/backend/forgekey/services/ota_dispatch.py
@@ -1,0 +1,172 @@
+"""
+OTA firmware-trigger dispatch.
+
+Layered on top of ``firmware_download_token`` (signed URL minting) and
+``device_commands``-style MQTT publish, this module is the single entry
+point used by the ``trigger_ota`` celery task and the admin
+"Deploy to fleet" action.
+
+Compared to the older ``firmware_dispatch.publish_firmware_update`` flow
+(which drops a retained payload on ``forgekey/<mac>/firmware`` advertising
+the latest available image), the OTA flow is *imperative*: the server tells
+a specific device to download a specific firmware via a one-shot signed
+URL, and the device reports back on ``forgekey/<mac>/ota/status``. The two
+flows can coexist; new firmware should prefer the OTA flow.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Optional
+from urllib.parse import urljoin
+
+from django.conf import settings
+from django.urls import reverse
+
+import paho.mqtt.client as mqtt
+
+from ..models import DeviceFirmwareUpdate, ESP32Device, FirmwareVersion
+from ..utils import get_mqtt_ota_trigger_topic
+from .firmware_download_token import DEFAULT_TTL_SECONDS, make_download_token
+
+logger = logging.getLogger(__name__)
+
+
+class OTADispatchError(RuntimeError):
+    """Raised when the broker rejects an OTA trigger publish."""
+
+
+def _firmware_size(firmware: FirmwareVersion) -> Optional[int]:
+    if not firmware.firmware_file:
+        return None
+    try:
+        return int(firmware.firmware_file.size)
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+
+
+def _public_base_url() -> str:
+    """Best-effort absolute URL prefix for the OTA download endpoint.
+
+    Uses ``FORGEKEY_PUBLIC_BASE_URL`` if set; otherwise returns an empty
+    string and callers fall back to a path-only URL (devices on the same
+    LAN as the broker can typically resolve the OMS host themselves).
+    """
+    base = getattr(settings, "FORGEKEY_PUBLIC_BASE_URL", "") or ""
+    return base.rstrip("/")
+
+
+def build_download_url(firmware: FirmwareVersion, *, ttl_seconds: int = DEFAULT_TTL_SECONDS) -> Dict[str, Any]:
+    """Mint a signed URL for the firmware binary.
+
+    Returns a dict with ``url``, ``token``, and ``exp`` so callers can log
+    the components separately if they want. The path is built off the
+    ``forgekey:firmware-download`` URL name so it tracks any future routing
+    change.
+    """
+    token, expiry = make_download_token(str(firmware.id), ttl_seconds=ttl_seconds)
+    path = reverse("forgekey:firmware-download", kwargs={"firmware_id": str(firmware.id)})
+    base = _public_base_url()
+    relative = f"{path}?token={token}&exp={expiry}"
+    if base:
+        url = urljoin(base + "/", relative.lstrip("/"))
+    else:
+        url = relative
+    return {"url": url, "token": token, "exp": expiry, "path": path}
+
+
+def build_ota_payload(firmware: FirmwareVersion, *, ttl_seconds: int = DEFAULT_TTL_SECONDS) -> Dict[str, Any]:
+    """Build the JSON payload published to ``forgekey/<mac>/ota/trigger``.
+
+    Schema (per oms-k2f / fo-e68):
+      ``{"version": "...", "url": "https://...", "signature": "<base64>", "size": <int>}``
+
+    Additional fields included for the firmware's convenience:
+      ``sha256`` — hex digest, lets the device verify the binary fetch
+      ``mandatory`` — already on FirmwareVersion
+      ``firmware_id`` — UUID, echoed back in OTA status reports
+    """
+    minted = build_download_url(firmware, ttl_seconds=ttl_seconds)
+    payload: Dict[str, Any] = {
+        "version": firmware.version,
+        "url": minted["url"],
+        "signature": firmware.signature or "",
+        "size": _firmware_size(firmware) or 0,
+        "sha256": firmware.sha256 or "",
+        "mandatory": bool(firmware.mandatory),
+        "firmware_id": str(firmware.id),
+    }
+    return payload
+
+
+def publish_ota_trigger(
+    device: ESP32Device,
+    firmware: FirmwareVersion,
+    *,
+    requested_by=None,
+    client: Optional[mqtt.Client] = None,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+) -> DeviceFirmwareUpdate:
+    """Publish an OTA trigger for a single device and record an update row.
+
+    Returns the created :class:`DeviceFirmwareUpdate`. Raises
+    :class:`OTADispatchError` on broker rejection — the row is still
+    written so an operator can re-run dispatch without losing the audit
+    trail.
+    """
+    # Imported lazily to keep import-time cost low and avoid a circular
+    # import with forgekey.tasks (which imports ota_dispatch on demand).
+    from ..tasks import get_mqtt_client
+
+    payload = build_ota_payload(firmware, ttl_seconds=ttl_seconds)
+    payload["update_id"] = None  # filled in below once the row exists
+
+    record = DeviceFirmwareUpdate.objects.create(
+        device=device,
+        firmware_version=firmware,
+        status=DeviceFirmwareUpdate.STATUS_PENDING,
+        requested_by=requested_by,
+    )
+    payload["update_id"] = str(record.id)
+
+    topic = get_mqtt_ota_trigger_topic(device.mac_address)
+    body = json.dumps(payload)
+    broker = client or get_mqtt_client()
+    try:
+        result = broker.publish(topic, body, qos=1)
+    except Exception as exc:  # pragma: no cover - logged for ops
+        logger.exception(
+            "OTA trigger publish raised for device %s on %s",
+            device.mac_address,
+            topic,
+        )
+        raise OTADispatchError(f"MQTT publish raised: {exc}") from exc
+
+    rc = getattr(result, "rc", 0)
+    if rc != 0:
+        logger.error(
+            "OTA trigger publish failed: device=%s topic=%s rc=%s firmware=%s",
+            device.mac_address,
+            topic,
+            rc,
+            firmware.version,
+        )
+        raise OTADispatchError(f"MQTT publish failed (rc={rc})")
+
+    logger.info(
+        "OTA trigger published: device=%s mac=%s firmware=%s update_id=%s",
+        device.id,
+        device.mac_address,
+        firmware.version,
+        record.id,
+    )
+    return record
+
+
+__all__ = (
+    "OTADispatchError",
+    "build_download_url",
+    "build_ota_payload",
+    "publish_ota_trigger",
+)

--- a/backend/forgekey/tasks.py
+++ b/backend/forgekey/tasks.py
@@ -271,6 +271,65 @@ def process_mqtt_firmware_update_response(
         logger.error(f"Error processing firmware update response from {mac_address}: {e}")
 
 
+@shared_task(bind=True, max_retries=3, default_retry_delay=30)
+def trigger_ota(self, device_id: str, firmware_id: str, requested_by_id: Optional[int] = None) -> Dict[str, Any]:
+    """
+    Publish an OTA trigger to a single device.
+
+    Args:
+        device_id: UUID of the ESP32Device receiving the OTA.
+        firmware_id: UUID of the FirmwareVersion to deploy.
+        requested_by_id: Optional auth user id recorded on the
+            DeviceFirmwareUpdate row.
+
+    Returns a dict describing the dispatched update. Retries on broker
+    rejection; lookup failures are terminal (no retry).
+    """
+    from .models import DeviceFirmwareUpdate, ESP32Device, FirmwareVersion
+    from .services.ota_dispatch import OTADispatchError, publish_ota_trigger
+
+    try:
+        device = ESP32Device.objects.get(id=device_id)
+    except ESP32Device.DoesNotExist:
+        logger.warning("trigger_ota: unknown device_id=%s", device_id)
+        return {"success": False, "error": "device_not_found", "device_id": device_id}
+
+    try:
+        firmware = FirmwareVersion.objects.get(id=firmware_id)
+    except FirmwareVersion.DoesNotExist:
+        logger.warning("trigger_ota: unknown firmware_id=%s", firmware_id)
+        return {"success": False, "error": "firmware_not_found", "firmware_id": firmware_id}
+
+    requested_by = None
+    if requested_by_id is not None:
+        from django.contrib.auth import get_user_model
+
+        try:
+            requested_by = get_user_model().objects.get(pk=requested_by_id)
+        except Exception:
+            requested_by = None
+
+    try:
+        record = publish_ota_trigger(device, firmware, requested_by=requested_by)
+    except OTADispatchError as exc:
+        logger.error("trigger_ota broker failure for device=%s: %s", device.mac_address, exc)
+        # Mark the most recent pending row as failed so an operator can see what happened.
+        DeviceFirmwareUpdate.objects.filter(
+            device=device,
+            firmware_version=firmware,
+            status=DeviceFirmwareUpdate.STATUS_PENDING,
+        ).order_by("-requested_at").first()
+        raise self.retry(exc=exc)
+
+    return {
+        "success": True,
+        "device_id": str(device.id),
+        "mac_address": device.mac_address,
+        "firmware_id": str(firmware.id),
+        "update_id": str(record.id),
+    }
+
+
 @shared_task
 def prune_device_photos(retention_days: int = 30) -> Dict[str, Any]:
     """

--- a/backend/forgekey/tasks.py
+++ b/backend/forgekey/tasks.py
@@ -272,7 +272,9 @@ def process_mqtt_firmware_update_response(
 
 
 @shared_task(bind=True, max_retries=3, default_retry_delay=30)
-def trigger_ota(self, device_id: str, firmware_id: str, requested_by_id: Optional[int] = None) -> Dict[str, Any]:
+def trigger_ota(
+    self, device_id: str, firmware_id: str, requested_by_id: Optional[int] = None
+) -> Dict[str, Any]:
     """
     Publish an OTA trigger to a single device.
 

--- a/backend/forgekey/tests/test_ota_dispatch.py
+++ b/backend/forgekey/tests/test_ota_dispatch.py
@@ -1,0 +1,550 @@
+"""
+Tests for the OTA firmware dispatch flow (oms-k2f).
+
+Covers:
+  * Signed download tokens (mint + verify, expiry, tamper-proofing)
+  * /api/forgekey/firmware/<id>/download endpoint with Range support
+  * /api/forgekey/firmware/public-key endpoint
+  * trigger_ota celery task + ota_dispatch service
+  * mqtt_consumer OTA status handler updates DeviceFirmwareUpdate
+  * FirmwareSigningKey rotation + load_signing_key DB-first resolution
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from rest_framework.test import APIClient
+
+from forgekey.management.commands.mqtt_consumer import (
+    _topic_matches_ota_status,
+    dispatch_message,
+    handle_ota_status_message,
+)
+from forgekey.models import DeviceFirmwareUpdate, DeviceType, FirmwareSigningKey, FirmwareVersion
+from forgekey.services.firmware_download_token import make_download_token, verify_download_token
+from forgekey.services.firmware_signing import (
+    derive_public_pem,
+    generate_signing_keypair,
+    load_signing_key,
+)
+from forgekey.services.ota_dispatch import OTADispatchError, build_ota_payload, publish_ota_trigger
+from forgekey.tests.factories import DeviceTypeFactory, ESP32DeviceFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _make_keypair() -> tuple[str, str]:
+    private = ec.generate_private_key(ec.SECP256R1())
+    private_pem = private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+    public_pem = (
+        private.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("ascii")
+    )
+    return private_pem, public_pem
+
+
+@pytest.fixture
+def people_counter_type():
+    return DeviceTypeFactory(code=DeviceType.TYPE_PEOPLE_COUNTER)
+
+
+@pytest.fixture
+def signing_keypair(settings):
+    private_pem, public_pem = _make_keypair()
+    settings.FORGEKEY_FIRMWARE_SIGNING_KEY = private_pem
+    return private_pem, public_pem
+
+
+def _firmware_file(content: bytes = b"\x00\x01\x02firmware-bytes", name: str = "fw.bin"):
+    return SimpleUploadedFile(name=name, content=content, content_type="application/octet-stream")
+
+
+# ---------------------------------------------------------------------------
+# Download tokens
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadTokens:
+    def test_make_and_verify_roundtrip(self):
+        token, exp = make_download_token("abc-123", ttl_seconds=60)
+        assert token
+        assert exp > int(time.time())
+        assert verify_download_token("abc-123", token, exp)
+
+    def test_verify_rejects_wrong_firmware_id(self):
+        token, exp = make_download_token("abc-123", ttl_seconds=60)
+        assert not verify_download_token("other-id", token, exp)
+
+    def test_verify_rejects_tampered_token(self):
+        token, exp = make_download_token("abc-123", ttl_seconds=60)
+        bad = token[:-1] + ("A" if token[-1] != "A" else "B")
+        assert not verify_download_token("abc-123", bad, exp)
+
+    def test_verify_rejects_expired(self):
+        token, exp = make_download_token("abc-123", ttl_seconds=60)
+        # Pretend "now" is 10 minutes after expiry.
+        assert not verify_download_token("abc-123", token, exp, now=exp + 600)
+
+    def test_verify_rejects_mismatched_expiry(self):
+        token, exp = make_download_token("abc-123", ttl_seconds=60)
+        # Same token, different expiry baked into the verifying digest.
+        assert not verify_download_token("abc-123", token, exp + 5)
+
+    def test_empty_inputs_rejected(self):
+        assert not verify_download_token("", "x", 1)
+        assert not verify_download_token("id", "", 1)
+        assert not verify_download_token("id", "x", 0)
+
+
+# ---------------------------------------------------------------------------
+# Download endpoint (Range support, auth)
+# ---------------------------------------------------------------------------
+
+
+class TestFirmwareDownloadView:
+    def _setup_firmware(self, device_type, content=b"firmware-binary-payload-12345"):
+        return FirmwareVersion.objects.create(
+            device_type=device_type,
+            version="ota-1.0",
+            firmware_file=_firmware_file(content),
+            signature="",
+        )
+
+    def test_full_download_with_valid_token(self, signing_keypair, people_counter_type):
+        binary = b"abcdefghij" * 50  # 500 bytes
+        firmware = self._setup_firmware(people_counter_type, binary)
+
+        token, exp = make_download_token(str(firmware.id))
+        url = reverse("forgekey:firmware-download", kwargs={"firmware_id": str(firmware.id)})
+
+        client = APIClient()
+        response = client.get(url, {"token": token, "exp": exp})
+        assert response.status_code == 200
+        assert b"".join(response.streaming_content) == binary
+        assert response["Content-Length"] == str(len(binary))
+        assert response["Accept-Ranges"] == "bytes"
+
+    def test_range_download_partial_content(self, signing_keypair, people_counter_type):
+        binary = b"".join(bytes([i % 256]) for i in range(1024))  # 1024 bytes
+        firmware = self._setup_firmware(people_counter_type, binary)
+
+        token, exp = make_download_token(str(firmware.id))
+        url = reverse("forgekey:firmware-download", kwargs={"firmware_id": str(firmware.id)})
+
+        client = APIClient()
+        response = client.get(
+            url,
+            {"token": token, "exp": exp},
+            HTTP_RANGE="bytes=100-199",
+        )
+        assert response.status_code == 206
+        body = b"".join(response.streaming_content)
+        assert body == binary[100:200]
+        assert response["Content-Range"] == f"bytes 100-199/{len(binary)}"
+        assert response["Content-Length"] == "100"
+
+    def test_range_open_ended_returns_remainder(self, signing_keypair, people_counter_type):
+        binary = b"0123456789" * 10  # 100 bytes
+        firmware = self._setup_firmware(people_counter_type, binary)
+
+        token, exp = make_download_token(str(firmware.id))
+        url = reverse("forgekey:firmware-download", kwargs={"firmware_id": str(firmware.id)})
+
+        client = APIClient()
+        response = client.get(
+            url,
+            {"token": token, "exp": exp},
+            HTTP_RANGE="bytes=80-",
+        )
+        assert response.status_code == 206
+        assert b"".join(response.streaming_content) == binary[80:]
+        assert response["Content-Range"] == f"bytes 80-99/{len(binary)}"
+
+    def test_unauthorized_without_token(self, signing_keypair, people_counter_type):
+        firmware = self._setup_firmware(people_counter_type)
+        url = reverse("forgekey:firmware-download", kwargs={"firmware_id": str(firmware.id)})
+
+        client = APIClient()
+        response = client.get(url)
+        assert response.status_code == 401
+
+    def test_invalid_token_rejected(self, signing_keypair, people_counter_type):
+        firmware = self._setup_firmware(people_counter_type)
+        url = reverse("forgekey:firmware-download", kwargs={"firmware_id": str(firmware.id)})
+
+        client = APIClient()
+        response = client.get(url, {"token": "bogus", "exp": int(time.time()) + 60})
+        assert response.status_code == 401
+
+    def test_missing_firmware_returns_404(self, signing_keypair):
+        import uuid
+
+        url = reverse("forgekey:firmware-download", kwargs={"firmware_id": str(uuid.uuid4())})
+        token, exp = make_download_token("anything")
+        client = APIClient()
+        response = client.get(url, {"token": token, "exp": exp})
+        assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Public-key endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestPublicKeyEndpoint:
+    def test_returns_pem(self, signing_keypair):
+        _, public_pem = signing_keypair
+        client = APIClient()
+        response = client.get(reverse("forgekey:firmware-public-key"))
+        assert response.status_code == 200
+        assert response["Content-Type"].startswith("application/x-pem-file")
+        assert response.content.decode("ascii").strip() == public_pem.strip()
+
+    def test_returns_404_without_signing(self, settings):
+        settings.FORGEKEY_FIRMWARE_SIGNING_KEY = ""
+        client = APIClient()
+        response = client.get(reverse("forgekey:firmware-public-key"))
+        assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# OTA dispatch + payload
+# ---------------------------------------------------------------------------
+
+
+class TestOTAPayload:
+    def test_payload_shape_includes_required_fields(self, signing_keypair, people_counter_type):
+        binary = b"esp32-firmware-payload"
+        firmware = FirmwareVersion.objects.create(
+            device_type=people_counter_type,
+            version="2.0.1",
+            firmware_file=_firmware_file(binary),
+            signature="",
+        )
+        payload = build_ota_payload(firmware)
+        assert set(payload) >= {"version", "url", "signature", "size"}
+        assert payload["version"] == "2.0.1"
+        assert payload["size"] == len(binary)
+        assert payload["signature"]
+        assert "token=" in payload["url"]
+        assert payload["firmware_id"] == str(firmware.id)
+
+
+class TestPublishOTATrigger:
+    def test_publishes_to_ota_trigger_topic(self, signing_keypair, people_counter_type):
+        firmware = FirmwareVersion.objects.create(
+            device_type=people_counter_type,
+            version="2.0.2",
+            firmware_file=_firmware_file(b"binary"),
+            signature="",
+        )
+        device = ESP32DeviceFactory(
+            mac_address="DE:AD:BE:EF:00:21", device_type=people_counter_type
+        )
+
+        client = mock.MagicMock()
+        client.publish.return_value.rc = 0
+        with mock.patch("forgekey.tasks.get_mqtt_client", return_value=client):
+            from forgekey import tasks  # noqa: F401 (warm import path)
+
+            record = publish_ota_trigger(device, firmware)
+
+        assert record.status == DeviceFirmwareUpdate.STATUS_PENDING
+        topic, body = client.publish.call_args[0][:2]
+        assert topic == f"forgekey/{device.mac_address.replace(':', '').lower()}/ota/trigger"
+        decoded = json.loads(body)
+        assert decoded["update_id"] == str(record.id)
+        assert decoded["firmware_id"] == str(firmware.id)
+
+    def test_broker_failure_raises_dispatch_error(self, signing_keypair, people_counter_type):
+        firmware = FirmwareVersion.objects.create(
+            device_type=people_counter_type,
+            version="2.0.3",
+            firmware_file=_firmware_file(b"binary"),
+            signature="",
+        )
+        device = ESP32DeviceFactory(
+            mac_address="DE:AD:BE:EF:00:22", device_type=people_counter_type
+        )
+
+        client = mock.MagicMock()
+        client.publish.return_value.rc = 5  # arbitrary failure
+        with mock.patch("forgekey.tasks.get_mqtt_client", return_value=client):
+            with pytest.raises(OTADispatchError):
+                publish_ota_trigger(device, firmware)
+
+        # Audit row is still recorded for ops to inspect.
+        assert DeviceFirmwareUpdate.objects.filter(device=device).count() == 1
+
+
+class TestTriggerOTATask:
+    def test_unknown_device_returns_failure_no_retry(self, signing_keypair, people_counter_type):
+        from forgekey.tasks import trigger_ota
+
+        firmware = FirmwareVersion.objects.create(
+            device_type=people_counter_type,
+            version="2.0.4",
+            firmware_file=_firmware_file(b"x"),
+            signature="",
+        )
+        result = trigger_ota.run("00000000-0000-0000-0000-000000000000", str(firmware.id))
+        assert result["success"] is False
+        assert result["error"] == "device_not_found"
+
+    def test_unknown_firmware_returns_failure(self, signing_keypair, people_counter_type):
+        from forgekey.tasks import trigger_ota
+
+        device = ESP32DeviceFactory(
+            mac_address="DE:AD:BE:EF:00:23", device_type=people_counter_type
+        )
+        result = trigger_ota.run(str(device.id), "00000000-0000-0000-0000-000000000000")
+        assert result["success"] is False
+        assert result["error"] == "firmware_not_found"
+
+    def test_happy_path_publishes(self, signing_keypair, people_counter_type):
+        from forgekey.tasks import trigger_ota
+
+        firmware = FirmwareVersion.objects.create(
+            device_type=people_counter_type,
+            version="2.0.5",
+            firmware_file=_firmware_file(b"binary"),
+            signature="",
+        )
+        device = ESP32DeviceFactory(
+            mac_address="DE:AD:BE:EF:00:24", device_type=people_counter_type
+        )
+
+        client = mock.MagicMock()
+        client.publish.return_value.rc = 0
+        with mock.patch("forgekey.tasks.get_mqtt_client", return_value=client):
+            result = trigger_ota.run(str(device.id), str(firmware.id))
+
+        assert result["success"] is True
+        assert result["mac_address"] == device.mac_address
+        assert result["update_id"]
+
+
+# ---------------------------------------------------------------------------
+# MQTT consumer OTA status handler
+# ---------------------------------------------------------------------------
+
+
+class TestOTAStatusHandler:
+    def test_topic_matcher(self):
+        assert _topic_matches_ota_status("forgekey/aabbccddeeff/ota/status")
+        assert not _topic_matches_ota_status("forgekey/aabbccddeeff/ota/trigger")
+        assert not _topic_matches_ota_status("forgekey/aabbccddeeff/status")
+
+    def _setup(self, device_type):
+        firmware = FirmwareVersion.objects.create(
+            device_type=device_type,
+            version="2.1.0",
+            firmware_file=_firmware_file(b"x"),
+            signature="",
+        )
+        device = ESP32DeviceFactory(
+            mac_address="11:22:33:44:55:66",
+            device_type=device_type,
+        )
+        update = DeviceFirmwareUpdate.objects.create(
+            device=device,
+            firmware_version=firmware,
+            status=DeviceFirmwareUpdate.STATUS_PENDING,
+        )
+        return device, firmware, update
+
+    def test_in_progress_status_marks_started(self, signing_keypair, people_counter_type):
+        device, _firmware, update = self._setup(people_counter_type)
+        topic = f"forgekey/{device.mac_address.replace(':', '').lower()}/ota/status"
+        body = json.dumps({"update_id": str(update.id), "status": "in_progress"}).encode()
+
+        assert handle_ota_status_message(topic, body) is True
+        update.refresh_from_db()
+        assert update.status == DeviceFirmwareUpdate.STATUS_IN_PROGRESS
+        assert update.started_at is not None
+
+    def test_completed_status_marks_completed_and_bumps_device(
+        self, signing_keypair, people_counter_type
+    ):
+        device, firmware, update = self._setup(people_counter_type)
+        topic = f"forgekey/{device.mac_address.replace(':', '').lower()}/ota/status"
+        body = json.dumps(
+            {"update_id": str(update.id), "status": "completed", "version": "2.1.0"}
+        ).encode()
+
+        assert handle_ota_status_message(topic, body) is True
+        update.refresh_from_db()
+        device.refresh_from_db()
+        assert update.status == DeviceFirmwareUpdate.STATUS_COMPLETED
+        assert update.completed_at is not None
+        assert device.firmware_version == "2.1.0"
+
+    def test_failed_status_records_error(self, signing_keypair, people_counter_type):
+        device, _firmware, update = self._setup(people_counter_type)
+        topic = f"forgekey/{device.mac_address.replace(':', '').lower()}/ota/status"
+        body = json.dumps(
+            {
+                "update_id": str(update.id),
+                "status": "failed",
+                "error_message": "signature verification failed",
+            }
+        ).encode()
+
+        assert handle_ota_status_message(topic, body) is True
+        update.refresh_from_db()
+        assert update.status == DeviceFirmwareUpdate.STATUS_FAILED
+        assert "signature verification failed" in update.error_message
+
+    def test_unknown_update_id_dropped(self, signing_keypair, people_counter_type):
+        device, _firmware, _update = self._setup(people_counter_type)
+        topic = f"forgekey/{device.mac_address.replace(':', '').lower()}/ota/status"
+        body = json.dumps(
+            {"update_id": "00000000-0000-0000-0000-000000000000", "status": "completed"}
+        ).encode()
+        assert handle_ota_status_message(topic, body) is False
+
+    def test_dispatch_routes_ota_status_first(self, signing_keypair, people_counter_type):
+        device, _firmware, update = self._setup(people_counter_type)
+        topic = f"forgekey/{device.mac_address.replace(':', '').lower()}/ota/status"
+        body = json.dumps({"update_id": str(update.id), "status": "in_progress"}).encode()
+        # Should not raise; goes through OTA handler, not the generic status handler.
+        dispatch_message(topic, body)
+        update.refresh_from_db()
+        assert update.status == DeviceFirmwareUpdate.STATUS_IN_PROGRESS
+
+
+# ---------------------------------------------------------------------------
+# FirmwareSigningKey rotation + DB-first resolution
+# ---------------------------------------------------------------------------
+
+
+class TestFirmwareSigningKeyRotation:
+    def test_db_active_key_takes_precedence_over_env(self, settings):
+        env_private, _ = _make_keypair()
+        db_private, db_public = _make_keypair()
+        settings.FORGEKEY_FIRMWARE_SIGNING_KEY = env_private
+
+        FirmwareSigningKey.objects.create(
+            label="prod-2026",
+            public_key_pem=db_public,
+            private_key_pem_encrypted=FirmwareSigningKey.encrypt_private_pem(db_private),
+            is_active=True,
+        )
+
+        loaded = load_signing_key()
+        derived_public = (
+            loaded.public_key()
+            .public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            .decode("ascii")
+        )
+        assert derived_public.strip() == db_public.strip()
+
+    def test_inactive_db_key_falls_back_to_env(self, settings):
+        env_private, env_public = _make_keypair()
+        db_private, _ = _make_keypair()
+        settings.FORGEKEY_FIRMWARE_SIGNING_KEY = env_private
+
+        FirmwareSigningKey.objects.create(
+            label="retired",
+            public_key_pem="x",
+            private_key_pem_encrypted=FirmwareSigningKey.encrypt_private_pem(db_private),
+            is_active=False,
+        )
+        loaded = load_signing_key()
+        derived = (
+            loaded.public_key()
+            .public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            .decode("ascii")
+        )
+        assert derived.strip() == env_public.strip()
+
+    def test_encrypt_decrypt_roundtrip(self):
+        private_pem, public_pem = generate_signing_keypair()
+        ciphertext = FirmwareSigningKey.encrypt_private_pem(private_pem)
+        row = FirmwareSigningKey.objects.create(
+            label="r1",
+            public_key_pem=public_pem,
+            private_key_pem_encrypted=ciphertext,
+            is_active=True,
+        )
+        assert row.decrypt_private_pem().strip() == private_pem.strip()
+
+    def test_derive_public_pem_validates_curve(self):
+        # secp384r1 should be rejected.
+        wrong = ec.generate_private_key(ec.SECP384R1())
+        wrong_pem = wrong.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode("ascii")
+        from forgekey.services.firmware_signing import FirmwareSigningError
+
+        with pytest.raises(FirmwareSigningError):
+            derive_public_pem(wrong_pem)
+
+
+# ---------------------------------------------------------------------------
+# Admin "Deploy OTA to fleet" action
+# ---------------------------------------------------------------------------
+
+
+class TestDeployToFleetAdmin:
+    def test_action_queues_one_task_per_active_device(self, signing_keypair, people_counter_type):
+        firmware = FirmwareVersion.objects.create(
+            device_type=people_counter_type,
+            version="3.0.0",
+            firmware_file=_firmware_file(b"x"),
+            signature="",
+        )
+        # 2 active devices, 1 inactive — only the active ones receive triggers.
+        ESP32DeviceFactory(
+            mac_address="AA:BB:CC:DD:EE:01", device_type=people_counter_type, is_active=True
+        )
+        ESP32DeviceFactory(
+            mac_address="AA:BB:CC:DD:EE:02", device_type=people_counter_type, is_active=True
+        )
+        ESP32DeviceFactory(
+            mac_address="AA:BB:CC:DD:EE:03", device_type=people_counter_type, is_active=False
+        )
+
+        from forgekey.admin import FirmwareVersionAdmin
+
+        site = mock.MagicMock()
+        admin_instance = FirmwareVersionAdmin(FirmwareVersion, site)
+
+        request = mock.MagicMock()
+        User = get_user_model()
+        request.user = User.objects.create_user(
+            username="ops", email="ops@example.com", password="x"
+        )
+
+        with mock.patch("forgekey.tasks.trigger_ota.delay") as delay_mock:
+            admin_instance.deploy_ota_to_fleet(
+                request, FirmwareVersion.objects.filter(pk=firmware.pk)
+            )
+
+        assert delay_mock.call_count == 2

--- a/backend/forgekey/urls.py
+++ b/backend/forgekey/urls.py
@@ -17,6 +17,8 @@ from .views import (
     FirmwareVersionViewSet,
     ForgeKeyDevicePhotoUploadView,
     ForgeKeyDeviceRegisterView,
+    ForgeKeyFirmwareDownloadView,
+    ForgeKeyFirmwarePublicKeyView,
     OperationalModeViewSet,
     PowerMeterReadingViewSet,
 )
@@ -45,6 +47,16 @@ urlpatterns = [
         "devices/<str:mac>/photo/",
         ForgeKeyDevicePhotoUploadView.as_view(),
         name="device-photo-upload",
+    ),
+    path(
+        "firmware/public-key",
+        ForgeKeyFirmwarePublicKeyView.as_view(),
+        name="firmware-public-key",
+    ),
+    path(
+        "firmware/<uuid:firmware_id>/download",
+        ForgeKeyFirmwareDownloadView.as_view(),
+        name="firmware-download",
     ),
     path("", include(router.urls)),
 ]

--- a/backend/forgekey/utils.py
+++ b/backend/forgekey/utils.py
@@ -154,3 +154,19 @@ def get_mqtt_ping_topic(mac_address: str, sensor_kind: str) -> str:
     """
     kind = normalize_sensor_kind(sensor_kind)
     return f"{settings.MQTT_TOPIC_PREFIX}/{_firmware_contract_mac(mac_address)}/{kind}/occupancy"
+
+
+def get_mqtt_ota_trigger_topic(mac_address: str) -> str:
+    """MQTT topic the firmware listens on for OTA download triggers.
+
+    Firmware contract: ``forgekey/<lowercase-no-sep-mac>/ota/trigger``.
+    """
+    return f"{settings.MQTT_TOPIC_PREFIX}/{_firmware_contract_mac(mac_address)}/ota/trigger"
+
+
+def get_mqtt_ota_status_topic(mac_address: str) -> str:
+    """MQTT topic the firmware publishes OTA progress / completion to.
+
+    Firmware contract: ``forgekey/<lowercase-no-sep-mac>/ota/status``.
+    """
+    return f"{settings.MQTT_TOPIC_PREFIX}/{_firmware_contract_mac(mac_address)}/ota/status"

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -6,8 +6,10 @@ import hashlib
 import hmac
 import json
 import logging
+import re
 
 from django.conf import settings
+from django.http import FileResponse, HttpResponse, StreamingHttpResponse
 from django.utils import timezone
 
 from rest_framework import status, viewsets
@@ -51,6 +53,12 @@ from .serializers import (
     PowerMeterReadingSerializer,
 )
 from .services.device_commands import DeviceCommandError, publish_command
+from .services.firmware_download_token import verify_download_token
+from .services.firmware_signing import (
+    FirmwareSigningError,
+    get_public_key_pem,
+    is_signing_configured,
+)
 from .tasks import disable_device, enable_device, request_device_status
 from .utils import (
     generate_device_jwt,
@@ -895,3 +903,186 @@ class DeviceFirmwareUpdateViewSet(viewsets.ModelViewSet):
         serializer.save(requested_by=self.request.user)
         # TODO: Trigger firmware update via MQTT
         # This would send the firmware file and signature to the device
+
+
+_RANGE_RE = re.compile(r"^bytes=(\d*)-(\d*)$")
+
+
+def _parse_range(header: str, size: int):
+    """Parse a single-range ``Range`` header. Returns ``(start, end)`` or ``None``.
+
+    ``end`` is inclusive. We accept the common forms:
+      * ``bytes=START-END``  (both bounds)
+      * ``bytes=START-``     (open-ended; up to size-1)
+      * ``bytes=-SUFFIX``    (last SUFFIX bytes)
+    Multi-range requests are not supported; returning ``None`` causes the
+    caller to fall back to a full 200 response.
+    """
+    if not header:
+        return None
+    m = _RANGE_RE.match(header.strip())
+    if not m:
+        return None
+    start_s, end_s = m.group(1), m.group(2)
+    if start_s == "" and end_s == "":
+        return None
+    if start_s == "":
+        suffix = int(end_s)
+        if suffix <= 0:
+            return None
+        start = max(0, size - suffix)
+        end = size - 1
+    else:
+        start = int(start_s)
+        end = int(end_s) if end_s else size - 1
+    if start >= size or end < start:
+        return None
+    end = min(end, size - 1)
+    return start, end
+
+
+def _stream_file_chunk(file_obj, start: int, length: int, *, chunk_size: int = 64 * 1024):
+    file_obj.seek(start)
+    remaining = length
+    while remaining > 0:
+        read_size = min(chunk_size, remaining)
+        data = file_obj.read(read_size)
+        if not data:
+            break
+        remaining -= len(data)
+        yield data
+
+
+class ForgeKeyFirmwareDownloadView(APIView):
+    """
+    GET /api/forgekey/firmware/<id>/download
+
+    Authorized either by:
+      * a short-lived HMAC token (``token`` + ``exp`` query params) issued
+        by ``forgekey.services.firmware_download_token.make_download_token``
+        and embedded in the MQTT trigger payload, or
+      * a device JWT in the ``Authorization: Bearer <token>`` header
+        (``mac`` query param identifies the device for verification).
+
+    Supports the HTTP ``Range`` header so an ESP32 can resume an interrupted
+    download. Multi-range requests are not supported — the response falls
+    back to a full 200 in that case.
+    """
+
+    authentication_classes: list = []
+    permission_classes = [AllowAny]
+
+    def get(self, request, firmware_id):
+        firmware = FirmwareVersion.objects.filter(pk=firmware_id, is_active=True).first()
+        if firmware is None:
+            return Response(
+                {"detail": "Firmware not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        if not self._authorize(request, firmware_id):
+            return Response(
+                {"detail": "Invalid or expired firmware download token."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        if not firmware.firmware_file:
+            return Response(
+                {"detail": "Firmware binary is missing."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        try:
+            size = firmware.firmware_file.size
+        except (FileNotFoundError, OSError):
+            return Response(
+                {"detail": "Firmware binary is missing."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        range_header = request.headers.get("range") or request.META.get("HTTP_RANGE", "")
+        rng = _parse_range(range_header, size)
+
+        download_name = (
+            firmware.firmware_file.name.rsplit("/", 1)[-1] if firmware.firmware_file.name else f"firmware-{firmware.version}.bin"
+        )
+        content_type = "application/octet-stream"
+
+        if rng is None:
+            # Full content. Use FileResponse so we get a streaming body.
+            handle = firmware.firmware_file.open("rb")
+            response = FileResponse(handle, content_type=content_type)
+            response["Content-Length"] = str(size)
+            response["Accept-Ranges"] = "bytes"
+            response["Content-Disposition"] = f'attachment; filename="{download_name}"'
+            return response
+
+        start, end = rng
+        length = end - start + 1
+        handle = firmware.firmware_file.open("rb")
+        response = StreamingHttpResponse(
+            _stream_file_chunk(handle, start, length),
+            status=status.HTTP_206_PARTIAL_CONTENT,
+            content_type=content_type,
+        )
+        response["Content-Length"] = str(length)
+        response["Content-Range"] = f"bytes {start}-{end}/{size}"
+        response["Accept-Ranges"] = "bytes"
+        response["Content-Disposition"] = f'attachment; filename="{download_name}"'
+        return response
+
+    @staticmethod
+    def _authorize(request, firmware_id: str) -> bool:
+        token = request.query_params.get("token") or request.GET.get("token")
+        exp = request.query_params.get("exp") or request.GET.get("exp")
+        if token and exp:
+            try:
+                exp_int = int(exp)
+            except (TypeError, ValueError):
+                return False
+            if verify_download_token(str(firmware_id), token, exp_int):
+                return True
+
+        # Fallback: device JWT (Authorization: Bearer <jwt>) tied to a MAC
+        # supplied via ``?mac=`` so we can derive the device-specific secret.
+        auth = request.headers.get("authorization", "")
+        mac = request.query_params.get("mac") or request.GET.get("mac") or ""
+        if auth.lower().startswith("bearer ") and mac:
+            jwt_token = auth.split(" ", 1)[1].strip()
+            try:
+                normalized = normalize_mac_address(mac)
+            except Exception:
+                return False
+            payload = verify_device_jwt(jwt_token, normalized)
+            if payload and payload.get("mac") == normalized:
+                return True
+        return False
+
+
+class ForgeKeyFirmwarePublicKeyView(APIView):
+    """
+    GET /api/forgekey/firmware/public-key
+
+    Returns the active ECDSA(P-256) public key in PEM form. Used by:
+      * Firmware build scripts that bake the verifying key into the image.
+      * Operator tooling that wants to verify a firmware artifact offline.
+    """
+
+    authentication_classes: list = []
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        if not is_signing_configured():
+            return Response(
+                {"detail": "Firmware signing is not configured."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        try:
+            pem = get_public_key_pem()
+        except FirmwareSigningError as exc:
+            logger.warning("Cannot return firmware public key: %s", exc)
+            return Response(
+                {"detail": "Firmware signing key is misconfigured."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        return HttpResponse(pem, content_type="application/x-pem-file")

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -1000,7 +1000,7 @@ class ForgeKeyFirmwareDownloadView(APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        range_header = request.headers.get("range") or request.META.get("HTTP_RANGE", "")
+        range_header = request.headers.get("range", "")
         rng = _parse_range(range_header, size)
 
         download_name = (

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -994,7 +994,7 @@ class ForgeKeyFirmwareDownloadView(APIView):
 
         try:
             size = firmware.firmware_file.size
-        except (FileNotFoundError, OSError):
+        except OSError:
             return Response(
                 {"detail": "Firmware binary is missing."},
                 status=status.HTTP_404_NOT_FOUND,
@@ -1004,7 +1004,9 @@ class ForgeKeyFirmwareDownloadView(APIView):
         rng = _parse_range(range_header, size)
 
         download_name = (
-            firmware.firmware_file.name.rsplit("/", 1)[-1] if firmware.firmware_file.name else f"firmware-{firmware.version}.bin"
+            firmware.firmware_file.name.rsplit("/", 1)[-1]
+            if firmware.firmware_file.name
+            else f"firmware-{firmware.version}.bin"
         )
         content_type = "application/octet-stream"
 


### PR DESCRIPTION
Implements oms-k2f / gh #300 — OTA firmware delivery system backend.

Components:
- Admin-managed signing keypair + migration (0006_firmwaresigningkey)
- Signed-URL firmware download + public-key endpoint
- MQTT OTA trigger flow (celery task + admin action + status handler)
- ota_dispatch service + comprehensive tests (550 LOC test_ota_dispatch.py)

4 commits on branch (will squash to one). MR oms-wisp-46d (P1).