### PR TITLE
feat(health): expand readyz to cover workers, EMQX, object-store, telemetry (oms-aam)

### DIFF
--- a/backend/config/health.py
+++ b/backend/config/health.py
@@ -1,18 +1,29 @@
 """
-Liveness and readiness endpoints (AC-11, AC-12).
+Liveness and readiness endpoints (AC-11, AC-12, oms-aam).
 
 Two distinct probes are exposed:
 
 * ``GET /api/health/livez/`` — liveness. Returns 200 as long as the WSGI
   process is running. Does NOT touch the database, cache, or broker. A
   green liveness response means "do not restart this container."
-* ``GET /api/health/readyz/`` — readiness. Returns 200 only when the
-  critical runtime dependencies are reachable: database, cache (Redis),
-  and the Celery broker. A red readiness response means "do not route
-  traffic here yet" without implying the process should be killed.
+* ``GET /api/health/readyz/`` — readiness. Returns 200 when every check
+  marked *required* is reachable. A red readiness response means "do not
+  route traffic here yet" without implying the process should be killed.
 
 Splitting the two prevents the failure mode where a transient Redis
 hiccup forces every pod to restart.
+
+Each individual check returns one of three states:
+
+* ``ok``       — dependency reachable
+* ``fail``     — configured and unreachable; populates ``failures``
+* ``skipped``  — not configured for this deployment; populates
+  ``skipped`` for operator visibility but never fails readiness
+
+Which checks count toward 503 is configurable via
+``settings.READYZ_REQUIRED_CHECKS`` (default: db/cache/broker — preserves
+the historical contract). Optional checks always report their status but
+their failure does not flap traffic.
 
 The endpoints intentionally do NOT echo back configuration values
 (connection strings, credentials, secrets) — they report status only.
@@ -20,15 +31,27 @@ The endpoints intentionally do NOT echo back configuration values
 
 from __future__ import annotations
 
+import socket
+from typing import Tuple
+from urllib.parse import urlparse
+
 from django.conf import settings
 from django.core.cache import cache
+from django.core.files.storage import default_storage
 from django.db import connections
 from django.http import JsonResponse
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_GET
 
+# Legacy bool-tuple checks return (ok: bool, error: str | None).
+# New checks return ("ok"|"fail"|"skipped", reason: str | None).
+LegacyResult = Tuple[bool, "str | None"]
+StatusResult = Tuple[str, "str | None"]
 
-def _check_database() -> tuple[bool, str | None]:
+DEFAULT_REQUIRED_CHECKS = ("database", "cache", "broker")
+
+
+def _check_database() -> LegacyResult:
     try:
         connections["default"].ensure_connection()
         with connections["default"].cursor() as cursor:
@@ -39,7 +62,7 @@ def _check_database() -> tuple[bool, str | None]:
         return False, type(exc).__name__
 
 
-def _check_cache() -> tuple[bool, str | None]:
+def _check_cache() -> LegacyResult:
     sentinel_key = "_health_readiness_probe"
     try:
         cache.set(sentinel_key, "1", timeout=5)
@@ -51,13 +74,12 @@ def _check_cache() -> tuple[bool, str | None]:
         return False, type(exc).__name__
 
 
-def _check_broker() -> tuple[bool, str | None]:
-    """
-    Confirm the Celery broker is reachable.
+def _check_broker() -> LegacyResult:
+    """Confirm the Celery broker (transport) is reachable.
 
-    Uses ``Connection.ensure_connection`` with a small max-retries budget
-    so the readiness probe never blocks a deployment for more than a few
-    seconds when the broker is down.
+    Distinct from ``_check_celery_worker``: a reachable broker only means
+    the AMQP/Redis socket is open. It does not imply any worker is
+    actually consuming.
     """
     broker_url = getattr(settings, "CELERY_BROKER_URL", None)
     if not broker_url or broker_url.startswith("memory://"):
@@ -71,6 +93,159 @@ def _check_broker() -> tuple[bool, str | None]:
         return True, None
     except Exception as exc:
         return False, type(exc).__name__
