### PR TITLE
fix(prod): liveness-only healthcheck + decouple EMQX + JWT-key validation + smoke gate (oms-801)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -63,6 +63,20 @@ FORGEKEY_PROVISIONING_TOKEN=
 # from a secret store and inject at deploy time.
 FORGEKEY_FIRMWARE_SIGNING_KEY=
 
+# ForgeKey JWT signing key — REQUIRED for ESP32 device MQTT auth.
+# Separate ECDSA(P-256) PEM private key (PR #306, oms-6h1). EMQX fetches the
+# matching public key from /api/forgekey/jwks/ and uses it to verify per-
+# device JWTs at MQTT CONNECT time. Without this set, the JWKS endpoint
+# returns 503 and EMQX cannot authenticate any device.
+#
+# Generate (run on a secure host, then paste the output below):
+#   openssl ecparam -genkey -name prime256v1 -noout \
+#     | awk '{printf "%s\\n", $0}'
+#
+# Use a SEPARATE keypair from FORGEKEY_FIRMWARE_SIGNING_KEY so the two trust
+# roots can be rotated independently.
+FORGEKEY_JWT_SIGNING_KEY=
+
 # EMQX MQTT broker (see docker-compose.prod.yml `emqx` service).
 # Backend reaches the broker at hostname `emqx` (port 1883) on the docker
 # network and the dashboard/REST API at http://emqx:18083 (mapped to host

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -578,6 +578,108 @@ jobs:
               --build-arg REACT_APP_GITHUB_URL=https://github.com/uid0/openmakersuite \
               frontend/
 
+  prod-stack-smoke:
+    # oms-801 / AC-5: boot the prod docker-compose stack with a minimal env
+    # and verify the backend serves a request within 60 seconds. Production
+    # workers timed out at 120s without ever serving a request after the
+    # PR #303-#308 batch shipped; this gate would have caught that locally.
+    name: Prod Stack Smoke (livez within 60s)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.docker == 'true' || needs.changes.outputs.deploy == 'true'
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Render minimal prod .env + bootstrap files
+        run: |
+          # Minimum env that satisfies validate-prod-env.sh + lets the prod
+          # compose come up. The forgekey JWT signing key is set to a real
+          # ephemeral keypair so a regression that loads it at boot would
+          # fail with a malformed-PEM error here, not silently pass.
+          jwt_pem=$(openssl ecparam -genkey -name prime256v1 -noout)
+          jwt_env=$(printf '%s' "$jwt_pem" | awk '{printf "%s\\n", $0}')
+
+          cat > .env <<EOF
+          DOMAIN=ci.example.com
+          LETSENCRYPT_EMAIL=ci@ci.example.com
+          LETSENCRYPT_DOMAINS=ci.example.com
+          DEBUG=0
+          SECRET_KEY=ci-secret-key-not-for-production-only-validator-test-padding-padding
+          ALLOWED_HOSTS=ci.example.com,localhost,127.0.0.1
+          CSRF_TRUSTED_ORIGINS=https://ci.example.com
+          CORS_ALLOWED_ORIGINS=https://ci.example.com
+          POSTGRES_DB=oms
+          POSTGRES_USER=oms
+          POSTGRES_PASSWORD=ci-password-1234567890
+          REDIS_URL=redis://redis:6379/0
+          CELERY_BROKER_URL=redis://redis:6379/0
+          FRONTEND_URL=https://ci.example.com
+          GIT_HASH=ci
+          REACT_APP_SENTRY_DSN=
+          GITHUB_URL=https://github.com/uid0/openmakersuite
+          EMQX_DASHBOARD_PASSWORD=Strong1Password
+          FORGEKEY_PROVISIONING_TOKEN=ci-provisioning-token-not-for-production-padding
+          FORGEKEY_JWT_SIGNING_KEY=${jwt_env}
+          SENTRY_DSN=
+          EOF
+
+          # bootstrap_users for EMQX is normally rendered by deploy.sh; the
+          # smoke just needs a syntactically valid file so the volume mount
+          # doesn't fail.
+          mkdir -p scripts/emqx
+          echo "admin:Strong1Password" > scripts/emqx/bootstrap-admins.txt
+
+      - name: Boot backend stack (db + redis + emqx + backend)
+        run: |
+          # frontend/nginx are skipped — we only need the API path to verify
+          # gunicorn workers boot and serve livez.
+          docker compose -f docker-compose.prod.yml --env-file .env \
+              up -d --build db redis emqx backend
+
+      - name: Wait for backend to serve /api/health/livez/ within 60s
+        run: |
+          deadline=$(( $(date +%s) + 60 ))
+          backend_id=$(docker compose -f docker-compose.prod.yml ps -q backend)
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            # Hit livez from inside the backend container so we don't depend
+            # on host port mapping or DNS.
+            if docker exec "$backend_id" python -c \
+                "import urllib.request; r=urllib.request.urlopen('http://localhost:8000/api/health/livez/', timeout=5); import sys; sys.exit(0 if r.status==200 else 1)" \
+                2>/dev/null; then
+              echo "✅ /api/health/livez/ returned 200 within $(( 60 - (deadline - $(date +%s)) ))s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "❌ backend did not serve /api/health/livez/ within 60s"
+          exit 1
+
+      - name: Show backend logs on failure
+        if: failure()
+        run: |
+          echo "::group::backend logs"
+          docker compose -f docker-compose.prod.yml logs backend || true
+          echo "::endgroup::"
+          echo "::group::db logs"
+          docker compose -f docker-compose.prod.yml logs db || true
+          echo "::endgroup::"
+          echo "::group::redis logs"
+          docker compose -f docker-compose.prod.yml logs redis || true
+          echo "::endgroup::"
+          echo "::group::emqx logs"
+          docker compose -f docker-compose.prod.yml logs emqx || true
+          echo "::endgroup::"
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker compose -f docker-compose.prod.yml down -v || true
+
   deploy-validation:
     name: Deploy Validation (Helm + K8s)
     runs-on: ubuntu-latest
