### PR TITLE
fix(forgekey): unblock EMQX JWKS fetch by adding 'backend' to ALLOWED_HOSTS (oms-zad)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -22,7 +22,12 @@ DEBUG=0
 # Generate a real key with:
 #   python -c 'import secrets; print(secrets.token_urlsafe(64))'
 SECRET_KEY=your-very-secret-production-key-here-change-this
-ALLOWED_HOSTS=oms.example.com,www.oms.example.com
+# MUST include `backend` so EMQX (running on the same docker network) can
+# fetch JWKS from http://backend:8000/api/forgekey/jwks/ for JWT auth. Without
+# it Django returns 400 Bad Request and EMQX rejects every device CONNECT.
+# `localhost` covers in-container healthchecks. docker-compose.prod.yml also
+# appends `,backend,localhost` defensively, but keep them here for clarity.
+ALLOWED_HOSTS=oms.example.com,www.oms.example.com,backend,localhost
 CSRF_TRUSTED_ORIGINS=https://oms.example.com,https://www.oms.example.com
 CORS_ALLOWED_ORIGINS=https://oms.example.com,https://www.oms.example.com
 

--- a/backend/env.production.example
+++ b/backend/env.production.example
@@ -20,8 +20,13 @@ DEVELOPMENT_MODE=0
 # ============================================================================
 
 # Comma-separated list of domains that can serve the application
-# Include all domains and subdomains that will be used
-ALLOWED_HOSTS=dms.openmakersuite.net,www.dms.openmakersuite.net
+# Include all domains and subdomains that will be used.
+#
+# MUST also include `backend` (the docker service name) so EMQX can fetch
+# JWKS from http://backend:8000/api/forgekey/jwks/ over the docker network
+# to verify device JWTs. Without `backend` Django returns 400 Bad Request
+# for that request and no MQTT device can connect.
+ALLOWED_HOSTS=dms.openmakersuite.net,www.dms.openmakersuite.net,backend,localhost
 
 # CRITICAL for CSRF protection when behind a reverse proxy with HTTPS
 # Must include the protocol (https://) and the domain

--- a/backend/forgekey/checks.py
+++ b/backend/forgekey/checks.py
@@ -9,6 +9,8 @@ empty signatures and devices on signature-verifying firmware will refuse them.
 
 from __future__ import annotations
 
+import os
+
 from django.conf import settings
 from django.core.checks import Tags, Warning, register
 
@@ -18,6 +20,8 @@ W_INVALID = "forgekey.W003"
 W_PROVISIONING_TOKEN = "forgekey.W004"  # nosec B105 — Django check ID, not a password
 W_EMQX_PASSWORD = "forgekey.W005"  # nosec B105 — Django check ID, not a password
 W_EMQX_API = "forgekey.W006"
+W_DOCKER_ALLOWED_HOSTS = "forgekey.W007"
+DOCKER_BACKEND_HOSTNAME = "backend"
 
 PLACEHOLDER_PROVISIONING_TOKEN = "REPLACE_ME_PROVISIONING_TOKEN"  # nosec B105
 PLACEHOLDER_EMQX_PASSWORD = "change-me-on-first-deploy"  # nosec B105
@@ -25,6 +29,20 @@ PLACEHOLDER_EMQX_PASSWORD = "change-me-on-first-deploy"  # nosec B105
 
 def _is_production() -> bool:
     return not getattr(settings, "DEBUG", False)
+
+
+def _running_in_docker() -> bool:
+    """Heuristic: presence of /.dockerenv (mounted by `docker run`) or a
+    DOCKER-style cgroup. We accept either signal so the check still fires in
+    rootless containers and on hosts that strip /.dockerenv."""
+    if os.path.exists("/.dockerenv"):
+        return True
+    try:
+        with open("/proc/1/cgroup", encoding="utf-8") as fh:
+            cgroup = fh.read()
+    except OSError:
+        return False
+    return "docker" in cgroup or "containerd" in cgroup or "kubepods" in cgroup
 
 
 def _looks_like_placeholder(pem: str) -> bool:
@@ -156,6 +174,46 @@ def check_emqx_dashboard_password(app_configs, **kwargs):
                 id=W_EMQX_PASSWORD,
             )
         )
