### PR TITLE
feat(reorder_queue): audit trail for webhook config + lifecycle

### DIFF
--- a/backend/reorder_queue/migrations/0020_webhookauditevent.py
+++ b/backend/reorder_queue/migrations/0020_webhookauditevent.py
@@ -13,6 +13,16 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
+        # Chained on the audit migration introduced in #353/PR #361 so
+        # the per-app migration tree stays linear (single leaf) once
+        # both land. Pointing this at 0008 (the prior leaf) instead
+        # would unblock CI here but create a multi-leaf situation on
+        # main after both PRs merge — Django's `validate_consistency`
+        # then fails any subsequent PR with "Conflicting migrations
+        # detected; multiple leaf nodes."
+        #
+        # Trade-off: this PR's CI stays BLOCKED until #361's migration
+        # is on main. Auto-merge picks it up the moment that happens.
         ("reorder_queue", "0019_purchaseorderauditevent"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]

--- a/backend/reorder_queue/migrations/0020_webhookauditevent.py
+++ b/backend/reorder_queue/migrations/0020_webhookauditevent.py
@@ -1,0 +1,96 @@
+# Generated for gh #357 — append-only audit events for webhook
+# configuration + lifecycle. Depends on 0019_purchaseorderauditevent
+# (gh #353) so the two reorder_queue audit tables are introduced in a
+# stable order even when their PRs land asynchronously.
+
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("reorder_queue", "0019_purchaseorderauditevent"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="WebhookAuditEvent",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "action",
+                    models.CharField(
+                        choices=[
+                            ("webhook_create", "Webhook created"),
+                            ("webhook_update", "Webhook config updated"),
+                            ("webhook_delete", "Webhook deleted"),
+                            ("webhook_disable", "Webhook disabled"),
+                            ("webhook_enable", "Webhook enabled"),
+                            ("webhook_secret_rotate", "Webhook secret rotated"),
+                        ],
+                        max_length=32,
+                    ),
+                ),
+                ("notes", models.TextField(blank=True)),
+                (
+                    "metadata",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        help_text=(
+                            "Action-specific payload. For webhook_update, "
+                            "includes a 'changes' dict mapping field name -> "
+                            "{before, after}. The webhook secret is NEVER "
+                            "included — only the fact that it changed is "
+                            "recorded."
+                        ),
+                    ),
+                ),
+                (
+                    "actor",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text=(
+                            "User who performed the action; null for " "system-initiated events."
+                        ),
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="webhook_audit_actions",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "webhook",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="audit_events",
+                        to="reorder_queue.webhook",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+                "indexes": [
+                    models.Index(fields=["webhook", "-created_at"], name="webhook_audit_wh_idx"),
+                    models.Index(fields=["actor", "-created_at"], name="webhook_audit_actor_idx"),
+                    models.Index(fields=["action", "-created_at"], name="webhook_audit_action_idx"),
+                ],
+            },
+        ),
+    ]

--- a/backend/reorder_queue/models.py
+++ b/backend/reorder_queue/models.py
@@ -1016,7 +1016,9 @@ class WebhookAuditEvent(models.Model):
     ACTION_WEBHOOK_DELETE = "webhook_delete"
     ACTION_WEBHOOK_DISABLE = "webhook_disable"
     ACTION_WEBHOOK_ENABLE = "webhook_enable"
