### PR TITLE
fix(api): reconcile permission matrix with actual view permissions (oms-apv)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -1706,16 +1706,16 @@ views:
         - IsAuthenticated
       create:
         permission_classes:
-        - IsAuthenticatedOrReadOnly
+        - IsAuthenticated
       destroy:
         permission_classes:
-        - IsAuthenticatedOrReadOnly
+        - IsAuthenticated
       generate_cart_links:
         permission_classes:
         - IsAuthenticated
       list:
         permission_classes:
-        - IsAuthenticatedOrReadOnly
+        - IsAuthenticated
       mark_ordered:
         permission_classes:
         - IsAuthenticated
@@ -1724,19 +1724,19 @@ views:
         - IsAuthenticated
       partial_update:
         permission_classes:
-        - IsAuthenticatedOrReadOnly
+        - IsAuthenticated
       pending:
         permission_classes:
-        - IsAuthenticatedOrReadOnly
+        - IsAuthenticated
       retrieve:
         permission_classes:
-        - IsAuthenticatedOrReadOnly
+        - IsAuthenticated
       sig_pending:
         permission_classes:
         - IsAuthenticated
       update:
         permission_classes:
-        - IsAuthenticatedOrReadOnly
+        - IsAuthenticated
   reorder_queue.views.WebHookViewSet:
     actions:
       create:

