### PR TITLE
feat(customization): audit trail for SiteSettings updates

### DIFF
--- a/backend/customization/audit.py
+++ b/backend/customization/audit.py
@@ -1,0 +1,96 @@
+"""Audit-event recording for SiteSettings updates (gh #358 / #334).
+
+Mirrors the helpers in #352-#357 so the eventual unified review
+surface (#359) can join across domains without per-domain quirks.
+
+File fields (``logo``, ``favicon``) are diffed by filename only —
+the binary content is never stored in the audit row. This is a
+deliberate AC-27 guardrail: audit rows must not become a covert
+data-export surface for files that may carry sensitive content.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from django.contrib.auth import get_user_model
+from django.db.models.fields.files import FieldFile
+
+from .models import SiteSettings, SiteSettingsAuditEvent
+
+User = get_user_model()
+
+
+# Fields the diff helper inspects. Keep this in sync with SiteSettings;
+# adding a new SiteSettings field that should be audited just means
+# extending this tuple.
+AUDITED_FIELDS: tuple = (
+    "site_name",
+    "site_tagline",
+    "logo",
+    "logo_alt_text",
+    "favicon",
+    "primary_color",
+    "secondary_color",
+    "footer_text",
+    "contact_email",
+    "contact_phone",
+    "website_url",
+)
+
+
+def record_event(
+    *,
+    action: str,
+    site_settings: SiteSettings,
+    actor: Optional[User] = None,
+    notes: str = "",
+    metadata: Optional[Dict[str, Any]] = None,
+) -> SiteSettingsAuditEvent:
+    """Record a SiteSettings audit event."""
+    return SiteSettingsAuditEvent.objects.create(
+        action=action,
+        actor=actor if (actor is not None and getattr(actor, "is_authenticated", False)) else None,
+        site_settings=site_settings,
+        notes=notes,
+        metadata=metadata or {},
+    )
+
+
+def diff_audited_fields(before: Dict[str, Any], after: SiteSettings) -> Dict[str, Dict[str, Any]]:
+    """Return ``{field: {before, after}}`` for changed audited fields.
+
+    ``before`` is a plain dict snapshotted from the pre-save instance
+    (the helper accepts a dict so callers can capture state without
+    holding a stale model reference). File fields are stringified to
+    their filename via ``_jsonable``; raw FieldFile/None values never
+    appear in the resulting metadata.
+    """
+    changes: Dict[str, Dict[str, Any]] = {}
+    for name in AUDITED_FIELDS:
+        old = before.get(name)
+        new = getattr(after, name)
+        old_norm = _jsonable(old)
+        new_norm = _jsonable(new)
+        if old_norm != new_norm:
+            changes[name] = {"before": old_norm, "after": new_norm}
+    return changes
+
+
+def snapshot(instance: SiteSettings) -> Dict[str, Any]:
+    """Return a JSON-clean snapshot of the audited fields on
+    ``instance``. Use this BEFORE save to capture state for diffing
+    against the post-save row.
+    """
+    return {name: _jsonable(getattr(instance, name)) for name in AUDITED_FIELDS}
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, FieldFile):
+        # Empty FieldFile (no file attached) renders as "" via .name;
+        # normalize to None so diffs treat "no file" the same regardless
+        # of whether the field is unset vs. set-to-empty.
+        return value.name or None
+    return value

--- a/backend/customization/migrations/0003_sitesettingsauditevent.py
+++ b/backend/customization/migrations/0003_sitesettingsauditevent.py
@@ -1,0 +1,91 @@
+# Generated for gh #358 — append-only audit events for SiteSettings
+# updates.
+
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("customization", "0002_sitesettings_authorized_signature_name_and_more"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SiteSettingsAuditEvent",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "action",
+                    models.CharField(
+                        choices=[("settings_update", "Site settings updated")],
+                        max_length=32,
+                    ),
+                ),
+                ("notes", models.TextField(blank=True)),
+                (
+                    "metadata",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        help_text=(
+                            "Action-specific payload. For settings_update, "
+                            "includes a 'changes' dict mapping field name -> "
+                            "{before, after}. File fields are summarized by "
+                            "filename only — binary content is never stored "
+                            "here."
+                        ),
+                    ),
+                ),
+                (
+                    "actor",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text=(
+                            "User who performed the action; null for " "system-initiated events."
+                        ),
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="site_settings_audit_actions",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "site_settings",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="audit_events",
+                        to="customization.sitesettings",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+                "indexes": [
+                    models.Index(
+                        fields=["site_settings", "-created_at"], name="settings_audit_ss_idx"
+                    ),
+                    models.Index(fields=["actor", "-created_at"], name="settings_audit_actor_idx"),
+                    models.Index(
+                        fields=["action", "-created_at"], name="settings_audit_action_idx"
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/backend/customization/models.py
+++ b/backend/customization/models.py
@@ -2,6 +2,9 @@
 Models for site customization.
 """
 
