### PR TITLE
feat(donations): audit trail for donation, tax-receipt, and disposition actions

### DIFF
--- a/backend/donations/audit.py
+++ b/backend/donations/audit.py
@@ -1,0 +1,69 @@
+"""Audit-event recording for donation actions (gh #354 / #334).
+
+Mirrors ``forgekey.audit.record_event`` (gh #352) and
+``reorder_queue.audit.record_event`` (gh #353) so the eventual unified
+review surface (gh #359) can join across domains without per-domain
+quirks.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from django.contrib.auth import get_user_model
+
+from .models import (
+    Disposition,
+    Donation,
+    DonationAuditEvent,
+    DonationItem,
+    TaxReceipt,
+)
+
+User = get_user_model()
+
+
+def record_event(
+    *,
+    action: str,
+    actor: Optional[User] = None,
+    donation: Optional[Donation] = None,
+    donation_item: Optional[DonationItem] = None,
+    tax_receipt: Optional[TaxReceipt] = None,
+    disposition: Optional[Disposition] = None,
+    notes: str = "",
+    metadata: Optional[Dict[str, Any]] = None,
+) -> DonationAuditEvent:
+    """Record a donation audit event.
+
+    At least one of ``donation``, ``donation_item``, ``tax_receipt``, or
+    ``disposition`` must be supplied so the row is queryable by entity.
+    The ``donation`` FK is auto-derived from the supplied tax_receipt /
+    donation_item / disposition when one is passed without an explicit
+    donation, so audit rows always have an entity-level pointer for
+    review-surface queries.
+
+    Anonymous / system-initiated actions are allowed (``actor=None``);
+    the audit row simply records "no known user."
+    """
+    if donation is None:
+        if tax_receipt is not None:
+            donation = tax_receipt.donation
+        elif donation_item is not None:
+            donation = donation_item.donation
+        elif disposition is not None:
+            # Disposition -> DonationItem -> Donation
+            disposition_item = getattr(disposition, "donation_item", None)
+            if disposition_item is not None:
+                donation = disposition_item.donation
+
+    return DonationAuditEvent.objects.create(
+        action=action,
+        actor=actor if (actor is not None and getattr(actor, "is_authenticated", False)) else None,
+        donation=donation,
+        donation_item=donation_item,
+        tax_receipt=tax_receipt,
+        disposition=disposition,
+        notes=notes,
+        metadata=metadata or {},
+    )

--- a/backend/donations/migrations/0004_donationauditevent.py
+++ b/backend/donations/migrations/0004_donationauditevent.py
@@ -1,0 +1,118 @@
+# Generated for gh #354 — append-only audit events for donation,
+# tax-receipt, and disposition actions.
+
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("donations", "0003_donation_tax_receipt_issued_at_taxreceipt"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DonationAuditEvent",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "action",
+                    models.CharField(
+                        choices=[
+                            ("donation_create", "Donation created"),
+                            ("tax_receipt_issued", "Tax receipt issued"),
+                            ("tax_receipt_regenerate", "Tax receipt regenerated"),
+                            ("item_disposed", "Donation item disposed"),
+                        ],
+                        max_length=32,
+                    ),
+                ),
+                ("notes", models.TextField(blank=True)),
+                (
+                    "metadata",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        help_text=(
+                            "Action-specific payload (serial number, " "disposition method, etc)."
+                        ),
+                    ),
+                ),
+                (
+                    "actor",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text=(
+                            "User who performed the action; null for " "system-initiated events."
+                        ),
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="donation_audit_actions",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "donation",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="audit_events",
+                        to="donations.donation",
+                    ),
+                ),
+                (
+                    "donation_item",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="audit_events",
+                        to="donations.donationitem",
+                    ),
+                ),
+                (
+                    "tax_receipt",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="audit_events",
+                        to="donations.taxreceipt",
+                    ),
+                ),
+                (
+                    "disposition",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="audit_events",
+                        to="donations.disposition",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+                "indexes": [
+                    models.Index(fields=["donation", "-created_at"], name="don_audit_donation_idx"),
+                    models.Index(fields=["actor", "-created_at"], name="don_audit_actor_idx"),
+                    models.Index(fields=["action", "-created_at"], name="don_audit_action_idx"),
+                ],
+            },
+        ),
+    ]

--- a/backend/donations/models.py
+++ b/backend/donations/models.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import uuid
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.utils import timezone
@@ -551,3 +552,92 @@ class TaxReceipt(models.Model):
     def __str__(self) -> str:
         copy_text = " (Copy)" if self.is_copy else ""
         return f"Tax Receipt {self.serial_number} - {self.donation.donor_name}{copy_text}"
+
+
+class DonationAuditEvent(models.Model):
+    """Append-only audit log for donation, tax-receipt, and disposition actions.
+
+    Captures actor, timestamp, affected entity, notes, and metadata for each
+    safety- or financial-relevant mutation. Rows are written by
+    ``donations.audit.record_event`` and never updated or deleted by
+    application code.
+
+    Per gh #354 / #334. Pattern mirrors
+    ``forgekey.ForgeKeyAuditEvent`` (gh #352) and
+    ``reorder_queue.PurchaseOrderAuditEvent`` (gh #353) so the eventual
+    unified review surface (gh #359) can join across domains cleanly.
+    """
+
+    ACTION_DONATION_CREATE = "donation_create"
+    ACTION_TAX_RECEIPT_ISSUED = "tax_receipt_issued"
+    ACTION_TAX_RECEIPT_REGENERATE = "tax_receipt_regenerate"
+    ACTION_ITEM_DISPOSED = "item_disposed"
+
+    ACTION_CHOICES = [
+        (ACTION_DONATION_CREATE, "Donation created"),
+        (ACTION_TAX_RECEIPT_ISSUED, "Tax receipt issued"),
+        (ACTION_TAX_RECEIPT_REGENERATE, "Tax receipt regenerated"),
+        (ACTION_ITEM_DISPOSED, "Donation item disposed"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    actor = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="donation_audit_actions",
+        help_text="User who performed the action; null for system-initiated events.",
+    )
+    action = models.CharField(max_length=32, choices=ACTION_CHOICES)
+    # Optional FKs to entities involved. At least one is set per row;
+    # SET_NULL on delete so the audit trail survives entity teardown.
+    donation = models.ForeignKey(
+        Donation,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="audit_events",
+    )
+    donation_item = models.ForeignKey(
+        DonationItem,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="audit_events",
+    )
+    tax_receipt = models.ForeignKey(
+        TaxReceipt,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="audit_events",
+    )
+    disposition = models.ForeignKey(
+        Disposition,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="audit_events",
+    )
+    notes = models.TextField(blank=True)
+    metadata = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Action-specific payload (serial number, disposition method, etc).",
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["donation", "-created_at"], name="don_audit_donation_idx"),
+            models.Index(fields=["actor", "-created_at"], name="don_audit_actor_idx"),
+            models.Index(fields=["action", "-created_at"], name="don_audit_action_idx"),
+        ]
+
+    def __str__(self) -> str:
+        target = (
+            self.donation_id or self.donation_item_id or self.tax_receipt_id or self.disposition_id
+        )
+        return f"{self.action} ({target}) @ {self.created_at:%Y-%m-%d %H:%M}"

--- a/backend/donations/tests/test_audit_events.py
+++ b/backend/donations/tests/test_audit_events.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 from django.urls import reverse
+from django.utils import timezone
 
 import pytest
 
@@ -19,6 +20,14 @@ from donations.tests.factories import (
 from forgekey.tests.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
+
+
+# DonationFactory.date_received defaults to ``timezone.now()`` (a
+# datetime) but ``Donation.date_received`` is a DateField. DRF serializers
+# refuse to coerce datetime -> date on read and 500 the
+# generate_tax_receipt response. Pass an explicit date so the codepath
+# under test is the audit hook, not a pre-existing factory shape bug.
+_TODAY = timezone.now().date()
 
 
 def test_donation_create_records_audit_event(api_client):
@@ -46,7 +55,7 @@ def test_donation_create_records_audit_event(api_client):
 
 def test_tax_receipt_issued_records_audit_event(api_client):
     actor = UserFactory()
-    donation = DonationFactory(donor_email="")
+    donation = DonationFactory(donor_email="", date_received=_TODAY)
     api_client.force_authenticate(user=actor)
 
     with patch("donations.views.TaxReceiptPDFGenerator") as generator_cls:
@@ -72,7 +81,7 @@ def test_tax_receipt_issued_records_audit_event(api_client):
 
 def test_tax_receipt_regenerate_records_audit_event(api_client):
     actor = UserFactory(is_staff=True, is_superuser=True)
-    tax_receipt = TaxReceiptFactory(donation__donor_email="")
+    tax_receipt = TaxReceiptFactory(donation__donor_email="", donation__date_received=_TODAY)
     api_client.force_authenticate(user=actor)
 
     with patch("donations.views.TaxReceiptPDFGenerator") as generator_cls:

--- a/backend/donations/tests/test_audit_events.py
+++ b/backend/donations/tests/test_audit_events.py
@@ -1,0 +1,186 @@
+"""Tests for donation audit-event emission hooks."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.urls import reverse
+
+import pytest
+
+from donations.audit import record_event
+from donations.models import DonationAuditEvent
+from donations.tests.factories import (
+    DispositionFactory,
+    DonationFactory,
+    DonationItemFactory,
+    TaxReceiptFactory,
+)
+from forgekey.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_donation_create_records_audit_event(api_client):
+    actor = UserFactory()
+    api_client.force_authenticate(user=actor)
+
+    response = api_client.post(
+        reverse("donation-list"),
+        {
+            "donor_name": "Acme",
+            "date_received": "2026-05-07",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 201, response.content
+    assert DonationAuditEvent.objects.count() == 1
+
+    event = DonationAuditEvent.objects.get(action=DonationAuditEvent.ACTION_DONATION_CREATE)
+    assert event.actor == actor
+    assert event.donation is not None
+    assert event.metadata["donor_name"] == "Acme"
+    assert event.metadata["donation_number"]
+
+
+def test_tax_receipt_issued_records_audit_event(api_client):
+    actor = UserFactory()
+    donation = DonationFactory(donor_email="")
+    api_client.force_authenticate(user=actor)
+
+    with patch("donations.views.TaxReceiptPDFGenerator") as generator_cls:
+        generator = MagicMock()
+        generator.generate_and_save.return_value = "tax_receipts/test.pdf"
+        generator_cls.return_value = generator
+
+        response = api_client.post(
+            reverse("donation-generate-tax-receipt", kwargs={"pk": donation.pk}),
+            {},
+            format="json",
+        )
+
+    assert response.status_code == 201, response.content
+    assert DonationAuditEvent.objects.count() == 1
+
+    event = DonationAuditEvent.objects.get(action=DonationAuditEvent.ACTION_TAX_RECEIPT_ISSUED)
+    assert event.actor == actor
+    assert event.donation == donation
+    assert event.tax_receipt is not None
+    assert event.metadata["serial_number"] == str(event.tax_receipt.serial_number)
+
+
+def test_tax_receipt_regenerate_records_audit_event(api_client):
+    actor = UserFactory(is_staff=True, is_superuser=True)
+    tax_receipt = TaxReceiptFactory(donation__donor_email="")
+    api_client.force_authenticate(user=actor)
+
+    with patch("donations.views.TaxReceiptPDFGenerator") as generator_cls:
+        generator = MagicMock()
+        generator.generate_and_save.return_value = "tax_receipts/test.pdf"
+        generator_cls.return_value = generator
+
+        response = api_client.post(
+            reverse("tax-receipt-regenerate", kwargs={"pk": tax_receipt.pk}),
+            {},
+            format="json",
+        )
+
+    assert response.status_code == 200, response.content
+    assert DonationAuditEvent.objects.count() == 1
+
+    event = DonationAuditEvent.objects.get(action=DonationAuditEvent.ACTION_TAX_RECEIPT_REGENERATE)
+    assert event.actor == actor
+    assert event.tax_receipt == tax_receipt
+    assert event.donation == tax_receipt.donation
+    assert event.metadata["serial_number"] == str(tax_receipt.serial_number)
+    assert event.metadata["is_copy"] is tax_receipt.is_copy
+
+
+def test_disposition_create_records_audit_event(api_client):
+    actor = UserFactory()
+    donation_item = DonationItemFactory()
+    api_client.force_authenticate(user=actor)
+
+    response = api_client.post(
+        reverse("disposition-list"),
+        {
+            "donation_item": donation_item.pk,
+            "disposition_type": "disposed",
+            "quantity": 1,
+            "disposition_date": "2026-05-07",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 201, response.content
+    assert DonationAuditEvent.objects.count() == 1
+
+    event = DonationAuditEvent.objects.get(action=DonationAuditEvent.ACTION_ITEM_DISPOSED)
+    assert event.actor == actor
+    assert event.disposition is not None
+    assert event.donation_item == donation_item
+    assert event.donation == donation_item.donation
+    assert event.metadata["disposition_type"] == "disposed"
+
+
+def test_record_event_with_anonymous_actor_creates_row_with_null_actor():
+    donation = DonationFactory()
+
+    event = record_event(
+        action=DonationAuditEvent.ACTION_DONATION_CREATE,
+        actor=None,
+        donation=donation,
+    )
+
+    assert DonationAuditEvent.objects.count() == 1
+    assert event.actor is None
+    assert event.donation == donation
+
+
+def test_record_event_derives_donation_from_tax_receipt():
+    actor = UserFactory()
+    tax_receipt = TaxReceiptFactory()
+
+    event = record_event(
+        action=DonationAuditEvent.ACTION_TAX_RECEIPT_ISSUED,
+        actor=actor,
+        tax_receipt=tax_receipt,
+    )
+
+    assert DonationAuditEvent.objects.count() == 1
+    assert event.actor == actor
+    assert event.tax_receipt == tax_receipt
+    assert event.donation == tax_receipt.donation
+
+
+def test_record_event_derives_donation_from_donation_item():
+    actor = UserFactory()
+    donation_item = DonationItemFactory()
+
+    event = record_event(
+        action=DonationAuditEvent.ACTION_ITEM_DISPOSED,
+        actor=actor,
+        donation_item=donation_item,
+    )
+
+    assert DonationAuditEvent.objects.count() == 1
+    assert event.actor == actor
+    assert event.donation_item == donation_item
+    assert event.donation == donation_item.donation
+
+
+def test_record_event_derives_donation_from_disposition():
+    actor = UserFactory()
+    disposition = DispositionFactory()
+
+    event = record_event(
+        action=DonationAuditEvent.ACTION_ITEM_DISPOSED,
+        actor=actor,
+        disposition=disposition,
+    )
+
+    assert DonationAuditEvent.objects.count() == 1
+    assert event.actor == actor
+    assert event.disposition == disposition
+    assert event.donation == disposition.donation_item.donation

--- a/backend/donations/views.py
+++ b/backend/donations/views.py
@@ -160,6 +160,14 @@ class DonationViewSet(viewsets.ModelViewSet):
                 issued_by=request.user,
                 is_copy=False,
             )
+            # ``issued_date`` is a DateField defaulting to ``timezone.now``
+            # (a datetime). Django stores it as a date, but the in-memory
+            # instance returned from ``create()`` keeps the datetime — and
+            # ``TaxReceiptSerializer`` (DRF) refuses to coerce datetime ->
+            # date on read, surfacing as an "Expected `date`, got
+            # `datetime`" 500. Refresh from DB so the field reflects the
+            # stored value before any serializer touches it.
+            tax_receipt.refresh_from_db()
 
             # Generate PDF
             generator = TaxReceiptPDFGenerator(is_copy=False)

--- a/backend/donations/views.py
+++ b/backend/donations/views.py
@@ -15,6 +15,7 @@ from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
+from .audit import record_event as record_audit_event
 from .models import Disposition, Donation, DonationItem, TaxReceipt
 from .serializers import (
     DispositionSerializer,
@@ -51,6 +52,18 @@ class DonationViewSet(viewsets.ModelViewSet):
         if status_filter:
             queryset = queryset.filter(status=status_filter)
         return queryset.select_related("received_by", "reviewed_by").prefetch_related("items")
+
+    def perform_create(self, serializer):
+        donation = serializer.save()
+        record_audit_event(
+            action="donation_create",
+            actor=self.request.user,
+            donation=donation,
+            metadata={
+                "donation_number": donation.donation_number,
+                "donor_name": donation.donor_name,
+            },
+        )
 
     @action(detail=True, methods=["post"])
     def generate_sticker_sheet(self, request, pk=None):
@@ -168,6 +181,17 @@ class DonationViewSet(viewsets.ModelViewSet):
                     "tax_receipt_number",
                     "tax_receipt_issued_at",
                 ]
+            )
+
+            record_audit_event(
+                action="tax_receipt_issued",
+                actor=request.user,
+                donation=donation,
+                tax_receipt=tax_receipt,
+                metadata={
+                    "serial_number": str(tax_receipt.serial_number),
+                    "signature_user_id": (signature_user.id if signature_user else request.user.id),
+                },
             )
 
             # Send email to donor
@@ -296,6 +320,19 @@ class DispositionViewSet(viewsets.ModelViewSet):
             "donation_item", "donation_item__donation", "disposed_by", "created_asset"
         )
 
+    def perform_create(self, serializer):
+        disposition = serializer.save()
+        record_audit_event(
+            action="item_disposed",
+            actor=self.request.user,
+            disposition=disposition,
+            donation_item=disposition.donation_item,
+            metadata={
+                "disposition_type": disposition.disposition_type,
+                "disposition_id": str(disposition.id),
+            },
+        )
+
 
 class TaxReceiptViewSet(viewsets.ReadOnlyModelViewSet):
     """ViewSet for TaxReceipt operations."""
@@ -393,6 +430,21 @@ class TaxReceiptViewSet(viewsets.ReadOnlyModelViewSet):
             # Update tax receipt with PDF path
             tax_receipt.pdf_file = pdf_path
             tax_receipt.save()
+
+            record_audit_event(
+                action="tax_receipt_regenerate",
+                actor=request.user,
+                tax_receipt=tax_receipt,
+                metadata={
+                    "serial_number": str(tax_receipt.serial_number),
+                    "is_copy": tax_receipt.is_copy,
+                    "signature_user_id": (
+                        signature_user.id
+                        if signature_user
+                        else (tax_receipt.issued_by.id if tax_receipt.issued_by else None)
+                    ),
+                },
+            )
 
             serializer = TaxReceiptSerializer(tax_receipt)
             return Response(serializer.data)


### PR DESCRIPTION
## Summary

Third domain landing of the #334 audit-trail work — **donations** (donation creation, tax-receipt issuance/regeneration, item dispositions). Mirrors the pattern from #352 (devices) and #353 (purchase orders) so the eventual unified review surface (#359) joins cleanly.

## What's new

- **`DonationAuditEvent`** model — append-only, FK to actor, action choices, optional FKs to `donation` / `donation_item` / `tax_receipt` / `disposition`, notes, JSON metadata.
- **`donations.audit.record_event(...)`** — single emission helper. Auto-derives `donation` from a supplied `tax_receipt`, `donation_item`, or `disposition`.

## Emission sites

| Site | Action | Notable metadata |
|------|--------|------------------|
| `DonationViewSet.perform_create` | `donation_create` | donation_number, donor_name |
| `DonationViewSet.generate_tax_receipt` | `tax_receipt_issued` | serial_number, signature_user_id |
| `TaxReceiptViewSet.regenerate` | `tax_receipt_regenerate` | serial_number, is_copy, signature_user_id |
| `DispositionViewSet.perform_create` | `item_disposed` | disposition_type, disposition_id |

## Out of scope (follow-ups)

- Donation `perform_update` / field-level edits.
- TaxReceipt revocation — not modeled today.
- Donor record edits — donor info is denormalized onto Donation rows; any donor-level audit would land in this same table.

## Test plan

Tests authored independently via **codex (OpenAI)** for AI-diversity coverage.

`backend/donations/tests/test_audit_events.py`:
- [ ] `test_donation_create_records_audit_event`
- [ ] `test_tax_receipt_issued_records_audit_event` (PDF generator mocked)
- [ ] `test_tax_receipt_regenerate_records_audit_event` (admin only)
- [ ] `test_disposition_create_records_audit_event` (auto-derives donation)
- [ ] `test_record_event_with_anonymous_actor_creates_row_with_null_actor`
- [ ] `test_record_event_derives_donation_from_tax_receipt`
- [ ] `test_record_event_derives_donation_from_donation_item`
- [ ] `test_record_event_derives_donation_from_disposition`

Manual: black/isort/flake8 clean. Migration hand-written following the `0003_*` pattern.

Fixes #354
Refs #334