### PR TITLE
fix(reorder_queue): require auth on all ReorderRequestViewSet actions (oms-97b)

### DIFF
--- a/backend/reorder_queue/tests/test_api.py
+++ b/backend/reorder_queue/tests/test_api.py
@@ -37,8 +37,9 @@ class TestReorderRequestAPI:
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data["results"]) == 3
 
-    def test_create_reorder_request_public(self, api_client):
-        """Test anyone can create a reorder request."""
+    def test_create_reorder_request_authenticated(self, authenticated_client):
+        """Authenticated users can create a reorder request."""
+        client, _user = authenticated_client
         item = InventoryItemFactory()
 
         url = reverse("reorderrequest-list")
@@ -49,22 +50,84 @@ class TestReorderRequestAPI:
             "request_notes": "We are running low",
             "priority": "high",
         }
-        response = api_client.post(url, data, format="json")
+        response = client.post(url, data, format="json")
 
         assert response.status_code == status.HTTP_201_CREATED
         assert str(response.data["item"]) == str(item.id)
         assert response.data["quantity"] == 25
         assert response.data["status"] == "pending"
 
-    def test_create_reorder_request_minimal(self, api_client):
+    def test_create_reorder_request_minimal(self, authenticated_client):
         """Test creating request with minimal required fields."""
+        client, _user = authenticated_client
+        item = InventoryItemFactory()
+
+        url = reverse("reorderrequest-list")
+        data = {"item": str(item.id), "quantity": 10}
+        response = client.post(url, data, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+    def test_create_reorder_request_anonymous_denied(self, api_client):
+        """Anonymous users cannot create reorder requests (gh #327)."""
         item = InventoryItemFactory()
 
         url = reverse("reorderrequest-list")
         data = {"item": str(item.id), "quantity": 10}
         response = api_client.post(url, data, format="json")
 
-        assert response.status_code == status.HTTP_201_CREATED
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_list_reorder_requests_anonymous_denied(self, api_client):
+        """Anonymous users cannot list reorder requests (gh #327)."""
+        ReorderRequestFactory.create_batch(2)
+
+        url = reverse("reorderrequest-list")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_retrieve_reorder_request_anonymous_denied(self, api_client):
+        """Anonymous users cannot retrieve a reorder request (gh #327)."""
+        request_obj = ReorderRequestFactory()
+
+        url = reverse("reorderrequest-detail", kwargs={"pk": request_obj.pk})
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_pending_reorder_requests_anonymous_denied(self, api_client):
+        """Anonymous users cannot view the pending queue (gh #327)."""
+        ReorderRequestFactory(status="pending")
+
+        url = reverse("reorderrequest-pending")
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.parametrize(
+        "action_name,method,detail",
+        [
+            ("by-supplier", "get", False),
+            ("sig-pending", "get", False),
+            ("generate-cart-links", "get", False),
+            ("approve", "post", True),
+            ("mark-ordered", "post", True),
+            ("mark-received", "post", True),
+            ("cancel", "post", True),
+        ],
+    )
+    def test_admin_actions_anonymous_denied(self, api_client, action_name, method, detail):
+        """All admin reorder actions reject anonymous callers (gh #327)."""
+        if detail:
+            request_obj = ReorderRequestFactory(status="pending")
+            url = reverse(f"reorderrequest-{action_name}", kwargs={"pk": request_obj.pk})
+        else:
+            url = reverse(f"reorderrequest-{action_name}")
+
+        response = getattr(api_client, method)(url, {}, format="json")
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_retrieve_reorder_request(self, authenticated_client):
         """Test retrieving a single reorder request."""

--- a/backend/reorder_queue/tests/test_in_app_notification.py
+++ b/backend/reorder_queue/tests/test_in_app_notification.py
@@ -26,9 +26,11 @@ class TestReorderRequestInAppNotification:
             username="admin", email="a@x.test", password="x", is_staff=True
         )
         non_admin = User.objects.create_user(username="regular", email="r@x.test", password="x")
