### PR TITLE
fix(forgekey): version-aware EMQX anonymous-disable in configure_emqx_jwt_auth (oms-779)

### DIFF
--- a/backend/forgekey/management/commands/configure_emqx_jwt_auth.py
+++ b/backend/forgekey/management/commands/configure_emqx_jwt_auth.py
@@ -7,9 +7,17 @@ API (``EMQX_API_URL``) using ``EMQX_API_KEY`` / ``EMQX_API_SECRET`` for HTTP
 basic auth. If a JWT authenticator already exists on the default
 authentication chain, the command skips the create — re-runs are safe.
 
-By default the command also flips the broker's ``allow_anonymous`` flag to
-``false`` so EMQX cannot fall back to insecure anonymous connections; pass
-``--keep-anonymous`` to skip that step (useful in dev rigs).
+By default the command also disables anonymous MQTT connections so EMQX cannot
+fall back to insecure anonymous access; pass ``--keep-anonymous`` to skip that
+step (useful in dev rigs).
+
+The "disable anonymous" step is version-aware (oms-779):
+
+* EMQX 4.x exposes a global ``mqtt.allow_anonymous`` flag at
+  ``PUT /configs/mqtt``.
+* EMQX 5.x removed that endpoint; the equivalent is per-listener
+  ``enable_authn=true``, which forces every connecting client through the
+  authentication chain (denying anonymous when no authenticator matches).
 
 Run after a fresh EMQX deploy or whenever the JWKS URL changes:
 
@@ -58,7 +66,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--keep-anonymous",
             action="store_true",
-            help="Do not disable mqtt.allow_anonymous (default: disable).",
+            help="Do not disable anonymous MQTT connections (default: disable).",
         )
         parser.add_argument(
             "--dry-run",
@@ -100,13 +108,18 @@ class Command(BaseCommand):
         auth = (api_key, api_secret)
         if dry_run:
             self.stdout.write("[dry-run] EMQX requests that would be issued:")
+            self.stdout.write(f"  GET    {api_url}/nodes  # detect EMQX version")
             self.stdout.write(f"  GET    {api_url}/authentication")
             self.stdout.write(f"  POST   {api_url}/authentication  body={authenticator_body}")
             if disable_anon:
+                self.stdout.write("  (4.x) PUT    /configs/mqtt  body={'allow_anonymous': False}")
                 self.stdout.write(
-                    f"  PUT    {api_url}/configs/mqtt  body={{'allow_anonymous': False}}"
+                    "  (5.x) GET    /listeners; PUT /listeners/<id>  body+={'enable_authn': True}"
                 )
             return
+
+        major, version = self._emqx_version(api_url, auth)
+        self.stdout.write(self.style.NOTICE(f"EMQX {version} detected (major={major})."))
 
         existing = self._existing_jwt_authenticator(api_url, auth)
         if existing is not None:
@@ -120,10 +133,53 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS("JWT authenticator created."))
 
         if disable_anon:
-            self._disable_anonymous(api_url, auth)
-            self.stdout.write(self.style.SUCCESS("mqtt.allow_anonymous set to false."))
+            if major >= 5:
+                changed = self._disable_anonymous_v5(api_url, auth)
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"EMQX 5.x: enable_authn=true on {changed} listener(s); "
+                        "anonymous connects will be denied via the auth chain."
+                    )
+                )
+            else:
+                self._disable_anonymous_v4(api_url, auth)
+                self.stdout.write(
+                    self.style.SUCCESS("EMQX 4.x: mqtt.allow_anonymous set to false.")
+                )
         else:
-            self.stdout.write(self.style.WARNING("Skipped disabling mqtt.allow_anonymous."))
+            self.stdout.write(self.style.WARNING("Skipped disabling anonymous connections."))
+
+    @staticmethod
+    def _emqx_version(api_url: str, auth) -> tuple[int, str]:
+        """Return ``(major_version_int, raw_version_string)`` from ``GET /nodes``.
+
+        EMQX 5.x and 4.x both expose ``GET /nodes`` returning a list of node
+        dicts with a ``version`` field like ``"5.4.1"`` or ``"4.4.19"``.
+        """
+        resp = requests.get(f"{api_url}/nodes", auth=auth, timeout=DEFAULT_TIMEOUT_SECONDS)
+        if resp.status_code != 200:
+            raise CommandError(
+                f"GET /nodes failed (cannot detect EMQX version): "
+                f"{resp.status_code} {resp.text[:200]}"
+            )
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise CommandError(f"GET /nodes did not return JSON: {exc}") from exc
+        nodes = payload.get("data", payload) if isinstance(payload, dict) else payload
+        if not nodes:
+            raise CommandError("GET /nodes returned an empty list; cannot detect EMQX version.")
+        version = (nodes[0] or {}).get("version") or ""
+        if not version:
+            raise CommandError(f"GET /nodes node entry has no 'version' field: {nodes[0]!r}")
+        head = version.lstrip("vV").split(".", 1)[0]
+        try:
+            major = int(head)
+        except ValueError as exc:
+            raise CommandError(
+                f"Could not parse major version from EMQX version string '{version}': {exc}"
+            ) from exc
+        return major, version
 
     @staticmethod
     def _existing_jwt_authenticator(api_url: str, auth) -> dict | None:
@@ -151,7 +207,7 @@ class Command(BaseCommand):
             raise CommandError(f"POST /authentication failed: {resp.status_code} {resp.text[:200]}")
 
     @staticmethod
-    def _disable_anonymous(api_url: str, auth) -> None:
+    def _disable_anonymous_v4(api_url: str, auth) -> None:
         resp = requests.put(
             f"{api_url}/configs/mqtt",
             auth=auth,
@@ -159,4 +215,57 @@ class Command(BaseCommand):
             timeout=DEFAULT_TIMEOUT_SECONDS,
         )
         if resp.status_code not in (200, 204):
-            raise CommandError(f"PUT /configs/mqtt failed: {resp.status_code} {resp.text[:200]}")
+            raise CommandError(
+                f"PUT /configs/mqtt failed (EMQX 4.x path): "
+                f"{resp.status_code} {resp.text[:200]}"
+            )
+
+    @staticmethod
+    def _disable_anonymous_v5(api_url: str, auth) -> int:
+        """Force per-listener authentication on EMQX 5.x.
+
+        Returns the count of listeners that needed an update (0 if all were
+        already enforcing auth). Re-runs are idempotent: listeners already at
+        ``enable_authn=true`` are skipped.
+        """
+        resp = requests.get(f"{api_url}/listeners", auth=auth, timeout=DEFAULT_TIMEOUT_SECONDS)
+        if resp.status_code != 200:
+            raise CommandError(
+                f"GET /listeners failed (EMQX 5.x path): " f"{resp.status_code} {resp.text[:200]}"
+            )
+        try:
+            listeners = resp.json()
+        except ValueError as exc:
+            raise CommandError(f"GET /listeners did not return JSON: {exc}") from exc
+        if isinstance(listeners, dict):
+            listeners = listeners.get("data", [])
+        if not listeners:
+            raise CommandError(
+                "GET /listeners returned no listeners; cannot enforce authentication on EMQX 5.x."
+            )
+
+        changed = 0
+        for listener in listeners:
+            lid = listener.get("id")
+            if not lid:
+                continue
+            # quick_deny_anonymous and true both deny anonymous; only false leaves
+            # the door open. Treat anything other than False as already-enforcing.
+            current = listener.get("enable_authn", True)
+            if current is not False:
+                continue
+            merged = dict(listener)
+            merged["enable_authn"] = True
+            put = requests.put(
+                f"{api_url}/listeners/{lid}",
+                auth=auth,
+                json=merged,
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+            if put.status_code not in (200, 204):
+                raise CommandError(
+                    f"PUT /listeners/{lid} failed (EMQX 5.x path): "
+                    f"{put.status_code} {put.text[:200]}"
+                )
+            changed += 1
+        return changed

--- a/backend/forgekey/tests/test_configure_emqx_jwt_auth.py
+++ b/backend/forgekey/tests/test_configure_emqx_jwt_auth.py
@@ -1,5 +1,5 @@
 """
-Tests for the configure_emqx_jwt_auth management command (oms-6h1).
+Tests for the configure_emqx_jwt_auth management command (oms-6h1, oms-779).
 """
 
 from io import StringIO
@@ -19,12 +19,61 @@ def _settings_present(settings):
     settings.EMQX_API_SECRET = "secret"
 
 
-def _ok(json_value=None, status_code=200):
+def _resp(json_value=None, status_code=200, text=""):
     resp = mock.Mock()
     resp.status_code = status_code
     resp.json.return_value = json_value if json_value is not None else []
-    resp.text = ""
+    resp.text = text
     return resp
+
+
+def _v5_nodes(version="5.4.1"):
+    return _resp([{"node": "emqx@127.0.0.1", "version": version}])
+
+
+def _v4_nodes(version="4.4.19"):
+    return _resp([{"node": "emqx@127.0.0.1", "version": version}])
+
+
+def _v5_listeners(items=None):
+    if items is None:
+        items = [
+            {"id": "tcp:default", "type": "tcp", "name": "default", "enable_authn": False},
+            {"id": "ssl:default", "type": "ssl", "name": "default", "enable_authn": False},
+        ]
+    return _resp(items)
+
+
+def _route_get(api_url, *, nodes=None, listeners=None, authentication=None):
+    """Build a side_effect for ``requests.get`` keyed by URL suffix."""
+    nodes = nodes if nodes is not None else _v5_nodes()
+    listeners = listeners if listeners is not None else _v5_listeners()
+    authentication = authentication if authentication is not None else _resp([])
+
+    def _side_effect(url, *args, **kwargs):
+        if url.endswith("/nodes"):
+            return nodes
+        if url.endswith("/listeners"):
+            return listeners
+        if url.endswith("/authentication"):
+            return authentication
+        raise AssertionError(f"unexpected GET to {url}")
+
+    return _side_effect
+
+
+def _route_put(*, mqtt=None, listener=None):
+    mqtt = mqtt if mqtt is not None else _resp(status_code=204)
+    listener = listener if listener is not None else _resp(status_code=204)
+
+    def _side_effect(url, *args, **kwargs):
+        if "/configs/mqtt" in url:
+            return mqtt
+        if "/listeners/" in url:
+            return listener
+        raise AssertionError(f"unexpected PUT to {url}")
+
+    return _side_effect
 
 
 @pytest.mark.unit
@@ -56,42 +105,112 @@ class TestConfigureEmqxJwtAuth:
         req.post.assert_not_called()
         req.put.assert_not_called()
 
-    def test_creates_authenticator_when_none_exists(self, settings):
+    def test_v5_creates_authenticator_and_enforces_listener_authn(self, settings):
+        """AC-1: 5.x flow disables anonymous via per-listener enable_authn."""
         _settings_present(settings)
         with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
-            req.get.return_value = _ok([])  # no existing authenticators
-            req.post.return_value = _ok(status_code=201)
-            req.put.return_value = _ok(status_code=204)
-            call_command("configure_emqx_jwt_auth", f"--jwks-url={JWKS_URL}", stdout=StringIO())
+            req.get.side_effect = _route_get(settings.EMQX_API_URL)
+            req.post.return_value = _resp(status_code=201)
+            req.put.side_effect = _route_put()
+            stdout = StringIO()
+            call_command(
+                "configure_emqx_jwt_auth",
+                f"--jwks-url={JWKS_URL}",
+                stdout=stdout,
+            )
         # POSTed the JWT body with the JWKS endpoint.
         post_call = req.post.call_args
         assert post_call.kwargs["json"]["mechanism"] == "jwt"
         assert post_call.kwargs["json"]["use_jwks"] is True
         assert post_call.kwargs["json"]["endpoint"] == JWKS_URL
-        assert post_call.kwargs["json"]["acl_claim_name"] == "acl"
-        assert post_call.kwargs["json"]["from"] == "password"
-        assert post_call.kwargs["json"]["verify_claims"] == {
-            "iss": settings.FORGEKEY_JWT_ISSUER,
-            "aud": settings.FORGEKEY_JWT_AUDIENCE,
-        }
-        # Disabled anonymous by default.
+        # On 5.x we never PUT /configs/mqtt — that endpoint is gone.
+        for put_call in req.put.call_args_list:
+            assert "/configs/mqtt" not in put_call.args[0]
+        # Each listener got PUT /listeners/<id> with enable_authn=true merged in.
+        listener_puts = [c for c in req.put.call_args_list if "/listeners/" in c.args[0]]
+        assert len(listener_puts) == 2
+        for c in listener_puts:
+            assert c.kwargs["json"]["enable_authn"] is True
+        # AC-4: success message names the version.
+        out = stdout.getvalue()
+        assert "5.4.1" in out
+        assert "EMQX 5.x" in out
+
+    def test_v5_idempotent_when_listeners_already_enforce_authn(self, settings):
+        """AC-2: re-running on 5.x with auth already enforced does not error or PUT."""
+        _settings_present(settings)
+        listeners = _v5_listeners(
+            [
+                {"id": "tcp:default", "type": "tcp", "name": "default", "enable_authn": True},
+                {
+                    "id": "ssl:default",
+                    "type": "ssl",
+                    "name": "default",
+                    "enable_authn": "quick_deny_anonymous",
+                },
+            ]
+        )
+        existing_authn = _resp([{"id": "jwt:abc", "mechanism": "jwt"}])
+        with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
+            req.get.side_effect = _route_get(
+                settings.EMQX_API_URL,
+                listeners=listeners,
+                authentication=existing_authn,
+            )
+            req.put.side_effect = _route_put()
+            call_command(
+                "configure_emqx_jwt_auth",
+                f"--jwks-url={JWKS_URL}",
+                stdout=StringIO(),
+            )
+        req.post.assert_not_called()  # authenticator already exists
+        req.put.assert_not_called()  # listeners already enforce auth
+
+    def test_v4_uses_legacy_configs_mqtt_endpoint(self, settings):
+        """AC-3: 4.x flow falls back to PUT /configs/mqtt."""
+        _settings_present(settings)
+        with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
+            req.get.side_effect = _route_get(
+                settings.EMQX_API_URL,
+                nodes=_v4_nodes(),
+            )
+            req.post.return_value = _resp(status_code=201)
+            req.put.side_effect = _route_put()
+            stdout = StringIO()
+            call_command(
+                "configure_emqx_jwt_auth",
+                f"--jwks-url={JWKS_URL}",
+                stdout=stdout,
+            )
+        # Exactly one PUT, hitting the legacy 4.x endpoint.
+        assert req.put.call_count == 1
         put_call = req.put.call_args
+        assert put_call.args[0].endswith("/configs/mqtt")
         assert put_call.kwargs["json"] == {"allow_anonymous": False}
+        # AC-4: success message mentions 4.x.
+        assert "EMQX 4.x" in stdout.getvalue()
+        assert "4.4.19" in stdout.getvalue()
 
     def test_skips_create_when_jwt_authenticator_already_exists(self, settings):
         _settings_present(settings)
+        existing_authn = _resp([{"id": "jwt:abc", "mechanism": "jwt"}])
         with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
-            req.get.return_value = _ok([{"id": "jwt:abc", "mechanism": "jwt"}])
-            req.put.return_value = _ok(status_code=204)
+            req.get.side_effect = _route_get(
+                settings.EMQX_API_URL,
+                authentication=existing_authn,
+            )
+            req.put.side_effect = _route_put()
             call_command("configure_emqx_jwt_auth", f"--jwks-url={JWKS_URL}", stdout=StringIO())
         req.post.assert_not_called()  # idempotent: no duplicate create
-        req.put.assert_called_once()  # still toggles allow_anonymous
+        # Listeners still get updated since they were enable_authn=False.
+        assert any("/listeners/" in c.args[0] for c in req.put.call_args_list)
 
-    def test_keep_anonymous_skips_put(self, settings):
+    def test_keep_anonymous_skips_disable_step(self, settings):
         _settings_present(settings)
         with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
-            req.get.return_value = _ok([])
-            req.post.return_value = _ok(status_code=201)
+            req.get.side_effect = _route_get(settings.EMQX_API_URL)
+            req.post.return_value = _resp(status_code=201)
+            req.put.side_effect = _route_put()
             call_command(
                 "configure_emqx_jwt_auth",
                 f"--jwks-url={JWKS_URL}",
@@ -103,11 +222,39 @@ class TestConfigureEmqxJwtAuth:
     def test_authentication_get_failure_raises(self, settings):
         _settings_present(settings)
         with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
-            err = mock.Mock()
-            err.status_code = 401
-            err.text = "unauthorized"
-            req.get.return_value = err
+            req.get.side_effect = _route_get(
+                settings.EMQX_API_URL,
+                authentication=_resp(status_code=401, text="unauthorized"),
+            )
             with pytest.raises(CommandError, match="GET /authentication"):
+                call_command(
+                    "configure_emqx_jwt_auth",
+                    f"--jwks-url={JWKS_URL}",
+                    stdout=StringIO(),
+                )
+
+    def test_nodes_failure_raises_with_version_context(self, settings):
+        """AC-4: failure to detect version surfaces a clear error."""
+        _settings_present(settings)
+        with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
+            req.get.return_value = _resp(status_code=403, text="forbidden")
+            with pytest.raises(CommandError, match="GET /nodes failed"):
+                call_command(
+                    "configure_emqx_jwt_auth",
+                    f"--jwks-url={JWKS_URL}",
+                    stdout=StringIO(),
+                )
+
+    def test_v5_listener_put_failure_message_is_specific(self, settings):
+        """AC-4: listener PUT failure points at the EMQX 5.x path explicitly."""
+        _settings_present(settings)
+        with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
+            req.get.side_effect = _route_get(settings.EMQX_API_URL)
+            req.post.return_value = _resp(status_code=201)
+            req.put.side_effect = _route_put(
+                listener=_resp(status_code=400, text="bad config"),
+            )
+            with pytest.raises(CommandError, match=r"PUT /listeners/.*EMQX 5\.x"):
                 call_command(
                     "configure_emqx_jwt_auth",
                     f"--jwks-url={JWKS_URL}",


### PR DESCRIPTION
Fixes oms-779 — configure_emqx_jwt_auth was hitting PUT /configs/mqtt 404 because that endpoint shape is for EMQX 4.x; 5.x has a different path. Adds version detection.

Single commit, 2 files (command + tests). MR oms-wisp-66m (P2).