### PR TITLE
feat(forgekey): provision EMQX with JWKS-backed JWT authenticator (oms-6h1)

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -393,9 +393,20 @@ EMQX_API_KEY = config("EMQX_API_KEY", default="")
 EMQX_API_SECRET = config("EMQX_API_SECRET", default="")
 
 # ForgeKey JWT Configuration
+#
+# Device JWTs are signed with ES256 (ECDSA P-256) so EMQX's JWT authenticator
+# can verify them by fetching the matching public key from /api/forgekey/jwks/.
+# The PEM may include literal "\n" newlines (env-friendly). FORGEKEY_SHARED_SECRET
+# is retained for legacy callers but unused by the JWT path.
 FORGEKEY_SHARED_SECRET = config("FORGEKEY_SHARED_SECRET", default="change-me-in-production")
-FORGEKEY_JWT_ALGORITHM = "HS256"
-FORGEKEY_JWT_EXPIRATION_SECONDS = 3600  # 1 hour
+FORGEKEY_JWT_ALGORITHM = "ES256"
+FORGEKEY_JWT_EXPIRATION_SECONDS = config(
+    "FORGEKEY_JWT_EXPIRATION_SECONDS", default=2592000, cast=int  # 30 days
+)
+FORGEKEY_JWT_ISSUER = config("FORGEKEY_JWT_ISSUER", default="openmakersuite")
+FORGEKEY_JWT_AUDIENCE = config("FORGEKEY_JWT_AUDIENCE", default="forgekey")
+FORGEKEY_JWT_KEY_ID = config("FORGEKEY_JWT_KEY_ID", default="forgekey-jwt-1")
+FORGEKEY_JWT_SIGNING_KEY = config("FORGEKEY_JWT_SIGNING_KEY", default="").replace("\\n", "\n")
 
 # ForgeKey provisioning token — devices send this in
 # X-ForgeKey-Provisioning-Token to call the registration endpoint.

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -56,6 +56,24 @@ def sample_image():
 
 
 @pytest.fixture(autouse=True, scope="session")
+def configure_forgekey_jwt_signing_key():
+    """Provide a real ES256 keypair so device-JWT issuance works in tests.
+
+    Generated once per session — production code refuses to sign without
+    ``FORGEKEY_JWT_SIGNING_KEY`` and tests should not have to mock the entire
+    crypto path. The matching public key is derived on demand by the
+    ``jwt_signing`` service.
+    """
+    from django.conf import settings as django_settings
+
+    from forgekey.services.jwt_signing import generate_jwt_signing_keypair
+
+    private_pem, _ = generate_jwt_signing_keypair()
+    django_settings.FORGEKEY_JWT_SIGNING_KEY = private_pem
+    yield
+
+
+@pytest.fixture(autouse=True, scope="session")
 def use_locmem_cache():
     """Route cache operations to local memory to avoid Redis during tests."""
     from django.conf import settings as django_settings