@@ -759,7 +861,7 @@ jobs:
   ci-complete:
     name: ✅ CI Complete
     runs-on: ubuntu-latest
-    needs: [changes, backend-lint, backend-tests, frontend-lint, frontend-tests, docker-build, security, deploy-validation, deploy-artifacts]
+    needs: [changes, backend-lint, backend-tests, frontend-lint, frontend-tests, docker-build, security, deploy-validation, deploy-artifacts, prod-stack-smoke]
     if: always()
     steps:
       - name: Check all jobs succeeded or were skipped
@@ -777,6 +879,7 @@ jobs:
           SECURITY="${{ needs.security.result }}"
           DEPLOY="${{ needs.deploy-validation.result }}"
           DEPLOY_ART="${{ needs.deploy-artifacts.result }}"
+          PROD_SMOKE="${{ needs.prod-stack-smoke.result }}"
 
           echo "Backend lint:    $BACKEND_LINT"
           echo "Backend tests:   $BACKEND"
@@ -786,9 +889,10 @@ jobs:
           echo "Security:        $SECURITY"
           echo "Deploy:          $DEPLOY"
           echo "Deploy artifacts:$DEPLOY_ART"
+          echo "Prod smoke:      $PROD_SMOKE"
 
           fail=0
-          for r in "$BACKEND_LINT" "$BACKEND" "$FRONTEND_LINT" "$FRONTEND" "$DOCKER" "$SECURITY" "$DEPLOY" "$DEPLOY_ART"; do
+          for r in "$BACKEND_LINT" "$BACKEND" "$FRONTEND_LINT" "$FRONTEND" "$DOCKER" "$SECURITY" "$DEPLOY" "$DEPLOY_ART" "$PROD_SMOKE"; do
             ok "$r" || fail=1
           done
 

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -42,6 +42,9 @@ ENTRYPOINT ["/app/docker-entrypoint.sh"]
 
 EXPOSE 8000
 
-# Health check
+# Liveness healthcheck (oms-801): hit /api/health/livez/, which performs no
+# DB or broker I/O, so a gunicorn worker that is alive but waiting on a slow
+# dependency does not cause a container restart loop. Use stdlib urllib so
+# the check works whether or not `requests` is installed.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD python -c "import requests; requests.get('http://localhost:8000/api/health/', timeout=5)" || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health/livez/', timeout=5)" || exit 1

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -130,13 +130,25 @@ services:
       redis:
         condition: service_healthy
       emqx:
-        condition: service_healthy
+        # service_started (not service_healthy): backend MQTT connect is lazy
+        # (forgekey.tasks.get_mqtt_client) and the EMQX REST API is only used
+        # during provisioning. Blocking backend boot on EMQX reaching healthy
+        # extends the dependency chain that contributed to oms-801, where the
+        # 60s EMQX start_period plus a slow first-healthcheck could push
+        # backend startup past the 120s gunicorn worker timeout.
+        condition: service_started
     healthcheck:
