### PR TITLE
fix(deploy): extend prod env validator with Sentry, observability, and cookie-secure checks

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -44,7 +44,21 @@ CELERY_BROKER_URL=redis://redis:6379/0
 # URLs
 FRONTEND_URL=https://oms.example.com
 
-# Sentry (Optional - for error tracking)
+# Observability (Highlight is the primary sink; Sentry is a fallback path)
+#
+# Production should configure at least one: the validator warns when both are
+# empty, since uncaught crashes will only appear in container logs.
+#
+# Highlight (preferred — replaced Sentry per oms-fjs / #319):
+#   HIGHLIGHT_PROJECT_ID    — verbose project id from the Highlight dashboard.
+#   HIGHLIGHT_OTLP_ENDPOINT — optional override for self-hosted collectors.
+#                             Must be https:// when set (no plaintext OTLP).
+HIGHLIGHT_PROJECT_ID=
+HIGHLIGHT_OTLP_ENDPOINT=
+
+# Sentry (Optional fallback). Both DSNs are validated when set: must be
+# https:// URLs (the validator refuses http to avoid plaintext error transport).
+# Empty is allowed.
 SENTRY_DSN=
 SENTRY_ENVIRONMENT=production
 REACT_APP_SENTRY_DSN=

--- a/backend/config/tests/test_deployment_validation.py
+++ b/backend/config/tests/test_deployment_validation.py
@@ -126,6 +126,8 @@ class TestProductionEnvValidatorAC23:
             ("LETSENCRYPT_EMAIL", "", "LETSENCRYPT_EMAIL"),
             ("HIGHLIGHT_OTLP_ENDPOINT", "http://otel.example.org:4317", "HIGHLIGHT_OTLP_ENDPOINT"),
             ("FORGEKEY_FIRMWARE_SIGNING_KEY", "not-a-pem", "FORGEKEY_FIRMWARE_SIGNING_KEY"),
+            ("SENTRY_DSN", "http://abc@o0.ingest.sentry.io/123", "SENTRY_DSN"),
+            ("REACT_APP_SENTRY_DSN", "http://abc@o0.ingest.sentry.io/123", "REACT_APP_SENTRY_DSN"),
         ],
     )
     def test_unsafe_value_rejected(self, tmp_path, key, value, fragment):
@@ -155,6 +157,70 @@ class TestProductionEnvValidatorAC23:
         result = _run_validator(env)
         assert result.returncode == 0, result.stdout
         assert "Warnings" in result.stdout
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "SENTRY_DSN",
+            "REACT_APP_SENTRY_DSN",
+        ],
+    )
+    def test_sentry_https_value_allowed(self, tmp_path, key):
+        env = _write_env(
+            tmp_path,
+            overrides={key: "https://abc@o0.ingest.sentry.io/123"},
+        )
+        result = _run_validator(env)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "SENTRY_DSN",
+            "REACT_APP_SENTRY_DSN",
+        ],
+    )
+    def test_empty_sentry_value_allowed(self, tmp_path, key):
+        env = _write_env(tmp_path, overrides={key: ""})
+        result = _run_validator(env)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_observability_warning_when_highlight_and_sentry_both_unset(self, tmp_path):
+        env = _write_env(
+            tmp_path,
+            overrides={"HIGHLIGHT_PROJECT_ID": "", "SENTRY_DSN": ""},
+        )
+        result = _run_validator(env)
+        assert result.returncode == 0, result.stdout
+        assert "Neither HIGHLIGHT_PROJECT_ID nor SENTRY_DSN" in result.stdout
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"HIGHLIGHT_PROJECT_ID": "proj_123", "SENTRY_DSN": ""},
+            {"HIGHLIGHT_PROJECT_ID": "", "SENTRY_DSN": "https://abc@o0.ingest.sentry.io/123"},
+        ],
+    )
+    def test_observability_warning_absent_when_highlight_or_sentry_present(self, tmp_path, overrides):
+        env = _write_env(tmp_path, overrides=overrides)
+        result = _run_validator(env)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Neither HIGHLIGHT_PROJECT_ID nor SENTRY_DSN" not in result.stdout
+
+    @pytest.mark.parametrize("value", ["False", "false", "0", "off", "no", ""])
+    @pytest.mark.parametrize("key", ["SESSION_COOKIE_SECURE", "CSRF_COOKIE_SECURE"])
+    def test_cookie_secure_falsy_override_warns(self, tmp_path, key, value):
+        env = _write_env(tmp_path, overrides={key: value})
+        result = _run_validator(env)
+        assert result.returncode == 0, result.stdout
+        assert key in result.stdout
+
+    @pytest.mark.parametrize("key", ["SESSION_COOKIE_SECURE", "CSRF_COOKIE_SECURE"])
+    def test_cookie_secure_unset_has_no_warning(self, tmp_path, key):
+        env = _write_env(tmp_path)
+        result = _run_validator(env)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert key not in result.stdout
 
 
 class TestNoOperatorSpecificDefaultsAC24:

