### PR TITLE
feat(inventory): audit trail for PM work orders + location problems

### DIFF
--- a/backend/inventory/audit.py
+++ b/backend/inventory/audit.py
@@ -1,0 +1,44 @@
+"""Audit-event recording for preventive-maintenance actions (gh #355 / #334).
+
+Mirrors the helpers in forgekey (#352), reorder_queue (#353), and
+donations (#354) so the eventual unified review surface (#359) can
+join across domains without per-domain quirks.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from django.contrib.auth import get_user_model
+
+from .models import LocationProblem, MaintenanceAuditEvent, WorkOrder
+
+User = get_user_model()
+
+
+def record_event(
+    *,
+    action: str,
+    actor: Optional[User] = None,
+    work_order: Optional[WorkOrder] = None,
+    location_problem: Optional[LocationProblem] = None,
+    notes: str = "",
+    metadata: Optional[Dict[str, Any]] = None,
+) -> MaintenanceAuditEvent:
+    """Record a maintenance audit event.
+
+    At least one of ``work_order`` or ``location_problem`` must be
+    supplied so the row is queryable by entity.
+
+    Anonymous / system-initiated actions are allowed (``actor=None``);
+    the audit row simply records "no known user." Caller is expected
+    to pass the request user when one exists.
+    """
+    return MaintenanceAuditEvent.objects.create(
+        action=action,
+        actor=actor if (actor is not None and getattr(actor, "is_authenticated", False)) else None,
+        work_order=work_order,
+        location_problem=location_problem,
+        notes=notes,
+        metadata=metadata or {},
+    )

--- a/backend/inventory/migrations/0057_maintenanceauditevent.py
+++ b/backend/inventory/migrations/0057_maintenanceauditevent.py
@@ -1,0 +1,100 @@
+# Generated for gh #355 — append-only audit events for preventive
+# maintenance work orders and location-problem resolutions.
+
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0056_asset_is_critical"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="MaintenanceAuditEvent",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "action",
+                    models.CharField(
+                        choices=[
+                            ("wo_create", "Work order created"),
+                            ("wo_complete", "Work order completed"),
+                            ("location_problem_resolve", "Location problem resolved"),
+                        ],
+                        max_length=32,
+                    ),
+                ),
+                ("notes", models.TextField(blank=True)),
+                (
+                    "metadata",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        help_text=(
+                            "Action-specific payload (status transition, " "severity, etc)."
+                        ),
+                    ),
+                ),
+                (
+                    "actor",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text=(
+                            "User who performed the action; null for " "system-initiated events."
+                        ),
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="maintenance_audit_actions",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "work_order",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="audit_events",
+                        to="inventory.workorder",
+                    ),
+                ),
+                (
+                    "location_problem",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="audit_events",
+                        to="inventory.locationproblem",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+                "indexes": [
+                    models.Index(fields=["work_order", "-created_at"], name="maint_audit_wo_idx"),
+                    models.Index(
+                        fields=["location_problem", "-created_at"], name="maint_audit_lp_idx"
+                    ),
+                    models.Index(fields=["actor", "-created_at"], name="maint_audit_actor_idx"),
+                    models.Index(fields=["action", "-created_at"], name="maint_audit_action_idx"),
+                ],
+            },
+        ),
+    ]

--- a/backend/inventory/models.py
+++ b/backend/inventory/models.py
@@ -2683,3 +2683,69 @@ class StockReconciliation(models.Model):
             f"{self.item.name}: {self.projected_count} -> {self.actual_count} "
             f"({self.delta:+d}) [{self.reason}]"
         )
+
+
+class MaintenanceAuditEvent(models.Model):
+    """Append-only audit log for preventive-maintenance work-order and
+    location-problem mutations not already covered by
+    ``maintenance_orders.ThirdPartyWorkOrderAuditLog``.
+
+    Per gh #355 / #334. Pattern mirrors the per-domain audit tables in
+    forgekey (#352), reorder_queue (#353), and donations (#354) so the
+    eventual unified review surface (#359) can join cleanly.
+    """
+
+    ACTION_WO_CREATE = "wo_create"
+    ACTION_WO_COMPLETE = "wo_complete"
+    ACTION_LOCATION_PROBLEM_RESOLVE = "location_problem_resolve"
+
+    ACTION_CHOICES = [
+        (ACTION_WO_CREATE, "Work order created"),
+        (ACTION_WO_COMPLETE, "Work order completed"),
+        (ACTION_LOCATION_PROBLEM_RESOLVE, "Location problem resolved"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    actor = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="maintenance_audit_actions",
+        help_text="User who performed the action; null for system-initiated events.",
+    )
+    action = models.CharField(max_length=32, choices=ACTION_CHOICES)
+    work_order = models.ForeignKey(
+        "WorkOrder",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="audit_events",
+    )
+    location_problem = models.ForeignKey(
+        "LocationProblem",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="audit_events",
+    )
+    notes = models.TextField(blank=True)
+    metadata = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Action-specific payload (status transition, severity, etc).",
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["work_order", "-created_at"], name="maint_audit_wo_idx"),
+            models.Index(fields=["location_problem", "-created_at"], name="maint_audit_lp_idx"),
+            models.Index(fields=["actor", "-created_at"], name="maint_audit_actor_idx"),
+            models.Index(fields=["action", "-created_at"], name="maint_audit_action_idx"),
+        ]
+
+    def __str__(self) -> str:
+        target = self.work_order_id or self.location_problem_id
+        return f"{self.action} ({target}) @ {self.created_at:%Y-%m-%d %H:%M}"

--- a/backend/inventory/tests/test_audit_events.py
+++ b/backend/inventory/tests/test_audit_events.py
@@ -1,0 +1,237 @@
+from datetime import date, timedelta
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from inventory.audit import record_event
+from inventory.models import (
+    LocationProblem,
+    MaintenanceAuditEvent,
+    MaintenanceItem,
+    WorkOrder,
+    WorkOrderValidation,
+)
+from inventory.tests.factories import AssetFactory, LocationFactory
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+
+def _staff_user(username: str) -> User:
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password=f"{username}-password",
+        is_staff=True,
+    )
+
+
+def _api_client(user: User) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _maintenance_item():
+    asset = AssetFactory()
+    return MaintenanceItem.objects.create(
+        asset=asset,
+        title="Monthly inspection",
+        description="Routine preventive maintenance",
+        interval_days=7,
+    )
+
+
+def _work_order(*, status: str = WorkOrder.STATUS_OPEN, notes: str = "") -> WorkOrder:
+    item = _maintenance_item()
+    return WorkOrder.objects.create(
+        maintenance_item=item,
+        status=status,
+        due_date=date.today() + timedelta(days=7),
+        notes=notes,
+    )
+
+
+def _complete_validation(work_order: WorkOrder, user: User) -> WorkOrderValidation:
+    return WorkOrderValidation.objects.create(
+        work_order=work_order,
+        validated_by=user,
+        electrical_acknowledged=True,
+        loto_acknowledged=True,
+        required_fields_acknowledged=True,
+    )
+
+
+def test_wo_create_records_audit_event():
+    user = _staff_user("wo-create-user")
+    client = _api_client(user)
+    maintenance_item = _maintenance_item()
+
+    response = client.post(
+        reverse("workorder-list"),
+        {
+            "maintenance_item": str(maintenance_item.id),
+            "due_date": (date.today() + timedelta(days=3)).isoformat(),
+            "notes": "Created from API test",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED, response.content
+
+    work_order = WorkOrder.objects.get(pk=response.json()["id"])
+    event = MaintenanceAuditEvent.objects.get(action=MaintenanceAuditEvent.ACTION_WO_CREATE)
+    assert event.actor == user
+    assert event.work_order == work_order
+    assert event.location_problem is None
+    assert event.metadata["maintenance_item_id"] == str(maintenance_item.id)
+
+
+def test_wo_complete_records_audit_event_on_status_transition():
+    user = _staff_user("wo-complete-user")
+    client = _api_client(user)
+    work_order = _work_order(status=WorkOrder.STATUS_OPEN)
+    _complete_validation(work_order, user)
+
+    response = client.patch(
+        reverse("workorder-detail", kwargs={"pk": work_order.pk}),
+        {"status": WorkOrder.STATUS_COMPLETED},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.content
+
+    event = MaintenanceAuditEvent.objects.get(action=MaintenanceAuditEvent.ACTION_WO_COMPLETE)
+    assert event.actor == user
+    assert event.work_order == work_order
+    assert event.metadata["previous_status"] == WorkOrder.STATUS_OPEN
+
+
+def test_wo_update_without_status_change_no_complete_audit():
+    user = _staff_user("wo-update-user")
+    client = _api_client(user)
+    work_order = _work_order()
+
+    response = client.patch(
+        reverse("workorder-detail", kwargs={"pk": work_order.pk}),
+        {"notes": "Updated notes only"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.content
+    assert (
+        MaintenanceAuditEvent.objects.filter(
+            action=MaintenanceAuditEvent.ACTION_WO_COMPLETE,
+            work_order=work_order,
+        ).count()
+        == 0
+    )
+
+
+def test_wo_already_completed_update_no_duplicate_audit():
+    user = _staff_user("wo-completed-user")
+    client = _api_client(user)
+    work_order = _work_order(status=WorkOrder.STATUS_COMPLETED)
+
+    response = client.patch(
+        reverse("workorder-detail", kwargs={"pk": work_order.pk}),
+        {"status": WorkOrder.STATUS_COMPLETED},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.content
+    assert (
+        MaintenanceAuditEvent.objects.filter(
+            action=MaintenanceAuditEvent.ACTION_WO_COMPLETE,
+            work_order=work_order,
+        ).count()
+        == 0
+    )
+
+
+def test_location_problem_resolve_records_audit_event():
+    user = _staff_user("lp-resolve-user")
+    client = _api_client(user)
+    location = LocationFactory()
+    problem = LocationProblem.objects.create(
+        location=location,
+        description="Standing water by the sink",
+        severity=LocationProblem.SEVERITY_HIGH,
+        status=LocationProblem.REPORTED,
+    )
+
+    response = client.post(
+        reverse("locationproblem-resolve", kwargs={"pk": problem.pk}),
+        {"resolution_notes": "swept and dried"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.content
+
+    problem.refresh_from_db()
+    assert problem.status == LocationProblem.RESOLVED
+
+    event = MaintenanceAuditEvent.objects.get(
+        action=MaintenanceAuditEvent.ACTION_LOCATION_PROBLEM_RESOLVE
+    )
+    assert event.actor == user
+    assert event.location_problem == problem
+    assert event.notes == "swept and dried"
+    assert event.metadata["new_status"] == LocationProblem.RESOLVED
+    assert event.metadata["severity"] == problem.severity
+
+
+def test_location_problem_resolve_invalid_status_no_audit():
+    user = _staff_user("lp-invalid-user")
+    client = _api_client(user)
+    problem = LocationProblem.objects.create(
+        location=LocationFactory(),
+        description="Broken latch",
+        status=LocationProblem.REPORTED,
+    )
+
+    response = client.post(
+        reverse("locationproblem-resolve", kwargs={"pk": problem.pk}),
+        {"status": "garbage"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert (
+        MaintenanceAuditEvent.objects.filter(
+            action=MaintenanceAuditEvent.ACTION_LOCATION_PROBLEM_RESOLVE,
+            location_problem=problem,
+        ).count()
+        == 0
+    )
+
+
+def test_record_event_with_anonymous_actor_creates_row_with_null_actor():
+    work_order = _work_order()
+
+    event = record_event(
+        action=MaintenanceAuditEvent.ACTION_WO_CREATE,
+        actor=None,
+        work_order=work_order,
+    )
+
+    assert event.actor is None
+    assert event.work_order == work_order
+
+
+def test_record_event_accepts_either_entity_only():
+    work_order = _work_order()
+
+    event = record_event(
+        action=MaintenanceAuditEvent.ACTION_WO_CREATE,
+        work_order=work_order,
+    )
+
+    assert event.actor is None
+    assert event.work_order == work_order
+    assert event.location_problem is None

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -24,6 +24,7 @@ from rest_framework.permissions import (
 )
 from rest_framework.response import Response
 
+from .audit import record_event as record_maintenance_audit_event
 from .models import (
     Asset,
     AssetPart,
@@ -2275,6 +2276,17 @@ class LocationProblemViewSet(viewsets.ReadOnlyModelViewSet):
                 problem.resolved_by = getattr(request.user, "handle", None) or request.user.username
         problem.save()
 
+        record_maintenance_audit_event(
+            action="location_problem_resolve",
+            actor=request.user,
+            location_problem=problem,
+            notes=problem.resolution_notes or "",
+            metadata={
+                "new_status": new_status,
+                "severity": problem.severity,
+            },
+        )
+
         serializer = LocationProblemSerializer(problem, context={"request": request})
         return Response(serializer.data)
 
@@ -3055,6 +3067,37 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_412_PRECONDITION_FAILED,
             )
         return None
+
+    def perform_create(self, serializer):
+        work_order = serializer.save()
+        record_maintenance_audit_event(
+            action="wo_create",
+            actor=self.request.user,
+            work_order=work_order,
+            metadata={
+                "maintenance_item_id": str(work_order.maintenance_item_id),
+                "due_date": work_order.due_date.isoformat() if work_order.due_date else None,
+            },
+        )
+
+    def perform_update(self, serializer):
+        old_status = serializer.instance.status
+        work_order = serializer.save()
+        if (
+            work_order.status == WorkOrder.STATUS_COMPLETED
+            and old_status != WorkOrder.STATUS_COMPLETED
+        ):
+            record_maintenance_audit_event(
+                action="wo_complete",
+                actor=self.request.user,
+                work_order=work_order,
+                metadata={
+                    "previous_status": old_status,
+                    "completed_at": (
+                        work_order.completed_at.isoformat() if work_order.completed_at else None
+                    ),
+                },
+            )
 
     def update(self, request, *args, **kwargs):
         gate = self._check_completion_gate(request)


### PR DESCRIPTION
## Summary

Fourth domain landing of the #334 audit-trail work — preventive-maintenance work orders and location-problem resolutions. Mirrors the pattern from #352–#354. `ThirdPartyWorkOrderAuditLog` already covers 3PWO; this fills the regular-WO and LocationProblem gap.

## What's new

- **`MaintenanceAuditEvent`** — append-only, FK to actor, action choices, optional FKs to `work_order` / `location_problem`, notes, JSON metadata.
- **`inventory.audit.record_event(...)`** — single emission helper.

## Emission sites

| Site | Action | Notable behavior |
|------|--------|------------------|
| `WorkOrderViewSet.perform_create` | `wo_create` | metadata: maintenance_item_id, due_date |
| `WorkOrderViewSet.perform_update` | `wo_complete` | **ONLY on transition into COMPLETED from a different prior status** (idempotent completed→completed updates emit nothing) |
| `LocationProblemViewSet.resolve` | `location_problem_resolve` | notes=resolution_notes, metadata: new_status, severity |

## Out of scope (follow-ups)

- LocationProblem `report` (creation) — multiple paths (viewset action + ingest service); deferred.
- WO assignment changes (`assigned_to`) — needs pre-save tracking; deferred.
- PM schedule changes on `MaintenanceItem` — separate change site.

## Test plan

Tests authored independently via **codex (OpenAI)** for AI-diversity coverage.

`backend/inventory/tests/test_audit_events.py`:
- [ ] `test_wo_create_records_audit_event`
- [ ] `test_wo_complete_records_audit_event_on_status_transition` (with WorkOrderValidation gate)
- [ ] `test_wo_update_without_status_change_no_complete_audit`
- [ ] `test_wo_already_completed_update_no_duplicate_audit` (idempotency)
- [ ] `test_location_problem_resolve_records_audit_event`
- [ ] `test_location_problem_resolve_invalid_status_no_audit`
- [ ] `test_record_event_with_anonymous_actor_creates_row_with_null_actor`
- [ ] `test_record_event_accepts_either_entity_only`

Manual: black/isort/flake8 clean. Migration hand-written following the `0056_*` pattern.

Fixes #355
Refs #334