+      # Liveness, not readiness (oms-801): /api/health/livez/ is dep-free and
+      # returns 200 if the gunicorn worker is alive. The previous probe hit
+      # /api/dashboard/health/ which executes a DB query, so a transient DB
+      # hiccup turns the healthcheck red and triggers a container restart even
+      # when the process is fine. Readiness is exposed at /api/health/readyz/
+      # for callers that do need the dependency check.
       test:
         - CMD
         - python
         - -c
-        - "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/dashboard/health/', timeout=5)"
+        - "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health/livez/', timeout=5)"
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docs/INCIDENTS/worker-timeout.md
+++ b/docs/INCIDENTS/worker-timeout.md
@@ -1,0 +1,111 @@
+# Incident runbook: backend gunicorn WORKER TIMEOUT at startup
+
+> Tracking bead: **oms-801** (P0, GH #309, user-reported 2026-05-02).
+> History: this doc was created alongside the first mitigation pass; update it
+> after each repeat occurrence with what was actually wrong this time.
+
+## Symptom
+
+The Django `backend` container starts, every gunicorn worker logs the
+`apps.ready()` line ("ForgeKey provisioning token configured ..."), then
+**all** workers go silent and are killed by the arbiter at exactly the
+configured `--timeout` (120s) without ever serving a request.
+
+Representative log slice from the original incident:
+
+```
+backend-1 | [21:22:59] [INFO] Control socket listening at /home/appuser/.gunicorn/gunicorn.ctl
+backend-1 | INFO 21:22:59 apps 416 ForgeKey provisioning token configured (length=36, fingerprint=a0467e88)
+backend-1 | INFO 21:22:59 apps 418 ForgeKey provisioning token configured (length=36, fingerprint=a0467e88)
+backend-1 | INFO 21:22:59 apps 420 ForgeKey provisioning token configured (length=36, fingerprint=a0467e88)
+backend-1 | INFO 21:22:59 apps 422 ForgeKey provisioning token configured (length=36, fingerprint=a0467e88)
+backend-1 | [21:25:01] [CRITICAL] WORKER TIMEOUT (pid:416)
+backend-1 | [21:25:01] [CRITICAL] WORKER TIMEOUT (pid:418)
+backend-1 | [21:25:01] [CRITICAL] WORKER TIMEOUT (pid:420)
+backend-1 | [21:25:01] [CRITICAL] WORKER TIMEOUT (pid:422)
+backend-1 | [21:25:01] [416] [ERROR] Error handling request (no URI read)
+```
+
+The "Error handling request (no URI read)" line means a connection was
+accepted but no HTTP request line was read before the worker was killed —
+typically the docker healthcheck connecting just as the arbiter sent SIGABRT.
+
+All four workers stopping their heartbeat at the same instant means a single
+shared blocking call after `apps.ready()` returns — not a per-request stall.
+
+## Mitigations already in place (oms-801 fix)
+
+These changes are now part of the repo; verify they are present on the
+target deploy before doing further triage.
+
+1. **Liveness-only container healthcheck.** Both `Dockerfile.prod` and
+   `docker-compose.prod.yml` now point the `HEALTHCHECK` at
+   `/api/health/livez/` (dep-free; returns 200 if the gunicorn worker is
+   alive). The previous endpoint, `/api/dashboard/health/`, executes a DB
+   query, so a transient DB hiccup turned the healthcheck red and triggered
+   container restarts even when the process was fine. Readiness with full
+   dep checks is still exposed at `/api/health/readyz/`.
+2. **Backend no longer waits for EMQX healthy.** `docker-compose.prod.yml`
+   `backend.depends_on.emqx` is `service_started` (was `service_healthy`).
+   MQTT publish from Django is lazy
+   (`forgekey.tasks.get_mqtt_client` only opens the broker socket on first
+   use), so blocking backend boot on EMQX reaching healthy added 60s+ to
+   the dependency chain.
+3. **`FORGEKEY_JWT_SIGNING_KEY` is validated at deploy time.** Both
+   `scripts/validate-prod-env.sh` and `.env.prod.example` were updated so a
+   missing or malformed PEM is surfaced before deploy, instead of as a
+   runtime 503 on the EMQX JWKS endpoint.
+4. **CI smoke gate.** A new `prod-stack-smoke` job in `.github/workflows/ci.yml`
+   boots `db + redis + emqx + backend` from `docker-compose.prod.yml` with a
+   minimal env and asserts `/api/health/livez/` returns 200 within 60s. A
+   regression that pushes startup past the gunicorn worker timeout fails CI.
+
+## Detect
+
+- **`docker compose ps` shows backend `Restarting`** with the healthcheck
+  unhealthy and the same workers being recycled every ~2 minutes.
+- **`docker compose logs backend --since 5m`** shows `WORKER TIMEOUT` lines
+  in clusters of four (one per worker), all on the same second.
+- **No request logs.** A worker that is serving traffic prints either access
+  logs (if `--access-logfile -` is set) or at minimum DRF exception logs;
+  silent workers + timeouts means the workers never entered their accept
+  loop.
+
+## Investigate (if this fires again post-mitigation)
+
+The mitigations above remove the most likely contributors but do not prove
+which one was the trigger. If the symptom returns:
+
+1. **Confirm the env.** `docker exec backend env | grep -E 'FORGEKEY|SENTRY'`.
+   Empty or malformed values for the required keys produce surprising
+   downstream behavior; the shipped validator now catches this at deploy.
+2. **Confirm the migrations finished.**
+   `docker exec backend python manage.py showmigrations | grep -v '\[X\]'`.
+   A migration stuck on a row-by-row data backfill (e.g. the
+   `electrical_circuits.0003` legacy-outlet migration) would block the
+   entrypoint script before gunicorn starts; that is a *different* failure
+   mode than this runbook (no worker logs at all).
+3. **Strace one worker.** `docker exec backend sh -c 'apt-get install -y strace
+   && strace -p <worker-pid> -tt -T -e trace=network,desc'`. If every
+   worker is blocked in the same syscall (e.g. `connect`, `read`,
+   `pthread_cond_wait`), grab the call stack with `py-spy dump --pid
+   <worker-pid>` from the host.
+4. **Check Sentry init.** Set `SENTRY_DSN=` (empty) in `.env` and bounce the
+   backend. If workers come up green, the previous DSN is unreachable or
+   the network path to it is blocked; switch DSNs or set the env empty.
+5. **Bisect the deploy.** The original outage shipped after a five-PR batch
+   (#303 OTA, #304 webhook, #306 JWT, #307 OOM hardening, #308 power
+   topology). Roll back to the last-known-good tag and re-land one PR at a
+   time, gating each on the `prod-stack-smoke` job.
+
+## After-action template
+
+When this incident recurs, append a section like:
+
+```
+### YYYY-MM-DD recurrence
+- Detected by: ...
+- Root cause: ...
+- Fix: ...
+- Mitigation update: ...
+```

--- a/scripts/validate-prod-env.sh
+++ b/scripts/validate-prod-env.sh
@@ -207,6 +207,21 @@ if [ -z "${FORGEKEY_PROVISIONING_TOKEN:-}" ] || is_placeholder "${FORGEKEY_PROVI
     warn "FORGEKEY_PROVISIONING_TOKEN is empty or a placeholder — ESP32 device registration will return 401 server_unconfigured. Generate with: python -c 'import secrets; print(secrets.token_urlsafe(32))'"
 fi
 
+# --- 8b. ForgeKey JWT signing key (PR #306) ---------------------------------
+# Required for the EMQX JWKS endpoint and for issuing per-device JWTs at
+# registration. Without it the JWKS endpoint returns 503 and EMQX rejects
+# every device connection. The PEM may include literal "\n" newlines for
+# env-file friendliness, so the validator only checks for the BEGIN header.
+
+if [ -n "${FORGEKEY_JWT_SIGNING_KEY:-}" ]; then
+    case "$FORGEKEY_JWT_SIGNING_KEY" in
+        *"-----BEGIN "*"PRIVATE KEY-----"*) ;;
+        *) err "FORGEKEY_JWT_SIGNING_KEY does not look like a PEM private key (no '-----BEGIN ... PRIVATE KEY-----' header). Generate with: openssl ecparam -genkey -name prime256v1 -noout | awk '{printf \"%s\\\\n\", \$0}'" ;;
+    esac
+else
+    warn "FORGEKEY_JWT_SIGNING_KEY is empty — the /api/forgekey/jwks/ endpoint will return 503 and EMQX cannot authenticate ESP32 devices. Generate with: openssl ecparam -genkey -name prime256v1 -noout | awk '{printf \"%s\\\\n\", \$0}'"
+fi
+
 # --- 9. Email ---------------------------------------------------------------
 
 case "${EMAIL_BACKEND:-}" in


### PR DESCRIPTION
Fixes oms-801 (P0) — production outage from backend workers hitting WORKER TIMEOUT at 120s, never serving requests (gh #309).

Single commit:
- Liveness-only healthcheck (decouples worker liveness from external dep readiness)
- Decouple EMQX from boot-blocking path
- JWT-key validation in validate-prod-env.sh + smoke gate
- ci.yml smoke-test workflow + Dockerfile.prod tweaks
- docs/INCIDENTS/worker-timeout.md (postmortem)

MR oms-wisp-fby (P0).