-    ACTION_WEBHOOK_SECRET_ROTATE = "webhook_secret_rotate"
+    ACTION_WEBHOOK_SECRET_ROTATE = (
+        "webhook_secret_rotate"  # nosec B105 — action name, not a credential
+    )
 
     ACTION_CHOICES = [
         (ACTION_WEBHOOK_CREATE, "Webhook created"),

--- a/backend/reorder_queue/models.py
+++ b/backend/reorder_queue/models.py
@@ -992,3 +992,89 @@ class PurchaseOrderAuditEvent(models.Model):
     def __str__(self) -> str:
         target = self.purchase_order_id or self.line_item_id or self.attachment_id
         return f"{self.action} ({target}) @ {self.created_at:%Y-%m-%d %H:%M}"
+
+
+class WebhookAuditEvent(models.Model):
+    """Append-only audit log for webhook configuration + lifecycle events.
+
+    Captures actor, action, webhook reference, notes, and per-action
+    metadata (incl. delta for config-field changes). Rows are written by
+    ``reorder_queue.webhook_audit.record_event`` and never updated or
+    deleted by application code.
+
+    Per gh #357 / #334. Mirrors the per-domain audit tables in #352-#356.
+
+    Inbound auth failures and outbound delivery failures are intentionally
+    NOT captured here — both are high-volume per-event and are summarized
+    on the WebHook row itself (failure_count + last_error). A future
+    aggregated-stat table can land separately if event-level capture
+    becomes operationally necessary.
+    """
+
+    ACTION_WEBHOOK_CREATE = "webhook_create"
+    ACTION_WEBHOOK_UPDATE = "webhook_update"
+    ACTION_WEBHOOK_DELETE = "webhook_delete"
+    ACTION_WEBHOOK_DISABLE = "webhook_disable"
+    ACTION_WEBHOOK_ENABLE = "webhook_enable"
+    ACTION_WEBHOOK_SECRET_ROTATE = "webhook_secret_rotate"
+
+    ACTION_CHOICES = [
+        (ACTION_WEBHOOK_CREATE, "Webhook created"),
+        (ACTION_WEBHOOK_UPDATE, "Webhook config updated"),
+        (ACTION_WEBHOOK_DELETE, "Webhook deleted"),
+        (ACTION_WEBHOOK_DISABLE, "Webhook disabled"),
+        (ACTION_WEBHOOK_ENABLE, "Webhook enabled"),
+        (ACTION_WEBHOOK_SECRET_ROTATE, "Webhook secret rotated"),
+    ]
+
+    # Non-secret config fields the audit hook tracks for diff capture.
+    # ``secret`` is intentionally excluded — its value never appears in
+    # audit metadata; only the fact that it changed is recorded via the
+    # `webhook_secret_rotate` action.
+    AUDITED_FIELDS = (
+        "name",
+        "url",
+        "event_type",
+        "is_active",
+    )
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    actor = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="webhook_audit_actions",
+        help_text="User who performed the action; null for system-initiated events.",
+    )
+    action = models.CharField(max_length=32, choices=ACTION_CHOICES)
+    webhook = models.ForeignKey(
+        WebHook,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="audit_events",
+    )
+    notes = models.TextField(blank=True)
+    metadata = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text=(
+            "Action-specific payload. For webhook_update, includes a "
+            "'changes' dict mapping field name -> {before, after}. The "
+            "webhook secret is NEVER included — only the fact that it "
+            "changed is recorded."
+        ),
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["webhook", "-created_at"], name="webhook_audit_wh_idx"),
+            models.Index(fields=["actor", "-created_at"], name="webhook_audit_actor_idx"),
+            models.Index(fields=["action", "-created_at"], name="webhook_audit_action_idx"),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.action} ({self.webhook_id}) @ {self.created_at:%Y-%m-%d %H:%M}"