--- a/backend/config/tests/test_deployment_validation.py
+++ b/backend/config/tests/test_deployment_validation.py
@@ -201,7 +201,9 @@ class TestProductionEnvValidatorAC23:
             {"HIGHLIGHT_PROJECT_ID": "", "SENTRY_DSN": "https://abc@o0.ingest.sentry.io/123"},
         ],
     )
-    def test_observability_warning_absent_when_highlight_or_sentry_present(self, tmp_path, overrides):
+    def test_observability_warning_absent_when_highlight_or_sentry_present(
+        self, tmp_path, overrides
+    ):
         env = _write_env(tmp_path, overrides=overrides)
         result = _run_validator(env)
         assert result.returncode == 0, result.stdout + result.stderr

--- a/scripts/validate-prod-env.sh
+++ b/scripts/validate-prod-env.sh
@@ -18,8 +18,13 @@
 #   - Webhook tokens: POSTMARK_INBOUND_TOKEN, LOCATION_PING_TOKEN (warned if empty)
 #   - Email: EMAIL_BACKEND must not be the console backend in prod
 #   - Highlight: if HIGHLIGHT_OTLP_ENDPOINT set, must be an https:// URL
-#   - Cookie security: SESSION_COOKIE_SECURE, CSRF_COOKIE_SECURE inferred from
-#     DEBUG=0 in settings.py — verified by Django's deployment check below
+#   - Sentry: if SENTRY_DSN / REACT_APP_SENTRY_DSN set, must be an https:// URL.
+#     A warning fires when neither Highlight nor Sentry is configured (no
+#     observability sink — production errors will only land in container logs).
+#   - Cookie security: SESSION_COOKIE_SECURE and CSRF_COOKIE_SECURE default to
+#     `not DEBUG` in settings.py. Operators who explicitly override either to
+#     a falsy value when DEBUG=0 are warned — this re-enables plaintext cookies
+#     and breaks the secure-by-default deploy contract.
 #
 # Exit codes:
 #   0 — environment is safe for production deploy
@@ -252,6 +257,59 @@ if [ -n "${HIGHLIGHT_OTLP_ENDPOINT:-}" ]; then
         https://*) ;;
         *) err "HIGHLIGHT_OTLP_ENDPOINT must be https:// for production (got: $HIGHLIGHT_OTLP_ENDPOINT)." ;;
     esac