+    return warnings
+
+
+@register(Tags.security)
+def check_docker_allowed_hosts(app_configs, **kwargs):
+    """W007: warn when running in docker without `backend` in ALLOWED_HOSTS.
+
+    EMQX (running on the same docker network) fetches JWKS from
+    ``http://backend:8000/api/forgekey/jwks/`` and Django returns 400 unless
+    the `backend` service hostname is in ALLOWED_HOSTS — see oms-zad. Catch
+    the misconfiguration at startup instead of when the first device fails to
+    connect.
+    """
+    warnings = []
+    if not _running_in_docker():
+        return warnings
+    if not _is_production():
+        return warnings
+
+    allowed = getattr(settings, "ALLOWED_HOSTS", []) or []
+    normalized = {(h or "").strip().lower() for h in allowed}
+    if "*" in normalized or DOCKER_BACKEND_HOSTNAME in normalized:
+        return warnings
+
+    warnings.append(
+        Warning(
+            f"ALLOWED_HOSTS does not include '{DOCKER_BACKEND_HOSTNAME}' but "
+            "this process appears to be running inside a docker container. "
+            "EMQX fetches JWKS via http://backend:8000/api/forgekey/jwks/ on "
+            "the docker network; Django will return 400 Bad Request and EMQX "
+            "will reject every device CONNECT.",
+            hint=(
+                "Add 'backend' to ALLOWED_HOSTS in .env, e.g. "
+                "ALLOWED_HOSTS=oms.example.com,backend,localhost. "
+                "docker-compose.prod.yml also appends 'backend' defensively, "
+                "so this warning usually means an override is overriding it."
+            ),
+            id=W_DOCKER_ALLOWED_HOSTS,
+        )
+    )
     return warnings
 
 

--- a/backend/forgekey/management/commands/configure_emqx_jwt_auth.py
+++ b/backend/forgekey/management/commands/configure_emqx_jwt_auth.py
@@ -73,6 +73,16 @@ class Command(BaseCommand):
             action="store_true",
             help="Print the requests that would be made without sending them.",
         )
+        parser.add_argument(
+            "--skip-jwks-check",
+            action="store_true",
+            help=(
+                "Skip the JWKS-URL reachability pre-flight check (oms-zad). "
+                "By default the command GETs --jwks-url before configuring "
+                "EMQX so a 400/404 from a misconfigured ALLOWED_HOSTS fails "
+                "fast with a clear error instead of silently breaking MQTT."
+            ),
+        )
 
     def handle(self, *args, **options):
         api_url = (getattr(settings, "EMQX_API_URL", "") or "").rstrip("/")
@@ -90,6 +100,7 @@ class Command(BaseCommand):
         refresh = int(options["refresh_interval"])
         dry_run = bool(options["dry_run"])
         disable_anon = not bool(options["keep_anonymous"])
+        skip_jwks_check = bool(options["skip_jwks_check"])
 
         verify_claims = {
             "iss": getattr(settings, "FORGEKEY_JWT_ISSUER", "openmakersuite"),
@@ -108,6 +119,8 @@ class Command(BaseCommand):
         auth = (api_key, api_secret)
         if dry_run:
             self.stdout.write("[dry-run] EMQX requests that would be issued:")
+            if not skip_jwks_check:
+                self.stdout.write(f"  GET    {jwks_url}  # JWKS reachability pre-flight (oms-zad)")
             self.stdout.write(f"  GET    {api_url}/nodes  # detect EMQX version")
             self.stdout.write(f"  GET    {api_url}/authentication")
             self.stdout.write(f"  POST   {api_url}/authentication  body={authenticator_body}")
@@ -117,6 +130,10 @@ class Command(BaseCommand):
                     "  (5.x) GET    /listeners; PUT /listeners/<id>  body+={'enable_authn': True}"
                 )
             return
+
+        if not skip_jwks_check:
+            self._verify_jwks_reachable(jwks_url)
+            self.stdout.write(self.style.SUCCESS(f"JWKS endpoint reachable at {jwks_url}."))
 
         major, version = self._emqx_version(api_url, auth)
         self.stdout.write(self.style.NOTICE(f"EMQX {version} detected (major={major})."))