+        requester = User.objects.create_user(username="requester", email="req@x.test", password="x")
         item = InventoryItemFactory(name="Widget A")
 
         client = APIClient()
+        client.force_authenticate(user=requester)
         resp = client.post(
             reverse("reorderrequest-list"),
             data={

--- a/backend/reorder_queue/tests/test_views_simple.py
+++ b/backend/reorder_queue/tests/test_views_simple.py
@@ -22,16 +22,14 @@ class SimpleReorderViewTests(TestCase):
         self.request = ReorderRequestFactory()
 
     def test_reorder_list_unauthenticated(self):
-        """Test reorder list without authentication."""
+        """Anonymous list requests are rejected (gh #327)."""
         response = self.client.get("/api/reorders/requests/")
-        # Just check we get a response
-        self.assertIn(response.status_code, [200, 401, 403])
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_reorder_detail_unauthenticated(self):
-        """Test reorder detail without authentication."""
+        """Anonymous retrieve requests are rejected (gh #327)."""
         response = self.client.get(f"/api/reorders/requests/{self.request.id}/")
-        # Just check we get a response
-        self.assertIn(response.status_code, [200, 401, 403])
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_authenticated_reorder_requests(self):
         """Test some authenticated reorder requests."""
@@ -49,7 +47,7 @@ class SimpleReorderViewTests(TestCase):
             self.assertIsNotNone(response.status_code)
 
     def test_create_reorder_request(self):
-        """Test creating a simple reorder request."""
+        """Authenticated users can create a reorder request."""
         from inventory.tests.factories import InventoryItemFactory
 
         item = InventoryItemFactory()
@@ -62,7 +60,26 @@ class SimpleReorderViewTests(TestCase):
         }
 
         client = APIClient(enforce_csrf_checks=True)
+        client.force_authenticate(user=self.user)
 
         response = client.post("/api/reorders/requests/", data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_create_reorder_request_anonymous_denied(self):
+        """Anonymous users cannot create reorder requests (gh #327)."""
+        from inventory.tests.factories import InventoryItemFactory
+
+        item = InventoryItemFactory()
+
+        data = {
+            "item": item.id,
+            "quantity": 10,
+            "priority": "normal",
+            "request_notes": "Test request",
+        }
+
+        client = APIClient()
+        response = client.post("/api/reorders/requests/", data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/backend/reorder_queue/views.py
+++ b/backend/reorder_queue/views.py
@@ -80,12 +80,14 @@ class ReorderRequestViewSet(viewsets.ModelViewSet):
     """
     API endpoint for reorder requests.
 
-    Public endpoint - allows unauthenticated QR code scanning for creating requests.
-    Admin actions require JWT authentication.
+    All actions require JWT authentication. Reorder request payloads include
+    purchasing-sensitive fields (cost, invoice, supplier URLs), so anonymous
+    access is not permitted on any action — see GH #327.
     """
 
     # Only JWT, no session auth needed
     authentication_classes = (JWTAuthentication,)
+    permission_classes = [IsAuthenticated]
     queryset = (
         ReorderRequest.objects.select_related(
             "item", "item__category", "item__location", "reviewed_by"
@@ -98,14 +100,6 @@ class ReorderRequestViewSet(viewsets.ModelViewSet):
         if self.action == "create":
             return ReorderRequestCreateSerializer
         return ReorderRequestSerializer
-
-    def get_permissions(self):
-        """Allow anyone to create reorder requests and view pending, but require auth for admin actions."""
-        # Public actions that don't require authentication
-        if self.action in ["create", "list", "retrieve", "pending"]:
-            return [AllowAny()]
-        # Admin actions require authentication
-        return [IsAuthenticated()]
 
     def create(self, request, *args, **kwargs):
         """Create a new reorder request."""


### PR DESCRIPTION
Fixes oms-97b (P0) — gh #327. Locks down anonymous access to the reorder queue endpoints.

Single commit, 4 files (views + tests). MR oms-wisp-2z9 (P0).