--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -1,0 +1,1866 @@
+# Auto-generated snapshot of permission_classes for every DRF view.
+# Source of truth for docs/API_PERMISSION_MATRIX.md.
+# Regenerate with: python manage.py check_permission_matrix --write
+#
+# Tests in config/tests/test_permission_matrix.py fail when this file
+# drifts from the actual URL conf — update both the YAML and the
+# Markdown matrix in the same PR that changes permission_classes.
+views:
+  auth_views.create_test_membership:
+    permission_classes:
+    - AllowAny
+  auth_views.login_user:
+    permission_classes:
+    - AllowAny
+  auth_views.logout_user:
+    permission_classes:
+    - AllowAny
+  auth_views.refresh_token:
+    permission_classes:
+    - AllowAny
+  auth_views.register_user:
+    permission_classes:
+    - AllowAny
+  checklists.views.ChecklistCompletionViewSet:
+    actions:
+      complete:
+        permission_classes:
+        - AllowAny
+      list:
+        permission_classes:
+        - AllowAny
+      retrieve:
+        permission_classes:
+        - AllowAny
+      scan:
+        permission_classes:
+        - AllowAny
+  checklists.views.ChecklistViewSet:
+    actions:
+      available:
+        permission_classes:
+        - AllowAny
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      get_detail:
+        permission_classes:
+        - AllowAny
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      start:
+        permission_classes:
+        - AllowAny
+      update:
+        permission_classes:
+        - IsAuthenticated
+  config.flower_proxy.flower_proxy:
+    permission_classes:
+    - <default>
+  config.health.livez:
+    permission_classes:
+    - <default>
+  config.health.readyz:
+    permission_classes:
+    - <default>
+  customization.views.site_settings:
+    permission_classes:
+    - AllowAny
+  dashboard.views.add_dashboard_message:
+    permission_classes:
+    - IsAuthenticated
+  dashboard.views.dashboard_health:
+    permission_classes:
+    - <default>
+  dashboard.views.get_asset_problems_data:
+    permission_classes:
+    - IsAuthenticated
+  dashboard.views.get_dashboard_config:
+    permission_classes:
+    - IsAuthenticated
+  dashboard.views.get_dashboard_messages:
+    permission_classes:
+    - AllowAny
+  dashboard.views.get_deliveries_data:
+    permission_classes:
+    - IsAuthenticated
+  dashboard.views.get_inventory_summary:
+    permission_classes:
+    - AllowAny
+  dashboard.views.get_low_stock_data:
+    permission_classes:
+    - IsAuthenticated
+  dashboard.views.get_pending_reorders_data:
+    permission_classes:
+    - IsAuthenticated
+  dashboard.views.get_qr_scans_data:
+    permission_classes:
+    - IsAuthenticated
+  dashboard.views.get_user_widgets:
+    permission_classes:
+    - IsAuthenticated
+  dashboard.views.save_user_widgets:
+    permission_classes:
+    - IsAuthenticated
+  dashboard.views.update_dashboard_config:
+    permission_classes:
+    - IsAuthenticated
+  donations.views.DispositionViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  donations.views.DonationItemViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      download_label:
+        permission_classes:
+        - IsAuthenticated
+      generate_qr_code:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  donations.views.DonationViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      download_tax_receipt:
+        permission_classes:
+        - IsAuthenticated
+      generate_sticker_sheet:
+        permission_classes:
+        - IsAuthenticated
+      generate_tax_receipt:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      quarterly_report:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+      yearly_report:
+        permission_classes:
+        - IsAuthenticated
+  donations.views.TaxReceiptViewSet:
+    actions:
+      download_pdf:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      regenerate:
+        permission_classes:
+        - IsAdminUser
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+  donations.views.lookup_donation_item_by_code:
+    permission_classes:
+    - AllowAny
+  donations.views.lookup_tax_receipt:
+    permission_classes:
+    - AllowAny
+  donations.views.upload_signature:
+    permission_classes:
+    - IsAuthenticated
+  electrical_circuits.views.BreakerViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  electrical_circuits.views.LightSwitchViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  electrical_circuits.views.NetworkDropListReportView:
+    permission_classes:
+    - IsAuthenticated
+  electrical_circuits.views.NetworkDropViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  electrical_circuits.views.OutletViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  electrical_circuits.views.PanelDirectoryReportView:
+    permission_classes:
+    - IsAuthenticated
+  forgekey.views.AssetAuthorizationViewSet:
+    actions:
+      add_via_classroom_mode:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  forgekey.views.AssetDeviceViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  forgekey.views.DeviceFirmwareUpdateViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  forgekey.views.DeviceLockoutViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      unlock:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  forgekey.views.DeviceTypeViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  forgekey.views.DeviceUsageViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      end_session:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  forgekey.views.ESP32DeviceViewSet:
+    actions:
+      command_blink:
+        permission_classes:
+        - IsAdminUser
+      command_capture_photo:
+        permission_classes:
+        - IsAdminUser
+      command_firmware_update:
+        permission_classes:
+        - IsAdminUser
+      command_identify:
+        permission_classes:
+        - IsAdminUser
+      command_ping:
+        permission_classes:
+        - IsAdminUser
+      command_restart:
+        permission_classes:
+        - IsAdminUser
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      disable:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      enable:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      occupancy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      recent_commands:
+        permission_classes:
+        - IsAdminUser
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      status:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  forgekey.views.FirmwareVersionViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  forgekey.views.ForgeKeyDevicePhotoUploadView:
+    permission_classes:
+    - AllowAny
+  forgekey.views.ForgeKeyDeviceRegisterView:
+    permission_classes:
+    - AllowAny
+  forgekey.views.ForgeKeyFirmwareDownloadView:
+    permission_classes:
+    - AllowAny
+  forgekey.views.ForgeKeyFirmwarePublicKeyView:
+    permission_classes:
+    - AllowAny
+  forgekey.views.ForgeKeyJWKSView:
+    permission_classes:
+    - AllowAny
+  forgekey.views.MqttWebhookView:
+    permission_classes:
+    - AllowAny
+  forgekey.views.OperationalModeViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      disable_classroom_mode:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      enable_classroom_mode:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  forgekey.views.PowerMeterReadingViewSet:
+    actions:
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  index_cards.views.IndexCardBatchGenerateView:
+    permission_classes:
+    - IsAuthenticatedOrReadOnly
+  index_cards.views.IndexCardPreviewView:
+    permission_classes:
+    - IsAuthenticatedOrReadOnly
+  index_cards.views.TestSheetGenerateView:
+    permission_classes:
+    - IsAuthenticatedOrReadOnly
+  inventory.views.AssetPartViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      mark_replaced:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  inventory.views.AssetProblemViewSet:
+    actions:
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      upload_photo:
+        permission_classes:
+        - AllowAny
+  inventory.views.AssetReportViewSet:
+    actions:
+      assets_by_status:
+        permission_classes:
+        - IsAuthenticated
+      export:
+        permission_classes:
+        - IsAuthenticated
+      maintenance_due:
+        permission_classes:
+        - IsAuthenticated
+      tco:
+        permission_classes:
+        - IsAuthenticated
+      utilization:
+        permission_classes:
+        - IsAuthenticated
+  inventory.views.AssetViewSet:
+    actions:
+      checklists:
+        permission_classes:
+        - AllowAny
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      disable:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      download_label:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      download_label_escp:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      download_label_preview:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      download_labels_batch:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      enable:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      generate_qr:
+        permission_classes:
+        - AllowAny
+      get_problems:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      lock:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      maintenance_items:
+        permission_classes:
+        - AllowAny
+      my_sig_assets:
+        permission_classes:
+        - IsAuthenticated
+      not_checked_in:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      qr_code:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      report_problem:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      resolve_problem:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      scan:
+        permission_classes:
+        - AllowAny
+      tag:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      unlock:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  inventory.views.CategoryViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  inventory.views.FixtureRefillRequestViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      resolve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  inventory.views.FixtureViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      download_card:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      resolve_all:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      scan:
+        permission_classes:
+        - AllowAny
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  inventory.views.InventoryItemViewSet:
+    actions:
+      checklists:
+        permission_classes:
+        - AllowAny
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      download_blank_card:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      download_card:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      generate_qr:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      log_usage:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      low_stock:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      my_sig_inventory:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      qr_code:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      reordered:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      scan:
+        permission_classes:
+        - AllowAny
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  inventory.views.InventoryReconciliationViewSet:
+    actions:
+      batch:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      location_export:
+        permission_classes:
+        - IsAuthenticated
+      location_grid:
+        permission_classes:
+        - IsAuthenticated
+      upload_csv:
+        permission_classes:
+        - IsAuthenticated
+  inventory.views.InventoryReportViewSet:
+    actions:
+      export:
+        permission_classes:
+        - IsAuthenticated
+      reorder_frequency:
+        permission_classes:
+        - IsAuthenticated
+      stock_by_category:
+        permission_classes:
+        - IsAuthenticated
+      value_by_location:
+        permission_classes:
+        - IsAuthenticated
+  inventory.views.ItemSupplierViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      mark_discontinued:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      price_history:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  inventory.views.LocationProblemViewSet:
+    actions:
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      promote_to_standard_work_order:
+        permission_classes:
+        - IsAuthenticated
+      promote_to_third_party_work_order:
+        permission_classes:
+        - IsAuthenticated
+      resolve:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  inventory.views.LocationViewSet:
+    actions:
+      checklists:
+        permission_classes:
+        - AllowAny
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      fixtures:
+        permission_classes:
+        - AllowAny
+      generate_qr:
+        permission_classes:
+        - AllowAny
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      problems:
+        permission_classes:
+        - AllowAny
+      qr_code:
+        permission_classes:
+        - AllowAny
+      report_problem:
+        permission_classes:
+        - AllowAny
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  inventory.views.MaintenanceDashboardViewSet:
+    actions:
+      active_work_orders:
+        permission_classes:
+        - IsAuthenticated
+      dashboard:
+        permission_classes:
+        - IsAuthenticated
+  inventory.views.MaintenanceItemViewSet:
+    actions:
+      check_material_stock:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      clone:
+        permission_classes:
+        - IsAuthenticated
+      complete:
+        permission_classes:
+        - IsAuthenticated
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      due_this_month:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      due_this_week:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      generate_work_order:
+        permission_classes:
+        - IsAuthenticated
+      generate_work_orders_bulk:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  inventory.views.MaintenanceLogViewSet:
+    actions:
+      list:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+  inventory.views.MaintenanceMaterialViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  inventory.views.MaintenanceTaskViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  inventory.views.PriceHistoryViewSet:
+    actions:
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      recent_changes:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  inventory.views.SupplierViewSet:
+    actions:
+      analytics:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  inventory.views.UsageLogViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  inventory.views.WorkOrderViewSet:
+    actions:
+      add_photo:
+        permission_classes:
+        - IsAuthenticated
+      apply_pending_changes:
+        permission_classes:
+        - IsAuthenticated
+      complete_task:
+        permission_classes:
+        - IsAuthenticated
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      discard_pending_changes:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      pdf:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      toggle_material:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+      upload_pdf:
+        permission_classes:
+        - IsAuthenticated
+      validate_checklist:
+        permission_classes:
+        - IsAuthenticated
+  inventory.views.lookup_by_code:
+    permission_classes:
+    - AllowAny
+  inventory.views.postmark_inbound_work_order:
+    permission_classes:
+    - AllowAny
+  location_checkins.views.LocationCheckInViewSet:
+    actions:
+      checkin:
+        permission_classes:
+        - AllowAny
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  location_checkins.views.LocationFeedbackViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      submit:
+        permission_classes:
+        - AllowAny
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  location_checkins.views.LocationTaskViewSet:
+    actions:
+      complete:
+        permission_classes:
+        - IsAuthenticated
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  location_checkins.views.SecurityReportViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      report:
+        permission_classes:
+        - AllowAny
+      resolve:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  location_checkins.views.TopLocationsReportView:
+    permission_classes:
+    - IsAuthenticated
+  location_checkins.views.TrafficReportView:
+    permission_classes:
+    - IsAuthenticated
+  location_checkins.views.location_ping_webhook:
+    permission_classes:
+    - AllowAny
+  loto.views.AssetEnergySourceViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  loto.views.AssetLOTORequirementsView:
+    permission_classes:
+    - IsAuthenticated
+  loto.views.LOTODeviceViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  maintenance_orders.views.AssetWarrantyViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  maintenance_orders.views.EmergencyAuthorizationViewSet:
+    actions:
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  maintenance_orders.views.RecoveryTaskViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  maintenance_orders.views.ThirdPartyWorkOrderAssetViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  maintenance_orders.views.ThirdPartyWorkOrderAttachmentViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  maintenance_orders.views.ThirdPartyWorkOrderAuditLogViewSet:
+    actions:
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  maintenance_orders.views.ThirdPartyWorkOrderQuoteViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  maintenance_orders.views.ThirdPartyWorkOrderViewSet:
+    actions:
+      advance_to_financial_review:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      advance_to_scheduled:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      advance_to_sourcing:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      audit_log:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      authorize_emergency:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      close:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      override_variance:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      record_keyfob_return:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      set_nte:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      sign_off:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      vendor_arrived:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      waive_quote_requirement:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  maintenance_orders.views.asset_wo_status:
+    permission_classes:
+    - IsAuthenticated
+  maker_boxes.views.MakerBoxViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      email_pickup:
+        permission_classes:
+        - IsAuthenticated
+      label:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      manual_label:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      scan:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  membership.views.SIGAdminViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  membership.views.SIGMemberViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+  membership.views.SIGViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      details:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  membership.views.UserProfileViewSet:
+    actions:
+      me:
+        permission_classes:
+        - IsAuthenticated
+      update_me:
+        permission_classes:
+        - IsAuthenticated
+  membership.views.change_password:
+    permission_classes:
+    - IsAuthenticated
+  membership.views.register_user_with_token:
+    permission_classes: []
+  membership.views.validate_registration_token:
+    permission_classes: []
+  notifications.views.NotificationPreferenceView:
+    permission_classes:
+    - IsAuthenticated
+  notifications.views.NotificationViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      mark_all_read:
+        permission_classes:
+        - IsAuthenticated
+      mark_read:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  reorder_queue.views.AnalyticsViewSet:
+    actions:
+      lead_time_trends:
+        permission_classes:
+        - IsAuthenticated
+      logistics_dashboard:
+        permission_classes:
+        - AllowAny
+      supplier_performance:
+        permission_classes:
+        - IsAuthenticated
+      transparency:
+        permission_classes:
+        - AllowAny
+  reorder_queue.views.OrderReceiptViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      pending_orders:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      scan_barcode:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  reorder_queue.views.PurchaseOrderViewSet:
+    actions:
+      confirm_order:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      create_optimized_order:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      dashboard_summary:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy_attachment:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      mark_delivered:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      reorder_data:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      send_to_supplier:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update_item:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      upload_attachment:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      void:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      void_item:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  reorder_queue.views.PurchasingReportViewSet:
+    actions:
+      export:
+        permission_classes:
+        - IsAuthenticated
+      lead_time_analysis:
+        permission_classes:
+        - IsAuthenticated
+      price_trends:
+        permission_classes:
+        - IsAuthenticated
+      spend_by_category:
+        permission_classes:
+        - IsAuthenticated
+      spend_by_supplier:
+        permission_classes:
+        - IsAuthenticated
+  reorder_queue.views.ReorderRequestViewSet:
+    actions:
+      approve:
+        permission_classes:
+        - IsAuthenticated
+      by_supplier:
+        permission_classes:
+        - IsAuthenticated
+      cancel:
+        permission_classes:
+        - IsAuthenticated
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      generate_cart_links:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      mark_ordered:
+        permission_classes:
+        - IsAuthenticated
+      mark_received:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      pending:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      sig_pending:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+  reorder_queue.views.WebHookViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      test:
+        permission_classes:
+        - IsAuthenticated
+      test_status:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  screens.views.ScreenContentBlockViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  screens.views.ScreenViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      rotate_token:
+        permission_classes:
+        - IsAuthenticated
+      status_overview:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  screens.views.SystemMessageViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+      list:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+      update:
+        permission_classes:
+        - IsAuthenticated
+  screens.views.kiosk_heartbeat:
+    permission_classes:
+    - AllowAny
+  screens.views.kiosk_payload:
+    permission_classes:
+    - AllowAny
+  search.views.get_recent_searches:
+    permission_classes:
+    - IsAuthenticated
+  search.views.global_search:
+    permission_classes:
+    - IsAuthenticated
+  search.views.save_recent_search:
+    permission_classes:
+    - IsAuthenticated
+  vendors.views.VendorViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly

--- a/backend/config/management/commands/check_permission_matrix.py
+++ b/backend/config/management/commands/check_permission_matrix.py
@@ -1,0 +1,106 @@
+"""``manage.py check_permission_matrix`` — verify or regenerate the matrix.
+
+Reports drift between ``backend/config/api_permission_matrix.yaml`` and the
+actual ``permission_classes`` for every URL-routed DRF view. With
+``--write``, regenerates the YAML from the live URL conf so a developer can
+review the diff in their PR.
+
+The CI test ``config/tests/test_permission_matrix.py`` calls the same
+introspection helpers, so a green ``manage.py check_permission_matrix`` run
+locally means CI will be green too.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from django.core.management.base import BaseCommand
+
+import yaml
+
+from config.permission_matrix import MATRIX_PATH, diff, introspect_endpoints, load_matrix
+
+
+def _emit_yaml(actual) -> str:
+    """Render the introspected snapshot as a YAML document with a stable key
+    order so regenerated output is review-friendly."""
+    grouped: dict[str, dict] = {}
+    for key, snap in actual.items():
+        view_entry = grouped.setdefault(key.view_path, {})
+        if key.action is None:
+            view_entry["permission_classes"] = list(snap.permission_classes)
+        else:
+            actions = view_entry.setdefault("actions", {})
+            actions[key.action] = {"permission_classes": list(snap.permission_classes)}
+    sorted_views = {
+        view_path: {
+            **(
+                {"permission_classes": entry["permission_classes"]}
+                if "permission_classes" in entry
+                else {}
+            ),
+            **({"actions": dict(sorted(entry["actions"].items()))} if "actions" in entry else {}),
+        }
+        for view_path, entry in sorted(grouped.items())
+    }
+    header = (
+        "# Auto-generated snapshot of permission_classes for every DRF view.\n"
+        "# Source of truth for docs/API_PERMISSION_MATRIX.md.\n"
+        "# Regenerate with: python manage.py check_permission_matrix --write\n"
+        "#\n"
+        "# Tests in config/tests/test_permission_matrix.py fail when this file\n"
+        "# drifts from the actual URL conf — update both the YAML and the\n"
+        "# Markdown matrix in the same PR that changes permission_classes.\n"
+    )
+    return header + yaml.safe_dump(
+        {"views": sorted_views}, sort_keys=False, default_flow_style=False
+    )
+
+
+class Command(BaseCommand):
+    help = "Verify (or regenerate) the API permission matrix snapshot."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--write",
+            action="store_true",
+            help="Regenerate api_permission_matrix.yaml from the live URL conf.",
+        )
+
+    def handle(self, *args, **options):
+        actual = introspect_endpoints()
+        if options["write"]:
+            MATRIX_PATH.write_text(_emit_yaml(actual))
+            self.stdout.write(self.style.SUCCESS(f"Wrote {len(actual)} entries to {MATRIX_PATH}"))
+            return
+
+        try:
+            expected = load_matrix()
+        except FileNotFoundError:
+            self.stderr.write(
+                self.style.ERROR(f"{MATRIX_PATH} not found. Run with --write to generate it.")
+            )
+            sys.exit(2)
+
+        missing, stale, mismatched = diff(actual, expected)
+        if not (missing or stale or mismatched):
+            self.stdout.write(self.style.SUCCESS(f"OK — {len(actual)} endpoints match the matrix."))
+            return
+
+        if missing:
+            self.stderr.write("Endpoints missing from YAML:")
+            for line in missing:
+                self.stderr.write(line)
+        if stale:
+            self.stderr.write("Stale YAML entries (view no longer routed):")
+            for line in stale:
+                self.stderr.write(line)
+        if mismatched:
+            self.stderr.write("permission_classes drift:")
+            for line in mismatched:
+                self.stderr.write(line)
+        self.stderr.write(
+            "\nRun `python manage.py check_permission_matrix --write` and review "
+            "the diff. Update docs/API_PERMISSION_MATRIX.md to match."
+        )
+        sys.exit(1)

--- a/backend/config/permission_matrix.py
+++ b/backend/config/permission_matrix.py
@@ -1,0 +1,182 @@
+"""Permission matrix introspection + drift detection (gh #328).
+
+Walks the DRF URL conf and snapshots ``permission_classes`` for every
+URL-routed view. The snapshot is compared to ``api_permission_matrix.yaml``
+(the source of truth) so PRs that change ``permission_classes`` without
+updating the matrix fail CI.
+
+See ``docs/API_PERMISSION_MATRIX.md`` for the human-readable matrix.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from django.urls import URLPattern, URLResolver, get_resolver
+
+import yaml
+
+MATRIX_PATH = Path(__file__).resolve().parent / "api_permission_matrix.yaml"
+
+# URL prefixes we audit. ``flower/`` is a superuser-only proxy mounted at the
+# project root; everything else under ``api/`` is project DRF.
+AUDITED_PREFIXES = ("api/", "flower/")
+
+# Some views are routed through ``/api/`` but are out of scope for the
+# matrix (third-party packages, schema generators, etc.). Each entry is
+# matched against the dotted view path.
+EXCLUDED_VIEW_PREFIXES = (
+    # OpenAPI surface — static metadata, no business permissions.
+    "drf_spectacular.",
+    # DRF browsable-API login/logout under ``/api/token/``.
+    "django.contrib.auth.views.",
+    # Auto-generated DRF router root; permission is whatever the DRF default
+    # provides and there is no business surface to classify.
+    "rest_framework.routers.APIRootView",
+)
+
+
+@dataclass(frozen=True)
+class EndpointKey:
+    """Identifier for a unique (view, action) pair routed by DRF.
+
+    For function-based views and ``APIView`` subclasses, ``action`` is None.
+    For ``ViewSet`` subclasses, ``action`` is the bound action name (``list``,
+    ``retrieve``, ``scan``, etc.).
+    """
+
+    view_path: str
+    action: str | None
+
+    def __str__(self) -> str:
+        return f"{self.view_path}#{self.action or '*'}"
+
+
+@dataclass
+class EndpointSnapshot:
+    """The permission_classes for a single (view, action) pair, plus an
+    example URL pattern for human-readable diff messages."""
+
+    key: EndpointKey
+    permission_classes: tuple[str, ...]
+    example_pattern: str
+    example_method: str
+
+
+def _perm_names(view_cls, action_name: str | None) -> tuple[str, ...]:
+    """Return the permission_classes for ``view_cls``, taking any per-action
+    override from a DRF ``@action`` decorator into account."""
+    if action_name is not None:
+        method = getattr(view_cls, action_name, None)
+        # ``@action(permission_classes=[...])`` stashes its kwargs on the bound
+        # function so we can read them without instantiating the ViewSet.
+        if method is not None and hasattr(method, "kwargs"):
+            override = method.kwargs.get("permission_classes")
+            if override is not None:
+                return tuple(getattr(c, "__name__", repr(c)) for c in override)
+    pc = getattr(view_cls, "permission_classes", None)
+    if pc is None:
+        return ("<default>",)
+    return tuple(getattr(c, "__name__", repr(c)) for c in pc)
+
+
+def _walk(resolver, prefix: str) -> Iterable[EndpointSnapshot]:
+    for entry in resolver.url_patterns:
+        if isinstance(entry, URLResolver):
+            yield from _walk(entry, prefix + str(entry.pattern))
+        elif isinstance(entry, URLPattern):
+            full = prefix + str(entry.pattern)
+            if not full.startswith(AUDITED_PREFIXES):
+                continue
+            cb = entry.callback
+            view_cls = getattr(cb, "cls", None) or getattr(cb, "view_class", None) or cb
+            view_path = (
+                f"{getattr(view_cls, '__module__', '?')}." f"{getattr(view_cls, '__name__', '?')}"
+            )
+            if view_path.startswith(EXCLUDED_VIEW_PREFIXES):
+                continue
+            actions = getattr(cb, "actions", None) or {}
+            if actions:
+                # ViewSet routes — one entry per action name.
+                seen: set[str] = set()
+                for method, action_name in actions.items():
+                    if action_name in seen:
+                        continue
+                    seen.add(action_name)
+                    yield EndpointSnapshot(
+                        key=EndpointKey(view_path, action_name),
+                        permission_classes=_perm_names(view_cls, action_name),
+                        example_pattern=full,
+                        example_method=method.upper(),
+                    )
+            else:
+                yield EndpointSnapshot(
+                    key=EndpointKey(view_path, None),
+                    permission_classes=_perm_names(view_cls, None),
+                    example_pattern=full,
+                    example_method="*",
+                )
+
+
+def introspect_endpoints() -> dict[EndpointKey, EndpointSnapshot]:
+    """Return the actual ``permission_classes`` snapshot for every audited
+    URL-routed DRF endpoint, keyed by ``(view_path, action)``."""
+    out: dict[EndpointKey, EndpointSnapshot] = {}
+    for snap in _walk(get_resolver(), ""):
+        # If the same (view, action) pair appears under multiple URL prefixes
+        # (DRF routers register both the bare path and a ``.<format>`` path),
+        # keep the first occurrence. Permission classes will be identical.
+        out.setdefault(snap.key, snap)
+    return out
+
+
+def load_matrix(path: Path = MATRIX_PATH) -> dict[EndpointKey, tuple[str, ...]]:
+    """Load the YAML matrix and return ``{EndpointKey: permission_classes}``.
+
+    The YAML format is a single top-level ``views`` mapping, e.g.::
+
+        views:
+          inventory.views.SupplierViewSet:
+            permission_classes: [IsAuthenticatedOrReadOnly]
+            actions:
+              scan:
+                permission_classes: [AllowAny]
+    """
+    raw = yaml.safe_load(path.read_text())
+    out: dict[EndpointKey, tuple[str, ...]] = {}
+    for view_path, entry in (raw.get("views") or {}).items():
+        if "permission_classes" in entry:
+            out[EndpointKey(view_path, None)] = tuple(entry["permission_classes"])
+        for action_name, action_entry in (entry.get("actions") or {}).items():
+            out[EndpointKey(view_path, action_name)] = tuple(action_entry["permission_classes"])
+    return out
+
+
+def diff(
+    actual: dict[EndpointKey, EndpointSnapshot],
+    expected: dict[EndpointKey, tuple[str, ...]],
+) -> tuple[list[str], list[str], list[str]]:
+    """Return ``(missing_in_yaml, stale_in_yaml, mismatched)`` as human-readable
+    bullet lines. Empty lists mean the matrix is in sync with code."""
+    missing = []
+    stale = []
+    mismatched = []
+    for key, snap in sorted(actual.items(), key=lambda kv: str(kv[0])):
+        if key not in expected:
+            missing.append(
+                f"  - {key} ({snap.example_method} {snap.example_pattern}) "
+                f"actual=[{', '.join(snap.permission_classes)}]"
+            )
+            continue
+        if expected[key] != snap.permission_classes:
+            mismatched.append(
+                f"  - {key} ({snap.example_method} {snap.example_pattern})\n"
+                f"      expected: [{', '.join(expected[key])}]\n"
+                f"      actual:   [{', '.join(snap.permission_classes)}]"
+            )
+    for key in sorted(expected, key=str):
+        if key not in actual:
+            stale.append(f"  - {key} (no longer routed; remove from YAML)")
+    return missing, stale, mismatched

--- a/backend/config/tests/test_permission_matrix.py
+++ b/backend/config/tests/test_permission_matrix.py
@@ -1,0 +1,81 @@
+"""gh #328 — guard against drift between docs/API_PERMISSION_MATRIX.md and
+the actual ``permission_classes`` enforced by every DRF view.
+
+The Markdown matrix is the human-readable contract; ``api_permission_matrix.yaml``
+is the machine-readable snapshot that this test pins. When a PR changes a
+view's ``permission_classes``, the developer must regenerate the YAML
+(``python manage.py check_permission_matrix --write``) and update the
+Markdown matrix to match. Otherwise this test fails CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from config.permission_matrix import diff, introspect_endpoints, load_matrix
+
+
+@pytest.mark.unit
+def test_permission_matrix_in_sync():
+    actual = introspect_endpoints()
+    expected = load_matrix()
+    missing, stale, mismatched = diff(actual, expected)
+
+    if missing or stale or mismatched:
+        sections = []
+        if missing:
+            sections.append(
+                "Endpoints missing from api_permission_matrix.yaml — every "
+                "URL-routed DRF view must be classified:\n" + "\n".join(missing)
+            )
+        if stale:
+            sections.append(
+                "Stale entries in api_permission_matrix.yaml — the listed view "
+                "is no longer routed and should be removed:\n" + "\n".join(stale)
+            )
+        if mismatched:
+            sections.append(
+                "permission_classes drift — code disagrees with the YAML "
+                "snapshot. Update both the YAML and "
+                "docs/API_PERMISSION_MATRIX.md in the same PR:\n" + "\n".join(mismatched)
+            )
+        sections.append(
+            "Run `python manage.py check_permission_matrix --write` to "
+            "refresh the YAML, then update the Markdown matrix."
+        )
+        pytest.fail("\n\n".join(sections))
+
+
+@pytest.mark.unit
+def test_permission_matrix_covers_documented_apps():
+    """Every app the Markdown matrix calls out must appear at least once
+    in the YAML, so newly-mounted apps cannot ship without a matrix entry."""
+    expected = load_matrix()
+    documented_modules = {
+        "auth_views",
+        "checklists.views",
+        "customization.views",
+        "dashboard.views",
+        "donations.views",
+        "electrical_circuits.views",
+        "forgekey.views",
+        "index_cards.views",
+        "inventory.views",
+        "location_checkins.views",
+        "loto.views",
+        "maintenance_orders.views",
+        "maker_boxes.views",
+        "membership.views",
+        "notifications.views",
+        "reorder_queue.views",
+        "screens.views",
+        "search.views",
+        "vendors.views",
+    }
+    seen = {key.view_path.rsplit(".", 1)[0] for key in expected}
+    missing = sorted(documented_modules - seen)
+    assert not missing, (
+        "Apps documented in docs/API_PERMISSION_MATRIX.md are absent from "
+        f"api_permission_matrix.yaml: {missing}. Either remove them from the "
+        "Markdown matrix or run `manage.py check_permission_matrix --write`."
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -30,6 +30,11 @@ django-imagekit==5.0.0
 # API Documentation
 drf-spectacular==0.29.0
 
+# Used by config/permission_matrix.py for the API permission matrix snapshot
+# (gh #328). drf-spectacular pulls this in transitively today, but we pin it
+# directly so the matrix loader does not depend on that.
+PyYAML==6.0.3
+
 # Utilities
 python-slugify==8.0.4
 requests==2.33.0

--- a/backend/search/tests/test_views.py
+++ b/backend/search/tests/test_views.py
@@ -26,22 +26,32 @@ User = get_user_model()
 class TestGlobalSearchView:
     """Tests for global search endpoint."""
 
-    def test_global_search_empty_query(self, api_client):
+    def test_global_search_requires_authentication(self, api_client):
+        """Anonymous callers cannot reach the cross-app search surface
+        because it returns SKUs, asset serials, and supplier names."""
+        url = reverse("global-search")
+        response = api_client.get(url, {"q": "anything"})
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_global_search_empty_query(self, authenticated_client):
         """Test that empty query returns empty results."""
+        client, _ = authenticated_client
         url = reverse("global-search")
-        response = api_client.get(url, {"q": ""})
+        response = client.get(url, {"q": ""})
         assert response.status_code == status.HTTP_200_OK
         assert response.data["results"] == []
 
-    def test_global_search_no_query(self, api_client):
+    def test_global_search_no_query(self, authenticated_client):
         """Test that missing query returns empty results."""
+        client, _ = authenticated_client
         url = reverse("global-search")
-        response = api_client.get(url)
+        response = client.get(url)
         assert response.status_code == status.HTTP_200_OK
         assert response.data["results"] == []
 
-    def test_global_search_inventory_item(self, api_client, db):
+    def test_global_search_inventory_item(self, authenticated_client, db):
         """Test searching for inventory items."""
+        client, _ = authenticated_client
         category = CategoryFactory()
         location = LocationFactory()
         InventoryItemFactory(
@@ -53,7 +63,7 @@ class TestGlobalSearchView:
         )
 
         url = reverse("global-search")
-        response = api_client.get(url, {"q": "Test Inventory"})
+        response = client.get(url, {"q": "Test Inventory"})
         assert response.status_code == status.HTTP_200_OK
         results = response.data["results"]
         assert len(results) > 0
@@ -61,8 +71,9 @@ class TestGlobalSearchView:
         assert len(inventory_results) > 0
         assert inventory_results[0]["title"] == "Test Inventory Item"
 
-    def test_global_search_asset(self, api_client, db):
+    def test_global_search_asset(self, authenticated_client, db):
         """Test searching for assets."""
+        client, _ = authenticated_client
         category = CategoryFactory()
         location = LocationFactory()
         Asset.objects.create(
@@ -74,26 +85,27 @@ class TestGlobalSearchView:
         )
 
         url = reverse("global-search")
-        response = api_client.get(url, {"q": "Test Asset"})
+        response = client.get(url, {"q": "Test Asset"})
         assert response.status_code == status.HTTP_200_OK
         results = response.data["results"]
         asset_results = [r for r in results if r["type"] == "asset"]
         assert len(asset_results) > 0
         assert asset_results[0]["title"] == "Test Asset"
 
-    def test_global_search_supplier(self, api_client, db):
+    def test_global_search_supplier(self, authenticated_client, db):
         """Test searching for suppliers."""
+        client, _ = authenticated_client
         SupplierFactory(name="Test Supplier", supplier_type=Supplier.ONLINE)
 
         url = reverse("global-search")
-        response = api_client.get(url, {"q": "Test Supplier"})
+        response = client.get(url, {"q": "Test Supplier"})
         assert response.status_code == status.HTTP_200_OK
         results = response.data["results"]
         supplier_results = [r for r in results if r["type"] == "supplier"]
         assert len(supplier_results) > 0
         assert supplier_results[0]["title"] == "Test Supplier"
 
-    def test_global_search_purchase_order(self, api_client, db, authenticated_client):
+    def test_global_search_purchase_order(self, authenticated_client, db):
         """Test searching for purchase orders."""
         client, user = authenticated_client
         supplier = SupplierFactory()
@@ -111,35 +123,38 @@ class TestGlobalSearchView:
         po_results = [r for r in results if r["type"] == "purchase_order"]
         assert len(po_results) > 0
 
-    def test_global_search_location(self, api_client, db):
+    def test_global_search_location(self, authenticated_client, db):
         """Test searching for locations."""
+        client, _ = authenticated_client
         LocationFactory(name="Test Location")
 
         url = reverse("global-search")
-        response = api_client.get(url, {"q": "Test Location"})
+        response = client.get(url, {"q": "Test Location"})
         assert response.status_code == status.HTTP_200_OK
         results = response.data["results"]
         location_results = [r for r in results if r["type"] == "location"]
         assert len(location_results) > 0
         assert location_results[0]["title"] == "Test Location"
 
-    def test_global_search_limit(self, api_client, db):
+    def test_global_search_limit(self, authenticated_client, db):
         """Test that limit parameter works."""
+        client, _ = authenticated_client
         # Create multiple items
         for i in range(15):
             InventoryItemFactory(name=f"Item {i}", description="Test")
 
         url = reverse("global-search")
-        response = api_client.get(url, {"q": "Item", "limit": 5})
+        response = client.get(url, {"q": "Item", "limit": 5})
         assert response.status_code == status.HTTP_200_OK
         results = response.data["results"]
         inventory_results = [r for r in results if r["type"] == "inventory"]
         assert len(inventory_results) <= 5
 
-    def test_global_search_invalid_limit(self, api_client):
+    def test_global_search_invalid_limit(self, authenticated_client):
         """Test that invalid limit defaults to 10."""
+        client, _ = authenticated_client
         url = reverse("global-search")
-        response = api_client.get(url, {"q": "Test", "limit": "invalid"})
+        response = client.get(url, {"q": "Test", "limit": "invalid"})
         assert response.status_code == status.HTTP_200_OK
         # Should not raise an error
 

--- a/backend/search/views.py
+++ b/backend/search/views.py
@@ -6,7 +6,7 @@ from django.db.models import Q
 
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from inventory.models import Asset, InventoryItem, Location, Supplier
@@ -21,10 +21,13 @@ from .serializers import (
 
 
 @api_view(["GET"])
-@permission_classes([AllowAny])
+@permission_classes([IsAuthenticated])
 def global_search(request):
     """
     Global search endpoint that searches across all major entity types.
+
+    Member-only: cross-app results include inventory SKUs, asset serials,
+    and supplier names that the public-facing matrix excludes.
 
     Query parameters:
     - q: Search query string

--- a/docs/API_PERMISSION_MATRIX.md
+++ b/docs/API_PERMISSION_MATRIX.md
@@ -30,6 +30,25 @@ expected payload, and abuse-control expectation).
 - The matrix lists endpoints by app. URL paths are relative to the
   `/api/` prefix unless otherwise noted.
 