@@ -148,6 +165,55 @@ class Command(BaseCommand):
                 )
         else:
             self.stdout.write(self.style.WARNING("Skipped disabling anonymous connections."))
+
+    @staticmethod
+    def _verify_jwks_reachable(jwks_url: str) -> None:
+        """Pre-flight: GET ``jwks_url`` and fail with a clear hint on non-200.
+
+        The 400 we hit on a fresh deploy comes from Django rejecting the
+        ``Host: backend:8000`` header EMQX sends because ``ALLOWED_HOSTS`` is
+        missing the docker service name. Detect that before writing config so
+        operators see the cause instead of an opaque MQTT auth failure.
+        """
+        try:
+            resp = requests.get(jwks_url, timeout=DEFAULT_TIMEOUT_SECONDS)
+        except requests.RequestException as exc:
+            raise CommandError(
+                f"JWKS pre-flight: GET {jwks_url} raised {exc.__class__.__name__}: {exc}. "
+                "Verify the URL is reachable from this container; if EMQX runs "
+                "on the same docker network use http://backend:8000/api/forgekey/jwks/."
+            ) from exc
+
+        if resp.status_code == 400:
+            body = (resp.text or "").strip()[:200]
+            raise CommandError(
+                f"JWKS pre-flight: GET {jwks_url} returned 400 (likely "
+                "ALLOWED_HOSTS misconfiguration). Add the Host header value "
+                "(e.g. `backend`) to ALLOWED_HOSTS in .env and redeploy. "
+                f"Response body: {body}"
+            )
+        if resp.status_code != 200:
+            body = (resp.text or "").strip()[:200]
+            raise CommandError(
+                f"JWKS pre-flight: GET {jwks_url} returned {resp.status_code}; "
+                "EMQX would not be able to fetch the public key. "
+                f"Response body: {body}"
+            )
+
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise CommandError(
+                f"JWKS pre-flight: GET {jwks_url} did not return JSON: {exc}. "
+                "Ensure the URL points at /api/forgekey/jwks/, not the SPA."
+            ) from exc
+
+        keys = (payload or {}).get("keys") if isinstance(payload, dict) else None
+        if not keys:
+            raise CommandError(
+                f"JWKS pre-flight: GET {jwks_url} returned JSON without a "
+                "non-empty `keys` array; FORGEKEY_JWT_SIGNING_KEY may be unset."
+            )
 
     @staticmethod
     def _emqx_version(api_url: str, auth) -> tuple[int, str]:

--- a/backend/forgekey/tests/test_configure_emqx_jwt_auth.py
+++ b/backend/forgekey/tests/test_configure_emqx_jwt_auth.py
@@ -44,11 +44,16 @@ def _v5_listeners(items=None):
     return _resp(items)
 
 
-def _route_get(api_url, *, nodes=None, listeners=None, authentication=None):
+def _ok_jwks():
+    return _resp({"keys": [{"kty": "EC", "crv": "P-256", "kid": "k1"}]})
+
+
+def _route_get(api_url, *, nodes=None, listeners=None, authentication=None, jwks=None):
     """Build a side_effect for ``requests.get`` keyed by URL suffix."""
     nodes = nodes if nodes is not None else _v5_nodes()
     listeners = listeners if listeners is not None else _v5_listeners()
     authentication = authentication if authentication is not None else _resp([])
+    jwks = jwks if jwks is not None else _ok_jwks()
 
     def _side_effect(url, *args, **kwargs):
         if url.endswith("/nodes"):
@@ -57,6 +62,8 @@ def _route_get(api_url, *, nodes=None, listeners=None, authentication=None):
             return listeners
         if url.endswith("/authentication"):
             return authentication
+        if "/jwks" in url:
+            return jwks
         raise AssertionError(f"unexpected GET to {url}")
 
     return _side_effect
@@ -237,7 +244,10 @@ class TestConfigureEmqxJwtAuth:
         """AC-4: failure to detect version surfaces a clear error."""
         _settings_present(settings)
         with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
