### PR TITLE
fix(forgekey): per-MAC wildcard JWT ACL for /capabilities + future topics (oms-uky)

### DIFF
--- a/backend/forgekey/tests/test_utils.py
+++ b/backend/forgekey/tests/test_utils.py
@@ -81,7 +81,7 @@ class TestJWTGeneration:
         assert header["kid"] == settings.FORGEKEY_JWT_KEY_ID
 
     def test_generated_token_carries_required_claims(self):
-        token = generate_device_jwt(self.MAC, sensor_kind="people_counter")
+        token = generate_device_jwt(self.MAC)
         payload = verify_device_jwt(token, self.MAC)
         assert payload is not None
         assert payload["iss"] == settings.FORGEKEY_JWT_ISSUER
@@ -91,36 +91,20 @@ class TestJWTGeneration:
         assert "iat" in payload and "exp" in payload
         assert payload["exp"] > payload["iat"]
 
-    def test_acl_claim_grants_least_privilege_per_device(self):
-        token = generate_device_jwt(self.MAC, sensor_kind="people_counter")
+    def test_acl_claim_grants_per_mac_wildcard(self):
+        token = generate_device_jwt(self.MAC)
         payload = verify_device_jwt(token, self.MAC)
         contract_mac = "aabbccddeeff"
         prefix = f"{settings.MQTT_TOPIC_PREFIX}/{contract_mac}"
         acl = payload["acl"]
-        # Pub: only this device's own telemetry / status / OTA / firmware-response.
-        assert f"{prefix}/people_counter/occupancy" in acl["pub"]
-        assert f"{prefix}/status" in acl["pub"]
-        assert f"{prefix}/firmware/response" in acl["pub"]
-        assert f"{prefix}/ota/status" in acl["pub"]
-        # Sub: only this device's command / firmware / config / OTA-trigger inbox.
-        assert acl["sub"] == [
-            f"{prefix}/command",
-            f"{prefix}/firmware",
-            f"{prefix}/config",
-            f"{prefix}/ota/trigger",
-        ]
-        # No wildcards anywhere.
-        for topic in acl["pub"] + acl["sub"]:
-            assert "+" not in topic and "#" not in topic
-            assert contract_mac in topic
-
-    def test_unknown_sensor_kind_grants_both_well_known_occupancy_topics(self):
-        token = generate_device_jwt(self.MAC)  # no sensor_kind
-        payload = verify_device_jwt(token, self.MAC)
-        contract_mac = "aabbccddeeff"
-        pubs = payload["acl"]["pub"]
-        assert f"{settings.MQTT_TOPIC_PREFIX}/{contract_mac}/people_counter/occupancy" in pubs
-        assert f"{settings.MQTT_TOPIC_PREFIX}/{contract_mac}/door_counter/occupancy" in pubs
+        # Per-MAC wildcard: device may pub/sub anywhere under its own MAC
+        # namespace, including future topics (e.g. /capabilities) without
+        # requiring backend changes. The MAC namespace is the security
+        # boundary — different MAC means different prefix.
+        assert acl == {
+            "pub": [f"{prefix}/#"],
+            "sub": [f"{prefix}/#"],
+        }
 
     def test_verify_invalid_jwt(self):
         invalid = "invalid.token.here"  # nosec B105 — fixed test sentinel

--- a/backend/forgekey/utils.py
+++ b/backend/forgekey/utils.py
@@ -28,45 +28,26 @@ def normalize_mac_address(mac_address: str) -> str:
     return ":".join(mac[i : i + 2] for i in range(0, len(mac), 2))
 
 
-def _device_acl_claims(mac_address: str, sensor_kind: Optional[str] = None) -> Dict:
+def _device_acl_claims(mac_address: str) -> Dict:
     """Build the per-device EMQX ACL claims for a given MAC.
 
-    Returns a least-privilege grant: the device may publish only to its own
-    telemetry / status / OTA-status / firmware-response topics, and subscribe
-    only to its own command / firmware / config / OTA-trigger topics. No
-    wildcards, no cross-device traffic.
+    Grants pub/sub on the device's entire MAC-scoped namespace
+    (``<prefix>/<mac>/#``). The MAC namespace is the security boundary —
+    different MAC means different prefix, so cross-device traffic is still
+    impossible. Wildcarding here means new per-device topics (capabilities,
+    future telemetry streams) work without re-issuing JWTs or backend changes.
     """
     contract_mac = _firmware_contract_mac(mac_address)
     prefix = f"{settings.MQTT_TOPIC_PREFIX}/{contract_mac}"
-    pub_topics = [
-        f"{prefix}/status",
-        f"{prefix}/firmware/response",
-        f"{prefix}/ota/status",
-    ]
-    # Sensor-kind-specific occupancy stream. Devices typically know one kind
-    # but for first-registration calls where sensor_kind is unknown, we grant
-    # both well-known occupancy topics so the device can pick.
-    kind = normalize_sensor_kind(sensor_kind) if sensor_kind else ""
-    if kind:
-        pub_topics.insert(0, f"{prefix}/{kind}/occupancy")
-    else:
-        pub_topics = [
-            f"{prefix}/people_counter/occupancy",
-            f"{prefix}/door_counter/occupancy",
-        ] + pub_topics
-    sub_topics = [
-        f"{prefix}/command",
-        f"{prefix}/firmware",
-        f"{prefix}/config",
-        f"{prefix}/ota/trigger",
-    ]
-    return {"pub": pub_topics, "sub": sub_topics}
+    return {
+        "pub": [f"{prefix}/#"],
+        "sub": [f"{prefix}/#"],
+    }
 
 
 def generate_device_jwt(
     mac_address: str,
     payload: Optional[Dict] = None,
-    sensor_kind: Optional[str] = None,
 ) -> str:
     """
     Generate an ES256-signed JWT for an ESP32 device.
@@ -79,8 +60,6 @@ def generate_device_jwt(
     Args:
         mac_address: MAC address of the device (any format).
         payload: Extra claims to merge into the token.
-        sensor_kind: Optional device-type code; narrows the ``acl.pub`` grant
-            to only the matching occupancy topic when known.
 
     Returns:
         Compact-serialized JWT string.
@@ -103,7 +82,7 @@ def generate_device_jwt(
         "mac": normalized_mac,
         "iat": int(now.timestamp()),
         "exp": int(now.timestamp()) + settings.FORGEKEY_JWT_EXPIRATION_SECONDS,
-        "acl": _device_acl_claims(normalized_mac, sensor_kind=sensor_kind),
+        "acl": _device_acl_claims(normalized_mac),
     }
     claims.update(payload)
 

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -303,7 +303,7 @@ class ForgeKeyDeviceRegisterView(APIView):
             device.device_type.code if device.device_type_id else ""
         )
         try:
-            token = generate_device_jwt(mac, sensor_kind=sensor_kind_for_topic)
+            token = generate_device_jwt(mac)
         except JwtSigningError as exc:
             logger.error("ForgeKey register: JWT signing key misconfigured: %s", exc)
             return Response(


### PR DESCRIPTION
Fixes oms-uky — JWT ACL claims were missing the /capabilities topic. Switches to per-MAC wildcard for future-proofing.

Single commit, 3 files (utils.py, views.py, test_utils.py). Net -37 LOC. MR oms-wisp-dji (P1).