### PR TITLE
fix(deploy): handle multiline PEM values in .env loader (hq-eqvnc)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,6 +526,82 @@ jobs:
           docker compose -f docker-compose.yml config -q
           rm -f .env
 
+      - name: deploy.sh loads .env with a multiline PEM JWT key
+        run: |
+          # oms-eqvnc / gh #311: deploy.sh used `export $(cat .env | xargs)`,
+          # which word-splits values whose first token contains whitespace
+          # (e.g. an EC PEM header) and aborts the script on the first such
+          # variable. Vars *after* it never get exported, so the subsequent
+          # EMQX_DASHBOARD_PASSWORD complexity check appears to fail with
+          # empty input. This step builds a .env containing a real
+          # ec-prime256v1 PEM rendered with the awk recipe documented in
+          # .env.prod.example, runs deploy.sh up through the env-load block,
+          # and asserts every variable (including ones placed after the JWT
+          # key) gets exported.
+          set -e
+          workdir=$(mktemp -d)
+          cp deploy.sh "$workdir/deploy.sh"
+          mkdir -p "$workdir/scripts"
+          cat > "$workdir/scripts/validate-prod-env.sh" <<'EOF'
+          #!/bin/bash
+          exit 0
+          EOF
+          chmod +x "$workdir/scripts/validate-prod-env.sh"
+
+          jwt_pem=$(openssl ecparam -genkey -name prime256v1 -noout)
+          jwt_env=$(printf '%s' "$jwt_pem" | awk '{printf "%s\\n", $0}')
+          cat > "$workdir/.env" <<EOF
+          # leading comment
+          DOMAIN=ci.example.com
+          POSTGRES_USER=oms
+          POSTGRES_DB=oms
+          FORGEKEY_JWT_SIGNING_KEY=${jwt_env}
+          EMQX_DASHBOARD_PASSWORD=Strong1Password
+          EMQX_API_KEY=ci-api-key-loaded-after-jwt
+          EMQX_API_SECRET=ci-api-secret-loaded-after-jwt
+          EOF
+
+          # Truncate deploy.sh after the env-load block, stub `git pull`,
+          # then echo the variables we need to assert.
+          sed -i '1,/^done < \.env$/!d' "$workdir/deploy.sh"
+          sed -i 's|^git pull$|: # git pull stubbed for env-load test|' "$workdir/deploy.sh"
+          cat >> "$workdir/deploy.sh" <<'EOF'
+          unset raw_line env_key env_value
+          printf 'ASSERT_DOMAIN=%s\n' "$DOMAIN"
+          printf 'ASSERT_EMQX_DASHBOARD_PASSWORD=%s\n' "$EMQX_DASHBOARD_PASSWORD"
+          printf 'ASSERT_EMQX_API_KEY=%s\n' "$EMQX_API_KEY"
+          printf 'ASSERT_EMQX_API_SECRET=%s\n' "$EMQX_API_SECRET"
+          printf 'ASSERT_JWT_LEN=%s\n' "${#FORGEKEY_JWT_SIGNING_KEY}"
+          EOF
+
+          ( cd "$workdir" && bash deploy.sh ) > "$workdir/out" 2>&1 || {
+              echo "❌ deploy.sh aborted while loading .env with a multiline PEM"
+              cat "$workdir/out"
+              exit 1
+          }
+
+          assert_eq() {
+              local key="$1" expected="$2"
+              local got
+              got=$(grep "^${key}=" "$workdir/out" | head -1 | cut -d= -f2-)
+              if [ "$got" != "$expected" ]; then
+                  echo "❌ $key: expected '$expected', got '$got'"
+                  cat "$workdir/out"
+                  exit 1
+              fi
+          }
+          assert_eq ASSERT_DOMAIN                ci.example.com
+          assert_eq ASSERT_EMQX_DASHBOARD_PASSWORD Strong1Password
+          assert_eq ASSERT_EMQX_API_KEY          ci-api-key-loaded-after-jwt
+          assert_eq ASSERT_EMQX_API_SECRET       ci-api-secret-loaded-after-jwt
+          jwt_len=$(grep '^ASSERT_JWT_LEN=' "$workdir/out" | head -1 | cut -d= -f2-)
+          if [ "${jwt_len:-0}" -lt 100 ]; then
+              echo "❌ FORGEKEY_JWT_SIGNING_KEY length $jwt_len < 100, value got truncated"
+              cat "$workdir/out"
+              exit 1
+          fi
+          echo "✅ deploy.sh loads .env with multiline PEM (vars after JWT key all set, JWT len=$jwt_len)"
+
       - name: Run prod env validator against happy-path env
         run: |
           # Drive scripts/validate-prod-env.sh with a synthesised env that

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,8 +23,31 @@ else
     echo "⚠️  scripts/validate-prod-env.sh missing — skipping pre-deploy env validation."
 fi
 
-# Load environment variables
-export $(cat .env | grep -v '^#' | xargs)
+# Load environment variables.
+#
+# We can't use `export $(cat .env | xargs)`: values with embedded spaces
+# (notably the FORGEKEY_JWT_SIGNING_KEY PEM, whose header line contains
+# literal whitespace and which uses literal `\n` separators between lines)
+# get word-split by xargs and fed to `export` as separate tokens — `export`
+# then errors with "not a valid identifier" on every token after the first,
+# and `set -e` aborts the deploy before any downstream check runs
+# (oms-eqvnc / gh #311).
+#
+# Parse line-by-line, accept any value (including spaces and `\n`),
+# strip surrounding quotes if present.
+while IFS= read -r raw_line || [ -n "$raw_line" ]; do
+    raw_line="${raw_line%$'\r'}"
+    [[ -z "$raw_line" || "$raw_line" =~ ^[[:space:]]*# ]] && continue
+    if [[ "$raw_line" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+        env_key="${BASH_REMATCH[1]}"
+        env_value="${BASH_REMATCH[2]}"
+        if [[ "$env_value" =~ ^\"(.*)\"$ ]] || [[ "$env_value" =~ ^\'(.*)\'$ ]]; then
+            env_value="${BASH_REMATCH[1]}"
+        fi
+        export "$env_key=$env_value"
+    fi
+done < .env
+unset raw_line env_key env_value
 
 # Get git hash for build
 export GIT_HASH=$(git rev-parse --short HEAD 2>/dev/null || echo "dev")


### PR DESCRIPTION
Fixes hq-eqvnc — backend services failing because deploy.sh's .env loader didn't handle multiline PEM-format values (FORGEKEY_FIRMWARE_SIGNING_KEY etc.).

Single commit, deploy.sh + ci.yml smoke test for the loader. MR oms-wisp-axn (P2).