-            req.get.return_value = _resp(status_code=403, text="forbidden")
+            req.get.side_effect = _route_get(
+                settings.EMQX_API_URL,
+                nodes=_resp(status_code=403, text="forbidden"),
+            )
             with pytest.raises(CommandError, match="GET /nodes failed"):
                 call_command(
                     "configure_emqx_jwt_auth",
@@ -260,3 +270,95 @@ class TestConfigureEmqxJwtAuth:
                     f"--jwks-url={JWKS_URL}",
                     stdout=StringIO(),
                 )
+
+
+@pytest.mark.unit
+class TestJwksPreflight:
+    """oms-zad: pre-flight JWKS reachability check before configuring EMQX."""
+
+    def test_jwks_400_blocks_with_allowed_hosts_hint(self, settings):
+        _settings_present(settings)
+        with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
+            req.get.side_effect = _route_get(
+                settings.EMQX_API_URL,
+                jwks=_resp(status_code=400, text="<html>Bad Request (400)</html>"),
+            )
+            with pytest.raises(CommandError, match=r"ALLOWED_HOSTS"):
+                call_command(
+                    "configure_emqx_jwt_auth",
+                    f"--jwks-url={JWKS_URL}",
+                    stdout=StringIO(),
+                )
+            req.post.assert_not_called()  # never wrote EMQX config
+
+    def test_jwks_503_blocks_with_status_code(self, settings):
+        _settings_present(settings)
+        with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
+            req.get.side_effect = _route_get(
+                settings.EMQX_API_URL,
+                jwks=_resp(status_code=503, text="signing key not configured"),
+            )
+            with pytest.raises(CommandError, match=r"returned 503"):
+                call_command(
+                    "configure_emqx_jwt_auth",
+                    f"--jwks-url={JWKS_URL}",
+                    stdout=StringIO(),
+                )
+            req.post.assert_not_called()
+
+    def test_jwks_connection_error_surfaces_clear_error(self, settings):
+        _settings_present(settings)
+        import requests as real_requests  # noqa: WPS433
+
+        def _boom(url, *a, **kw):
+            if "/jwks" in url:
+                raise real_requests.ConnectionError("name resolution failed")
+            raise AssertionError(f"unexpected GET to {url}")
+
+        with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
+            req.RequestException = real_requests.RequestException
+            req.get.side_effect = _boom
+            with pytest.raises(CommandError, match=r"JWKS pre-flight"):
+                call_command(
+                    "configure_emqx_jwt_auth",
+                    f"--jwks-url={JWKS_URL}",
+                    stdout=StringIO(),
+                )
+            req.post.assert_not_called()
+
+    def test_jwks_empty_keys_blocks(self, settings):
+        _settings_present(settings)
+        with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
+            req.get.side_effect = _route_get(
+                settings.EMQX_API_URL,
+                jwks=_resp({"keys": []}),
+            )
+            with pytest.raises(CommandError, match=r"non-empty `keys` array"):
+                call_command(
+                    "configure_emqx_jwt_auth",
+                    f"--jwks-url={JWKS_URL}",
+                    stdout=StringIO(),
+                )
+
+    def test_skip_jwks_check_bypasses_preflight(self, settings):
+        """--skip-jwks-check skips the GET so it doesn't fail on a 400."""
+        _settings_present(settings)
+        with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
+            # Provide good responses for everything except JWKS, which we
+            # don't expect to be called.
+            req.get.side_effect = _route_get(
+                settings.EMQX_API_URL,
+                jwks=_resp(status_code=400, text="should not be hit"),
+            )
+            req.post.return_value = _resp(status_code=201)
+            req.put.side_effect = _route_put()
+            call_command(
+                "configure_emqx_jwt_auth",
+                f"--jwks-url={JWKS_URL}",
+                "--skip-jwks-check",
+                stdout=StringIO(),
+            )
+            # Pre-flight skipped: only EMQX URLs hit, never the JWKS URL.
+            for c in req.get.call_args_list:
+                assert "/jwks" not in c.args[0]
+            req.post.assert_called()  # configuration proceeded