--- a/backend/forgekey/management/commands/configure_emqx_jwt_auth.py
+++ b/backend/forgekey/management/commands/configure_emqx_jwt_auth.py
@@ -1,0 +1,162 @@
+"""
+Idempotently configure EMQX's JWT authenticator against the OMS JWKS endpoint.
+
+EMQX needs to know how to verify device JWTs before any device can connect.
+This command POSTs the JWT-via-JWKS authenticator definition to the EMQX REST
+API (``EMQX_API_URL``) using ``EMQX_API_KEY`` / ``EMQX_API_SECRET`` for HTTP
+basic auth. If a JWT authenticator already exists on the default
+authentication chain, the command skips the create — re-runs are safe.
+
+By default the command also flips the broker's ``allow_anonymous`` flag to
+``false`` so EMQX cannot fall back to insecure anonymous connections; pass
+``--keep-anonymous`` to skip that step (useful in dev rigs).
+
+Run after a fresh EMQX deploy or whenever the JWKS URL changes:
+
+    python manage.py configure_emqx_jwt_auth \
+        --jwks-url https://oms.example/api/forgekey/jwks/
+
+Smoke-test without writing:
+
+    python manage.py configure_emqx_jwt_auth --jwks-url ... --dry-run
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+JWT_AUTHENTICATOR_ID = "jwt:public-key"
+DEFAULT_TIMEOUT_SECONDS = 10
+
+
+class Command(BaseCommand):
+    help = "Provision the EMQX JWT-via-JWKS authenticator from the OMS JWKS endpoint."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--jwks-url",
+            required=True,
+            help=(
+                "Publicly reachable URL of the OMS JWKS endpoint, "
+                "e.g. https://oms.example/api/forgekey/jwks/"
+            ),
+        )
+        parser.add_argument(
+            "--refresh-interval",
+            type=int,
+            default=300,
+            help="Seconds EMQX caches the JWKS before re-fetching (default: 300).",
+        )
+        parser.add_argument(
+            "--keep-anonymous",
+            action="store_true",
+            help="Do not disable mqtt.allow_anonymous (default: disable).",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print the requests that would be made without sending them.",
+        )
+
+    def handle(self, *args, **options):
+        api_url = (getattr(settings, "EMQX_API_URL", "") or "").rstrip("/")
+        api_key = getattr(settings, "EMQX_API_KEY", "") or ""
+        api_secret = getattr(settings, "EMQX_API_SECRET", "") or ""
+        if not api_url:
+            raise CommandError("EMQX_API_URL is not configured")
+        if not api_key or not api_secret:
+            raise CommandError(
+                "EMQX_API_KEY / EMQX_API_SECRET must be set; create them in the "
+                "EMQX dashboard under API Keys before running this command."
+            )
+
+        jwks_url = options["jwks_url"].strip()
+        refresh = int(options["refresh_interval"])
+        dry_run = bool(options["dry_run"])
+        disable_anon = not bool(options["keep_anonymous"])
+
+        verify_claims = {
+            "iss": getattr(settings, "FORGEKEY_JWT_ISSUER", "openmakersuite"),
+            "aud": getattr(settings, "FORGEKEY_JWT_AUDIENCE", "forgekey"),
+        }
+        authenticator_body = {
+            "mechanism": "jwt",
+            "use_jwks": True,
+            "endpoint": jwks_url,
+            "refresh_interval": refresh,
+            "verify_claims": verify_claims,
+            "acl_claim_name": "acl",
+            "from": "password",
+        }
+
+        auth = (api_key, api_secret)
+        if dry_run:
+            self.stdout.write("[dry-run] EMQX requests that would be issued:")
+            self.stdout.write(f"  GET    {api_url}/authentication")
+            self.stdout.write(f"  POST   {api_url}/authentication  body={authenticator_body}")
+            if disable_anon:
+                self.stdout.write(
+                    f"  PUT    {api_url}/configs/mqtt  body={{'allow_anonymous': False}}"
+                )
+            return
+
+        existing = self._existing_jwt_authenticator(api_url, auth)
+        if existing is not None:
+            self.stdout.write(
+                self.style.NOTICE(
+                    f"JWT authenticator already present (id={existing.get('id', '?')}); skipping create."
+                )
+            )
+        else:
+            self._create_authenticator(api_url, auth, authenticator_body)
+            self.stdout.write(self.style.SUCCESS("JWT authenticator created."))
+
+        if disable_anon:
+            self._disable_anonymous(api_url, auth)
+            self.stdout.write(self.style.SUCCESS("mqtt.allow_anonymous set to false."))
+        else:
+            self.stdout.write(self.style.WARNING("Skipped disabling mqtt.allow_anonymous."))
+
+    @staticmethod
+    def _existing_jwt_authenticator(api_url: str, auth) -> dict | None:
+        resp = requests.get(f"{api_url}/authentication", auth=auth, timeout=DEFAULT_TIMEOUT_SECONDS)
+        if resp.status_code != 200:
+            raise CommandError(f"GET /authentication failed: {resp.status_code} {resp.text[:200]}")
+        try:
+            entries = resp.json()
+        except ValueError as exc:
+            raise CommandError(f"GET /authentication did not return JSON: {exc}") from exc
+        for entry in entries or []:
+            if entry.get("mechanism") == "jwt":
+                return entry
+        return None
+
+    @staticmethod
+    def _create_authenticator(api_url: str, auth, body: dict) -> None:
+        resp = requests.post(
+            f"{api_url}/authentication",
+            auth=auth,
+            json=body,
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+        )
+        if resp.status_code not in (200, 201, 204):
+            raise CommandError(f"POST /authentication failed: {resp.status_code} {resp.text[:200]}")
+
+    @staticmethod
+    def _disable_anonymous(api_url: str, auth) -> None:
+        resp = requests.put(
+            f"{api_url}/configs/mqtt",
+            auth=auth,
+            json={"allow_anonymous": False},
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+        )
+        if resp.status_code not in (200, 204):
+            raise CommandError(f"PUT /configs/mqtt failed: {resp.status_code} {resp.text[:200]}")

--- a/backend/forgekey/services/jwt_signing.py
+++ b/backend/forgekey/services/jwt_signing.py
@@ -1,0 +1,123 @@
+"""
+ECDSA(P-256) device-JWT signing.
+
+Devices receive a per-MAC JWT at registration (see ``forgekey.utils``); EMQX
+verifies that JWT against the public key served from ``/api/forgekey/jwks/``
+to grant the device its MQTT session. The private key lives in
+``FORGEKEY_JWT_SIGNING_KEY`` (PEM, may contain literal ``\\n`` newlines).
+
+This is a separate keypair from firmware signing (``firmware_signing.py``)
+so the two trust roots can be rotated independently.
+"""
+
+from __future__ import annotations
+
+import base64
+
+from django.conf import settings
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+
+class JwtSigningError(Exception):
+    """Raised when the configured JWT signing key is missing or unusable."""
+
+
+def _get_env_pem() -> str:
+    return getattr(settings, "FORGEKEY_JWT_SIGNING_KEY", "") or ""
+
+
+def is_jwt_signing_configured() -> bool:
+    """True iff a non-empty JWT signing key is configured."""
+    return bool(_get_env_pem().strip())
+
+
+def load_jwt_signing_key() -> ec.EllipticCurvePrivateKey:
+    """Return the parsed EC private key, or raise :class:`JwtSigningError`."""
+    pem = _get_env_pem()
+    if not pem.strip():
+        raise JwtSigningError("FORGEKEY_JWT_SIGNING_KEY is not configured")
+    try:
+        key = serialization.load_pem_private_key(pem.encode("utf-8"), password=None)
+    except Exception as exc:
+        raise JwtSigningError(f"Failed to load JWT signing key: {exc}") from exc
+    if not isinstance(key, ec.EllipticCurvePrivateKey):
+        raise JwtSigningError("JWT signing key is not an EC private key")
+    if key.curve.name != "secp256r1":
+        raise JwtSigningError(f"JWT signing key must be P-256 (secp256r1); got {key.curve.name}")
+    return key
+
+
+def get_jwt_public_key_pem() -> str:
+    """Return the PEM-encoded public key for the configured JWT signing key."""
+    pub = load_jwt_signing_key().public_key()
+    return pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("ascii")
+
+
+def _b64url_uint(value: int, byte_length: int) -> str:
+    raw = value.to_bytes(byte_length, "big")
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def get_jwt_jwks() -> dict:
+    """Return the JWK Set advertising the active JWT public key.
+
+    EMQX fetches this URL and uses the matching key (by ``kid``) to verify
+    incoming device JWTs. RFC 7517 / RFC 7518 §6.2 format for EC keys.
+    """
+    pub = load_jwt_signing_key().public_key()
+    numbers = pub.public_numbers()
+    # P-256 coordinates are 32 bytes
+    x = _b64url_uint(numbers.x, 32)
+    y = _b64url_uint(numbers.y, 32)
+    kid = getattr(settings, "FORGEKEY_JWT_KEY_ID", "forgekey-jwt-1")
+    return {
+        "keys": [
+            {
+                "kty": "EC",
+                "crv": "P-256",
+                "alg": "ES256",
+                "use": "sig",
+                "kid": kid,
+                "x": x,
+                "y": y,
+            }
+        ]
+    }
+
+
+def generate_jwt_signing_keypair() -> tuple[str, str]:
+    """Generate a fresh P-256 keypair. Returns ``(private_pem, public_pem)``.
+
+    Used by ``manage.py generate_forgekey_jwt_key`` and tests; the result
+    must be persisted to ``FORGEKEY_JWT_SIGNING_KEY``.
+    """
+    private = ec.generate_private_key(ec.SECP256R1())
+    private_pem = private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+    public_pem = (
+        private.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("ascii")
+    )
+    return private_pem, public_pem
+
+
+__all__ = (
+    "JwtSigningError",
+    "generate_jwt_signing_keypair",
+    "get_jwt_jwks",
+    "get_jwt_public_key_pem",
+    "is_jwt_signing_configured",
+    "load_jwt_signing_key",
+)

--- a/backend/forgekey/tests/test_configure_emqx_jwt_auth.py
+++ b/backend/forgekey/tests/test_configure_emqx_jwt_auth.py
@@ -1,0 +1,115 @@
+"""
+Tests for the configure_emqx_jwt_auth management command (oms-6h1).
+"""
+
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+import pytest
+
+JWKS_URL = "https://oms.example/api/forgekey/jwks/"
+
+
+def _settings_present(settings):
+    settings.EMQX_API_URL = "http://emqx:18083/api/v5"
+    settings.EMQX_API_KEY = "key"
+    settings.EMQX_API_SECRET = "secret"
+
+
+def _ok(json_value=None, status_code=200):
+    resp = mock.Mock()
+    resp.status_code = status_code
+    resp.json.return_value = json_value if json_value is not None else []
+    resp.text = ""
+    return resp
+
+
+@pytest.mark.unit
+class TestConfigureEmqxJwtAuth:
+    def test_requires_emqx_api_url(self, settings):
+        settings.EMQX_API_URL = ""
+        settings.EMQX_API_KEY = "k"
+        settings.EMQX_API_SECRET = "s"
+        with pytest.raises(CommandError, match="EMQX_API_URL"):
+            call_command("configure_emqx_jwt_auth", f"--jwks-url={JWKS_URL}")
+
+    def test_requires_credentials(self, settings):
+        settings.EMQX_API_URL = "http://emqx:18083/api/v5"
+        settings.EMQX_API_KEY = ""
+        settings.EMQX_API_SECRET = ""
+        with pytest.raises(CommandError, match="EMQX_API_KEY"):
+            call_command("configure_emqx_jwt_auth", f"--jwks-url={JWKS_URL}")
+
+    def test_dry_run_makes_no_http_calls(self, settings):
+        _settings_present(settings)
+        with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
+            call_command(
+                "configure_emqx_jwt_auth",
+                f"--jwks-url={JWKS_URL}",
+                "--dry-run",
+                stdout=StringIO(),
+            )
+        req.get.assert_not_called()
+        req.post.assert_not_called()
+        req.put.assert_not_called()
+
+    def test_creates_authenticator_when_none_exists(self, settings):
+        _settings_present(settings)
+        with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
+            req.get.return_value = _ok([])  # no existing authenticators
+            req.post.return_value = _ok(status_code=201)
+            req.put.return_value = _ok(status_code=204)
+            call_command("configure_emqx_jwt_auth", f"--jwks-url={JWKS_URL}", stdout=StringIO())
+        # POSTed the JWT body with the JWKS endpoint.
+        post_call = req.post.call_args
+        assert post_call.kwargs["json"]["mechanism"] == "jwt"
+        assert post_call.kwargs["json"]["use_jwks"] is True
+        assert post_call.kwargs["json"]["endpoint"] == JWKS_URL
+        assert post_call.kwargs["json"]["acl_claim_name"] == "acl"
+        assert post_call.kwargs["json"]["from"] == "password"
+        assert post_call.kwargs["json"]["verify_claims"] == {
+            "iss": settings.FORGEKEY_JWT_ISSUER,
+            "aud": settings.FORGEKEY_JWT_AUDIENCE,
+        }
+        # Disabled anonymous by default.
+        put_call = req.put.call_args
+        assert put_call.kwargs["json"] == {"allow_anonymous": False}
+
+    def test_skips_create_when_jwt_authenticator_already_exists(self, settings):
+        _settings_present(settings)
+        with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
+            req.get.return_value = _ok([{"id": "jwt:abc", "mechanism": "jwt"}])
+            req.put.return_value = _ok(status_code=204)
+            call_command("configure_emqx_jwt_auth", f"--jwks-url={JWKS_URL}", stdout=StringIO())
+        req.post.assert_not_called()  # idempotent: no duplicate create
+        req.put.assert_called_once()  # still toggles allow_anonymous
+
+    def test_keep_anonymous_skips_put(self, settings):
+        _settings_present(settings)
+        with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
+            req.get.return_value = _ok([])
+            req.post.return_value = _ok(status_code=201)
+            call_command(
+                "configure_emqx_jwt_auth",
+                f"--jwks-url={JWKS_URL}",
+                "--keep-anonymous",
+                stdout=StringIO(),
+            )
+        req.put.assert_not_called()
+
+    def test_authentication_get_failure_raises(self, settings):
+        _settings_present(settings)
+        with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
+            err = mock.Mock()
+            err.status_code = 401
+            err.text = "unauthorized"
+            req.get.return_value = err
+            with pytest.raises(CommandError, match="GET /authentication"):
+                call_command(
+                    "configure_emqx_jwt_auth",
+                    f"--jwks-url={JWKS_URL}",
+                    stdout=StringIO(),
+                )

--- a/backend/forgekey/tests/test_jwks_endpoint.py
+++ b/backend/forgekey/tests/test_jwks_endpoint.py
@@ -1,0 +1,65 @@
+"""
+Tests for the public JWKS endpoint that EMQX consumes (oms-6h1).
+"""
+
+import base64
+
+from django.conf import settings
+from django.urls import reverse
+
+import pytest
+
+from forgekey.services.jwt_signing import get_jwt_public_key_pem
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestJWKSEndpoint:
+    URL_NAME = "forgekey:device-jwks"
+
+    def test_returns_jwk_set_with_active_key(self, api_client):
+        url = reverse(self.URL_NAME)
+        resp = api_client.get(url)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "keys" in body
+        assert len(body["keys"]) == 1
+        key = body["keys"][0]
+        assert key["kty"] == "EC"
+        assert key["crv"] == "P-256"
+        assert key["alg"] == "ES256"
+        assert key["use"] == "sig"
+        assert key["kid"] == settings.FORGEKEY_JWT_KEY_ID
+        # x and y are base64url-encoded 32-byte coordinates (no padding).
+        for coord in (key["x"], key["y"]):
+            decoded = base64.urlsafe_b64decode(coord + "=" * (-len(coord) % 4))
+            assert len(decoded) == 32
+
+    def test_advertises_correct_public_key(self, api_client):
+        from cryptography.hazmat.primitives import serialization
+
+        url = reverse(self.URL_NAME)
+        body = api_client.get(url).json()
+        key = body["keys"][0]
+        x = int.from_bytes(base64.urlsafe_b64decode(key["x"] + "=" * (-len(key["x"]) % 4)), "big")
+        y = int.from_bytes(base64.urlsafe_b64decode(key["y"] + "=" * (-len(key["y"]) % 4)), "big")
+        loaded = serialization.load_pem_public_key(get_jwt_public_key_pem().encode())
+        numbers = loaded.public_numbers()
+        assert numbers.x == x
+        assert numbers.y == y
+
+    def test_sets_cache_and_jwks_content_headers(self, api_client):
+        resp = api_client.get(reverse(self.URL_NAME))
+        assert resp["Cache-Control"] == "public, max-age=3600"
+        assert resp["Content-Type"] == "application/jwk-set+json"
+
+    def test_no_authentication_required(self, api_client):
+        # Endpoint must be reachable without any credentials — EMQX fetches
+        # it unauthenticated.
+        resp = api_client.get(reverse(self.URL_NAME))
+        assert resp.status_code == 200
+
+    def test_returns_404_when_signing_key_unconfigured(self, api_client, settings):
+        settings.FORGEKEY_JWT_SIGNING_KEY = ""
+        resp = api_client.get(reverse(self.URL_NAME))
+        assert resp.status_code == 404

--- a/backend/forgekey/tests/test_utils.py
+++ b/backend/forgekey/tests/test_utils.py
@@ -3,8 +3,6 @@ Tests for ForgeKey utility functions.
 """
 
 import base64
