### PR TITLE
feat(forgekey): EMQX webhook bridge for inbound MQTT messages (oms-2zo)

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -414,6 +414,21 @@ FORGEKEY_FIRMWARE_SIGNING_KEY = config("FORGEKEY_FIRMWARE_SIGNING_KEY", default=
 # by the prune_device_photos celery task.
 FORGEKEY_PHOTO_RETENTION_DAYS = config("FORGEKEY_PHOTO_RETENTION_DAYS", default=30, cast=int)
 
+# Shared secret EMQX must send in the X-ForgeKey-Webhook-Secret header on
+# WebHook bridge POSTs to /api/forgekey/mqtt-webhook/. Empty disables the
+# endpoint (returns 503) so a misconfigured deployment fails closed instead
+# of silently accepting unauthenticated traffic.
+FORGEKEY_WEBHOOK_SECRET = config("FORGEKEY_WEBHOOK_SECRET", default="")
+
+# Optional comma-separated IP allowlist for the MQTT webhook. When set, the
+# request's REMOTE_ADDR must match one of these entries or the request is
+# rejected before the secret check runs. Leave empty to skip IP filtering.
+FORGEKEY_WEBHOOK_ALLOWED_IPS = [
+    entry.strip()
+    for entry in config("FORGEKEY_WEBHOOK_ALLOWED_IPS", default="").split(",")
+    if entry.strip()
+]
+
 # Spectacular settings for API documentation
 SPECTACULAR_SETTINGS = {
     "TITLE": "Makerspace Inventory Management API",

--- a/backend/forgekey/tasks.py
+++ b/backend/forgekey/tasks.py
@@ -4,7 +4,8 @@ Celery tasks for ForgeKey MQTT operations.
 
 import json
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
+from datetime import timezone as dt_timezone
 from typing import Any, Dict, Optional
 
 from django.conf import settings
@@ -13,7 +14,7 @@ from django.utils import timezone
 import paho.mqtt.client as mqtt
 from celery import shared_task
 
-from .models import ESP32Device, ESP32DevicePhoto, PowerMeterReading
+from .models import ESP32Device, ESP32DevicePhoto, OccupancyEvent, PowerMeterReading
 from .utils import get_mqtt_command_topic, normalize_mac_address
 
 logger = logging.getLogger(__name__)
@@ -188,6 +189,83 @@ def process_mqtt_status_message(mac_address: str, message_data: Dict[str, Any]) 
         logger.warning(f"Received status message from unknown device: {mac_address}")
     except Exception as e:
         logger.error(f"Error processing status message from {mac_address}: {e}")
+
+
+def _coerce_event_timestamp(raw: Any) -> datetime:
+    """Best-effort parse of a device-supplied event timestamp.
+
+    Mirrors the long-running consumer's behavior: accept ISO-8601 (with or
+    without trailing ``Z``) or epoch seconds; fall back to current server
+    time on anything unparseable.
+    """
+    if isinstance(raw, (int, float)):
+        try:
+            return datetime.fromtimestamp(float(raw), tz=dt_timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return timezone.now()
+    if isinstance(raw, str) and raw:
+        candidate = raw.strip()
+        if candidate.endswith("Z"):
+            candidate = candidate[:-1] + "+00:00"
+        try:
+            parsed = datetime.fromisoformat(candidate)
+        except ValueError:
+            return timezone.now()
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=dt_timezone.utc)
+        return parsed
+    return timezone.now()
+
+
+@shared_task
+def process_mqtt_occupancy(
+    mac_address: str, sensor_kind: str, message_data: Dict[str, Any]
+) -> None:
+    """Persist a single occupancy event from an EMQX webhook dispatch.
+
+    Mirrors the long-running consumer's ``handle_occupancy_message`` so the
+    two ingest paths converge on the same model state.
+    """
+    try:
+        normalized_mac = normalize_mac_address(mac_address)
+    except Exception:
+        logger.warning("Dropping occupancy event: malformed MAC %r", mac_address)
+        return
+
+    if not isinstance(message_data, dict):
+        logger.warning("Dropping occupancy event from %s: payload is not an object", normalized_mac)
+        return
+
+    try:
+        device = ESP32Device.objects.get(mac_address=normalized_mac)
+    except ESP32Device.DoesNotExist:
+        logger.info("Dropping occupancy event: unknown MAC %s", normalized_mac)
+        return
+
+    try:
+        count_in = max(int(message_data.get("in", 0)), 0)
+        count_out = max(int(message_data.get("out", 0)), 0)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Dropping occupancy event from %s: non-integer in/out values",
+            normalized_mac,
+        )
+        return
+
+    OccupancyEvent.objects.create(
+        device=device,
+        sensor_kind=sensor_kind or "",
+        count_in=count_in,
+        count_out=count_out,
+        event_timestamp_utc=_coerce_event_timestamp(message_data.get("ts")),
+        raw_payload=message_data,
+    )
+    # Touch last_seen so dashboards reflect liveness, not just last boot.
+    ESP32Device.objects.filter(pk=device.pk).update(
+        last_seen=timezone.now(),
+        is_online=True,
+    )
+    logger.info("Recorded occupancy event for device %s", normalized_mac)
 
 
 @shared_task

--- a/backend/forgekey/tests/test_mqtt_webhook.py
+++ b/backend/forgekey/tests/test_mqtt_webhook.py
@@ -1,0 +1,313 @@
+"""
+Tests for the EMQX -> Django MQTT webhook bridge introduced for oms-2zo.
+
+Covers:
+  - Auth: missing/wrong secret rejected, IP allowlist enforced when set
+  - Payload parsing: malformed JSON, non-object body, missing topic
+  - Routing: each topic suffix dispatches to the matching Celery task
+    (.delay) with the right args
+  - End-to-end: process_mqtt_occupancy creates an OccupancyEvent row
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from django.urls import reverse
+
+import pytest
+
+from forgekey.models import OccupancyEvent
+from forgekey.tests.factories import ESP32DeviceFactory
+
+pytestmark = pytest.mark.django_db
+
+
+WEBHOOK_SECRET = "test-secret-abc123"
+
+
+def _topic_segment(mac: str) -> str:
+    return mac.replace(":", "").lower()
+
+
+def _post(api_client, body, *, secret: str | None = WEBHOOK_SECRET, remote_addr: str | None = None):
+    headers = {}
+    if secret is not None:
+        headers["HTTP_X_FORGEKEY_WEBHOOK_SECRET"] = secret
+    if remote_addr is not None:
+        headers["REMOTE_ADDR"] = remote_addr
+    return api_client.post(
+        reverse("forgekey:mqtt-webhook"),
+        data=json.dumps(body),
+        content_type="application/json",
+        **headers,
+    )
+
+
+@pytest.fixture(autouse=True)
+def configured_secret(settings):
+    settings.FORGEKEY_WEBHOOK_SECRET = WEBHOOK_SECRET
+    settings.FORGEKEY_WEBHOOK_ALLOWED_IPS = []
+    settings.MQTT_TOPIC_PREFIX = "forgekey"
+    return settings
+
+
+# ---------------------------------------------------------------------------
+# AC-3: auth
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookAuth:
+    def test_missing_secret_header_rejected(self, api_client):
+        response = _post(
+            api_client,
+            {"topic": "forgekey/aabbccddeeff/status", "payload": "{}"},
+            secret=None,
+        )
+        assert response.status_code == 401
+
+    def test_wrong_secret_rejected(self, api_client):
+        response = _post(
+            api_client,
+            {"topic": "forgekey/aabbccddeeff/status", "payload": "{}"},
+            secret="not-the-secret",
+        )
+        assert response.status_code == 401
+
+    def test_unconfigured_server_rejects_all(self, api_client, settings):
+        settings.FORGEKEY_WEBHOOK_SECRET = ""
+        response = _post(
+            api_client,
+            {"topic": "forgekey/aabbccddeeff/status", "payload": "{}"},
+            secret="anything",
+        )
+        assert response.status_code == 401
+
+    def test_ip_not_in_allowlist_rejected(self, api_client, settings):
+        settings.FORGEKEY_WEBHOOK_ALLOWED_IPS = ["10.0.0.5"]
+        response = _post(
+            api_client,
+            {"topic": "forgekey/aabbccddeeff/status", "payload": "{}"},
+            remote_addr="10.0.0.6",
+        )
+        assert response.status_code == 401
+
+    def test_ip_in_allowlist_passes(self, api_client, settings):
+        settings.FORGEKEY_WEBHOOK_ALLOWED_IPS = ["10.0.0.5"]
+        with patch("forgekey.views.process_mqtt_status_message.delay") as mock_delay:
+            response = _post(
+                api_client,
+                {"topic": "forgekey/aabbccddeeff/status", "payload": "{}"},
+                remote_addr="10.0.0.5",
+            )
+        assert response.status_code == 204
+        assert mock_delay.called
+
+    def test_auth_runs_before_payload_parsing(self, api_client):
+        # Garbage payload + bad secret must still 401, not 400.
+        response = _post(
+            api_client,
+            {"topic": "forgekey/zzzz/status", "payload": "not-json {{{"},
+            secret="wrong",
+        )
+        assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# AC-1: payload parsing
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookPayloadParsing:
+    def test_non_object_body_400(self, api_client):
+        response = api_client.post(
+            reverse("forgekey:mqtt-webhook"),
+            data=json.dumps([1, 2, 3]),
+            content_type="application/json",
+            HTTP_X_FORGEKEY_WEBHOOK_SECRET=WEBHOOK_SECRET,
+        )
+        assert response.status_code == 400
+
+    def test_missing_topic_400(self, api_client):
+        response = _post(api_client, {"payload": "{}"})
+        assert response.status_code == 400
+
+    def test_malformed_json_payload_400(self, api_client):
+        response = _post(
+            api_client,
+            {"topic": "forgekey/aabbccddeeff/status", "payload": "not-json {{{"},
+        )
+        assert response.status_code == 400
+
+    def test_payload_as_object_accepted(self, api_client):
+        # Some EMQX bridge configs forward payload as an object, not a string.
+        with patch("forgekey.views.process_mqtt_status_message.delay") as mock_delay:
+            response = _post(
+                api_client,
+                {
+                    "topic": "forgekey/aabbccddeeff/status",
+                    "payload": {"online": True},
+                },
+            )
+        assert response.status_code == 204
+        mock_delay.assert_called_once_with("AA:BB:CC:DD:EE:FF", {"online": True})
+
+    def test_topic_too_short_400(self, api_client):
+        response = _post(api_client, {"topic": "forgekey", "payload": "{}"})
+        assert response.status_code == 400
+
+    def test_unrouted_topic_returns_204(self, api_client):
+        # Unknown suffix is dropped silently (no retry storm from EMQX).
+        response = _post(
+            api_client,
+            {"topic": "forgekey/aabbccddeeff/something/weird", "payload": "{}"},
+        )
+        assert response.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# AC-1: routing
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookRouting:
+    def test_status_topic_dispatches_status_task(self, api_client):
+        with patch("forgekey.views.process_mqtt_status_message.delay") as mock_delay:
+            response = _post(
+                api_client,
+                {
+                    "topic": "forgekey/aabbccddeeff/status",
+                    "payload": json.dumps({"online": True, "boot_count": 3}),
+                },
+            )
+        assert response.status_code == 204
+        mock_delay.assert_called_once_with(
+            "AA:BB:CC:DD:EE:FF",
+            {"online": True, "boot_count": 3},
+        )
+
+    def test_occupancy_topic_dispatches_occupancy_task(self, api_client):
+        with patch("forgekey.views.process_mqtt_occupancy.delay") as mock_delay:
+            response = _post(
+                api_client,
+                {
+                    "topic": "forgekey/aabbccddeeff/people_counter/occupancy",
+                    "payload": json.dumps({"in": 1, "out": 0}),
+                },
+            )
+        assert response.status_code == 204
+        mock_delay.assert_called_once_with(
+            "AA:BB:CC:DD:EE:FF",
+            "people_counter",
+            {"in": 1, "out": 0},
+        )
+
+    def test_power_topic_dispatches_power_task(self, api_client):
+        with patch("forgekey.views.process_mqtt_power_reading.delay") as mock_delay:
+            response = _post(
+                api_client,
+                {
+                    "topic": "forgekey/aabbccddeeff/power",
+                    "payload": json.dumps(
+                        {
+                            "asset_id": "11111111-1111-1111-1111-111111111111",
+                            "voltage": 120.0,
+                            "current": 1.5,
+                        }
+                    ),
+                },
+            )
+        assert response.status_code == 204
+        mock_delay.assert_called_once()
+        args, _kwargs = mock_delay.call_args
+        assert args[0] == "AA:BB:CC:DD:EE:FF"
+        assert args[1] == "11111111-1111-1111-1111-111111111111"
+        assert args[2]["voltage"] == 120.0
+
+    def test_power_topic_without_asset_id_dropped(self, api_client):
+        with patch("forgekey.views.process_mqtt_power_reading.delay") as mock_delay:
+            response = _post(
+                api_client,
+                {
+                    "topic": "forgekey/aabbccddeeff/power",
+                    "payload": json.dumps({"voltage": 120.0}),
+                },
+            )
+        assert response.status_code == 204
+        assert not mock_delay.called
+
+    def test_firmware_response_dispatches_update_task(self, api_client):
+        with patch("forgekey.views.process_mqtt_firmware_update_response.delay") as mock_delay:
+            response = _post(
+                api_client,
+                {
+                    "topic": "forgekey/aabbccddeeff/firmware/response",
+                    "payload": json.dumps(
+                        {
+                            "update_id": "22222222-2222-2222-2222-222222222222",
+                            "status": "completed",
+                        }
+                    ),
+                },
+            )
+        assert response.status_code == 204
+        mock_delay.assert_called_once_with(
+            "AA:BB:CC:DD:EE:FF",
+            "22222222-2222-2222-2222-222222222222",
+            "completed",
+            None,
+        )
+
+    def test_firmware_response_missing_fields_dropped(self, api_client):
+        with patch("forgekey.views.process_mqtt_firmware_update_response.delay") as mock_delay:
+            response = _post(
+                api_client,
+                {
+                    "topic": "forgekey/aabbccddeeff/firmware/response",
+                    "payload": json.dumps({"status": "completed"}),
+                },
+            )
+        assert response.status_code == 204
+        assert not mock_delay.called
+
+
+# ---------------------------------------------------------------------------
+# AC-2: end-to-end occupancy persistence
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookOccupancyEndToEnd:
+    def test_occupancy_webhook_creates_event(self, api_client, settings):
+        # CELERY_TASK_ALWAYS_EAGER should be on for tests (typical in Django
+        # test settings); if not, force it here so .delay runs synchronously.
+        settings.CELERY_TASK_ALWAYS_EAGER = True
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:11:22:33")
+
+        response = _post(
+            api_client,
+            {
+                "topic": f"forgekey/{_topic_segment(device.mac_address)}/people_counter/occupancy",
+                "payload": json.dumps({"in": 1, "out": 0, "ts": "2026-05-01T03:00:00Z"}),
+            },
+        )
+
+        assert response.status_code == 204
+        events = OccupancyEvent.objects.filter(device=device)
+        assert events.count() == 1
+        event = events.get()
+        assert event.count_in == 1
+        assert event.count_out == 0
+        assert event.sensor_kind == "people_counter"
+
+    def test_occupancy_webhook_drops_unknown_mac(self, api_client, settings):
+        settings.CELERY_TASK_ALWAYS_EAGER = True
+        response = _post(
+            api_client,
+            {
+                "topic": "forgekey/aabbccddeeff/people_counter/occupancy",
+                "payload": json.dumps({"in": 1, "out": 0}),
+            },
+        )
+        assert response.status_code == 204
+        assert OccupancyEvent.objects.count() == 0

--- a/backend/forgekey/urls.py
+++ b/backend/forgekey/urls.py
@@ -19,6 +19,7 @@ from .views import (
     ForgeKeyDeviceRegisterView,
     ForgeKeyFirmwareDownloadView,
     ForgeKeyFirmwarePublicKeyView,
+    MqttWebhookView,
     OperationalModeViewSet,
     PowerMeterReadingViewSet,
 )
@@ -57,6 +58,11 @@ urlpatterns = [
         "firmware/<uuid:firmware_id>/download",
         ForgeKeyFirmwareDownloadView.as_view(),
         name="firmware-download",
+    ),
+    path(
+        "mqtt-webhook/",
+        MqttWebhookView.as_view(),
+        name="mqtt-webhook",
     ),
     path("", include(router.urls)),
 ]

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -59,7 +59,15 @@ from .services.firmware_signing import (
     get_public_key_pem,
     is_signing_configured,
 )
-from .tasks import disable_device, enable_device, request_device_status
+from .tasks import (
+    disable_device,
+    enable_device,
+    process_mqtt_firmware_update_response,
+    process_mqtt_occupancy,
+    process_mqtt_power_reading,
+    process_mqtt_status_message,
+    request_device_status,
+)
 from .utils import (
     generate_device_jwt,
     get_mqtt_firmware_topic,
@@ -385,6 +393,177 @@ class ForgeKeyDevicePhotoUploadView(APIView):
             if payload and payload.get("mac") == mac:
                 return True
         return _provisioning_token_valid(request)
+
+
+class MqttWebhookView(APIView):
+    """
+    POST /api/forgekey/mqtt-webhook/
+
+    EMQX WebHook bridge target. EMQX is configured to POST every published
+    MQTT message matching the configured topic filters to this endpoint as
+    JSON. We authenticate the request, parse the topic + payload, and
+    dispatch to the matching processor Celery task. Returns 204 once the
+    task is queued so EMQX does not block on Celery completion.
+
+    Auth (in order):
+      1. If ``settings.FORGEKEY_WEBHOOK_ALLOWED_IPS`` is set, REMOTE_ADDR
+         must match one of the entries.
+      2. The ``X-ForgeKey-Webhook-Secret`` header must match
+         ``settings.FORGEKEY_WEBHOOK_SECRET`` (constant-time compare).
+
+    Both checks run before any payload parsing so unauthenticated spam
+    cannot consume CPU on JSON decode or DB lookups.
+    """
+
+    authentication_classes: list = []
+    permission_classes = [AllowAny]
+    parser_classes = [JSONParser]
+
+    OCCUPANCY_SUFFIX = "occupancy"
+    STATUS_SUFFIX = "status"
+    POWER_SUFFIX = "power"
+    FIRMWARE_RESPONSE_SUFFIX = ("firmware", "response")
+
+    def post(self, request):
+        if not self._ip_allowed(request):
+            logger.warning(
+                "ForgeKey webhook: IP %s not in allowlist",
+                request.META.get("REMOTE_ADDR", "?"),
+            )
+            return Response(
+                {"detail": "Source IP not allowed."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        if not self._secret_valid(request):
+            logger.warning(
+                "ForgeKey webhook: secret mismatch from %s",
+                request.META.get("REMOTE_ADDR", "?"),
+            )
+            return Response(
+                {"detail": "Invalid webhook secret."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        body = request.data
+        if not isinstance(body, dict):
+            return Response(
+                {"detail": "Request body must be a JSON object."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        topic = body.get("topic")
+        if not isinstance(topic, str) or not topic:
+            return Response(
+                {"detail": "topic is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # EMQX sends payload as a JSON-encoded string by default; some bridge
+        # configurations forward it as a parsed object. Accept both.
+        raw_payload = body.get("payload")
+        if isinstance(raw_payload, str):
+            try:
+                message_data = json.loads(raw_payload) if raw_payload else {}
+            except json.JSONDecodeError:
+                logger.warning("ForgeKey webhook: malformed JSON payload on topic %s", topic)
+                return Response(
+                    {"detail": "payload is not valid JSON."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+        elif isinstance(raw_payload, dict) or raw_payload is None:
+            message_data = raw_payload or {}
+        else:
+            return Response(
+                {"detail": "payload must be a JSON object or string."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        parts = topic.split("/")
+        # Topic shape: <prefix>/<mac-segment>/[<sensor>/]<suffix...>
+        if len(parts) < 3:
+            return Response(
+                {"detail": "topic is too short to extract a MAC."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            mac = normalize_mac_address(parts[1])
+        except Exception:
+            return Response(
+                {"detail": "topic MAC segment is malformed."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        dispatched = self._dispatch(parts, mac, message_data)
+        if not dispatched:
+            logger.info("ForgeKey webhook: ignoring unrouted topic %s", topic)
+            # Still 204 — EMQX should not retry topics we deliberately drop.
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @staticmethod
+    def _ip_allowed(request) -> bool:
+        allowed = getattr(settings, "FORGEKEY_WEBHOOK_ALLOWED_IPS", []) or []
+        if not allowed:
+            return True
+        return request.META.get("REMOTE_ADDR", "") in allowed
+
+    @staticmethod
+    def _secret_valid(request) -> bool:
+        expected = getattr(settings, "FORGEKEY_WEBHOOK_SECRET", "") or ""
+        if not expected:
+            # Fail closed: an empty configured secret means the deployment
+            # forgot to set FORGEKEY_WEBHOOK_SECRET; we refuse all traffic.
+            return False
+        supplied = request.headers.get("x-forgekey-webhook-secret", "") or ""
+        return hmac.compare_digest(supplied, expected)
+
+    def _dispatch(self, parts: list[str], mac: str, message_data: dict) -> bool:
+        """Route the parsed message; return True if a task was queued."""
+        last = parts[-1]
+        # Status: <prefix>/<mac>/status (3 parts, last == "status")
+        if len(parts) == 3 and last == self.STATUS_SUFFIX:
+            process_mqtt_status_message.delay(mac, message_data)
+            return True
+
+        # Firmware response: <prefix>/<mac>/firmware/response
+        if (
+            len(parts) >= 4
+            and parts[-2] == self.FIRMWARE_RESPONSE_SUFFIX[0]
+            and parts[-1] == self.FIRMWARE_RESPONSE_SUFFIX[1]
+        ):
+            update_id = message_data.get("update_id") if isinstance(message_data, dict) else None
+            status_value = message_data.get("status") if isinstance(message_data, dict) else None
+            error_message = (
+                message_data.get("error_message") if isinstance(message_data, dict) else None
+            )
+            if not update_id or not status_value:
+                logger.warning(
+                    "ForgeKey webhook: firmware response missing update_id/status for %s",
+                    mac,
+                )
+                return False
+            process_mqtt_firmware_update_response.delay(
+                mac, str(update_id), str(status_value), error_message
+            )
+            return True
+
+        # Occupancy: <prefix>/<mac>/<sensor>/occupancy (4 parts)
+        if len(parts) == 4 and last == self.OCCUPANCY_SUFFIX:
+            sensor_kind = normalize_sensor_kind(parts[2])
+            process_mqtt_occupancy.delay(mac, sensor_kind, message_data or {})
+            return True
+
+        # Power: <prefix>/<mac>/power or <prefix>/<mac>/<sensor>/power
+        if last == self.POWER_SUFFIX and len(parts) in (3, 4):
+            asset_id = message_data.get("asset_id") if isinstance(message_data, dict) else None
+            if not asset_id:
+                logger.warning("ForgeKey webhook: power reading from %s missing asset_id", mac)
+                return False
+            process_mqtt_power_reading.delay(mac, str(asset_id), message_data)
+            return True
+
+        return False
 
 
 class DeviceTypeViewSet(viewsets.ModelViewSet):

--- a/deploy/EMQX_WEBHOOK.md
+++ b/deploy/EMQX_WEBHOOK.md
@@ -1,0 +1,79 @@
+# EMQX → Django MQTT WebHook Bridge
+
+The ForgeKey Django backend exposes `POST /api/forgekey/mqtt-webhook/`,
+which receives every published MQTT message that EMQX is configured to
+forward and dispatches it to the matching Celery processor task. This is
+the production ingest path for device telemetry — it removes the need
+for a long-running `mqtt_consumer` management command.
+
+## Required Django settings
+
+Set these in the deployment environment (e.g. `.env`, Helm values,
+docker-compose env):
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `FORGEKEY_WEBHOOK_SECRET` | yes | Shared secret EMQX must send in `X-ForgeKey-Webhook-Secret`. The view fails closed (401) when this is empty. |
+| `FORGEKEY_WEBHOOK_ALLOWED_IPS` | no | Comma-separated IP allowlist. When set, the request's `REMOTE_ADDR` must match one of the entries. Leave empty to skip IP filtering. |
+
+Generate a secret with `python -c "import secrets; print(secrets.token_urlsafe(32))"`.
+
+## EMQX 5.x WebHook bridge configuration
+
+In the EMQX dashboard:
+
+1. **Integration → Connectors → Create → HTTP Server**
+   - URL: `https://<your-host>/api/forgekey/mqtt-webhook/`
+   - Headers:
+     - `Content-Type: application/json`
+     - `X-ForgeKey-Webhook-Secret: <FORGEKEY_WEBHOOK_SECRET value>`
+   - Connection pool: defaults are fine.
+
+2. **Integration → Rules → Create**
+   - SQL:
+     ```sql
+     SELECT
+       topic,
+       payload,
+       clientid,
+       username,
+       qos,
+       retain,
+       timestamp
+     FROM
+       "forgekey/+/+/occupancy",
+       "forgekey/+/status",
+       "forgekey/+/power",
+       "forgekey/+/+/power",
+       "forgekey/+/firmware/response"
+     ```
+   - Action: forward to the HTTP connector created above.
+
+3. Test the rule from the dashboard's SQL tester with a sample message;
+   confirm the backend returns 204 in EMQX's action history.
+
+## Topic → task routing
+
+The view extracts the MAC from the second topic segment (lowercase, no
+separators) and routes by suffix:
+
+| Topic shape | Celery task |
+| --- | --- |
+| `forgekey/<mac>/<sensor>/occupancy` | `process_mqtt_occupancy(mac, sensor_kind, payload)` |
+| `forgekey/<mac>/status` | `process_mqtt_status_message(mac, payload)` |
+| `forgekey/<mac>/power` *or* `forgekey/<mac>/<sensor>/power` | `process_mqtt_power_reading(mac, payload["asset_id"], payload)` |
+| `forgekey/<mac>/firmware/response` | `process_mqtt_firmware_update_response(mac, payload["update_id"], payload["status"], payload["error_message"])` |
+
+Unknown suffixes are logged and dropped with 204 so EMQX does not retry.
+
+## Operational notes
+
+- The view returns 204 immediately after queueing the Celery task so
+  EMQX never blocks on processor work.
+- The secret check uses `hmac.compare_digest`. The IP allowlist runs
+  first, then the secret check, both before any payload parsing — so
+  unauthenticated traffic cannot consume CPU on JSON decode or DB I/O.
+- Payload may arrive as either a JSON-encoded string (default EMQX
+  rule output) or a parsed object; the view accepts both shapes.
+- If a request fails authentication, the response is `401` with a
+  short JSON detail. EMQX will retry per its action retry policy.


### PR DESCRIPTION
## Summary

PR #299 (oms-yyg) added inbound MQTT processor Celery tasks (`process_mqtt_status_message`, `process_mqtt_power_reading`, `process_mqtt_firmware_update_response`) but never wired anything to *call* them with payload data from the broker — symptom: even with the firmware topic-prefix fix, the Sewing people-counter publishes `forgekey/<mac>/people_counter/occupancy` and no `OccupancyEvent` rows appear.

This wires an EMQX HTTP WebHook bridge target so each published message is POSTed to Django and dispatched to the right processor task. No long-running consumer needed; scales with existing web workers.

## Changes (oms-2zo)

- **AC-1** — `MqttWebhookView` at `POST /api/forgekey/mqtt-webhook/`. Parses the EMQX payload (JSON-string *or* object), extracts MAC from the second topic segment, routes by suffix, returns 204 immediately after queueing the Celery task.
- **AC-2** — New `process_mqtt_occupancy` Celery task. `OccupancyEvent` model already shipped in oms-yyg; this task mirrors the long-running consumer's `handle_occupancy_message` semantics (count clamping, ISO/epoch timestamp coercion, `last_seen` touch).
- **AC-3** — Two-layer auth: optional `FORGEKEY_WEBHOOK_ALLOWED_IPS` allowlist + constant-time `X-ForgeKey-Webhook-Secret` check against `FORGEKEY_WEBHOOK_SECRET`. **Both checks run before any payload parsing or DB hit.** Empty configured secret fails closed (401).
- **AC-4** — 20 webhook tests + `deploy/EMQX_WEBHOOK.md` documenting EMQX connector + rule SQL.

## Topic → task routing

| Topic shape | Task |
| --- | --- |
| `forgekey/<mac>/<sensor>/occupancy` | `process_mqtt_occupancy(mac, sensor_kind, payload)` |
| `forgekey/<mac>/status` | `process_mqtt_status_message(mac, payload)` |
| `forgekey/<mac>/power` *or* `forgekey/<mac>/<sensor>/power` | `process_mqtt_power_reading(mac, payload["asset_id"], payload)` |
| `forgekey/<mac>/firmware/response` | `process_mqtt_firmware_update_response(mac, update_id, status, error_message)` |

Unknown suffixes → 204 + log (no EMQX retry storm).

## Test plan

- [x] `pytest forgekey/tests/test_mqtt_webhook.py` — 20/20 pass
- [x] `pytest forgekey/tests/test_mqtt_consumer.py forgekey/tests/test_tasks.py` — 45/45 pass (no regressions)
- [x] Full `pytest --ignore=inventory/tests/test_work_order_id_extraction.py` — 1018 pass / 3 skipped (the ignored test fails on `main` HEAD, unrelated)
- [x] `pre-commit run --all-files` — only pre-existing errors on files I didn't touch (`auth_views.py`, `conftest.py`, migration `0030`, `scripts/serve-spa.py`); same 13 errors exist on `main`
- [ ] **Manual smoke (operator):** configure EMQX WebHook bridge per `deploy/EMQX_WEBHOOK.md`; verify Sewing people-counter generates `OccupancyEvent` rows within seconds of motion

## Out of scope (per bead)

- Replacing the `mqtt_consumer` management command (left in place; deployment chooses one ingest path)
- Backfill of events from before the bridge came online
- Frontend dashboard updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)