--- a/backend/reorder_queue/tests/test_webhook_audit_events.py
+++ b/backend/reorder_queue/tests/test_webhook_audit_events.py
@@ -1,0 +1,218 @@
+from django.urls import reverse
+
+import pytest
+from rest_framework import status
+
+from reorder_queue.models import WebHook, WebhookAuditEvent
+from reorder_queue.webhook_audit import diff_audited_fields, record_event
+
+pytestmark = pytest.mark.django_db
+
+
+def _webhook_payload(**overrides):
+    payload = {
+        "name": "Inventory Alerts",
+        "url": "https://example.com/webhooks/inventory",
+        "event_type": WebHook.REORDER_REQUEST_CREATED,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _create_webhook(**overrides):
+    return WebHook.objects.create(
+        name="Inventory Alerts",
+        url="https://example.com/webhooks/inventory",
+        event_type=WebHook.REORDER_REQUEST_CREATED,
+        is_active=True,
+        secret="initial-secret",
+        **overrides,
+    )
+
+
+def test_webhook_create_records_audit_event(authenticated_client):
+    client, user = authenticated_client
+
+    response = client.post(reverse("webhook-list"), _webhook_payload(), format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED
+    event = WebhookAuditEvent.objects.get()
+    webhook = WebHook.objects.get(pk=response.data["id"])
+    assert event.action == WebhookAuditEvent.ACTION_WEBHOOK_CREATE
+    assert event.actor == user
+    assert event.webhook == webhook
+    assert event.metadata == {
+        "name": webhook.name,
+        "url": webhook.url,
+        "event_type": webhook.event_type,
+    }
+
+
+def test_webhook_update_records_diff(authenticated_client):
+    client, user = authenticated_client
+    webhook = _create_webhook()
+
+    response = client.patch(
+        reverse("webhook-detail", kwargs={"pk": webhook.pk}),
+        {
+            "name": "Updated Inventory Alerts",
+            "url": "https://example.com/webhooks/updated",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    event = WebhookAuditEvent.objects.get()
+    assert event.action == WebhookAuditEvent.ACTION_WEBHOOK_UPDATE
+    assert event.actor == user
+    assert event.webhook == webhook
+    assert event.metadata["changes"] == {
+        "name": {
+            "before": "Inventory Alerts",
+            "after": "Updated Inventory Alerts",
+        },
+        "url": {
+            "before": "https://example.com/webhooks/inventory",
+            "after": "https://example.com/webhooks/updated",
+        },
+    }
+    assert "is_active" not in event.metadata["changes"]
+
+
+def test_webhook_secret_rotate_emits_distinct_event(authenticated_client):
+    client, _user = authenticated_client
+    webhook = _create_webhook()
+
+    response = client.patch(
+        reverse("webhook-detail", kwargs={"pk": webhook.pk}),
+        {"secret": "new-secret"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    event = WebhookAuditEvent.objects.get()
+    assert event.action == WebhookAuditEvent.ACTION_WEBHOOK_SECRET_ROTATE
+    assert "secret" not in event.metadata
+    assert "new-secret" not in str(event.metadata)
+    assert "new-secret" not in event.notes
+    assert not WebhookAuditEvent.objects.filter(
+        action=WebhookAuditEvent.ACTION_WEBHOOK_UPDATE
+    ).exists()
+
+
+def test_webhook_disable_records_audit(authenticated_client):
+    client, user = authenticated_client
+    webhook = _create_webhook(is_active=True)
+
+    response = client.patch(
+        reverse("webhook-detail", kwargs={"pk": webhook.pk}),
+        {"is_active": False},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    event = WebhookAuditEvent.objects.get()
+    assert event.action == WebhookAuditEvent.ACTION_WEBHOOK_DISABLE
+    assert event.actor == user
+    assert event.webhook == webhook
+
+
+def test_webhook_enable_records_audit(authenticated_client):
+    client, user = authenticated_client
+    webhook = _create_webhook(is_active=False)
+
+    response = client.patch(
+        reverse("webhook-detail", kwargs={"pk": webhook.pk}),
+        {"is_active": True},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    event = WebhookAuditEvent.objects.get()
+    assert event.action == WebhookAuditEvent.ACTION_WEBHOOK_ENABLE
+    assert event.actor == user
+    assert event.webhook == webhook
+
+
+def test_webhook_update_does_not_include_is_active_in_diff(authenticated_client):
+    client, user = authenticated_client
+    webhook = _create_webhook(is_active=True)
+
+    response = client.patch(
+        reverse("webhook-detail", kwargs={"pk": webhook.pk}),
+        {
+            "name": "Updated Inventory Alerts",
+            "is_active": False,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert WebhookAuditEvent.objects.count() == 2
+
+    update_event = WebhookAuditEvent.objects.get(action=WebhookAuditEvent.ACTION_WEBHOOK_UPDATE)
+    disable_event = WebhookAuditEvent.objects.get(action=WebhookAuditEvent.ACTION_WEBHOOK_DISABLE)
+
+    assert update_event.actor == user
+    assert update_event.webhook == webhook
+    assert update_event.metadata["changes"] == {
+        "name": {
+            "before": "Inventory Alerts",
+            "after": "Updated Inventory Alerts",
+        }
+    }
+    assert "is_active" not in update_event.metadata["changes"]
+    assert disable_event.actor == user
+    assert disable_event.webhook == webhook
+
+
+def test_webhook_delete_records_audit_before_delete(authenticated_client):
+    client, user = authenticated_client
+    webhook = _create_webhook()
+
+    response = client.delete(reverse("webhook-detail", kwargs={"pk": webhook.pk}))
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    event = WebhookAuditEvent.objects.get()
+    assert event.action == WebhookAuditEvent.ACTION_WEBHOOK_DELETE
+    assert event.actor == user
+    assert event.metadata == {
+        "name": "Inventory Alerts",
+        "url": "https://example.com/webhooks/inventory",
+        "event_type": WebHook.REORDER_REQUEST_CREATED,
+    }
+    event.refresh_from_db()
+    assert event.webhook is None
+
+
+def test_diff_audited_fields_excludes_secret():
+    before = WebHook(
+        name="Inventory Alerts",
+        url="https://example.com/webhooks/inventory",
+        event_type=WebHook.REORDER_REQUEST_CREATED,
+        is_active=True,
+        secret="old-secret",
+    )
+    after = WebHook(
+        name="Inventory Alerts",
+        url="https://example.com/webhooks/inventory",
+        event_type=WebHook.REORDER_REQUEST_CREATED,
+        is_active=True,
+        secret="new-secret",
+    )
+
+    assert diff_audited_fields(before, after) == {}
+
+
+def test_record_event_with_anonymous_actor_creates_row_with_null_actor():
+    webhook = _create_webhook()
+
+    event = record_event(
+        action=WebhookAuditEvent.ACTION_WEBHOOK_CREATE,
+        webhook=webhook,
+        actor=None,
+    )
+
+    assert event.actor is None
+    assert event.webhook == webhook
+    assert event.action == WebhookAuditEvent.ACTION_WEBHOOK_CREATE

--- a/backend/reorder_queue/tests/test_webhook_audit_events.py
+++ b/backend/reorder_queue/tests/test_webhook_audit_events.py
@@ -20,14 +20,15 @@ def _webhook_payload(**overrides):
 
 
 def _create_webhook(**overrides):
-    return WebHook.objects.create(
-        name="Inventory Alerts",
-        url="https://example.com/webhooks/inventory",
-        event_type=WebHook.REORDER_REQUEST_CREATED,
-        is_active=True,
-        secret="initial-secret",
-        **overrides,
-    )
+    defaults = {
+        "name": "Inventory Alerts",
+        "url": "https://example.com/webhooks/inventory",
+        "event_type": WebHook.REORDER_REQUEST_CREATED,
+        "is_active": True,
+        "secret": "initial-secret",
+    }
+    defaults.update(overrides)
+    return WebHook.objects.create(**defaults)
 
 
 def test_webhook_create_records_audit_event(authenticated_client):
@@ -35,9 +36,12 @@ def test_webhook_create_records_audit_event(authenticated_client):
 
     response = client.post(reverse("webhook-list"), _webhook_payload(), format="json")
 
-    assert response.status_code == status.HTTP_201_CREATED
+    assert response.status_code == status.HTTP_201_CREATED, response.content
+    # Test DB is fresh per @django_db, so the test just created the only
+    # WebHook row. Look it up by query rather than relying on the
+    # serializer's id-key shape (which may be `id` / `uuid` / etc).
+    webhook = WebHook.objects.get()
     event = WebhookAuditEvent.objects.get()
-    webhook = WebHook.objects.get(pk=response.data["id"])
     assert event.action == WebhookAuditEvent.ACTION_WEBHOOK_CREATE
     assert event.actor == user
     assert event.webhook == webhook

--- a/backend/reorder_queue/views.py
+++ b/backend/reorder_queue/views.py
@@ -28,6 +28,7 @@ from .models import (
     PurchaseOrderItem,
     ReorderRequest,
     WebHook,
+    WebhookAuditEvent,
 )
 from .serializers import (
     BarcodeReceiptSerializer,
@@ -44,6 +45,8 @@ from .serializers import (
     WebHookSerializer,
     WebHookTestResultSerializer,
 )
+from .webhook_audit import diff_audited_fields as diff_webhook_audited_fields
+from .webhook_audit import record_event as record_webhook_audit_event
 
 
 def _create_lead_time_log(po_item, delivery_date):
@@ -2041,6 +2044,82 @@ class WebHookViewSet(viewsets.ModelViewSet):
         if self.action == "create":
             return WebHookCreateSerializer
         return WebHookSerializer
+
+    def perform_create(self, serializer):
+        webhook = serializer.save()
+        record_webhook_audit_event(
+            action=WebhookAuditEvent.ACTION_WEBHOOK_CREATE,
+            actor=self.request.user,
+            webhook=webhook,
+            metadata={
+                "name": webhook.name,
+                "url": webhook.url,
+                "event_type": webhook.event_type,
+            },
+        )
+
+    def perform_update(self, serializer):
+        # Snapshot pre-save attrs so we can detect:
+        #   * config changes (webhook_update with diff)
+        #   * is_active flip (webhook_disable / webhook_enable)
+        #   * secret rotation (webhook_secret_rotate; value never recorded)
+        instance = serializer.instance
+        before_attrs = {name: getattr(instance, name) for name in WebhookAuditEvent.AUDITED_FIELDS}
+        before_secret = instance.secret
+        before_active = instance.is_active
+
+        webhook = serializer.save()
+
+        if webhook.secret != before_secret:
+            record_webhook_audit_event(
+                action=WebhookAuditEvent.ACTION_WEBHOOK_SECRET_ROTATE,
+                actor=self.request.user,
+                webhook=webhook,
+            )
+
+        # Build a synthetic 'before' for the diff helper. Using attribute
+        # cloning avoids hitting the DB again and keeps the helper pure.
+        synthetic_before = WebHook(**before_attrs)
+        changes = diff_webhook_audited_fields(synthetic_before, webhook)
+        # is_active flips are surfaced as their own action — pull them out
+        # of the generic 'webhook_update' diff so reviewers see the
+        # lifecycle event explicitly.
+        is_active_changed = "is_active" in changes
+        if is_active_changed:
+            changes.pop("is_active")
+        if changes:
+            record_webhook_audit_event(
+                action=WebhookAuditEvent.ACTION_WEBHOOK_UPDATE,
+                actor=self.request.user,
+                webhook=webhook,
+                metadata={"changes": changes},
+            )
+        if before_active != webhook.is_active:
+            record_webhook_audit_event(
+                action=(
+                    WebhookAuditEvent.ACTION_WEBHOOK_ENABLE
+                    if webhook.is_active
+                    else WebhookAuditEvent.ACTION_WEBHOOK_DISABLE
+                ),
+                actor=self.request.user,
+                webhook=webhook,
+            )
+
+    def perform_destroy(self, instance):
+        # Record audit BEFORE delete so the metadata captures identifying
+        # fields while we still have the row. The webhook FK on the audit
+        # row is SET_NULL on cascade, so the audit row survives the delete.
+        record_webhook_audit_event(
+            action=WebhookAuditEvent.ACTION_WEBHOOK_DELETE,
+            actor=self.request.user,
+            webhook=instance,
+            metadata={
+                "name": instance.name,
+                "url": instance.url,
+                "event_type": instance.event_type,
+            },
+        )
+        instance.delete()
 
     @action(detail=True, methods=["post"], url_path="test", url_name="test")
     def test(self, request, pk=None):

--- a/backend/reorder_queue/webhook_audit.py
+++ b/backend/reorder_queue/webhook_audit.py
@@ -1,0 +1,51 @@
+"""Audit-event recording for webhook configuration + lifecycle
+(gh #357 / #334).
+
+Kept in a sibling module to ``reorder_queue.audit`` (purchase-order
+audit) so the two concerns can evolve independently while sharing
+the reorder_queue app.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from django.contrib.auth import get_user_model
+
+from .models import WebHook, WebhookAuditEvent
+
+User = get_user_model()
+
+
+def record_event(
+    *,
+    action: str,
+    webhook: WebHook,
+    actor: Optional[User] = None,
+    notes: str = "",
+    metadata: Optional[Dict[str, Any]] = None,
+) -> WebhookAuditEvent:
+    """Record a webhook audit event. ``webhook`` is required."""
+    return WebhookAuditEvent.objects.create(
+        action=action,
+        actor=actor if (actor is not None and getattr(actor, "is_authenticated", False)) else None,
+        webhook=webhook,
+        notes=notes,
+        metadata=metadata or {},
+    )
+
+
+def diff_audited_fields(before: WebHook, after: WebHook) -> Dict[str, Dict[str, Any]]:
+    """Return ``{field: {before, after}}`` for changed audited fields.
+
+    The ``secret`` field is intentionally excluded — its value never
+    appears in audit metadata; only the fact that it changed is recorded
+    via the ``webhook_secret_rotate`` action.
+    """
+    changes: Dict[str, Dict[str, Any]] = {}
+    for name in WebhookAuditEvent.AUDITED_FIELDS:
+        old = getattr(before, name)
+        new = getattr(after, name)
+        if old != new:
+            changes[name] = {"before": old, "after": new}
+    return changes


### PR DESCRIPTION
## Summary

Sixth domain landing of the #334 audit-trail work — webhook configuration + lifecycle. Captures create / update / delete / disable / enable / secret rotation.

**Inbound auth failures and outbound delivery failures are intentionally NOT here** — both are high-volume per-event and are already summarized on the `WebHook` row itself (`failure_count`, `last_error`). A future aggregated-stat table can land separately if event-level capture becomes operationally necessary.

## What's new

- **`WebhookAuditEvent`** — actions: `webhook_create`, `webhook_update`, `webhook_delete`, `webhook_disable`, `webhook_enable`, `webhook_secret_rotate`.
- **`AUDITED_FIELDS = ("name", "url", "event_type", "is_active")`** — `secret` is intentionally excluded; only the fact that it changed is recorded via `webhook_secret_rotate`. **The value never appears in audit metadata.**
- **`webhook_audit.record_event(...)`** + **`diff_audited_fields(before, after)`** helpers.

## Emission sites

| Site | Action | Notes |
|------|--------|-------|
| `WebHookViewSet.perform_create` | `webhook_create` | metadata: name, url, event_type |
| `WebHookViewSet.perform_update` | `webhook_secret_rotate` | When `secret` changes; **no value in metadata** |
| `WebHookViewSet.perform_update` | `webhook_disable` / `webhook_enable` | On `is_active` flip |
| `WebHookViewSet.perform_update` | `webhook_update` | When `{name,url,event_type}` change; metadata carries the per-field diff. `is_active` is never in the diff — surfaced via lifecycle action. |
| `WebHookViewSet.perform_destroy` | `webhook_delete` | Recorded BEFORE delete so identifying fields survive in metadata. Webhook FK is SET_NULL after cascade. |

A single PATCH can emit up to three rows (secret-rotate + lifecycle + diff).

## Migration ordering

`0020_webhookauditevent` depends on `0019_purchaseorderauditevent` (gh #353 / PR #361) so the two reorder_queue audit tables introduce in a stable order. PR #361 is in flight with auto-merge — this PR's CI resolves once #361 lands.

## Test plan

Tests via **codex (OpenAI)** — `reorder_queue/tests/test_webhook_audit_events.py` covers each emission path, the diff helper's secret-field exclusion, and an explicit assertion that the secret value never lands in audit metadata or notes.

Manual: black/isort/flake8 clean.

Fixes #357
Refs #334