### PR TITLE
feat(vendors): audit trail for compliance + lifecycle

### DIFF
--- a/backend/vendors/audit.py
+++ b/backend/vendors/audit.py
@@ -1,0 +1,61 @@
+"""Audit-event recording for vendor compliance/lifecycle actions
+(gh #356 / #334).
+
+Mirrors the helpers in #352-#355 so the eventual unified review surface
+(#359) joins across domains without per-domain quirks.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from django.contrib.auth import get_user_model
+
+from .models import Vendor, VendorAuditEvent
+
+User = get_user_model()
+
+
+def record_event(
+    *,
+    action: str,
+    vendor: Vendor,
+    actor: Optional[User] = None,
+    notes: str = "",
+    metadata: Optional[Dict[str, Any]] = None,
+) -> VendorAuditEvent:
+    """Record a vendor audit event. ``vendor`` is required."""
+    return VendorAuditEvent.objects.create(
+        action=action,
+        actor=actor if (actor is not None and getattr(actor, "is_authenticated", False)) else None,
+        vendor=vendor,
+        notes=notes,
+        metadata=metadata or {},
+    )
+
+
+def diff_compliance_fields(before: Vendor, after: Vendor) -> Dict[str, Dict[str, Any]]:
+    """Return ``{field: {before: ..., after: ...}}`` for changed compliance
+    fields. Returns ``{}`` when nothing tracked changed.
+
+    Date fields are serialized to ISO strings so the audit row stays
+    JSON-clean for downstream review surfaces.
+    """
+    changes: Dict[str, Dict[str, Any]] = {}
+    for name in VendorAuditEvent.COMPLIANCE_FIELDS:
+        old = getattr(before, name)
+        new = getattr(after, name)
+        if old != new:
+            changes[name] = {
+                "before": _jsonable(old),
+                "after": _jsonable(new),
+            }
+    return changes
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return value

--- a/backend/vendors/migrations/0002_vendorauditevent.py
+++ b/backend/vendors/migrations/0002_vendorauditevent.py
@@ -1,0 +1,90 @@
+# Generated for gh #356 — append-only audit events for vendor
+# compliance and lifecycle actions.
+
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("vendors", "0001_initial"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="VendorAuditEvent",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "action",
+                    models.CharField(
+                        choices=[
+                            ("vendor_create", "Vendor created"),
+                            ("vendor_deactivate", "Vendor deactivated"),
+                            ("vendor_reactivate", "Vendor reactivated"),
+                            ("compliance_update", "Compliance fields updated"),
+                        ],
+                        max_length=32,
+                    ),
+                ),
+                ("notes", models.TextField(blank=True)),
+                (
+                    "metadata",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        help_text=(
+                            "Action-specific payload. For compliance_update, "
+                            "includes a 'changes' dict mapping field name -> "
+                            "{before, after}."
+                        ),
+                    ),
+                ),
+                (
+                    "actor",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text=(
+                            "User who performed the action; null for " "system-initiated events."
+                        ),
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="vendor_audit_actions",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "vendor",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="audit_events",
+                        to="vendors.vendor",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+                "indexes": [
+                    models.Index(fields=["vendor", "-created_at"], name="vendor_audit_vendor_idx"),
+                    models.Index(fields=["actor", "-created_at"], name="vendor_audit_actor_idx"),
+                    models.Index(fields=["action", "-created_at"], name="vendor_audit_action_idx"),
+                ],
+            },
+        ),
+    ]

--- a/backend/vendors/models.py
+++ b/backend/vendors/models.py
@@ -10,6 +10,7 @@ apply to service vendors (TDLR licensing, COI tracking).
 
 import uuid
 
+from django.conf import settings
 from django.db import models
 
 
@@ -112,3 +113,76 @@ class Vendor(models.Model):
         if not self.coi_expires_at:
             return False
         return timezone.now().date() > self.coi_expires_at
+
+
+class VendorAuditEvent(models.Model):
+    """Append-only audit log for vendor compliance and lifecycle actions.
+
+    Captures actor, action, vendor reference, notes, and per-action metadata
+    (incl. before/after for compliance-field changes so reviewers can answer
+    'who changed the COI date and to what?'). Rows are written by
+    ``vendors.audit.record_event`` and never updated or deleted by
+    application code.
+
+    Per gh #356 / #334. Mirrors the per-domain audit tables in #352-#355.
+    """
+
+    ACTION_VENDOR_CREATE = "vendor_create"
+    ACTION_VENDOR_DEACTIVATE = "vendor_deactivate"
+    ACTION_VENDOR_REACTIVATE = "vendor_reactivate"
+    ACTION_COMPLIANCE_UPDATE = "compliance_update"
+
+    ACTION_CHOICES = [
+        (ACTION_VENDOR_CREATE, "Vendor created"),
+        (ACTION_VENDOR_DEACTIVATE, "Vendor deactivated"),
+        (ACTION_VENDOR_REACTIVATE, "Vendor reactivated"),
+        (ACTION_COMPLIANCE_UPDATE, "Compliance fields updated"),
+    ]
+
+    # Compliance fields the audit hook tracks for diff capture.
+    COMPLIANCE_FIELDS = (
+        "tdlr_license_number",
+        "tdlr_license_expires_at",
+        "coi_provider",
+        "coi_policy_number",
+        "coi_expires_at",
+    )
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    actor = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="vendor_audit_actions",
+        help_text="User who performed the action; null for system-initiated events.",
+    )
+    action = models.CharField(max_length=32, choices=ACTION_CHOICES)
+    vendor = models.ForeignKey(
+        Vendor,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="audit_events",
+    )
+    notes = models.TextField(blank=True)
+    metadata = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text=(
+            "Action-specific payload. For compliance_update, includes a "
+            "'changes' dict mapping field name -> {before, after}."
+        ),
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["vendor", "-created_at"], name="vendor_audit_vendor_idx"),
+            models.Index(fields=["actor", "-created_at"], name="vendor_audit_actor_idx"),
+            models.Index(fields=["action", "-created_at"], name="vendor_audit_action_idx"),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.action} ({self.vendor_id}) @ {self.created_at:%Y-%m-%d %H:%M}"

--- a/backend/vendors/tests/test_audit_events.py
+++ b/backend/vendors/tests/test_audit_events.py
@@ -1,0 +1,235 @@
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils.crypto import get_random_string
+
+import pytest
+from rest_framework.test import APIClient
+
+from vendors.audit import diff_compliance_fields, record_event
+from vendors.models import Vendor, VendorAuditEvent
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+
+@pytest.fixture
+def admin_user():
+    return User.objects.create_user(
+        username="vendor-audit-admin",
+        email="vendor-audit-admin@example.com",
+        password=get_random_string(24),
+        is_staff=True,
+        is_superuser=True,
+    )
+
+
+@pytest.fixture
+def admin_client(admin_user):
+    client = APIClient()
+    client.force_authenticate(user=admin_user)
+    return client
+
+
+def test_vendor_create_records_audit_event(admin_client, admin_user):
+    response = admin_client.post(
+        reverse("vendor-list"),
+        {"name": "Acme", "vendor_kind": Vendor.KIND_HVAC},
+        format="json",
+    )
+
+    assert response.status_code == 201, response.content
+
+    vendor = Vendor.objects.get(id=response.json()["id"])
+    event = VendorAuditEvent.objects.get(action=VendorAuditEvent.ACTION_VENDOR_CREATE)
+    assert event.vendor == vendor
+    assert event.actor == admin_user
+    assert event.metadata["name"] == "Acme"
+    assert event.metadata["vendor_kind"] == Vendor.KIND_HVAC
+
+
+def test_compliance_update_records_diff(admin_client, admin_user):
+    vendor = Vendor.objects.create(
+        name="Acme",
+        vendor_kind=Vendor.KIND_HVAC,
+        tdlr_license_number="TX-100",
+        tdlr_license_expires_at=date(2026, 1, 15),
+    )
+
+    response = admin_client.patch(
+        reverse("vendor-detail", args=[vendor.id]),
+        {
+            "tdlr_license_number": "TX-200",
+            "tdlr_license_expires_at": "2026-02-20",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 200, response.content
+
+    event = VendorAuditEvent.objects.get(action=VendorAuditEvent.ACTION_COMPLIANCE_UPDATE)
+    changes = event.metadata["changes"]
+    assert event.vendor == vendor
+    assert event.actor == admin_user
+    assert changes["tdlr_license_number"] == {"before": "TX-100", "after": "TX-200"}
+    assert changes["tdlr_license_expires_at"] == {
+        "before": "2026-01-15",
+        "after": "2026-02-20",
+    }
+
+
+def test_compliance_update_no_event_when_unchanged(admin_client):
+    vendor = Vendor.objects.create(
+        name="Acme",
+        vendor_kind=Vendor.KIND_HVAC,
+        tdlr_license_number="TX-100",
+    )
+
+    response = admin_client.patch(
+        reverse("vendor-detail", args=[vendor.id]),
+        {"phone": "555-0100"},
+        format="json",
+    )
+
+    assert response.status_code == 200, response.content
+    assert not VendorAuditEvent.objects.filter(
+        vendor=vendor,
+        action=VendorAuditEvent.ACTION_COMPLIANCE_UPDATE,
+    ).exists()
+
+
+def test_deactivate_records_audit_event(admin_client, admin_user):
+    vendor = Vendor.objects.create(
+        name="Acme",
+        vendor_kind=Vendor.KIND_HVAC,
+        is_active=True,
+    )
+
+    response = admin_client.patch(
+        reverse("vendor-detail", args=[vendor.id]),
+        {"is_active": False},
+        format="json",
+    )
+
+    assert response.status_code == 200, response.content
+
+    event = VendorAuditEvent.objects.get(action=VendorAuditEvent.ACTION_VENDOR_DEACTIVATE)
+    assert event.vendor == vendor
+    assert event.actor == admin_user
+
+
+def test_reactivate_records_audit_event(admin_client, admin_user):
+    vendor = Vendor.objects.create(
+        name="Acme",
+        vendor_kind=Vendor.KIND_HVAC,
+        is_active=False,
+    )
+
+    response = admin_client.patch(
+        reverse("vendor-detail", args=[vendor.id]),
+        {"is_active": True},
+        format="json",
+    )
+
+    assert response.status_code == 200, response.content
+
+    event = VendorAuditEvent.objects.get(action=VendorAuditEvent.ACTION_VENDOR_REACTIVATE)
+    assert event.vendor == vendor
+    assert event.actor == admin_user
+
+
+def test_active_unchanged_no_lifecycle_event(admin_client):
+    vendor = Vendor.objects.create(
+        name="Acme",
+        vendor_kind=Vendor.KIND_HVAC,
+        is_active=True,
+    )
+
+    response = admin_client.patch(
+        reverse("vendor-detail", args=[vendor.id]),
+        {"phone": "555-0101"},
+        format="json",
+    )
+
+    assert response.status_code == 200, response.content
+    assert not VendorAuditEvent.objects.filter(
+        vendor=vendor,
+        action__in=[
+            VendorAuditEvent.ACTION_VENDOR_DEACTIVATE,
+            VendorAuditEvent.ACTION_VENDOR_REACTIVATE,
+        ],
+    ).exists()
+
+
+def test_combined_compliance_and_lifecycle_emit_both(admin_client, admin_user):
+    vendor = Vendor.objects.create(
+        name="Acme",
+        vendor_kind=Vendor.KIND_HVAC,
+        is_active=True,
+        coi_provider="Old Carrier",
+    )
+
+    response = admin_client.patch(
+        reverse("vendor-detail", args=[vendor.id]),
+        {"coi_provider": "New Carrier", "is_active": False},
+        format="json",
+    )
+
+    assert response.status_code == 200, response.content
+
+    events = list(VendorAuditEvent.objects.filter(vendor=vendor).order_by("created_at"))
+    assert len(events) == 2
+    assert {event.action for event in events} == {
+        VendorAuditEvent.ACTION_COMPLIANCE_UPDATE,
+        VendorAuditEvent.ACTION_VENDOR_DEACTIVATE,
+    }
+    assert {event.actor_id for event in events} == {admin_user.id}
+
+
+def test_diff_compliance_fields_returns_empty_when_unchanged():
+    vendor = Vendor(
+        name="Acme",
+        vendor_kind=Vendor.KIND_HVAC,
+        tdlr_license_number="TX-100",
+        tdlr_license_expires_at=date(2026, 1, 15),
+        coi_provider="Carrier",
+        coi_policy_number="POL-1",
+        coi_expires_at=date(2026, 3, 1),
+    )
+
+    assert diff_compliance_fields(vendor, vendor) == {}
+
+
+def test_diff_compliance_fields_serializes_dates_iso():
+    before = Vendor(
+        name="Acme",
+        vendor_kind=Vendor.KIND_HVAC,
+        coi_expires_at=date(2026, 4, 1),
+    )
+    after = Vendor(
+        name="Acme",
+        vendor_kind=Vendor.KIND_HVAC,
+        coi_expires_at=date(2026, 5, 1),
+    )
+
+    changes = diff_compliance_fields(before, after)
+
+    assert changes["coi_expires_at"]["before"] == "2026-04-01"
+    assert changes["coi_expires_at"]["after"] == "2026-05-01"
+    assert not isinstance(changes["coi_expires_at"]["before"], date)
+    assert not isinstance(changes["coi_expires_at"]["after"], date)
+
+
+def test_record_event_with_anonymous_actor_creates_row_with_null_actor():
+    vendor = Vendor.objects.create(name="Acme", vendor_kind=Vendor.KIND_HVAC)
+
+    event = record_event(
+        action=VendorAuditEvent.ACTION_VENDOR_CREATE,
+        vendor=vendor,
+        actor=None,
+    )
+
+    assert event.actor is None
+    assert event.vendor == vendor

--- a/backend/vendors/views.py
+++ b/backend/vendors/views.py
@@ -3,7 +3,9 @@
 from rest_framework import viewsets
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 
-from .models import Vendor
+from .audit import diff_compliance_fields
+from .audit import record_event as record_vendor_audit_event
+from .models import Vendor, VendorAuditEvent
 from .serializers import VendorSerializer
 
 
@@ -30,3 +32,49 @@ class VendorViewSet(viewsets.ModelViewSet):
         if only_active and only_active.lower() in ("1", "true", "yes"):
             qs = qs.filter(is_active=True)
         return qs
+
+    def perform_create(self, serializer):
+        vendor = serializer.save()
+        record_vendor_audit_event(
+            action=VendorAuditEvent.ACTION_VENDOR_CREATE,
+            actor=self.request.user,
+            vendor=vendor,
+            metadata={
+                "name": vendor.name,
+                "vendor_kind": vendor.vendor_kind,
+            },
+        )
+
+    def perform_update(self, serializer):
+        # Snapshot the pre-save instance so we can diff compliance fields and
+        # detect is_active toggles. ``serializer.instance`` is the loaded row;
+        # we reload it cheaply by deep-copying the relevant attrs.
+        before_compliance = Vendor(
+            **{
+                name: getattr(serializer.instance, name)
+                for name in VendorAuditEvent.COMPLIANCE_FIELDS
+            }
+        )
+        before_is_active = serializer.instance.is_active
+
+        vendor = serializer.save()
+
+        changes = diff_compliance_fields(before_compliance, vendor)
+        if changes:
+            record_vendor_audit_event(
+                action=VendorAuditEvent.ACTION_COMPLIANCE_UPDATE,
+                actor=self.request.user,
+                vendor=vendor,
+                metadata={"changes": changes},
+            )
+
+        if before_is_active != vendor.is_active:
+            record_vendor_audit_event(
+                action=(
+                    VendorAuditEvent.ACTION_VENDOR_REACTIVATE
+                    if vendor.is_active
+                    else VendorAuditEvent.ACTION_VENDOR_DEACTIVATE
+                ),
+                actor=self.request.user,
+                vendor=vendor,
+            )


### PR DESCRIPTION
## Summary

Fifth domain landing of the #334 audit-trail work — third-party service vendors. Captures vendor creation, compliance-field changes (TDLR + COI), and `is_active` lifecycle toggles. Mirrors #352–#355.

## What's new

- **`VendorAuditEvent`** — actions: `vendor_create`, `vendor_deactivate`, `vendor_reactivate`, `compliance_update`.
- **`vendors.audit.record_event(...)`** — emission helper.
- **`vendors.audit.diff_compliance_fields(before, after)`** — date-aware compliance diff, `{field: {before, after}}`.

## Emission sites

| Site | Action | Notes |
|------|--------|-------|
| `VendorViewSet.perform_create` | `vendor_create` | metadata: name, vendor_kind |
| `VendorViewSet.perform_update` | `compliance_update` | When any TDLR/COI field changes; metadata carries the per-field diff |
| `VendorViewSet.perform_update` | `vendor_deactivate` / `vendor_reactivate` | On `is_active` flip |

A single PATCH that changes both compliance and `is_active` emits both rows.

## Out of scope (follow-ups)

- Compliance doc upload/replace (no doc model today; TDLR/COI are scalar fields).
- Waivers + emergency overrides — already in `maintenance_orders.EmergencyAuthorization` + `ThirdPartyWorkOrderAuditLog`.
- Computed expiry-state transitions (date-driven, no user action).

## Test plan

Tests via **codex (OpenAI)** — `vendors/tests/test_audit_events.py` covers all emission paths, the diff helper's ISO date handling, anonymous-actor null handling, and the combined compliance+lifecycle PATCH case.

Manual: black/isort/flake8 clean. Migration hand-written.

Fixes #356
Refs #334