### PR TITLE
fix(forgekey): mint server JWT for backend MQTT auth (oms-y5p)

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -435,6 +435,19 @@ FORGEKEY_JWT_AUDIENCE = config("FORGEKEY_JWT_AUDIENCE", default="forgekey")
 FORGEKEY_JWT_KEY_ID = config("FORGEKEY_JWT_KEY_ID", default="forgekey-jwt-1")
 FORGEKEY_JWT_SIGNING_KEY = config("FORGEKEY_JWT_SIGNING_KEY", default="").replace("\\n", "\n")
 
+# Server-JWT (oms-y5p): the backend authenticates to EMQX as 'oms-backend'
+# using a self-issued ES256 JWT signed with the same key as device JWTs.
+# The token's exp is intentionally long (1 year) because rotation is driven by
+# FORGEKEY_JWT_KEY_ID changes, not by token churn. Within a process the JWT is
+# cached for FORGEKEY_SERVER_JWT_CACHE_SECONDS so we don't re-sign on every
+# MQTT connect.
+FORGEKEY_SERVER_JWT_EXPIRATION_SECONDS = config(
+    "FORGEKEY_SERVER_JWT_EXPIRATION_SECONDS", default=60 * 60 * 24 * 365, cast=int
+)
+FORGEKEY_SERVER_JWT_CACHE_SECONDS = config(
+    "FORGEKEY_SERVER_JWT_CACHE_SECONDS", default=60 * 60 * 24, cast=int  # 24h
+)
+
 # ForgeKey provisioning token — devices send this in
 # X-ForgeKey-Provisioning-Token to call the registration endpoint.
 FORGEKEY_PROVISIONING_TOKEN = config("FORGEKEY_PROVISIONING_TOKEN", default="")

--- a/backend/forgekey/checks.py
+++ b/backend/forgekey/checks.py
@@ -21,6 +21,7 @@ W_PROVISIONING_TOKEN = "forgekey.W004"  # nosec B105 — Django check ID, not a 
 W_EMQX_PASSWORD = "forgekey.W005"  # nosec B105 — Django check ID, not a password
 W_EMQX_API = "forgekey.W006"
 W_DOCKER_ALLOWED_HOSTS = "forgekey.W007"
+W_BACKEND_LITERAL_MQTT_PASSWORD = "forgekey.W008"  # nosec B105 — Django check ID, not a password
 DOCKER_BACKEND_HOSTNAME = "backend"
 
 PLACEHOLDER_PROVISIONING_TOKEN = "REPLACE_ME_PROVISIONING_TOKEN"  # nosec B105
@@ -212,6 +213,40 @@ def check_docker_allowed_hosts(app_configs, **kwargs):
                 "so this warning usually means an override is overriding it."
             ),
             id=W_DOCKER_ALLOWED_HOSTS,
+        )
+    )
+    return warnings
+
+
+@register(Tags.security)
+def check_backend_mqtt_uses_jwt(app_configs, **kwargs):
+    """W008 (oms-y5p): warn when literal MQTT_BROKER_USERNAME/PASSWORD are
+    configured. Since oms-y5p the backend self-issues an ES256 server JWT and
+    EMQX's JWT authenticator (with anonymous disabled) will reject literal
+    username/password credentials — silently dropping every command publish.
+    """
+    warnings = []
+    if not _is_production():
+        return warnings
+
+    username = (getattr(settings, "MQTT_BROKER_USERNAME", "") or "").strip()
+    password = (getattr(settings, "MQTT_BROKER_PASSWORD", "") or "").strip()
+    if not username and not password:
+        return warnings
+
+    warnings.append(
+        Warning(
+            "MQTT_BROKER_USERNAME / MQTT_BROKER_PASSWORD are set, but the "
+            "backend now mints its own ES256 server JWT (oms-y5p). EMQX's JWT "
+            "authenticator will reject these literal credentials and every "
+            "device command will silently fail to publish.",
+            hint=(
+                "Unset MQTT_BROKER_USERNAME and MQTT_BROKER_PASSWORD in .env. "
+                "The backend authenticates as 'oms-backend' using a JWT "
+                "signed with FORGEKEY_JWT_SIGNING_KEY — no separate "
+                "user-management is needed."
+            ),
+            id=W_BACKEND_LITERAL_MQTT_PASSWORD,
         )
     )
     return warnings

