### PR TITLE
fix(emqx): bound JWKS nxdomain recovery to ~30s + connector retry docs (oms-4jw)

### DIFF
--- a/backend/forgekey/management/commands/configure_emqx_jwt_auth.py
+++ b/backend/forgekey/management/commands/configure_emqx_jwt_auth.py
@@ -60,8 +60,15 @@ class Command(BaseCommand):
         parser.add_argument(
             "--refresh-interval",
             type=int,
-            default=300,
-            help="Seconds EMQX caches the JWKS before re-fetching (default: 300).",
+            default=30,
+            help=(
+                "Seconds EMQX caches the JWKS before re-fetching (default: 30). "
+                "Doubles as the post-failure retry cadence: when EMQX boots before "
+                "the backend is reachable on the docker network, the initial JWKS "
+                "fetch hits nxdomain and EMQX caches the failure until the next "
+                "refresh tick. A short interval bounds the recovery window so a "
+                "backend restart doesn't permanently break MQTT auth (oms-4jw)."
+            ),
         )
         parser.add_argument(
             "--keep-anonymous",

--- a/backend/forgekey/tests/test_configure_emqx_jwt_auth.py
+++ b/backend/forgekey/tests/test_configure_emqx_jwt_auth.py
@@ -130,6 +130,10 @@ class TestConfigureEmqxJwtAuth:
         assert post_call.kwargs["json"]["mechanism"] == "jwt"
         assert post_call.kwargs["json"]["use_jwks"] is True
         assert post_call.kwargs["json"]["endpoint"] == JWKS_URL
+        # oms-4jw: default refresh_interval must be short enough that EMQX
+        # recovers from a transient nxdomain (backend bouncing) within the
+        # next refresh tick instead of staying broken for the legacy 300s.
+        assert post_call.kwargs["json"]["refresh_interval"] == 30
         # On 5.x we never PUT /configs/mqtt — that endpoint is gone.
         for put_call in req.put.call_args_list:
             assert "/configs/mqtt" not in put_call.args[0]
@@ -142,6 +146,21 @@ class TestConfigureEmqxJwtAuth:
         out = stdout.getvalue()
         assert "5.4.1" in out
         assert "EMQX 5.x" in out
+
+    def test_refresh_interval_flag_overrides_default(self, settings):
+        """oms-4jw: --refresh-interval is forwarded to EMQX so operators can tune."""
+        _settings_present(settings)
+        with mock.patch("forgekey.management.commands.configure_emqx_jwt_auth.requests") as req:
+            req.get.side_effect = _route_get(settings.EMQX_API_URL)
+            req.post.return_value = _resp(status_code=201)
+            req.put.side_effect = _route_put()
+            call_command(
+                "configure_emqx_jwt_auth",
+                f"--jwks-url={JWKS_URL}",
+                "--refresh-interval=15",
+                stdout=StringIO(),
+            )
+        assert req.post.call_args.kwargs["json"]["refresh_interval"] == 15
 
     def test_v5_idempotent_when_listeners_already_enforce_authn(self, settings):
         """AC-2: re-running on 5.x with auth already enforced does not error or PUT."""

--- a/deploy/EMQX_WEBHOOK.md
+++ b/deploy/EMQX_WEBHOOK.md
@@ -28,6 +28,19 @@ In the EMQX dashboard:
      - `Content-Type: application/json`
      - `X-ForgeKey-Webhook-Secret: <FORGEKEY_WEBHOOK_SECRET value>`
    - Connection pool: defaults are fine.
+   - **Resilience knobs (oms-4jw)** — set these so the connector recovers
+     from a transient backend outage without needing a manual restart:
+     - **Connect timeout**: `5s` (short, since the backend is on the same
+       docker network).
+     - **Request timeout**: `10s`.
+     - **Health check interval**: `15s`. EMQX re-resolves the URL and
+       re-establishes the resource on each tick, which clears any cached
+       nxdomain from a backend bounce.
+     - **Auto restart interval**: leave at the EMQX default; the resource
+       manager retries with backoff when the health check fails.
+     If your EMQX was provisioned with a longer health-check interval and
+     the connector is currently stuck on a cached nxdomain, see
+     `docs/INCIDENTS/emqx-jwks-nxdomain.md` for force-recovery procedures.
 
 2. **Integration → Rules → Create**
    - SQL:

--- a/docs/EMQX_CONFIGURATION.md
+++ b/docs/EMQX_CONFIGURATION.md
@@ -60,7 +60,9 @@ If you prefer the dashboard, you can do the same by hand:
 2. Pick **JWT**.
 3. **Use JWKS**: yes.
 4. **JWKS URL**: `https://oms.example/api/forgekey/jwks/`.
-5. **Refresh interval**: `300` (seconds).
+5. **Refresh interval**: `30` (seconds). Doubles as the post-failure retry
+   cadence — see "Recovery from JWKS fetch failure" below for why we keep
+   this short.
 6. **JWT From**: `password`.
 7. **Verify Claims**: add `iss = openmakersuite` and `aud = forgekey`.
 8. **ACL Claim Name**: `acl`.
@@ -84,6 +86,32 @@ If the device fails to connect:
 - Visit `<jwks-url>` from a browser — it must return JSON (`{"keys":[...]}`).
 - In the EMQX dashboard, **Diagnose → Log** filters by client; the JWT
   validation failure reason is logged there.
+
+## Recovery from JWKS fetch failure (oms-4jw)
+
+The JWKS authenticator's `refresh_interval` (30 seconds by default) doubles as
+a retry cadence. If EMQX boots before the backend's container is reachable on
+the docker network — common with `docker compose up` from cold — the initial
+JWKS fetch hits `nxdomain` and EMQX caches that failure. Subsequent device
+auth attempts fail with "JWKS endpoint unreachable" until the next refresh
+tick fetches successfully.
+
+With the 30s default, recovery is automatic within ~30 seconds of the backend
+becoming reachable. If you raised the interval (or you are running an EMQX
+that was provisioned with the legacy 300s value), the recovery window grows
+to match. Two ways to force-recover:
+
+1. **Restart EMQX**: `docker compose restart emqx`. EMQX re-fetches JWKS on
+   startup. Use this when devices need to connect right now and you don't
+   want to wait for the next refresh tick.
+2. **Re-run `configure_emqx_jwt_auth` after deleting the existing
+   authenticator** (Authentication → Authentication → trash icon → re-run the
+   management command). Required if you want to update an existing
+   authenticator's `refresh_interval`; the command's idempotent path
+   intentionally skips creating a duplicate but does **not** rewrite an
+   existing authenticator's settings.
+
+See `docs/INCIDENTS/emqx-jwks-nxdomain.md` for the full runbook.
 
 ## Key rotation
 

--- a/docs/INCIDENTS/emqx-jwks-nxdomain.md
+++ b/docs/INCIDENTS/emqx-jwks-nxdomain.md
@@ -1,0 +1,134 @@
+# Incident runbook: EMQX cannot resolve `backend` (JWKS / WebHook nxdomain)
+
+> Tracking bead: **oms-4jw** (P2, user-reported 2026-05-03).
+> Cross-references: oms-zad (ALLOWED_HOSTS — same family of issues),
+> oms-2zo (the WebHook bridge that's failing as the OpenMakerSuite connector).
+
+## Symptom
+
+EMQX logs one of these on startup or after a backend container restart:
+
+```
+failed_to_request_jwks_endpoint, reason:
+  {failed_connect, [{to_address,{"backend",8000}}, {inet,[inet],nxdomain}]}
+
+CONNECTOR/WEBHOOK, msg: start_resource_failed,
+  reason: nxdomain, resource_id: connector:http:OpenMakerSuite
+```
+
+Devices that connect after the failure are rejected at MQTT auth, and any
+EMQX rule that publishes to the OpenMakerSuite WebHook stops dispatching. A
+manual `curl http://backend:8000/api/forgekey/jwks/` from inside the EMQX
+container DOES resolve and return JSON — the docker network is fine. The
+problem is that EMQX cached the initial nxdomain in the JWKS authenticator's
+state and the connector's resource manager.
+
+## Root cause
+
+Container start ordering during `docker compose up`. EMQX's `depends_on`
+chain does not include `backend` (that would create a cycle: backend already
+depends on EMQX for `service_started`). When EMQX wins the race, its
+authenticator initializes against a hostname that hasn't been published to
+the docker DNS yet, the lookup returns nxdomain, and EMQX caches the
+failure until the next refresh tick.
+
+The same race fires when the `backend` container is recycled (deploy, OOM
+kill, gunicorn worker storm) — backend's IP goes away, EMQX's next JWKS
+refresh hits nxdomain, and the failure persists for the rest of the
+`refresh_interval`.
+
+## Mitigations in place (oms-4jw fix)
+
+These changes are part of the repo; verify they are present on the target
+deploy before doing further triage.
+
+1. **JWKS `refresh_interval` lowered to 30 seconds.** The default for
+   `python manage.py configure_emqx_jwt_auth` is now `30` (was `300`).
+   EMQX retries the JWKS fetch every refresh tick, so a transient
+   nxdomain self-heals within ~30s of the backend becoming reachable.
+   See `backend/forgekey/management/commands/configure_emqx_jwt_auth.py`.
+2. **Operator-facing docs updated.** `docs/EMQX_CONFIGURATION.md` and
+   `deploy/EMQX_WEBHOOK.md` call out the retry behavior so a new operator
+   provisioning a fresh EMQX picks the short interval and the
+   `start_after_created` / `request_timeout` knobs on the WebHook
+   connector.
+
+## Force-recovery procedures
+
+Use these when MQTT auth is broken right now and you cannot wait for the
+next refresh tick (e.g. an existing EMQX provisioned with the legacy 300s
+interval, or the WebHook connector stuck on a cached nxdomain).
+
+### A. Restart EMQX (fastest, always works)
+
+```bash
+docker compose -f docker-compose.prod.yml restart emqx
+```
+
+EMQX re-fetches JWKS and re-creates the WebHook connector resource on boot.
+Devices reconnect within seconds. Safe to run any time — no data loss; MQTT
+sessions are re-established by clients.
+
+### B. Update the JWKS authenticator's refresh interval in place
+
+For an EMQX that was provisioned with the legacy 300s interval, the
+management command's idempotent path skips re-creating the authenticator,
+so re-running it does NOT update `refresh_interval`. Either:
+
+1. Delete the JWT authenticator in the dashboard
+   (Authentication → Authentication → trash icon) and re-run
+   `python manage.py configure_emqx_jwt_auth --jwks-url=...` from the
+   backend container, or
+2. Edit the authenticator in the dashboard and set Refresh Interval to
+   `30` directly.
+
+### C. Restart the WebHook connector resource
+
+EMQX 5.x dashboard: Integration → Connectors → OpenMakerSuite → restart.
+This clears the cached nxdomain on the connector specifically without
+bouncing the broker.
+
+## Detect (proactive)
+
+- **Devices fail to connect** but the EMQX dashboard shows zero auth
+  failures from a specific listener — they're being rejected at JWKS
+  lookup, not at signature verification.
+- **`docker compose logs emqx --since 5m | grep -E 'nxdomain|jwks|connector'`**
+  shows the failure lines above.
+- **Backend's gunicorn access log shows no JWKS hits**
+  (`grep '/api/forgekey/jwks/' backend.log`) for >1× the configured
+  refresh interval, even though devices are trying to connect.
+
+## Investigate (if this fires post-mitigation)
+
+1. **Confirm refresh_interval on the live authenticator.**
+   ```bash
+   curl -s -u "$EMQX_API_KEY:$EMQX_API_SECRET" \
+     http://localhost:18083/api/v5/authentication \
+     | jq '.[] | select(.mechanism=="jwt") | .refresh_interval'
+   ```
+   Expect `30`. Anything ≥`300` is a stale configuration — see
+   "Force-recovery B" above.
+2. **Confirm DNS resolves from inside EMQX.**
+   `docker exec oms-emqx getent hosts backend`. Empty output means the
+   docker network itself is broken (different problem); non-empty means
+   EMQX has the cached failure and needs a kick.
+3. **Confirm the JWKS endpoint is healthy.**
+   `docker exec oms-emqx curl -sf http://backend:8000/api/forgekey/jwks/`.
+   If this returns the JWS JSON, the broker just needs to refresh.
+4. **Check the WebHook connector resource state** in the dashboard's
+   Integration → Connectors view. A connector stuck in `disconnected` after
+   the network is healthy is the same nxdomain-cache symptom on a different
+   subsystem.
+
+## After-action template
+
+When this incident recurs, append a section like:
+
+```
+### YYYY-MM-DD recurrence
+- Detected by: ...
+- Root cause: ...
+- Fix: ...
+- Mitigation update: ...
+```


### PR DESCRIPTION
Fixes oms-4jw — EMQX JWT/connector hostname resolution flakiness: backend nxdomain after restart sequence wasn't recovering for minutes.

Single commit, 5 files (configure_emqx_jwt_auth + tests, deploy/EMQX_WEBHOOK.md, docs/EMQX_CONFIGURATION.md, INCIDENTS/emqx-jwks-nxdomain.md postmortem). MR oms-wisp-7z0 (P2).