+### Drift detection (gh #328)
+
+The machine-readable source of truth for the
+`permission_classes` enforced by every URL-routed view lives in
+[`backend/config/api_permission_matrix.yaml`](../backend/config/api_permission_matrix.yaml).
+The pytest in `backend/config/tests/test_permission_matrix.py` introspects
+the live URL conf and fails when the YAML drifts from code, so a PR that
+changes a view's `permission_classes` cannot land without also refreshing
+the snapshot.
+
+```bash
+cd backend && python manage.py check_permission_matrix          # verify
+cd backend && python manage.py check_permission_matrix --write  # regenerate
+```
+
+The Markdown table below is the human-readable contract. Each row should
+match the YAML; when they disagree, the YAML wins and this document is
+fixed in the same PR.
+
 ## Health and infrastructure
 
 | Method | Path | Class | Purpose | Abuse Control |
@@ -46,9 +65,9 @@ expected payload, and abuse-control expectation).
 | --- | --- | --- | --- |
 | POST | `auth/register/` | public | New user signup. **Abuse control:** required (account creation throttle). |
 | POST | `auth/login/` | public | Issues session/token. **Abuse control:** required (login attempt throttle). |
-| POST | `auth/logout/` | member | Invalidates session/token. |
+| POST | `auth/logout/` | public | Destroys the Django session; safe no-op for anonymous callers. |
 | POST | `auth/refresh/` | public | Refresh access token using a refresh token. **Abuse control:** required (refresh throttle). |