+
+
+def _check_celery_worker() -> StatusResult:
+    """Verify at least one Celery worker replies to a control ping.
+
+    A broker-up / worker-down deployment will accept tasks but never run
+    them — readiness must catch this so we don't quietly drop work.
+
+    Skipped under the in-memory eager test broker (no workers exist by
+    design) so the test suite doesn't fail readiness on an empty queue.
+    """
+    broker_url = getattr(settings, "CELERY_BROKER_URL", "") or ""
+    if not broker_url or broker_url.startswith("memory://"):
+        return "skipped", "no real broker configured"
+    if getattr(settings, "CELERY_TASK_ALWAYS_EAGER", False):
+        return "skipped", "celery is eager"
+    try:
+        from config.celery import app
+
+        replies = app.control.ping(timeout=1.0)
+    except Exception as exc:
+        return "fail", type(exc).__name__
+    if not replies:
+        return "fail", "no workers responded"
+    return "ok", None
+
+
+def _check_emqx() -> StatusResult:
+    """Ping the EMQX REST API ``/status`` endpoint.
+
+    Skipped when no API credentials are configured: ``EMQX_API_URL`` has a
+    default value baked in (so its presence alone does not mean a real
+    EMQX is wired up), but a deployment that talks to EMQX must set
+    ``EMQX_API_KEY`` / ``EMQX_API_SECRET`` (see configure_emqx_jwt_auth
+    command). Treating empty creds as "not deployed here" matches that
+    contract.
+    """
+    api_url = (getattr(settings, "EMQX_API_URL", "") or "").rstrip("/")
+    api_key = getattr(settings, "EMQX_API_KEY", "") or ""
+    api_secret = getattr(settings, "EMQX_API_SECRET", "") or ""
+    if not api_url or not api_key or not api_secret:
+        return "skipped", "EMQX credentials not configured"
+    try:
+        import requests
+
+        # /status is the EMQX REST liveness endpoint and does not require
+        # auth; we still pass creds because some reverse proxies block
+        # unauthenticated requests outright.
+        resp = requests.get(
+            f"{api_url}/status",
+            auth=(api_key, api_secret),
+            timeout=2,
+        )
+    except Exception as exc:
+        return "fail", type(exc).__name__
+    if resp.status_code >= 500:
+        return "fail", f"HTTP {resp.status_code}"
+    return "ok", None
+
+
+def _check_object_store() -> StatusResult:
+    """Verify the configured object store (S3 or compatible) is reachable.
+
+    Skipped when the deployment uses local-filesystem media (the default —
+    ``MEDIA_ROOT`` on disk). Detected by inspecting Django's STORAGES
+    setting for an S3 / boto backend.
+    """
+    storages = getattr(settings, "STORAGES", {}) or {}
+    default_backend = (storages.get("default", {}) or {}).get("BACKEND", "") or ""
+    legacy_backend = getattr(settings, "DEFAULT_FILE_STORAGE", "") or ""
+    backend_name = (default_backend + "|" + legacy_backend).lower()
+    if "s3" not in backend_name and "boto" not in backend_name:
+        return "skipped", "no object store configured"
+    try:
+        # exists() forces a HEAD against the bucket. The probe key does
+        # not need to exist — a 404 still proves the bucket is reachable.
+        default_storage.exists("_health_probe")
+        return "ok", None
+    except Exception as exc:
+        return "fail", type(exc).__name__
+
+
+def _check_telemetry() -> StatusResult:
+    """Verify the error/observability backend (Highlight, fallback Sentry).
+
+    Highlight replaced Sentry per oms-fjs; we still honour ``SENTRY_DSN``
+    so historical deployments can opt in by setting either variable.
+
+    Reachability is a TCP connect to the OTLP collector (Highlight) or
+    the DSN host (Sentry). We don't post real telemetry — that would
+    pollute the dashboard from every readiness probe.
+    """
+    highlight_project = getattr(settings, "HIGHLIGHT_PROJECT_ID", "") or ""
+    highlight_endpoint = getattr(settings, "HIGHLIGHT_OTLP_ENDPOINT", "") or ""
+    sentry_dsn = getattr(settings, "SENTRY_DSN", "") or ""
+    target_url: str = ""
+    if highlight_project:
+        # Highlight cloud uses public OTLP collectors; if the deployment
+        # didn't override the endpoint, the SDK targets Highlight's
+        # default collector — we can't probe that without hardcoding it.
+        # Treat "project set, endpoint default" as ok-by-config.
+        if not highlight_endpoint:
+            return "ok", None
+        target_url = highlight_endpoint
+    elif sentry_dsn:
+        target_url = sentry_dsn
+    else:
+        return "skipped", "no telemetry DSN configured"
+    try:
+        parsed = urlparse(target_url)
+        host = parsed.hostname
+        if not host:
+            return "fail", "unparseable telemetry URL"
+        port = parsed.port or (443 if parsed.scheme in ("https", "grpcs") else 80)
+        with socket.create_connection((host, port), timeout=2):
+            pass
+        return "ok", None
+    except Exception as exc:
+        return "fail", type(exc).__name__
+
+
+# Map of public check name -> attribute name on this module. We resolve the
+# callable via ``getattr`` at request time so ``unittest.mock.patch`` on the
+# underlying ``_check_*`` symbols takes effect (a dict of direct function
+# references would freeze the originals at import time).
+CHECKS: dict[str, str] = {
+    "database": "_check_database",
+    "cache": "_check_cache",
+    "broker": "_check_broker",
+    "celery_worker": "_check_celery_worker",
+    "emqx": "_check_emqx",
+    "object_store": "_check_object_store",
+    "telemetry": "_check_telemetry",
+}
+
+
+def _normalize(raw) -> StatusResult:
+    """Coerce legacy bool-tuple results into the 3-state form."""
+    status, reason = raw
+    if isinstance(status, bool):
+        return ("ok" if status else "fail"), reason
+    return status, reason
+
+
+def _required_checks() -> "set[str]":
+    raw = getattr(settings, "READYZ_REQUIRED_CHECKS", None)
+    if raw is None:
+        return set(DEFAULT_REQUIRED_CHECKS)
+    if isinstance(raw, str):
+        names = [n.strip() for n in raw.split(",") if n.strip()]
+    else:
+        names = [str(n).strip() for n in raw if str(n).strip()]
+    return set(names)
 
 
 @require_GET