--- a/backend/forgekey/tasks.py
+++ b/backend/forgekey/tasks.py
@@ -16,7 +16,14 @@ import paho.mqtt.client as mqtt
 from celery import shared_task
 
 from .models import ESP32Device, ESP32DevicePhoto, OccupancyEvent, PowerMeterReading
-from .utils import get_mqtt_command_topic, normalize_mac_address
+from .services.jwt_signing import JwtSigningError, is_jwt_signing_configured
+from .utils import (
+    SERVER_JWT_SUBJECT,
+    generate_server_jwt,
+    get_mqtt_command_topic,
+    invalidate_server_jwt_cache,
+    normalize_mac_address,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +48,7 @@ def _reset_mqtt_client_state_for_tests() -> None:
     global _mqtt_client, _mqtt_connect_failed_at
     _mqtt_client = None
     _mqtt_connect_failed_at = 0.0
+    invalidate_server_jwt_cache()
 
 
 def get_mqtt_client() -> mqtt.Client:
@@ -73,7 +81,18 @@ def get_mqtt_client() -> mqtt.Client:
         protocol=mqtt.MQTTv5,
     )
 
-    if settings.MQTT_BROKER_USERNAME:
+    # Prefer the server-JWT pattern (oms-y5p): a self-issued ES256 JWT signed
+    # with the device-JWT key. EMQX verifies it via the same JWKS endpoint, so
+    # no separate user-management is required. Fall back to literal
+    # MQTT_BROKER_USERNAME / MQTT_BROKER_PASSWORD only when JWT signing is
+    # unconfigured — exists for dev rigs that haven't enrolled in JWT auth yet.
+    if is_jwt_signing_configured():
+        try:
+            client.username_pw_set(SERVER_JWT_SUBJECT, generate_server_jwt())
+        except JwtSigningError as exc:
+            logger.error("Failed to mint server JWT for MQTT: %s", exc)
+            raise
+    elif settings.MQTT_BROKER_USERNAME:
         client.username_pw_set(
             settings.MQTT_BROKER_USERNAME,
             settings.MQTT_BROKER_PASSWORD,
@@ -107,6 +126,10 @@ def get_mqtt_client() -> mqtt.Client:
         # not exist yet); we log + swallow because re-raising here would mask
         # the real connect failure below.
         _mqtt_connect_failed_at = time.monotonic()
+        # The credential we passed may have been rejected (expired token, key
+        # rotation, clock skew). Drop the cached server JWT so the next attempt
+        # mints a fresh one — see oms-y5p AC-3.
+        invalidate_server_jwt_cache()
         try:
             client.loop_stop()
         except Exception as cleanup_exc:

--- a/backend/forgekey/tests/test_doctor_checks.py
+++ b/backend/forgekey/tests/test_doctor_checks.py
@@ -7,10 +7,12 @@ from unittest import mock
 import pytest
 
 from forgekey.checks import (
+    W_BACKEND_LITERAL_MQTT_PASSWORD,
     W_DOCKER_ALLOWED_HOSTS,
     W_EMQX_API,
     W_EMQX_PASSWORD,
     W_PROVISIONING_TOKEN,
+    check_backend_mqtt_uses_jwt,
     check_docker_allowed_hosts,
     check_emqx_api_credentials,
     check_emqx_dashboard_password,
@@ -140,3 +142,38 @@ class TestDockerAllowedHostsCheck:
         prod.ALLOWED_HOSTS = ["oms.example.com", "Backend"]
         with mock.patch("forgekey.checks._running_in_docker", return_value=True):
             assert check_docker_allowed_hosts(app_configs=None) == []
+
+
+class TestBackendMqttUsesJwtCheck:
+    """oms-y5p AC-4: W008 warns when literal MQTT_BROKER credentials are set,
+    because EMQX's JWT authenticator silently rejects them and every device
+    command publish then fails."""
+
+    def test_no_warnings_in_debug(self, settings):
+        settings.DEBUG = True
+        settings.MQTT_BROKER_USERNAME = "literal-user"
+        settings.MQTT_BROKER_PASSWORD = "literal-pass"  # nosec B105
+        assert check_backend_mqtt_uses_jwt(app_configs=None) == []
+
+    def test_no_warning_when_unset(self, prod):
+        prod.MQTT_BROKER_USERNAME = ""
+        prod.MQTT_BROKER_PASSWORD = ""
+        assert check_backend_mqtt_uses_jwt(app_configs=None) == []
+
+    def test_warns_when_username_set(self, prod):
+        prod.MQTT_BROKER_USERNAME = "oms-backend"
+        prod.MQTT_BROKER_PASSWORD = ""
+        warnings = check_backend_mqtt_uses_jwt(app_configs=None)
+        assert [w.id for w in warnings] == [W_BACKEND_LITERAL_MQTT_PASSWORD]
+
+    def test_warns_when_password_set(self, prod):
+        prod.MQTT_BROKER_USERNAME = ""
+        prod.MQTT_BROKER_PASSWORD = "literal-secret"  # nosec B105
+        warnings = check_backend_mqtt_uses_jwt(app_configs=None)
+        assert [w.id for w in warnings] == [W_BACKEND_LITERAL_MQTT_PASSWORD]
+
+    def test_warns_when_both_set(self, prod):
+        prod.MQTT_BROKER_USERNAME = "user"
+        prod.MQTT_BROKER_PASSWORD = "pw"  # nosec B105
+        warnings = check_backend_mqtt_uses_jwt(app_configs=None)
+        assert [w.id for w in warnings] == [W_BACKEND_LITERAL_MQTT_PASSWORD]

--- a/backend/forgekey/tests/test_tasks.py
+++ b/backend/forgekey/tests/test_tasks.py
@@ -203,20 +203,18 @@ class TestMQTTTasks:
         mock_client.loop_start.assert_called_once()
 
     @patch("paho.mqtt.client.Client")
-    @patch("forgekey.tasks.settings")
-    def test_get_mqtt_client_with_auth(self, mock_settings, mock_client_class):
-        """Test MQTT client creation with authentication."""
+    def test_get_mqtt_client_uses_server_jwt(self, mock_client_class):
+        """oms-y5p AC-2: backend authenticates with a self-signed server JWT.
+
+        EMQX's JWT authenticator (with anonymous disabled) accepts no other
+        credential, so this must be the default path whenever
+        FORGEKEY_JWT_SIGNING_KEY is configured (always true in tests via the
+        session-level conftest).
+        """
         from forgekey.tasks import _reset_mqtt_client_state_for_tests, get_mqtt_client
+        from forgekey.utils import SERVER_JWT_SUBJECT, verify_device_jwt  # noqa: F401
 
         _reset_mqtt_client_state_for_tests()
-
-        mock_settings.MQTT_CLIENT_ID = "test-client"
-        mock_settings.MQTT_BROKER_HOST = "localhost"
-        mock_settings.MQTT_BROKER_PORT = 1883
-        mock_settings.MQTT_KEEPALIVE = 60
-        mock_settings.MQTT_BROKER_USERNAME = "user"
-        mock_settings.MQTT_BROKER_PASSWORD = "pass"  # nosec B105
-        mock_settings.MQTT_CONNECT_RETRY_COOLDOWN_SECONDS = 30
 
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
@@ -224,7 +222,41 @@ class TestMQTTTasks:
         client = get_mqtt_client()
 
         assert client is not None
-        mock_client.username_pw_set.assert_called_once_with("user", "pass")
+        mock_client.username_pw_set.assert_called_once()
+        username, password = mock_client.username_pw_set.call_args[0]
+        assert username == SERVER_JWT_SUBJECT
+        # Compact JWT: header.payload.signature
+        assert password.count(".") == 2
+
+    @patch("paho.mqtt.client.Client")
+    @patch("forgekey.tasks.settings")
+    def test_get_mqtt_client_falls_back_to_literal_creds(
+        self, mock_settings, mock_client_class, settings
+    ):
+        """When JWT signing is unconfigured (dev rigs), fall back to literal
+        MQTT_BROKER_USERNAME/PASSWORD. Production never hits this path because
+        forgekey.W008 warns and the JWT key must be set for device auth too.
+        """
+        from forgekey.tasks import _reset_mqtt_client_state_for_tests, get_mqtt_client
+
+        _reset_mqtt_client_state_for_tests()
+        # Disable JWT signing so the fallback branch is taken.
+        settings.FORGEKEY_JWT_SIGNING_KEY = ""
+
+        mock_settings.MQTT_CLIENT_ID = "test-client"
+        mock_settings.MQTT_BROKER_HOST = "localhost"
+        mock_settings.MQTT_BROKER_PORT = 1883
+        mock_settings.MQTT_KEEPALIVE = 60
+        mock_settings.MQTT_BROKER_USERNAME = "legacy-user"
+        mock_settings.MQTT_BROKER_PASSWORD = "legacy-pass"  # nosec B105
+        mock_settings.MQTT_CONNECT_RETRY_COOLDOWN_SECONDS = 30
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        get_mqtt_client()
+
+        mock_client.username_pw_set.assert_called_once_with("legacy-user", "legacy-pass")
 
     @patch("paho.mqtt.client.Client")
     @patch("forgekey.tasks.settings")

--- a/backend/forgekey/tests/test_utils.py
+++ b/backend/forgekey/tests/test_utils.py
@@ -16,10 +16,13 @@ from forgekey.services.jwt_signing import (
     get_jwt_public_key_pem,
 )
 from forgekey.utils import (
+    SERVER_JWT_SUBJECT,
     generate_device_jwt,
+    generate_server_jwt,
     get_mqtt_command_topic,
     get_mqtt_data_topic,
     get_mqtt_status_topic,
+    invalidate_server_jwt_cache,
     normalize_mac_address,
     verify_device_jwt,
 )
@@ -152,3 +155,100 @@ class TestJWTGeneration:
             issuer=settings.FORGEKEY_JWT_ISSUER,
         )
         assert payload["mac"] == normalize_mac_address(self.MAC)
+
+
+@pytest.mark.unit
+class TestServerJWT:
+    """oms-y5p: backend mints its own ES256 JWT to authenticate to EMQX."""
+
+    def setup_method(self):
+        invalidate_server_jwt_cache()
+
+    def teardown_method(self):
+        invalidate_server_jwt_cache()
+
+    def test_returns_compact_es256_token_signed_by_jwks_key(self):
+        """AC-1: token verifies against the same JWKS the device JWTs use."""
+        token = generate_server_jwt()
+        assert isinstance(token, str)
+        assert token.count(".") == 2
+
+        header_b64 = token.split(".")[0]
+        header_b64 += "=" * (-len(header_b64) % 4)
+        header = json.loads(base64.urlsafe_b64decode(header_b64))
+        assert header["alg"] == "ES256"
+        assert header["kid"] == settings.FORGEKEY_JWT_KEY_ID
+
+        public_pem = get_jwt_public_key_pem()
+        payload = jwt.decode(
+            token,
+            public_pem,
+            algorithms=["ES256"],
+            audience=settings.FORGEKEY_JWT_AUDIENCE,
+            issuer=settings.FORGEKEY_JWT_ISSUER,
+        )
+        assert payload["sub"] == SERVER_JWT_SUBJECT
+        assert payload["iss"] == settings.FORGEKEY_JWT_ISSUER
+        assert payload["aud"] == settings.FORGEKEY_JWT_AUDIENCE
+        assert payload["exp"] > payload["iat"]
+
+    def test_acl_grants_broad_pubsub_under_topic_prefix(self):
+        """AC-1: server JWT can pub/sub anywhere under MQTT_TOPIC_PREFIX so it
+        can dispatch to and consume from every device."""
+        token = generate_server_jwt()
+        public_pem = get_jwt_public_key_pem()
+        payload = jwt.decode(
+            token,
+            public_pem,
+            algorithms=["ES256"],
+            audience=settings.FORGEKEY_JWT_AUDIENCE,
+            issuer=settings.FORGEKEY_JWT_ISSUER,
+        )
+        prefix = settings.MQTT_TOPIC_PREFIX
+        assert payload["acl"] == {
+            "pub": [f"{prefix}/#"],
+            "sub": [f"{prefix}/#"],
+        }
+
+    def test_signing_unconfigured_raises(self, settings):
+        settings.FORGEKEY_JWT_SIGNING_KEY = ""
+        with pytest.raises(JwtSigningError):
+            generate_server_jwt()
+
+    def test_token_is_cached_within_ttl(self):
+        """AC-3: don't re-sign every connect — cached token is reused."""
+        first = generate_server_jwt()
+        second = generate_server_jwt()
+        assert first == second
+
+    def test_cache_can_be_invalidated(self):
+        """AC-3: connect-failure path drops the cache; next call re-signs."""
+        first = generate_server_jwt()
+        invalidate_server_jwt_cache()
+        # Sleep a hair so iat moves forward and the new signature differs.
+        import time as _time
+
+        _time.sleep(1.1)
+        second = generate_server_jwt()
+        assert first != second
+
+    def test_cache_refreshes_when_ttl_elapsed(self, settings):
+        """AC-3: cached token must not be reused past FORGEKEY_SERVER_JWT_CACHE_SECONDS."""
+        settings.FORGEKEY_SERVER_JWT_CACHE_SECONDS = 0
+        first = generate_server_jwt()
+        import time as _time
+
+        _time.sleep(1.1)
+        second = generate_server_jwt()
+        assert first != second
+
+    def test_cache_refreshes_before_expiry(self, settings):
+        """AC-3: refresh shortly before exp so EMQX never sees a stale token."""
+        # exp = 30s from now, refresh buffer is 60s → next call must re-sign.
+        settings.FORGEKEY_SERVER_JWT_EXPIRATION_SECONDS = 30
+        first = generate_server_jwt()
+        import time as _time
+
+        _time.sleep(1.1)
+        second = generate_server_jwt()
+        assert first != second

--- a/backend/forgekey/utils.py
+++ b/backend/forgekey/utils.py
@@ -2,6 +2,7 @@
 Utility functions for ForgeKey.
 """
 
+import time
 from datetime import datetime, timezone
 from typing import Dict, Optional
 
@@ -10,6 +11,11 @@ from django.conf import settings
 import jwt
 
 from .services.jwt_signing import JwtSigningError, get_jwt_public_key_pem, load_jwt_signing_key
+
+SERVER_JWT_SUBJECT = "oms-backend"
+# Refresh the cached server JWT this many seconds before its `exp`. Bounds the
+# worst-case clock-skew window between OMS and EMQX.
+_SERVER_JWT_REFRESH_BUFFER_SECONDS = 60
 
 
 def normalize_mac_address(mac_address: str) -> str:
@@ -93,6 +99,75 @@ def generate_device_jwt(
         headers={"kid": settings.FORGEKEY_JWT_KEY_ID},
     )
 
+    return token
+
+
+_server_jwt_cache: Dict[str, object] = {"token": None, "cached_at": 0.0, "exp": 0}
+
+
+def invalidate_server_jwt_cache() -> None:
+    """Drop the cached server JWT so the next call re-signs.
+
+    Called from the MQTT connect-failure path (oms-y5p AC-3): if EMQX rejects
+    our credential we mint a fresh one rather than retrying with the same
+    (possibly clock-skewed or expired) token.
+    """
+    _server_jwt_cache["token"] = None
+    _server_jwt_cache["cached_at"] = 0.0
+    _server_jwt_cache["exp"] = 0
+
+
+def generate_server_jwt() -> str:
+    """ES256-signed JWT for the OMS backend's own MQTT connection.
+
+    Issued by the same signing key that signs device JWTs; EMQX verifies it via
+    the JWKS endpoint with no extra configuration. Subject is ``oms-backend``
+    and the ACL grants pub/sub on the entire ``MQTT_TOPIC_PREFIX`` namespace
+    so the backend can dispatch commands to every device and consume status
+    from any of them.
+
+    Cached per-process for ``FORGEKEY_SERVER_JWT_CACHE_SECONDS`` so we don't
+    re-sign on every MQTT connect, with a small refresh buffer before ``exp``
+    to absorb clock skew.
+
+    Raises:
+        JwtSigningError: if ``FORGEKEY_JWT_SIGNING_KEY`` is unconfigured.
+    """
+    now = time.time()
+    cached_token = _server_jwt_cache["token"]
+    cached_at = float(_server_jwt_cache["cached_at"])
+    cached_exp = int(_server_jwt_cache["exp"])
+    cache_ttl = getattr(settings, "FORGEKEY_SERVER_JWT_CACHE_SECONDS", 60 * 60 * 24)
+    if (
+        cached_token
+        and now - cached_at < cache_ttl
+        and now < cached_exp - _SERVER_JWT_REFRESH_BUFFER_SECONDS
+    ):
+        return str(cached_token)
+
+    private_key = load_jwt_signing_key()
+    iat = int(now)
+    exp = iat + getattr(settings, "FORGEKEY_SERVER_JWT_EXPIRATION_SECONDS", 60 * 60 * 24 * 365)
+    claims = {
+        "iss": settings.FORGEKEY_JWT_ISSUER,
+        "aud": settings.FORGEKEY_JWT_AUDIENCE,
+        "sub": SERVER_JWT_SUBJECT,
+        "iat": iat,
+        "exp": exp,
+        "acl": {
+            "pub": [f"{settings.MQTT_TOPIC_PREFIX}/#"],
+            "sub": [f"{settings.MQTT_TOPIC_PREFIX}/#"],
+        },
+    }
+    token = jwt.encode(
+        claims,
+        private_key,
+        algorithm=settings.FORGEKEY_JWT_ALGORITHM,
+        headers={"kid": settings.FORGEKEY_JWT_KEY_ID},
+    )
+    _server_jwt_cache["token"] = token
+    _server_jwt_cache["cached_at"] = now
+    _server_jwt_cache["exp"] = exp
     return token
 
 

--- a/docs/EMQX_CONFIGURATION.md
+++ b/docs/EMQX_CONFIGURATION.md
@@ -113,6 +113,38 @@ to match. Two ways to force-recover:
 
 See `docs/INCIDENTS/emqx-jwks-nxdomain.md` for the full runbook.
 
+## Backend authentication (oms-y5p)
+
+The OMS backend itself also speaks MQTT — it publishes commands (blink,
+restart, capture, OTA triggers) to devices and consumes status messages. With
+`mqtt.allow_anonymous = false` the backend needs a credential too, and EMQX's
+JWT authenticator does not accept literal username/password pairs.
+
+The backend solves this by **issuing its own server JWT**, signed with the
+same `FORGEKEY_JWT_SIGNING_KEY` that signs device JWTs. EMQX verifies it via
+the same JWKS endpoint with no extra configuration:
+
+- **Username**: `oms-backend`
+- **Password**: a self-signed ES256 JWT with `sub=oms-backend`, the standard
+  `iss` / `aud` claims, and an `acl` claim granting `pub`/`sub` on the entire
+  `MQTT_TOPIC_PREFIX/#` namespace so the backend can talk to every device.
+- **Caching**: the JWT is cached in-process for
+  `FORGEKEY_SERVER_JWT_CACHE_SECONDS` (default 24 hours) so we don't re-sign
+  on every MQTT connect. The token's own `exp` is
+  `FORGEKEY_SERVER_JWT_EXPIRATION_SECONDS` (default 1 year) and the cache is
+  refreshed shortly before expiry. On any MQTT connect failure the cache is
+  invalidated so the next reconnect mints a fresh credential.
+
+There is **no separate user-management** for the backend — no Built-in DB
+entry, no extra password env var to rotate. As long as
+`FORGEKEY_JWT_SIGNING_KEY` is set (which it must be for device auth to work
+at all), the backend can authenticate.
+
+If `MQTT_BROKER_USERNAME` / `MQTT_BROKER_PASSWORD` are set in the environment,
+the backend's `forgekey.W008` system check warns at startup — those literal
+credentials are ignored by the JWT authenticator and silently break every
+command publish. Unset them.
+
 ## Key rotation
 
 To rotate the device-JWT signing key:


### PR DESCRIPTION
Fixes oms-y5p (P1) — backend MQTT auth was using a literal username/password; switches to minting a server JWT. Adds doctor checks for the JWT path.

Single commit. MR oms-wisp-md0 (P1).