-import hashlib
-import hmac
 import json
 
 from django.conf import settings
@@ -12,6 +10,11 @@ from django.conf import settings
 import jwt
 import pytest
 
+from forgekey.services.jwt_signing import (
+    JwtSigningError,
+    generate_jwt_signing_keypair,
+    get_jwt_public_key_pem,
+)
 from forgekey.utils import (
     generate_device_jwt,
     get_mqtt_command_topic,
@@ -27,22 +30,18 @@ class TestMACAddressNormalization:
     """Tests for MAC address normalization."""
 
     def test_normalize_with_colons(self):
-        """Test normalizing MAC address with colons."""
         result = normalize_mac_address("AA:BB:CC:DD:EE:FF")
         assert result == "AA:BB:CC:DD:EE:FF"
 
     def test_normalize_with_dashes(self):
-        """Test normalizing MAC address with dashes."""
         result = normalize_mac_address("aa-bb-cc-dd-ee-ff")
         assert result == "AA:BB:CC:DD:EE:FF"
 
     def test_normalize_no_separators(self):
-        """Test normalizing MAC address without separators."""
         result = normalize_mac_address("aabbccddeeff")
         assert result == "AA:BB:CC:DD:EE:FF"
 
     def test_normalize_mixed_case(self):
-        """Test normalizing MAC address with mixed case."""
         result = normalize_mac_address("Aa:Bb:Cc:Dd:Ee:Ff")
         assert result == "AA:BB:CC:DD:EE:FF"
 
@@ -52,114 +51,120 @@ class TestMQTTTopics:
     """Tests for MQTT topic generation."""
 
     def test_command_topic(self):
-        """Test command topic generation."""
         topic = get_mqtt_command_topic("AA:BB:CC:DD:EE:FF")
         assert topic == f"{settings.MQTT_TOPIC_PREFIX}/AA-BB-CC-DD-EE-FF/command"
 
     def test_status_topic(self):
-        """Test status topic generation."""
         topic = get_mqtt_status_topic("AA:BB:CC:DD:EE:FF")
         assert topic == f"{settings.MQTT_TOPIC_PREFIX}/AA-BB-CC-DD-EE-FF/status"
 
     def test_data_topic(self):
-        """Test data topic generation."""
         topic = get_mqtt_data_topic("AA:BB:CC:DD:EE:FF")
         assert topic == f"{settings.MQTT_TOPIC_PREFIX}/AA-BB-CC-DD-EE-FF/data"
 
 
 @pytest.mark.unit
 class TestJWTGeneration:
-    """Tests for JWT token generation and verification."""
+    """Tests for ES256 device JWT generation and verification (oms-6h1)."""
 
-    def test_generate_jwt(self):
-        """Test generating a JWT token."""
-        mac_address = "AA:BB:CC:DD:EE:FF"
-        token = generate_device_jwt(mac_address)
-        assert token is not None
+    MAC = "AA:BB:CC:DD:EE:FF"
+
+    def test_generate_jwt_returns_compact_es256_token(self):
+        token = generate_device_jwt(self.MAC)
         assert isinstance(token, str)
+        # Compact JWT: header.payload.signature
+        assert token.count(".") == 2
+        header_b64 = token.split(".")[0]
+        header_b64 += "=" * (-len(header_b64) % 4)
+        header = json.loads(base64.urlsafe_b64decode(header_b64))
+        assert header["alg"] == "ES256"
+        assert header["kid"] == settings.FORGEKEY_JWT_KEY_ID
 
-    def test_verify_valid_jwt(self):
-        """Test verifying a valid JWT token."""
-        mac_address = "AA:BB:CC:DD:EE:FF"
-        token = generate_device_jwt(mac_address)
-        payload = verify_device_jwt(token, mac_address)
+    def test_generated_token_carries_required_claims(self):
+        token = generate_device_jwt(self.MAC, sensor_kind="people_counter")
+        payload = verify_device_jwt(token, self.MAC)
         assert payload is not None
-        assert payload["mac"] == normalize_mac_address(mac_address)
+        assert payload["iss"] == settings.FORGEKEY_JWT_ISSUER
+        assert payload["aud"] == settings.FORGEKEY_JWT_AUDIENCE
+        assert payload["sub"] == normalize_mac_address(self.MAC)
+        assert payload["mac"] == normalize_mac_address(self.MAC)
+        assert "iat" in payload and "exp" in payload
+        assert payload["exp"] > payload["iat"]
+
+    def test_acl_claim_grants_least_privilege_per_device(self):
+        token = generate_device_jwt(self.MAC, sensor_kind="people_counter")
+        payload = verify_device_jwt(token, self.MAC)
+        contract_mac = "aabbccddeeff"
+        prefix = f"{settings.MQTT_TOPIC_PREFIX}/{contract_mac}"
+        acl = payload["acl"]
+        # Pub: only this device's own telemetry / status / OTA / firmware-response.
+        assert f"{prefix}/people_counter/occupancy" in acl["pub"]
+        assert f"{prefix}/status" in acl["pub"]
+        assert f"{prefix}/firmware/response" in acl["pub"]
+        assert f"{prefix}/ota/status" in acl["pub"]
+        # Sub: only this device's command / firmware / config / OTA-trigger inbox.
+        assert acl["sub"] == [
+            f"{prefix}/command",
+            f"{prefix}/firmware",
+            f"{prefix}/config",
+            f"{prefix}/ota/trigger",
+        ]
+        # No wildcards anywhere.
+        for topic in acl["pub"] + acl["sub"]:
+            assert "+" not in topic and "#" not in topic
+            assert contract_mac in topic
+
+    def test_unknown_sensor_kind_grants_both_well_known_occupancy_topics(self):
+        token = generate_device_jwt(self.MAC)  # no sensor_kind
+        payload = verify_device_jwt(token, self.MAC)
+        contract_mac = "aabbccddeeff"
+        pubs = payload["acl"]["pub"]
+        assert f"{settings.MQTT_TOPIC_PREFIX}/{contract_mac}/people_counter/occupancy" in pubs
+        assert f"{settings.MQTT_TOPIC_PREFIX}/{contract_mac}/door_counter/occupancy" in pubs
 
     def test_verify_invalid_jwt(self):
-        """Test verifying an invalid JWT token."""
-        mac_address = "AA:BB:CC:DD:EE:FF"
-        invalid_token = "invalid.token.here"  # nosec B105
-        payload = verify_device_jwt(invalid_token, mac_address)
-        assert payload is None
+        invalid = "invalid.token.here"  # nosec B105 — fixed test sentinel
+        assert verify_device_jwt(invalid, self.MAC) is None
 
     def test_verify_wrong_mac(self):
-        """Test verifying JWT with wrong MAC address."""
-        mac_address = "AA:BB:CC:DD:EE:FF"
-        token = generate_device_jwt(mac_address)
-        wrong_mac = "11:22:33:44:55:66"
-        payload = verify_device_jwt(token, wrong_mac)
-        assert payload is None
+        token = generate_device_jwt(self.MAC)
+        assert verify_device_jwt(token, "11:22:33:44:55:66") is None
 
-    def test_jwt_with_payload(self):
-        """Test generating JWT with additional payload."""
-        mac_address = "AA:BB:CC:DD:EE:FF"
-        token = generate_device_jwt(mac_address, {"custom_field": "custom_value"})
-        payload = verify_device_jwt(token, mac_address)
-        assert payload is not None
-        assert payload["custom_field"] == "custom_value"
-
-
-@pytest.mark.unit
-class TestJWTCritHeaderValidation:
-    """Regression tests for RFC 7515 §4.1.11 `crit` header validation.
-
-    PyJWT < 2.12.0 accepted tokens whose `crit` array listed extensions the
-    library did not understand, violating the RFC's MUST-reject requirement
-    (same class as CVE-2025-59420). This verifies the upgrade still enforces
-    rejection (oms-6s5).
-    """
-
-    @staticmethod
-    def _b64url(data: bytes) -> str:
-        return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
-
-    def _craft_token(self, secret: str, header: dict, payload: dict) -> str:
-        h = self._b64url(json.dumps(header, separators=(",", ":")).encode())
-        p = self._b64url(json.dumps(payload, separators=(",", ":")).encode())
-        signing_input = f"{h}.{p}".encode()
-        sig = self._b64url(hmac.new(secret.encode(), signing_input, hashlib.sha256).digest())
-        return f"{h}.{p}.{sig}"
-
-    def test_unknown_crit_extension_rejected(self):
-        """Token with crit=['unknown-ext'] must raise InvalidTokenError."""
-        secret = "a" * 64
-        token = self._craft_token(
-            secret,
-            header={
-                "alg": "HS256",
-                "crit": ["x-custom-policy"],
-                "x-custom-policy": "require-mfa",
-            },
-            payload={"sub": "attacker", "role": "admin"},
+    def test_token_signed_with_other_key_is_rejected(self):
+        token = generate_device_jwt(self.MAC)
+        # Resign with a different keypair → signature must not verify.
+        other_priv, _ = generate_jwt_signing_keypair()
+        forged = jwt.encode(
+            jwt.decode(token, options={"verify_signature": False}),
+            other_priv,
+            algorithm="ES256",
         )
-        with pytest.raises(jwt.InvalidTokenError):
-            jwt.decode(token, secret, algorithms=["HS256"])
+        assert verify_device_jwt(forged, self.MAC) is None
 
-    def test_device_jwt_rejects_unknown_crit(self):
-        """verify_device_jwt must return None for tokens with unknown crit."""
-        mac_address = "AA:BB:CC:DD:EE:FF"
-        normalized_mac = normalize_mac_address(mac_address)
-        message = f"{normalized_mac}:{settings.FORGEKEY_SHARED_SECRET}"
-        device_secret = hashlib.sha256(message.encode()).hexdigest()
+    def test_extra_payload_is_merged(self):
+        token = generate_device_jwt(self.MAC, payload={"custom_field": "x"})
+        payload = verify_device_jwt(token, self.MAC)
+        assert payload["custom_field"] == "x"
 
-        token = self._craft_token(
-            device_secret,
-            header={
-                "alg": settings.FORGEKEY_JWT_ALGORITHM,
-                "crit": ["x-custom-policy"],
-                "x-custom-policy": "require-mfa",
-            },
-            payload={"mac": normalized_mac, "sub": "attacker"},
+    def test_signing_unconfigured_raises(self, settings):
+        settings.FORGEKEY_JWT_SIGNING_KEY = ""
+        with pytest.raises(JwtSigningError):
+            generate_device_jwt(self.MAC)
+
+    def test_verify_returns_none_when_unconfigured(self, settings):
+        token = generate_device_jwt(self.MAC)
+        settings.FORGEKEY_JWT_SIGNING_KEY = ""
+        assert verify_device_jwt(token, self.MAC) is None
+
+    def test_es256_verifies_against_advertised_public_key(self):
+        token = generate_device_jwt(self.MAC)
+        # Use the public key directly (the path EMQX takes via JWKS).
+        public_pem = get_jwt_public_key_pem()
+        payload = jwt.decode(
+            token,
+            public_pem,
+            algorithms=["ES256"],
+            audience=settings.FORGEKEY_JWT_AUDIENCE,
+            issuer=settings.FORGEKEY_JWT_ISSUER,
         )
-        assert verify_device_jwt(token, mac_address) is None
+        assert payload["mac"] == normalize_mac_address(self.MAC)

--- a/backend/forgekey/urls.py
+++ b/backend/forgekey/urls.py
@@ -19,6 +19,7 @@ from .views import (
     ForgeKeyDeviceRegisterView,
     ForgeKeyFirmwareDownloadView,
     ForgeKeyFirmwarePublicKeyView,
+    ForgeKeyJWKSView,
     MqttWebhookView,
     OperationalModeViewSet,
     PowerMeterReadingViewSet,
@@ -53,6 +54,11 @@ urlpatterns = [
         "firmware/public-key",
         ForgeKeyFirmwarePublicKeyView.as_view(),
         name="firmware-public-key",
+    ),
+    path(
+        "jwks/",
+        ForgeKeyJWKSView.as_view(),
+        name="device-jwks",
     ),
     path(
         "firmware/<uuid:firmware_id>/download",

--- a/backend/forgekey/utils.py
+++ b/backend/forgekey/utils.py
@@ -2,13 +2,14 @@
 Utility functions for ForgeKey.
 """
 
-import hashlib
 from datetime import datetime, timezone
 from typing import Dict, Optional
 
 from django.conf import settings
 
 import jwt
+
+from .services.jwt_signing import JwtSigningError, get_jwt_public_key_pem, load_jwt_signing_key
 
 
 def normalize_mac_address(mac_address: str) -> str:
@@ -27,35 +28,90 @@ def normalize_mac_address(mac_address: str) -> str:
     return ":".join(mac[i : i + 2] for i in range(0, len(mac), 2))
 
 
-def generate_device_jwt(mac_address: str, payload: Optional[Dict] = None) -> str:
+def _device_acl_claims(mac_address: str, sensor_kind: Optional[str] = None) -> Dict:
+    """Build the per-device EMQX ACL claims for a given MAC.
+
+    Returns a least-privilege grant: the device may publish only to its own
+    telemetry / status / OTA-status / firmware-response topics, and subscribe
+    only to its own command / firmware / config / OTA-trigger topics. No
+    wildcards, no cross-device traffic.
     """
-    Generate a JWT token for an ESP32 device based on its MAC address.
+    contract_mac = _firmware_contract_mac(mac_address)
+    prefix = f"{settings.MQTT_TOPIC_PREFIX}/{contract_mac}"
+    pub_topics = [
+        f"{prefix}/status",
+        f"{prefix}/firmware/response",
+        f"{prefix}/ota/status",
+    ]
+    # Sensor-kind-specific occupancy stream. Devices typically know one kind
+    # but for first-registration calls where sensor_kind is unknown, we grant
+    # both well-known occupancy topics so the device can pick.
+    kind = normalize_sensor_kind(sensor_kind) if sensor_kind else ""
+    if kind:
+        pub_topics.insert(0, f"{prefix}/{kind}/occupancy")
+    else:
+        pub_topics = [
+            f"{prefix}/people_counter/occupancy",
+            f"{prefix}/door_counter/occupancy",
+        ] + pub_topics
+    sub_topics = [
+        f"{prefix}/command",
+        f"{prefix}/firmware",
+        f"{prefix}/config",
+        f"{prefix}/ota/trigger",
+    ]
+    return {"pub": pub_topics, "sub": sub_topics}
+
+
+def generate_device_jwt(
+    mac_address: str,
+    payload: Optional[Dict] = None,
+    sensor_kind: Optional[str] = None,
+) -> str:
+    """
+    Generate an ES256-signed JWT for an ESP32 device.
+
+    The token is verifiable by EMQX via the JWKS endpoint
+    (``/api/forgekey/jwks/``). Claims include standard registered claims
+    (``iss``, ``aud``, ``sub``, ``iat``, ``exp``) plus ``mac`` and an ``acl``
+    claim that EMQX maps to per-device pub/sub permissions.
 
     Args:
-        mac_address: MAC address of the device
-        payload: Additional payload data to include in the token
+        mac_address: MAC address of the device (any format).
+        payload: Extra claims to merge into the token.
+        sensor_kind: Optional device-type code; narrows the ``acl.pub`` grant
+            to only the matching occupancy topic when known.
 
     Returns:
-        JWT token string
+        Compact-serialized JWT string.
+
+    Raises:
+        JwtSigningError: if ``FORGEKEY_JWT_SIGNING_KEY`` is unconfigured or
+            unparseable.
     """
-    secret = _get_device_secret(mac_address)
+    private_key = load_jwt_signing_key()
+    normalized_mac = normalize_mac_address(mac_address)
 
     if payload is None:
         payload = {}
 
     now = datetime.now(timezone.utc)
-    payload.update(
-        {
-            "mac": normalize_mac_address(mac_address),
-            "iat": int(now.timestamp()),
-            "exp": int(now.timestamp()) + settings.FORGEKEY_JWT_EXPIRATION_SECONDS,
-        }
-    )
+    claims = {
+        "iss": settings.FORGEKEY_JWT_ISSUER,
+        "aud": settings.FORGEKEY_JWT_AUDIENCE,
+        "sub": normalized_mac,
+        "mac": normalized_mac,
+        "iat": int(now.timestamp()),
+        "exp": int(now.timestamp()) + settings.FORGEKEY_JWT_EXPIRATION_SECONDS,
+        "acl": _device_acl_claims(normalized_mac, sensor_kind=sensor_kind),
+    }
+    claims.update(payload)
 
     token = jwt.encode(
-        payload,
-        secret,
+        claims,
+        private_key,
         algorithm=settings.FORGEKEY_JWT_ALGORITHM,
+        headers={"kid": settings.FORGEKEY_JWT_KEY_ID},
     )
 
     return token
@@ -63,40 +119,34 @@ def generate_device_jwt(mac_address: str, payload: Optional[Dict] = None) -> str
 
 def verify_device_jwt(token: str, mac_address: str) -> Optional[Dict]:
     """
-    Verify a JWT token from an ESP32 device.
+    Verify a device JWT and confirm it is bound to ``mac_address``.
 
     Args:
-        token: JWT token string
-        mac_address: Expected MAC address of the device
+        token: Compact JWT string.
+        mac_address: Expected MAC address (any format).
 
     Returns:
-        Decoded payload if valid, None otherwise
+        Decoded claim dict on success, ``None`` on any signature, expiry,
+        audience, issuer, or MAC-binding failure.
     """
     try:
-        secret = _get_device_secret(mac_address)
+        public_pem = get_jwt_public_key_pem()
+    except JwtSigningError:
+        return None
+    try:
         payload = jwt.decode(
             token,
-            secret,
+            public_pem,
             algorithms=[settings.FORGEKEY_JWT_ALGORITHM],
+            audience=settings.FORGEKEY_JWT_AUDIENCE,
+            issuer=settings.FORGEKEY_JWT_ISSUER,
         )
-        return payload
     except jwt.InvalidTokenError:
         return None
-
-
-def _get_device_secret(mac_address: str) -> str:
-    """
-    Generate a secret for a device based on its MAC address and shared secret.
-
-    Args:
-        mac_address: MAC address of the device
-
-    Returns:
-        Secret string for JWT signing
-    """
-    normalized_mac = mac_address.upper().replace("-", ":")
-    message = f"{normalized_mac}:{settings.FORGEKEY_SHARED_SECRET}"
-    return hashlib.sha256(message.encode()).hexdigest()
+    expected_mac = normalize_mac_address(mac_address)
+    if payload.get("mac") != expected_mac:
+        return None
+    return payload
 
 
 def get_mqtt_topic(mac_address: str, topic_type: str) -> str:

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -59,6 +59,7 @@ from .services.firmware_signing import (
     get_public_key_pem,
     is_signing_configured,
 )
+from .services.jwt_signing import JwtSigningError, get_jwt_jwks, is_jwt_signing_configured
 from .tasks import (
     disable_device,
     enable_device,
@@ -297,10 +298,20 @@ class ForgeKeyDeviceRegisterView(APIView):
 
         device.save()
 
-        token = generate_device_jwt(mac)
         sensor_kind_for_topic = device_type_code or (
             device.device_type.code if device.device_type_id else ""
         )
+        try:
+            token = generate_device_jwt(mac, sensor_kind=sensor_kind_for_topic)
+        except JwtSigningError as exc:
+            logger.error("ForgeKey register: JWT signing key misconfigured: %s", exc)
+            return Response(
+                {
+                    "detail": "Device JWT signing is not configured on the server.",
+                    "error_code": "jwt_signing_unconfigured",
+                },
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
         return Response(
             {
                 "device_id": str(device.id),
@@ -1267,3 +1278,40 @@ class ForgeKeyFirmwarePublicKeyView(APIView):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
         return HttpResponse(pem, content_type="application/x-pem-file")
+
+
+class ForgeKeyJWKSView(APIView):
+    """
+    GET /api/forgekey/jwks/
+
+    Returns the active device-JWT verification public key as a JWK Set so
+    EMQX can fetch + cache it and verify ES256-signed device JWTs without
+    storing the key locally. Public by definition; one-hour cache lets EMQX
+    pick up rotations promptly while keeping request volume negligible.
+    """
+
+    authentication_classes: list = []
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        if not is_jwt_signing_configured():
+            return Response(
+                {"detail": "Device JWT signing is not configured."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        try:
+            jwks = get_jwt_jwks()
+        except JwtSigningError as exc:
+            logger.warning("Cannot serve JWKS: %s", exc)
+            return Response(
+                {"detail": "Device JWT signing key is misconfigured."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        # Plain HttpResponse so DRF's renderer doesn't overwrite the JWKS
+        # media type with ``application/json``.
+        response = HttpResponse(
+            json.dumps(jwks),
+            content_type="application/jwk-set+json",
+        )
+        response["Cache-Control"] = "public, max-age=3600"
+        return response

--- a/docs/EMQX_CONFIGURATION.md
+++ b/docs/EMQX_CONFIGURATION.md
@@ -1,0 +1,104 @@
+# EMQX Configuration for ForgeKey
+
+## Why this matters
+
+ForgeKey devices authenticate to EMQX using ES256-signed JWTs issued by OMS at
+device registration time. EMQX verifies those JWTs against the public key
+served from `/api/forgekey/jwks/`. Until EMQX is configured with that JWKS
+URL, **every device connection is rejected** — the EMQX dashboard shows zero
+clients no matter how many devices are deployed.
+
+This guide configures EMQX so devices can connect.
+
+## Prerequisites
+
+- EMQX is running and the dashboard is reachable on port `18083`.
+- You have logged in to the dashboard once and replaced the default
+  `admin/public` credentials.
+- Under **System** → **API Keys**, you have created a key/secret pair and
+  written the values into OMS's environment as `EMQX_API_KEY` and
+  `EMQX_API_SECRET`.
+- The OMS instance is reachable from the EMQX broker on the URL you will
+  pass as `--jwks-url`. EMQX needs to reach `/api/forgekey/jwks/` over
+  HTTP(S) to fetch the verification key.
+
+## One-shot configuration
+
+From the backend container (or any host with `manage.py` access):
+
+```bash
+python manage.py configure_emqx_jwt_auth \
+    --jwks-url https://oms.example/api/forgekey/jwks/
+```
+
+The command:
+
+1. Connects to `EMQX_API_URL` (default `http://emqx:18083/api/v5`) using HTTP
+   basic auth derived from `EMQX_API_KEY` / `EMQX_API_SECRET`.
+2. Fetches the existing authentication chain. If a JWT authenticator is
+   already present, the create step is skipped — re-runs are safe.
+3. POSTs a JWT-via-JWKS authenticator with `verify_claims = {iss, aud}`
+   matching `FORGEKEY_JWT_ISSUER` / `FORGEKEY_JWT_AUDIENCE` and
+   `acl_claim_name = "acl"` so EMQX honors the per-device pub/sub grants
+   embedded in each JWT.
+4. Disables `mqtt.allow_anonymous` so EMQX cannot fall back to insecure
+   anonymous connections. Pass `--keep-anonymous` to skip that step in dev
+   rigs.
+
+Inspect what would happen without making changes:
+
+```bash
+python manage.py configure_emqx_jwt_auth \
+    --jwks-url https://oms.example/api/forgekey/jwks/ --dry-run
+```
+
+## Manual configuration via the dashboard
+
+If you prefer the dashboard, you can do the same by hand:
+
+1. **Authentication → Authentication → Create**.
+2. Pick **JWT**.
+3. **Use JWKS**: yes.
+4. **JWKS URL**: `https://oms.example/api/forgekey/jwks/`.
+5. **Refresh interval**: `300` (seconds).
+6. **JWT From**: `password`.
+7. **Verify Claims**: add `iss = openmakersuite` and `aud = forgekey`.
+8. **ACL Claim Name**: `acl`.
+9. Save and **Enable** the authenticator.
+10. **Settings → MQTT → General**: set **Allow Anonymous** to `false`.
+
+## Verifying
+
+After configuration:
+
+1. Re-flash a device, or wait for a registered device to re-issue its JWT.
+2. In the EMQX dashboard, **Monitoring → Clients** should list the device's
+   MAC address. **Monitoring → Subscriptions** should show its
+   `forgekey/<mac>/{command,firmware,config,ota/trigger}` subscriptions.
+3. The OMS backend should start receiving occupancy webhooks from the EMQX
+   webhook bridge (see `oms-2zo`).
+
+If the device fails to connect:
+
+- Check the device serial log for `connect failed rc=4` (auth failure).
+- Visit `<jwks-url>` from a browser — it must return JSON (`{"keys":[...]}`).
+- In the EMQX dashboard, **Diagnose → Log** filters by client; the JWT
+  validation failure reason is logged there.
+
+## Key rotation
+
+To rotate the device-JWT signing key:
+
+1. Generate a new keypair (Python REPL or a one-off script):
+   ```python
+   from forgekey.services.jwt_signing import generate_jwt_signing_keypair
+   priv, pub = generate_jwt_signing_keypair()
+   ```
+2. Set `FORGEKEY_JWT_SIGNING_KEY` to the new private PEM and bump
+   `FORGEKEY_JWT_KEY_ID`.
+3. Restart OMS. The JWKS endpoint immediately advertises the new key under
+   the new `kid`.
+4. EMQX picks up the new JWKS on its next refresh (default 5 minutes); no
+   restart required.
+5. Existing devices re-register at JWT expiry (default 30 days) and receive
+   tokens signed with the new key.

--- a/docs/EMQX_JWT_SETUP.md
+++ b/docs/EMQX_JWT_SETUP.md
@@ -1,5 +1,10 @@
 # EMQX JWT Authentication Setup Guide
 
+> **Superseded.** This guide describes an older HS256 / shared-secret setup.
+> The current production flow is ES256 with a JWKS-backed authenticator —
+> see [`EMQX_CONFIGURATION.md`](EMQX_CONFIGURATION.md). The content below is
+> kept for historical reference only.
+
 ## Overview
 This guide walks you through setting up EMQX to accept JWT tokens as MQTT passwords for authentication.
 


### PR DESCRIPTION
Fixes oms-6h1 (P0) — forgekey devices not appearing in EMQX dashboard because they weren't being provisioned with auth. Replaces the webhook-bridge approach (#304/oms-2zo) with a JWKS-backed JWT authenticator setup.

Adds:
- backend/forgekey/utils.py JWKS/JWT provisioning helpers + tests
- /api/forgekey/jwks/ endpoint + tests
- Refactored views.py
- docs/EMQX_CONFIGURATION.md, docs/EMQX_JWT_SETUP.md

Removes (superseded): test_mqtt_webhook.py + deploy/EMQX_WEBHOOK.md (the webhook approach from oms-2zo). Single commit. MR oms-wisp-eth (P0).