@@ -87,23 +262,38 @@ def livez(request):
 @require_GET
 @never_cache
 def readyz(request):
-    """Readiness probe — critical dependencies reachable.
+    """Readiness probe — required dependencies reachable.
 
-    Reports the status of each checked dependency; if any check fails
-    the response is 503 with details so operators can see which
-    component is unhealthy.
+    Reports per-check status (``ok``/``fail``/``skipped``). HTTP 503 only
+    when a *required* check fails; optional check failures are surfaced
+    in the body for operators but do not gate traffic.
     """
-    checks = {
-        "database": _check_database(),
-        "cache": _check_cache(),
-        "broker": _check_broker(),
+    required = _required_checks()
+    module = globals()
+    results: dict[str, StatusResult] = {
+        name: _normalize(module[attr]()) for name, attr in CHECKS.items()
     }
-    failures = {name: err for name, (ok, err) in checks.items() if not ok}
-    body = {
-        "status": "ok" if not failures else "unavailable",
-        "checks": {name: ("ok" if ok else "fail") for name, (ok, _) in checks.items()},
+
+    checks_view: dict[str, str] = {name: status for name, (status, _) in results.items()}
+    failures: dict[str, str] = {
+        name: (reason or "fail") for name, (status, reason) in results.items() if status == "fail"
+    }
+    skipped: dict[str, str] = {
+        name: (reason or "skipped")
+        for name, (status, reason) in results.items()
+        if status == "skipped"
+    }
+    required_failures = {name: failures[name] for name in failures if name in required}
+
+    body: dict = {
+        "status": "ok" if not required_failures else "unavailable",
+        "checks": checks_view,
+        "required": sorted(required),
     }
     if failures:
         body["failures"] = failures
-        return JsonResponse(body, status=503)
-    return JsonResponse(body, status=200)
+    if skipped:
+        body["skipped"] = skipped
+
+    status_code = 503 if required_failures else 200
+    return JsonResponse(body, status=status_code)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -526,6 +526,15 @@ HIGHLIGHT_OTLP_ENDPOINT = config("HIGHLIGHT_OTLP_ENDPOINT", default="")
 HIGHLIGHT_ENVIRONMENT = config("HIGHLIGHT_ENVIRONMENT", default="development")
 HIGHLIGHT_SERVICE_VERSION = config("HIGHLIGHT_SERVICE_VERSION", default="")
 
+# Readiness probe — which checks gate HTTP 200 vs 503 (oms-aam).
+# Comma-separated list. Defaults to db/cache/broker (the historical
+# contract). Optional checks (celery_worker, emqx, object_store, telemetry)
+# always report status but only flap traffic when explicitly listed here.
+READYZ_REQUIRED_CHECKS = config(
+    "READYZ_REQUIRED_CHECKS",
+    default="database,cache,broker",
+)
+
 if HIGHLIGHT_PROJECT_ID:
     # CeleryIntegration is enabled automatically as part of the SDK's
     # DEFAULT_INTEGRATIONS list (see highlight_io.integrations.all). Django

--- a/backend/config/tests/test_health.py
+++ b/backend/config/tests/test_health.py
@@ -1,4 +1,4 @@
-"""Tests for liveness and readiness probes (AC-11, AC-12)."""
+"""Tests for liveness and readiness probes (AC-11, AC-12, oms-aam)."""
 
 from unittest.mock import patch
 
@@ -28,14 +28,23 @@ def test_livez_only_allows_get(api_client):
 
 
 @pytest.mark.django_db
-def test_readyz_returns_200_when_all_checks_pass(api_client):
-    """All dependencies are healthy under the test harness (memory broker
-    treated as healthy, locmem cache, sqlite DB)."""
+def test_readyz_returns_200_when_required_checks_pass(api_client):
+    """Required deps healthy under the test harness; optional checks
+    (celery worker, emqx, object store, telemetry) skip cleanly."""
     resp = api_client.get(reverse("health-readyz"))
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] == "ok"
-    assert body["checks"] == {"database": "ok", "cache": "ok", "broker": "ok"}
+    # Required checks all green:
+    for name in ("database", "cache", "broker"):
+        assert body["checks"][name] == "ok"
+    # New checks are present and skipped under the test harness:
+    for name in ("celery_worker", "emqx", "object_store", "telemetry"):
+        assert body["checks"][name] == "skipped"
+    # Failures dict only present when something failed:
+    assert "failures" not in body
+    # Skipped dict surfaces per-check reasons for operator visibility:
+    assert set(body["skipped"]) == {"celery_worker", "emqx", "object_store", "telemetry"}
 
 
 @pytest.mark.django_db
@@ -46,7 +55,7 @@ def test_readyz_returns_503_when_database_fails(api_client):
     body = resp.json()
     assert body["status"] == "unavailable"
     assert body["checks"]["database"] == "fail"
-    assert body["failures"] == {"database": "ConnectionError"}
+    assert body["failures"]["database"] == "ConnectionError"
 
 
 @pytest.mark.django_db
@@ -66,7 +75,7 @@ def test_readyz_returns_503_when_broker_fails(api_client):
 
 
 @pytest.mark.django_db
-def test_readyz_lists_all_failures_simultaneously(api_client):
+def test_readyz_lists_all_required_failures_simultaneously(api_client):
     with (
         patch("config.health._check_database", return_value=(False, "DBError")),
         patch("config.health._check_cache", return_value=(False, "CacheError")),
@@ -75,7 +84,7 @@ def test_readyz_lists_all_failures_simultaneously(api_client):
         resp = api_client.get(reverse("health-readyz"))
     assert resp.status_code == 503
     failures = resp.json()["failures"]
-    assert set(failures) == {"database", "cache", "broker"}
+    assert {"database", "cache", "broker"}.issubset(failures)
 
 
 @pytest.mark.django_db
@@ -93,3 +102,243 @@ def test_readyz_response_does_not_leak_connection_strings(api_client):
 def test_readyz_only_allows_get(api_client):
     resp = api_client.post(reverse("health-readyz"))
     assert resp.status_code == 405
+
+
+# ---------------------------------------------------------------------------
+# New per-check coverage (oms-aam)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_readyz_optional_check_failure_does_not_503(api_client):
+    """An optional check failing must surface in failures but stay 200."""
+    with patch("config.health._check_emqx", return_value=("fail", "ConnectionError")):
+        resp = api_client.get(reverse("health-readyz"))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["checks"]["emqx"] == "fail"
+    assert body["failures"]["emqx"] == "ConnectionError"
+
+
+@pytest.mark.django_db
+def test_readyz_required_checks_setting_can_promote_optional(api_client, settings):
+    """Operators can promote any check to required via settings."""
+    settings.READYZ_REQUIRED_CHECKS = ["database", "cache", "broker", "emqx"]
+    with patch("config.health._check_emqx", return_value=("fail", "ConnectionError")):
+        resp = api_client.get(reverse("health-readyz"))
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "unavailable"
+    assert "emqx" in body["failures"]
+
+
+@pytest.mark.django_db
+def test_readyz_required_checks_setting_csv_form(api_client, settings):
+    """READYZ_REQUIRED_CHECKS may be a comma-separated string (env-var friendly)."""
+    settings.READYZ_REQUIRED_CHECKS = "database,cache,broker,celery_worker"
+    with patch("config.health._check_celery_worker", return_value=("fail", "no workers responded")):
+        resp = api_client.get(reverse("health-readyz"))
+    assert resp.status_code == 503
+    assert "celery_worker" in resp.json()["failures"]
+
+
+@pytest.mark.django_db
+def test_readyz_skipped_checks_never_cause_503(api_client, settings):
+    """Even if promoted to required, a skipped check (not configured)
+    must not 503 — skipped means "not deployed here" not "broken"."""
+    settings.READYZ_REQUIRED_CHECKS = ["database", "cache", "broker", "emqx"]
+    # Default test env: no EMQX creds -> _check_emqx returns ("skipped", ...)
+    resp = api_client.get(reverse("health-readyz"))
+    assert resp.status_code == 200
+    assert resp.json()["checks"]["emqx"] == "skipped"
+
+
+# Per-check unit coverage --------------------------------------------------
+
+
+def test_check_celery_worker_skips_on_eager_broker(settings):
+    from config.health import _check_celery_worker
+
+    settings.CELERY_BROKER_URL = "memory://"
+    status, reason = _check_celery_worker()
+    assert status == "skipped"
+    assert reason
+
+
+def test_check_celery_worker_fails_when_no_workers(settings):
+    from config import health
+
+    settings.CELERY_BROKER_URL = "redis://localhost:6379/0"
+    settings.CELERY_TASK_ALWAYS_EAGER = False
+    with patch("config.celery.app.control.ping", return_value=[]):
+        status, reason = health._check_celery_worker()
+    assert status == "fail"
+    assert "no workers" in reason
+
+
+def test_check_celery_worker_ok_when_worker_replies(settings):
+    from config import health
+
+    settings.CELERY_BROKER_URL = "redis://localhost:6379/0"
+    settings.CELERY_TASK_ALWAYS_EAGER = False
+    with patch("config.celery.app.control.ping", return_value=[{"worker@host": {"ok": "pong"}}]):
+        status, _ = health._check_celery_worker()
+    assert status == "ok"
+
+
+def test_check_emqx_skipped_without_credentials(settings):
+    from config.health import _check_emqx
+
+    settings.EMQX_API_URL = "http://emqx:18083/api/v5"
+    settings.EMQX_API_KEY = ""
+    settings.EMQX_API_SECRET = ""
+    status, reason = _check_emqx()
+    assert status == "skipped"
+    assert "credentials" in reason.lower()
+
+
+def test_check_emqx_ok_on_2xx(settings):
+    from config import health
+
+    settings.EMQX_API_URL = "http://emqx:18083/api/v5"
+    settings.EMQX_API_KEY = "k"
+    settings.EMQX_API_SECRET = "s"
+
+    class _Resp:
+        status_code = 200
+
+    with patch("requests.get", return_value=_Resp()):
+        status, _ = health._check_emqx()
+    assert status == "ok"
+
+
+def test_check_emqx_fail_on_5xx(settings):
+    from config import health
+
+    settings.EMQX_API_URL = "http://emqx:18083/api/v5"
+    settings.EMQX_API_KEY = "k"
+    settings.EMQX_API_SECRET = "s"
+
+    class _Resp:
+        status_code = 503
+
+    with patch("requests.get", return_value=_Resp()):
+        status, reason = health._check_emqx()
+    assert status == "fail"
+    assert "503" in reason
+
+
+def test_check_emqx_fail_on_exception(settings):
+    from config import health
+
+    settings.EMQX_API_URL = "http://emqx:18083/api/v5"
+    settings.EMQX_API_KEY = "k"
+    settings.EMQX_API_SECRET = "s"
+    with patch("requests.get", side_effect=ConnectionError("refused")):
+        status, reason = health._check_emqx()
+    assert status == "fail"
+    assert reason == "ConnectionError"
+
+
+def test_check_object_store_skipped_for_filesystem(settings):
+    from config.health import _check_object_store
+
+    settings.STORAGES = {"default": {"BACKEND": "django.core.files.storage.FileSystemStorage"}}
+    status, reason = _check_object_store()
+    assert status == "skipped"
+    assert "object store" in reason
+
+
+def test_check_object_store_probes_when_s3_configured(settings):
+    from unittest.mock import MagicMock
+
+    from config import health
+
+    settings.STORAGES = {
+        "default": {"BACKEND": "storages.backends.s3boto3.S3Boto3Storage"},
+    }
+    fake_storage = MagicMock()
+    fake_storage.exists.return_value = False
+    with patch.object(health, "default_storage", fake_storage):
+        status, _ = health._check_object_store()
+    assert status == "ok"
+    fake_storage.exists.assert_called_once()
+
+
+def test_check_object_store_fails_when_probe_raises(settings):
+    from unittest.mock import MagicMock
+
+    from config import health
+
+    settings.STORAGES = {
+        "default": {"BACKEND": "storages.backends.s3boto3.S3Boto3Storage"},
+    }
+    fake_storage = MagicMock()
+    fake_storage.exists.side_effect = ConnectionError("nope")
+    with patch.object(health, "default_storage", fake_storage):
+        status, reason = health._check_object_store()
+    assert status == "fail"
+    assert reason == "ConnectionError"
+
+
+def test_check_telemetry_skipped_when_no_dsn(settings):
+    from config.health import _check_telemetry
+
+    settings.HIGHLIGHT_PROJECT_ID = ""
+    settings.HIGHLIGHT_OTLP_ENDPOINT = ""
+    settings.SENTRY_DSN = ""
+    status, reason = _check_telemetry()
+    assert status == "skipped"
+    assert "DSN" in reason
+
+
+def test_check_telemetry_ok_when_highlight_default_collector(settings):
+    """A configured Highlight project with no explicit endpoint targets
+    the SDK default collector — we accept that as ok-by-config."""
+    from config.health import _check_telemetry
+
+    settings.HIGHLIGHT_PROJECT_ID = "abc123"
+    settings.HIGHLIGHT_OTLP_ENDPOINT = ""
+    status, _ = _check_telemetry()
+    assert status == "ok"
+
+
+def test_check_telemetry_probes_explicit_endpoint(settings):
+    from config import health
+
+    settings.HIGHLIGHT_PROJECT_ID = "abc123"
+    settings.HIGHLIGHT_OTLP_ENDPOINT = "https://otel.example.org:4317"
+    with patch("socket.create_connection") as connect:
+        connect.return_value.__enter__.return_value = None
+        connect.return_value.__exit__.return_value = False
+        status, _ = health._check_telemetry()
+    assert status == "ok"
+    args, _kwargs = connect.call_args
+    assert args[0] == ("otel.example.org", 4317)
+
+
+def test_check_telemetry_fails_when_endpoint_unreachable(settings):
+    from config import health
+
+    settings.HIGHLIGHT_PROJECT_ID = "abc123"
+    settings.HIGHLIGHT_OTLP_ENDPOINT = "https://otel.example.org:4317"
+    with patch("socket.create_connection", side_effect=OSError("no route")):
+        status, reason = health._check_telemetry()
+    assert status == "fail"
+    assert reason == "OSError"
+
+
+def test_check_telemetry_falls_back_to_sentry_dsn(settings):
+    from config import health
+
+    settings.HIGHLIGHT_PROJECT_ID = ""
+    settings.HIGHLIGHT_OTLP_ENDPOINT = ""
+    settings.SENTRY_DSN = "https://k@sentry.io/1234"
+    with patch("socket.create_connection") as connect:
+        connect.return_value.__enter__.return_value = None
+        connect.return_value.__exit__.return_value = False
+        status, _ = health._check_telemetry()
+    assert status == "ok"
+    args, _kwargs = connect.call_args
+    assert args[0] == ("sentry.io", 443)


### PR DESCRIPTION
Implements oms-aam — gh #329. Expands /readyz checks to cover Celery workers, EMQX broker, object store, and telemetry integrations.

Single commit, 3 files (config/health.py + tests + settings touch). MR oms-wisp-hv3 (P2).