--- a/backend/forgekey/tests/test_doctor_checks.py
+++ b/backend/forgekey/tests/test_doctor_checks.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from unittest import mock
+
 import pytest
 
 from forgekey.checks import (
+    W_DOCKER_ALLOWED_HOSTS,
     W_EMQX_API,
     W_EMQX_PASSWORD,
     W_PROVISIONING_TOKEN,
+    check_docker_allowed_hosts,
     check_emqx_api_credentials,
     check_emqx_dashboard_password,
     check_forgekey_provisioning_token,
@@ -100,3 +104,39 @@ class TestEmqxApiCredentialsCheck:
         prod.EMQX_API_KEY = "key"
         prod.EMQX_API_SECRET = "secret"
         assert check_emqx_api_credentials(app_configs=None) == []
+
+
+class TestDockerAllowedHostsCheck:
+    """oms-zad: W007 warns when running in docker without 'backend' in ALLOWED_HOSTS."""
+
+    def test_no_warnings_in_debug_even_in_docker(self, settings):
+        settings.DEBUG = True
+        settings.ALLOWED_HOSTS = ["oms.example.com"]
+        with mock.patch("forgekey.checks._running_in_docker", return_value=True):
+            assert check_docker_allowed_hosts(app_configs=None) == []
+
+    def test_no_warnings_outside_docker(self, prod):
+        prod.ALLOWED_HOSTS = ["oms.example.com"]
+        with mock.patch("forgekey.checks._running_in_docker", return_value=False):
+            assert check_docker_allowed_hosts(app_configs=None) == []
+
+    def test_warns_in_docker_without_backend(self, prod):
+        prod.ALLOWED_HOSTS = ["oms.example.com", "localhost"]
+        with mock.patch("forgekey.checks._running_in_docker", return_value=True):
+            warnings = check_docker_allowed_hosts(app_configs=None)
+        assert [w.id for w in warnings] == [W_DOCKER_ALLOWED_HOSTS]
+
+    def test_no_warning_when_backend_present(self, prod):
+        prod.ALLOWED_HOSTS = ["oms.example.com", "backend", "localhost"]
+        with mock.patch("forgekey.checks._running_in_docker", return_value=True):
+            assert check_docker_allowed_hosts(app_configs=None) == []
+
+    def test_no_warning_when_wildcard(self, prod):
+        prod.ALLOWED_HOSTS = ["*"]
+        with mock.patch("forgekey.checks._running_in_docker", return_value=True):
+            assert check_docker_allowed_hosts(app_configs=None) == []
+
+    def test_case_insensitive_match(self, prod):
+        prod.ALLOWED_HOSTS = ["oms.example.com", "Backend"]
+        with mock.patch("forgekey.checks._running_in_docker", return_value=True):
+            assert check_docker_allowed_hosts(app_configs=None) == []

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -111,7 +111,11 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-makerspace}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-makerspace_inventory}
       - REDIS_URL=redis://redis:6379/0
       - CELERY_BROKER_URL=redis://redis:6379/0
-      - ALLOWED_HOSTS=${ALLOWED_HOSTS:-oms.example.com,localhost}
+      # Always append `backend,localhost` so EMQX (which fetches JWKS via
+      # http://backend:8000/api/forgekey/jwks/ on the docker network) and
+      # in-container healthchecks always pass Django ALLOWED_HOSTS even if an
+      # operator forgets to include them in .env. Duplicates are harmless.
+      - ALLOWED_HOSTS=${ALLOWED_HOSTS:-oms.example.com,localhost},backend,localhost
       - CSRF_TRUSTED_ORIGINS=https://${DOMAIN:-oms.example.com}
       - CORS_ALLOWED_ORIGINS=https://${DOMAIN:-oms.example.com}
       - FRONTEND_URL=https://${DOMAIN:-oms.example.com}

--- a/docs/DEPLOYMENT.MD
+++ b/docs/DEPLOYMENT.MD
@@ -183,6 +183,37 @@ docker-compose -f docker-compose.prod.yml exec nginx ls -la /app/frontend
 - Check `env_file:` section in docker-compose.prod.yml
 - Restart containers after changing .env
 