+fi
+
+# --- 10a. Sentry -------------------------------------------------------------
+# Highlight replaced Sentry per oms-fjs (#319), but the backend still honours
+# SENTRY_DSN as a fallback path (see backend/config/health.py). Treat Sentry
+# DSNs as optional-but-validated: empty is fine, but any value that's set must
+# be an https:// URL — http leaks events in plaintext, and a typo would
+# silently disable error reporting in production.
+
+if [ -n "${SENTRY_DSN:-}" ]; then
+    case "$SENTRY_DSN" in
+        https://*) ;;
+        *) err "SENTRY_DSN must be an https:// URL for production (got: $SENTRY_DSN)." ;;
+    esac
+fi
+
+if [ -n "${REACT_APP_SENTRY_DSN:-}" ]; then
+    case "$REACT_APP_SENTRY_DSN" in
+        https://*) ;;
+        *) err "REACT_APP_SENTRY_DSN must be an https:// URL for production (got: $REACT_APP_SENTRY_DSN)." ;;
+    esac
+fi
+
+# Observability presence policy: production needs at least one error sink so
+# crashes don't disappear into container logs the operator never reads.
+# Warn (not error) so air-gapped or self-hosted-without-telemetry deploys can
+# proceed if the operator has accepted that trade-off.
+
+if [ -z "${HIGHLIGHT_PROJECT_ID:-}" ] && [ -z "${SENTRY_DSN:-}" ]; then
+    warn "Neither HIGHLIGHT_PROJECT_ID nor SENTRY_DSN is set — production errors will only appear in container logs. Configure one for visibility into crashes and 5xx responses."
+fi
+
+# --- 10b. Cookie security ----------------------------------------------------
+# settings.py defaults SESSION_COOKIE_SECURE / CSRF_COOKIE_SECURE to `not DEBUG`,
+# so DEBUG=0 enables them automatically. But the env-driven config() lookup
+# means an operator can still override either to "False"/"0"/"off" and ship a
+# production deploy that emits cookies over plaintext HTTP. Warn loudly when
+# that happens — the override is almost never intentional in prod.
+
+is_falsy() {
+    case "${1,,}" in
+        ""|0|false|off|no) return 0 ;;
+    esac
+    return 1
+}
+
+# Only warn when the env explicitly sets the value to a falsy literal — an
+# unset variable inherits the secure default and is fine.
+if [ "${SESSION_COOKIE_SECURE+set}" = set ] && is_falsy "${SESSION_COOKIE_SECURE}"; then
+    warn "SESSION_COOKIE_SECURE=${SESSION_COOKIE_SECURE} — production with DEBUG=0 should leave this unset (defaults to True) so session cookies are not sent over plaintext HTTP."
+fi
+if [ "${CSRF_COOKIE_SECURE+set}" = set ] && is_falsy "${CSRF_COOKIE_SECURE}"; then
+    warn "CSRF_COOKIE_SECURE=${CSRF_COOKIE_SECURE} — production with DEBUG=0 should leave this unset (defaults to True) so CSRF tokens are not sent over plaintext HTTP."
 fi
 
 # --- 11. Webhook / IoT shared secrets ---------------------------------------


### PR DESCRIPTION
## Summary

Per AC-23 the production env validator should refuse unsafe Sentry/cookie config on top of existing checks. Adds four new policies + tests.

- **SENTRY_DSN / REACT_APP_SENTRY_DSN** — must be `https://` when set, empty allowed (refuses `http://` to avoid plaintext error transport)
- **Observability presence** — non-fatal warning when neither `HIGHLIGHT_PROJECT_ID` nor `SENTRY_DSN` is configured (otherwise crashes only appear in container logs)
- **Cookie security** — non-fatal warning when `SESSION_COOKIE_SECURE` or `CSRF_COOKIE_SECURE` is explicitly overridden to a falsy literal under `DEBUG=0`

`.env.prod.example` now has `HIGHLIGHT_PROJECT_ID`/`HIGHLIGHT_OTLP_ENDPOINT` slots and clarified Sentry policy comments.

## Test plan

Tests authored independently via **codex (OpenAI)** for AI-diversity coverage — Claude wrote the validator + example changes; codex wrote the pytest cases:

- [ ] CI runs `backend/config/tests/test_deployment_validation.py` — parametrized rejection of `http://` Sentry DSNs (extends existing AC-23 unsafe-value list)
- [ ] Allowed-https Sentry DSN cases pass (`test_sentry_https_value_allowed`)
- [ ] Empty Sentry DSN cases pass (`test_empty_sentry_value_allowed`)
- [ ] Observability presence warning fires when both unset; absent when either set
- [ ] Cookie-secure falsy-literal warnings (False/false/0/off/no/empty); no warning when unset

Manual smoke tests run before commit:
- baseline well-formed env still passes (with new presence warning)
- `SENTRY_DSN=http://...` rejected with clear error
- `REACT_APP_SENTRY_DSN=http://...` rejected
- `SESSION_COOKIE_SECURE=False` warns but does not fail
- valid `https://` Sentry DSN suppresses presence warning

Fixes #337