+import uuid
+
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 
@@ -156,3 +159,66 @@ class SiteSettings(models.Model):
         if not obj:
             obj = cls.objects.create()
         return obj
+
+
+class SiteSettingsAuditEvent(models.Model):
+    """Append-only audit log for SiteSettings updates.
+
+    Captures actor, action, settings reference, notes, and a per-field
+    diff in metadata. Rows are written by
+    ``customization.audit.record_event`` and never updated or deleted by
+    application code.
+
+    Per gh #358 / #334. Mirrors the per-domain audit tables in
+    #352-#357.
+
+    File fields (``logo``, ``favicon``) are diffed by filename only —
+    the binary content is never stored in the audit row.
+    """
+
+    ACTION_SETTINGS_UPDATE = "settings_update"
+
+    ACTION_CHOICES = [
+        (ACTION_SETTINGS_UPDATE, "Site settings updated"),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    actor = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="site_settings_audit_actions",
+        help_text="User who performed the action; null for system-initiated events.",
+    )
+    action = models.CharField(max_length=32, choices=ACTION_CHOICES)
+    site_settings = models.ForeignKey(
+        SiteSettings,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="audit_events",
+    )
+    notes = models.TextField(blank=True)
+    metadata = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text=(
+            "Action-specific payload. For settings_update, includes a "
+            "'changes' dict mapping field name -> {before, after}. "
+            "File fields are summarized by filename only — binary "
+            "content is never stored here."
+        ),
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["site_settings", "-created_at"], name="settings_audit_ss_idx"),
+            models.Index(fields=["actor", "-created_at"], name="settings_audit_actor_idx"),
+            models.Index(fields=["action", "-created_at"], name="settings_audit_action_idx"),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.action} @ {self.created_at:%Y-%m-%d %H:%M}"