+### Issue: EMQX rejects every device CONNECT (JWKS 400)
+
+**Problem**: After enabling JWT auth (`configure_emqx_jwt_auth`), no devices
+can connect. From inside the EMQX container:
+
+```bash
+docker-compose -f docker-compose.prod.yml exec emqx \
+    curl -s http://backend:8000/api/forgekey/jwks/
+# <html>Bad Request (400)</html>
+```
+
+**Root cause**: EMQX fetches JWKS via the docker service name
+(`Host: backend:8000`), but `ALLOWED_HOSTS` lists only the public hostname
+plus `localhost`. Django rejects the request with 400, so EMQX never gets a
+public key and refuses every CONNECT.
+
+**Solution**: Add `backend` to `ALLOWED_HOSTS`:
+
+```bash
+# .env
+ALLOWED_HOSTS=oms.example.com,www.oms.example.com,backend,localhost
+docker-compose -f docker-compose.prod.yml up -d backend
+```
+
+`docker-compose.prod.yml` also appends `backend,localhost` to whatever you
+set, so this is the belt-and-suspenders configuration. The Django check
+`forgekey.W007` warns about this at startup when running in docker, and
+`configure_emqx_jwt_auth` now pre-flights the JWKS URL before writing EMQX
+config — pass `--skip-jwks-check` only if you already verified manually.
+Tracked: oms-zad.
+
 ### Issue: Database connection failed
 
 **Problem**: Backend can't connect to PostgreSQL
@@ -279,7 +310,7 @@ docker stats
 - [ ] Use strong `POSTGRES_PASSWORD`
 - [ ] Set `DEBUG=0` in production
 - [ ] Configure HTTPS with SSL certificate
-- [ ] Set proper `ALLOWED_HOSTS`
+- [ ] Set proper `ALLOWED_HOSTS` (must include `backend` for in-cluster JWKS — see EMQX troubleshooting above)
 - [ ] Configure firewall (allow only 80, 443)
 - [ ] Regular backups of database and media (see [`deploy/BACKUP_RESTORE.md`](../deploy/BACKUP_RESTORE.md))
 - [ ] Keep Docker images updated


### PR DESCRIPTION
## Summary

Fixes a P1 deploy-time failure: EMQX (running on the docker network) fetches JWKS from `http://backend:8000/api/forgekey/jwks/`, but `ALLOWED_HOSTS` only listed the public hostname + `localhost`. Django returned 400, EMQX never got a public key, and every device MQTT CONNECT was rejected — silently bricking the entire ForgeKey data path on a fresh deploy.

Defense in depth across env defaults, docker-compose defaults, the configure command, a startup check, and the docs:

- **AC-1**: `.env.prod.example` and `backend/env.production.example` now include `backend,localhost` in `ALLOWED_HOSTS` with a comment explaining why.
- **AC-2**: `docker-compose.prod.yml` appends `,backend,localhost` to whatever the operator sets, so the in-cluster JWKS path always works even if the env var is wrong.
- **AC-3**: `configure_emqx_jwt_auth` pre-flights the JWKS URL before writing EMQX config. 400 → explicit `ALLOWED_HOSTS` hint. 503 / non-200 → status code surfaced. Empty `keys` → fails fast (likely unset signing key). New `--skip-jwks-check` escape hatch.
- **AC-4**: `forgekey.W007` Django system check warns at startup when running in docker (via `/.dockerenv` or cgroup heuristic) without `backend` in `ALLOWED_HOSTS`.
- **AC-5**: `docs/DEPLOYMENT.MD` documents the gotcha + fix in Troubleshooting and the security checklist.

## Test plan

- [x] `pytest forgekey/` — 232 passed
- [x] `pytest config/tests/test_deployment_validation.py` — 36 passed (covers `.env.prod.example` keys)
- [x] Full backend `pytest` — only pre-existing unrelated failures in `inventory/tests/test_work_order_id_extraction.py` (QR/PDF, fail on `main` too)
- [x] `pre-commit run` on changed files — black/isort/flake8/bandit/django-upgrade all green
- [x] No frontend changes; `npm test` not applicable

## New tests

- `TestJwksPreflight` (5 cases): 400 → ALLOWED_HOSTS hint, 503 → status surfaced, ConnectionError → clear error, empty `keys` → fails, `--skip-jwks-check` bypasses cleanly
- `TestDockerAllowedHostsCheck` (6 cases): debug skip, non-docker skip, missing backend warns, present clears, wildcard clears, case-insensitive match

🤖 Generated with [Claude Code](https://claude.com/claude-code)