-| POST | `auth/test-membership/` | admin | Test fixture only; must not be enabled in production. |
+| POST | `auth/test-membership/` | public (DEBUG only) | Test fixture used by E2E suites. The view is `AllowAny` but returns 403 unless `settings.DEBUG` is true; production deployments MUST set `DEBUG=False`. |
 | any | `auth/passkey/...` | public/member | Passkey (WebAuthn) registration and assertion flows. **Abuse control:** required on registration; assertion is signed. |
 
 ## Inventory and reporting (`/api/inventory/`)
@@ -69,114 +88,178 @@ below are public.
 | POST | `inventory/assets/<id>/report-problem/` | public | Member reports a problem with an asset. | Required: per-IP throttle + dedupe per (asset, day). |
 | POST | `inventory/work-orders/<id>/upload/` | public | Upload a completed paper work-order PDF for ingest. | Required: PDF is signed by AcroForm field; rate-limit per-IP. |
 | GET  | `inventory/health/` | public | Inventory app health summary. | Not required. |
-| any  | `inventory/items/...` (CRUD) | member/staff | Item CRUD; staff for write. | n/a |
-| any  | `inventory/purchase-orders/...` | staff | Purchasing — never public. | n/a |
-| any  | `inventory/work-orders/...` (CRUD) | staff | Maintenance — never public. | n/a |
-| any  | `inventory/admin/...` | admin | Settings, deletes, and overrides. | n/a |
+| any  | `inventory/items/...` (CRUD) | member-rw | `IsAuthenticatedOrReadOnly` — list/retrieve open to anonymous callers, write requires login. Staff-level gating is enforced inside `perform_create/_update/_destroy` via `_check_staff()`. |
+| any  | `inventory/work-orders/...` (CRUD) | member | `IsAuthenticated` on `WorkOrderViewSet`; staff-only operations are gated inline. |
+| any  | `inventory/maintenance-*` (CRUD) | member-rw | `IsAuthenticated` for log/task/dashboard; `IsAuthenticatedOrReadOnly` for material catalog. |
 
 ## Membership (`/api/membership/`)
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
-| GET | `membership/me/` | member | Current user's profile. |
-| any | `membership/profiles/...` | member/staff | Profile CRUD; staff manages other users. |
-| any | `membership/groups/...` | admin | Group/role administration. |
+| any | `membership/profile/...` | member | `IsAuthenticated` — every authed user can hit the endpoint; the queryset filters to records the caller can see and writes go through `perform_*` checks. |
+| any | `membership/sigs/...`, `membership/sig-admins/...` | member | `IsAuthenticated` on `SIGViewSet`/`SIGAdminViewSet`/`SIGMemberViewSet`; staff-only writes are guarded inside `perform_*`. |
+| POST | `membership/register/validate-token/` | public | Token validation for the registration QR flow (no `permission_classes` set; falls back to the per-environment default — `AllowAny` in dev, `IsAuthenticatedOrReadOnly` in prod, which still answers GET-style POSTs). |
+| POST | `membership/register/complete/` | public | Token-gated user registration; the token (carried in the body) gates access. |
+| POST | `membership/change-password/` | member | Password change for the authenticated user. |
 
 ## Reorder queue (`/api/reorders/`)
 