--- a/backend/customization/tests.py
+++ b/backend/customization/tests.py
@@ -2,11 +2,17 @@
 Tests for customization app.
 """
 
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 import pytest
+from rest_framework.test import APIClient
 
-from .models import SiteSettings
+from .audit import diff_audited_fields, record_event, snapshot
+from .models import SiteSettings, SiteSettingsAuditEvent
+
+User = get_user_model()
 
 
 @pytest.mark.unit
@@ -151,3 +157,115 @@ class TestSiteSettingsAPI:
         assert data["dashboard_title"] == "Custom Dashboard"
         assert data["dashboard_subtitle"] == "Custom Subtitle"
         assert data["show_logo_on_dashboard"] is False
+
+
+@pytest.mark.django_db
+class TestSiteSettingsAudit:
+    """Test SiteSettings audit helpers and API integration."""
+
+    def test_settings_update_records_audit_event(self):
+        """PATCH with a real change records one audit event."""
+        user = User.objects.create_user(
+            username="superuser",
+            password="testpass123",
+            is_staff=True,
+            is_superuser=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        settings = SiteSettings.get()
+
+        response = client.patch("/api/customization/settings/", {"site_name": "New Name"})
+
+        assert response.status_code == 200
+        assert SiteSettingsAuditEvent.objects.count() == 1
+
+        event = SiteSettingsAuditEvent.objects.get()
+        assert event.action == SiteSettingsAuditEvent.ACTION_SETTINGS_UPDATE
+        assert event.actor == user
+        assert event.site_settings == settings
+        assert event.metadata["changes"]["site_name"]["before"] == "Makerspace Inventory"
+        assert event.metadata["changes"]["site_name"]["after"] == "New Name"
+
+    def test_settings_update_no_event_on_empty_diff(self):
+        """PATCH with an unchanged value should not record an event."""
+        user = User.objects.create_user(
+            username="superuser-noop",
+            password="testpass123",
+            is_staff=True,
+            is_superuser=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        settings = SiteSettings.get()
+
+        response = client.patch(
+            "/api/customization/settings/",
+            {"site_name": settings.site_name},
+        )
+
+        assert response.status_code == 200
+        assert SiteSettingsAuditEvent.objects.count() == 0
+
+    def test_settings_update_unauthenticated_no_event(self):
+        """Unauthenticated PATCH is rejected and does not record an event."""
+        SiteSettings.get()
+        client = APIClient()
+
+        response = client.patch("/api/customization/settings/", {"site_name": "Blocked"})
+
+        assert response.status_code == 401
+        assert SiteSettingsAuditEvent.objects.count() == 0
+
+    def test_settings_update_non_superuser_no_event(self):
+        """Non-superuser staff cannot update settings or create audit rows."""
+        user = User.objects.create_user(
+            username="staff-user",
+            password="testpass123",
+            is_staff=True,
+            is_superuser=False,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        SiteSettings.get()
+
+        response = client.patch("/api/customization/settings/", {"site_name": "Blocked"})
+
+        assert response.status_code == 403
+        assert SiteSettingsAuditEvent.objects.count() == 0
+
+    def test_diff_audited_fields_returns_empty_when_unchanged(self):
+        """Diff helper returns an empty dict when audited fields match."""
+        settings = SiteSettings.get()
+        before = snapshot(settings)
+
+        assert diff_audited_fields(before, settings) == {}
+
+    def test_diff_audited_fields_summarizes_file_field_by_filename(self):
+        """Diff helper reduces file-field changes to a filename string."""
+        settings = SiteSettings.get()
+        before = snapshot(settings)
+        settings.logo = SimpleUploadedFile(
+            "audit-logo.png",
+            b"fake-image-bytes",
+            content_type="image/png",
+        )
+
+        changes = diff_audited_fields(before, settings)
+
+        assert changes["logo"]["before"] is None
+        assert isinstance(changes["logo"]["after"], str)
+        assert changes["logo"]["after"].endswith("audit-logo.png")
+
+    def test_record_event_with_anonymous_actor_creates_row_with_null_actor(self):
+        """record_event stores a null actor when called anonymously."""
+        settings = SiteSettings.get()
+
+        event = record_event(
+            action=SiteSettingsAuditEvent.ACTION_SETTINGS_UPDATE,
+            site_settings=settings,
+            actor=None,
+        )
+
+        assert SiteSettingsAuditEvent.objects.count() == 1
+        assert event.actor is None

--- a/backend/customization/views.py
+++ b/backend/customization/views.py
@@ -7,7 +7,14 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
-from .models import SiteSettings
+from .audit import (
+    diff_audited_fields,
+)
+from .audit import record_event as record_settings_audit_event
+from .audit import (
+    snapshot,
+)
+from .models import SiteSettings, SiteSettingsAuditEvent
 from .serializers import SiteSettingsSerializer, SiteSettingsUpdateSerializer
 
 
@@ -54,7 +61,19 @@ def site_settings(request):
     )
 
     if serializer.is_valid():
+        before = snapshot(settings_obj)
         serializer.save()
+        # Refresh to ensure file fields reflect post-save state when the
+        # storage backend renames on upload.
+        settings_obj.refresh_from_db()
+        changes = diff_audited_fields(before, settings_obj)
+        if changes:
+            record_settings_audit_event(
+                action=SiteSettingsAuditEvent.ACTION_SETTINGS_UPDATE,
+                actor=request.user,
+                site_settings=settings_obj,
+                metadata={"changes": changes},
+            )
         # Return updated settings using the read serializer
         read_serializer = SiteSettingsSerializer(settings_obj, context={"request": request})
         return Response(read_serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Summary

Seventh domain landing of the #334 audit-trail work — site-level configuration changes. Records one `settings_update` event per non-empty PATCH/PUT, with a per-field diff in metadata.

## What's new

- **`SiteSettingsAuditEvent`** — append-only audit row.
- **`customization.audit`** helpers: `record_event(...)`, `diff_audited_fields(before, after)`, `snapshot(instance)`, plus `AUDITED_FIELDS` tuple.
- Hook in the `site_settings` view PUT/PATCH path: snapshot → save → refresh → diff → emit (only when changes non-empty).

## AC-27 guardrail

File fields (logo, favicon) are diffed by **filename only**. The helper's `_jsonable` normalizer prevents binary content from ever landing in audit metadata. Issue #358 explicitly calls this out.

## Out of scope (follow-ups)

- Permission matrix / role grants / revocations — different app (`membership`); follow-up.
- Feature-flag toggles — none modeled today.
- Email + integration credential changes — values live in env vars (validated by `validate-prod-env.sh`, gh #337), not in DB. No DB-side audit hook applies.

## Test plan

Tests via **codex (OpenAI)** — `customization/tests.py::TestSiteSettingsAudit`:
- happy-path emit on change
- empty-diff no-emit
- unauthenticated → 401, no event
- non-superuser → 403, no event
- diff helper returns `{}` when unchanged
- file fields normalized to filename string in diff
- anonymous-actor `record_event` → null actor

Manual: black/isort/flake8 clean.

Fixes #358
Refs #334