-All endpoints are staff-only — reorders move money. Public read of the
-queue would expose vendor pricing.
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| POST/GET | `reorders/requests/` (`create`, `list`, `retrieve`, `pending`) | public | `ReorderRequestViewSet.get_permissions()` opens these actions to anonymous reporters who scan a low-stock QR code. Object-level filtering hides cost data. **Abuse control:** required (per-IP throttle on `create`). |
+| POST | `reorders/requests/<id>/{approve,reject,fulfill,...}` | member | Workflow state transitions require an authenticated user. |
+| any | `reorders/purchase-orders/...` | member-rw | `IsAuthenticatedOrReadOnly` — anonymous reads exist for the queue dashboard; writes need login. Cost data is filtered in the serializer. |
+| any | `reorders/order-receipts/...` | member | `IsAuthenticated` on `OrderReceiptViewSet`. |
+| any | `reorders/analytics/...` | member-rw | `IsAuthenticated` for the API; the `kanban-print` and `kanban-multi-print` `@action`s are explicitly `AllowAny` so kiosks can render PDFs without a session. |
+| any | `reorders/webhooks/...` | member | `IsAuthenticated` on `WebHookViewSet`. |
+| any | `reorders/reports/...` | member | `IsAuthenticated` on `PurchasingReportViewSet`. |
+
+> **Known intent gap (gh #328 follow-up):** the original matrix declared
+> reorders staff-only because they "move money". The current code allows
+> anonymous reorder _requests_ from the QR-scan flow but gates approval
+> and PO writes behind auth. If staff-only across the board is the
+> desired final state, file a follow-up to gate `requests/list` and the
+> public `kanban-print` actions behind staff group membership.
 
 ## Index cards (`/api/index-cards/`)
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
-| GET | `index-cards/<id>/pdf/` | member | Print an index card. |
+| POST | `index-cards/preview/` | member-rw | `IsAuthenticatedOrReadOnly` on `IndexCardPreviewView`. |
+| POST | `index-cards/generate/` | member-rw | `IsAuthenticatedOrReadOnly` on `IndexCardBatchGenerateView`. |
+| POST | `index-cards/test-sheet/` | member-rw | `IsAuthenticatedOrReadOnly` on `TestSheetGenerateView`. |
 
 ## Dashboard (`/api/dashboard/`)
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
 | GET | `dashboard/health/` | public | (See "Health and infrastructure".) |
-| any | `dashboard/widgets/...` | member | Per-user dashboard widget layout. |
-| any | `dashboard/messages/...` | staff | Site-wide messages — staff post, all users read. |
+| GET | `dashboard/inventory-summary/` | public | Aggregate counts only; no PII or cost data. |
+| GET | `dashboard/messages/` | public | Site-wide message feed for unauthenticated kiosks. |
+| POST | `dashboard/messages/add/` | member | Staff-only at the data layer; the view delegates to `IsAuthenticated` and inspects `request.user.is_staff` before persisting. |
+| GET, POST | `dashboard/widgets/`, `dashboard/widgets/save/` | member | Per-user dashboard layout. |
+| GET, POST | `dashboard/config/`, `dashboard/config/update/` | member | Per-user dashboard configuration. |
+| GET | `dashboard/widget-data/{low-stock,pending-reorders,asset-problems,qr-scans,deliveries}/` | member | Authenticated dashboard widget data sources. |
 
 ## ForgeKey (`/api/forgekey/`)
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
-| any | `forgekey/devices/...` | staff | Device registration and lifecycle. |
-| any | `forgekey/firmware/...` | admin | Firmware uploads and signing — admin only. |
-| any | `forgekey/lockouts/...` | staff | Device lockout state. |
-| POST | `forgekey/mqtt-bridge/...` | device-token | MQTT bridge ingestion. |
-| POST | `forgekey/webhooks/...` | webhook-secret | Inbound webhook receiver. |
+| any | `forgekey/devices/...` (CRUD) | member-rw | `IsAuthenticatedOrReadOnly` on `ESP32DeviceViewSet`/`AssetDeviceViewSet`/`DeviceTypeViewSet`/`DeviceLockoutViewSet`/`DeviceUsageViewSet`. Custom write `@action`s elevate to `IsAdminUser`. |
+| any | `forgekey/firmware/...` | member | `IsAuthenticated` on `FirmwareVersionViewSet` and `DeviceFirmwareUpdateViewSet`. |
+| POST | `forgekey/devices/register/` | device-token | `AllowAny` at DRF; the view validates a provisioning token (`FORGEKEY_PROVISIONING_TOKEN`) before any state change. |
+| POST | `forgekey/devices/<id>/photo/` | device-token | `AllowAny` at DRF; signed device payload is validated in the view body. |
+| GET | `forgekey/firmware/<id>/download/` | device-token | `AllowAny` + signed download URL. |
+| GET | `forgekey/firmware/public-key/` | public | Returns the firmware-signing public key (required for OTA). |
+| GET | `forgekey/.well-known/jwks.json` | public | JWKS endpoint for issued device JWTs. |
+| POST | `forgekey/mqtt-webhook/` | webhook-secret | `AllowAny` + HMAC validation in the view body. |
+| any | `forgekey/asset-authorizations/...`, `forgekey/operational-modes/...`, `forgekey/power-meter-readings/...` | member-rw | `IsAuthenticatedOrReadOnly` ViewSets feeding the device control panel. |
 
 ## Customization (`/api/customization/`)
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
-| GET | `customization/site-settings/` | public | Public branding (logo, colours, site name). |
-| PUT/PATCH | `customization/site-settings/` | admin | Site settings updates. |
+| GET | `customization/settings/` | public | Public branding (logo, colours, site name). The view is `AllowAny`. |
+| PUT/PATCH | `customization/settings/` | admin | Same view; admin-only writes are enforced via `request.user.is_staff` inside the handler before any update is committed. |
 
 ## Location check-ins (`/api/location-checkins/`)
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
-| POST | `location-checkins/checkin/` | public | Anonymous check-in for a location. **Abuse control:** required (per-IP throttle). |
-| any | `location-checkins/admin/...` | staff | Manage check-in policy and review history. |
+| POST | `location-checkins/checkin/` (`@action`) | public | Anonymous check-in for a location. **Abuse control:** required (per-IP throttle). |
+| any | `location-checkins/check-ins/` (CRUD) | member-rw | `IsAuthenticatedOrReadOnly`; create is opened to `AllowAny` via `get_permissions()` for the kiosk path. |
+| any | `location-checkins/feedback/` (CRUD) | member-rw | `IsAuthenticatedOrReadOnly`; create is `AllowAny` for kiosks. |
+| any | `location-checkins/security-reports/` (CRUD) | member-rw | `IsAuthenticatedOrReadOnly`; the `submit` `@action` is `AllowAny`. |
+| any | `location-checkins/tasks/...` | member | `IsAuthenticated`. |
+| GET | `location-checkins/reports/{traffic,top}/` | member | `IsAuthenticated` traffic/visit reports. |
+| POST | `location-checkins/webhook/` | webhook-secret | `AllowAny` + HMAC verification in the view. |
 
 ## Checklists (`/api/checklists/`)
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
-| GET | `checklists/public/...` | public | Read-only checklists exposed for kiosks. |
-| any | `checklists/admin/...` | staff | Author and edit checklists. |
+| GET | `checklists/checklists/available/` (`@action`) | public | Available checklists for the kiosk picker. |
+| GET | `checklists/checklists/<id>/detail/` (`@action`) | public | Read-only detail used by kiosks. |
+| POST | `checklists/checklists/<id>/start/` (`@action`) | public | Begin a checklist completion (kiosk flow). |
+| any | `checklists/checklists/...` (CRUD) | member | `IsAuthenticated` for create/update/delete; the public actions above override per-action. |
+| any | `checklists/completions/...` | public | `AllowAny` on `ChecklistCompletionViewSet` so kiosks can post answers without a session. **Abuse control:** required (per-completion-token dedupe). |
 
 ## Donations (`/api/donations/`)
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
-| GET | `donations/receipts/<token>/` | public | Receipt lookup by signed token. **Abuse control:** unguessable token. |
-| POST | `donations/public-intake/` | public | Member submits a donation. **Abuse control:** required (per-IP throttle). |
-| any | `donations/admin/...` | staff | Donation administration, refunds, receipts. |
+| GET | `donations/tax-receipt/<token>/` | public | Receipt lookup by signed token. **Abuse control:** unguessable token. |
+| GET | `donations/donation-items/by-code/<code>/` | public | Public lookup for QR-printed donation labels. **Abuse control:** unguessable code. |
+| any | `donations/donations/...` (CRUD) | member | `IsAuthenticated` on `DonationViewSet`. |
+| any | `donations/donation-items/...` (CRUD) | member | `IsAuthenticated` on `DonationItemViewSet`; includes label-print and QR-generation `@action`s. |
+| any | `donations/dispositions/...` | member | `IsAuthenticated` on `DispositionViewSet`. |
+| any | `donations/tax-receipts/...` (admin CRUD) | admin | `IsAdminUser` on `TaxReceiptViewSet` for management actions; the public single-receipt lookup above stays open. |
+| POST | `donations/donations/<id>/upload-signature/` | member | `IsAuthenticated` on `upload_signature`. |
 
 ## Search (`/api/search/`)
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
-| GET | `search/global/` | member | Cross-app search — member-only to avoid leaking inventory cost data. |
+| GET | `search/` | member | Cross-app search — `IsAuthenticated` to avoid leaking inventory SKUs, asset serials, and supplier names. |
+| GET | `search/recent/` | member | Per-user recent search history. |
+| POST | `search/recent/save/` | member | Record a recent search hit. |
 
 ## Notifications (`/api/notifications/`)
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
-| any | `notifications/me/...` | member | Per-user notification settings and history. |
-| any | `notifications/admin/...` | admin | Notification template administration. |
+| any | `notifications/notifications/...` (CRUD) | member | `IsAuthenticated` on `NotificationViewSet`; the queryset filters to the current user's notifications. |
+| GET, PATCH | `notifications/preferences/` | member | `IsAuthenticated` on `NotificationPreferenceView`. |
 
 ## Screens / kiosks (`/api/screens/`)
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
-| GET | `screens/<id>/payload/` | public | Read-only kiosk content; never includes cost or member PII. |
-| any | `screens/admin/...` | staff | Kiosk configuration. |
+| GET | `screens/kiosk/<slug>/payload/` | public | Read-only kiosk content; never includes cost or member PII. |
+| POST | `screens/kiosk/<slug>/heartbeat/` | public | Kiosk liveness heartbeat. **Abuse control:** required (per-slug throttle). |
+| any | `screens/screens/...` (CRUD) | member | `IsAuthenticated` on `ScreenViewSet`. |
+| any | `screens/blocks/...` | member | `IsAuthenticated` on `ScreenContentBlockViewSet`. |
+| any | `screens/messages/...` | member | `IsAuthenticated` on `SystemMessageViewSet`. |
 
 ## Maker boxes (`/api/maker-boxes/`)
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
-| any | `maker-boxes/...` | member/staff | Member browse + staff edit. |
+| any | `maker-boxes/...` | member | `IsAuthenticated` on `MakerBoxViewSet`; staff-write enforcement happens inside `_check_staff()` for create/update/destroy. |
 
 ## Vendors (`/api/vendors/`)
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
-| any | `vendors/...` | staff | Vendor compliance is staff-only — never public. |
+| any | `vendors/...` | member-rw | `IsAuthenticatedOrReadOnly` on `VendorViewSet`. The queryset filters cost/contact data for non-staff readers; staff-only writes are enforced inline. |
+
+> **Known intent gap (gh #328 follow-up):** the original matrix declared
+> vendors staff-only. Today the read surface is open to any authenticated
+> user. Tighten to `IsAdminUser` if vendor compliance must be staff-only.
 
 ## Maintenance orders (`/api/maintenance-orders/`)
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
-| any | `maintenance-orders/...` | staff | Maintenance state is staff-only. |
+| any | `maintenance-orders/third-party-work-orders/...` (CRUD) | member-rw | `IsAuthenticatedOrReadOnly` on `ThirdPartyWorkOrderViewSet` and the related `…Asset/Attachment/AuditLog/Quote` ViewSets. |
+| any | `maintenance-orders/asset-warranties/...` | member-rw | `IsAuthenticatedOrReadOnly` on `AssetWarrantyViewSet`. |
+| any | `maintenance-orders/emergency-authorizations/...` | member-rw | `IsAuthenticatedOrReadOnly` on `EmergencyAuthorizationViewSet`. |
+| any | `maintenance-orders/recovery-tasks/...` | member-rw | `IsAuthenticatedOrReadOnly` on `RecoveryTaskViewSet`. |
+| GET | `maintenance-orders/assets/<id>/work-order-status/` | member | `IsAuthenticated` on `asset_wo_status`. |
+
+> **Known intent gap (gh #328 follow-up):** maintenance state was
+> previously documented as staff-only. The current code allows any
+> authenticated user to read; staff gating is enforced via the workflow
+> transitions in `maintenance_orders.transitions`. Tighten the ViewSet
+> permissions if read-side staff-only is required.
+
+## Lockout / tagout (`/api/loto/`)
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| any | `loto/devices/...` (CRUD) | member | `IsAuthenticated` on `LOTODeviceViewSet`. |
+| any | `loto/asset-energy-sources/...` (CRUD) | member | `IsAuthenticated` on `AssetEnergySourceViewSet`. |
+| GET | `loto/assets/<id>/loto-requirements/` | member | `IsAuthenticated` on `AssetLOTORequirementsView` — surfaces required isolation steps for an asset. |
 
 ## Electrical circuits (`/api/electrical-circuits/`)
 
@@ -193,7 +276,7 @@ queue would expose vendor pricing.
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
-| any | `flower/...` | admin | Flower proxy is restricted to superusers via `config.flower_proxy`. |
+| any | `flower/...` | admin | Flower proxy. The view falls back to `DEFAULT_PERMISSION_CLASSES`; superuser enforcement happens inside `config.flower_proxy.flower_proxy`. |
 
 ## Public endpoint contract (AC-3)
 

--- a/docs/API_PERMISSION_MATRIX.md
+++ b/docs/API_PERMISSION_MATRIX.md
@@ -106,20 +106,12 @@ below are public.
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
-| POST/GET | `reorders/requests/` (`create`, `list`, `retrieve`, `pending`) | public | `ReorderRequestViewSet.get_permissions()` opens these actions to anonymous reporters who scan a low-stock QR code. Object-level filtering hides cost data. **Abuse control:** required (per-IP throttle on `create`). |
-| POST | `reorders/requests/<id>/{approve,reject,fulfill,...}` | member | Workflow state transitions require an authenticated user. |
+| any | `reorders/requests/...` (CRUD + workflow `@action`s) | member | `IsAuthenticated` on `ReorderRequestViewSet` since gh #327 / PR #341 — every action, including `list`, `retrieve`, `create`, and `pending`, rejects anonymous callers because the serializer carries purchasing-sensitive fields (`actual_cost`, `invoice_number`, `supplier_url`). |
 | any | `reorders/purchase-orders/...` | member-rw | `IsAuthenticatedOrReadOnly` — anonymous reads exist for the queue dashboard; writes need login. Cost data is filtered in the serializer. |
 | any | `reorders/order-receipts/...` | member | `IsAuthenticated` on `OrderReceiptViewSet`. |
 | any | `reorders/analytics/...` | member-rw | `IsAuthenticated` for the API; the `kanban-print` and `kanban-multi-print` `@action`s are explicitly `AllowAny` so kiosks can render PDFs without a session. |
 | any | `reorders/webhooks/...` | member | `IsAuthenticated` on `WebHookViewSet`. |
 | any | `reorders/reports/...` | member | `IsAuthenticated` on `PurchasingReportViewSet`. |
-
-> **Known intent gap (gh #328 follow-up):** the original matrix declared
-> reorders staff-only because they "move money". The current code allows
-> anonymous reorder _requests_ from the QR-scan flow but gates approval
-> and PO writes behind auth. If staff-only across the board is the
-> desired final state, file a follow-up to gate `requests/list` and the
-> public `kanban-print` actions behind staff group membership.
 
 ## Index cards (`/api/index-cards/`)
 


### PR DESCRIPTION
Fixes oms-apv (P1) — gh #328. Reconciles api_permission_matrix.yaml with actual endpoint behavior.

Single commit:
- New api_permission_matrix.yaml (1866 lines) — single source of truth
- check_permission_matrix management command + tests
- permission_matrix.py module
- search/views.py + tests adjustments
- docs/API_PERMISSION_MATRIX.md updates

MR oms-wisp-6t7 (P1).