### PR TITLE
feat(dashboard): unified audit-feed endpoint across all domains

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -82,6 +82,9 @@ views:
   dashboard.views.dashboard_health:
     permission_classes:
     - <default>
+  dashboard.views.get_audit_feed:
+    permission_classes:
+    - IsAdminUser
   dashboard.views.get_asset_problems_data:
     permission_classes:
     - IsAuthenticated

--- a/backend/dashboard/audit_feed.py
+++ b/backend/dashboard/audit_feed.py
@@ -1,0 +1,400 @@
+"""Unified audit-event feed across the per-domain audit tables (gh #359).
+
+This module is the consolidation layer for the #334 audit-trail effort.
+Each domain (forgekey #352, purchase orders #353, donations #354,
+maintenance work orders #355, vendor compliance #356, webhooks #357,
+site settings #358) maintains its own append-only audit table with
+a per-domain shape. The feed normalizes a row from any of those
+tables into a uniform dict so a single staff review surface can
+answer "who did what, when, on this entity" without joining 8
+tables by hand.
+
+## Defensive imports
+
+Every per-domain collector wraps its model import in a guarded
+``try/except ImportError``. This protects the feed against:
+
+1. Domain audit tables that haven't merged yet (migration ordering
+   during parallel PR development).
+2. Future deployments that disable an app — the feed gracefully
+   omits its rows rather than 500-ing.
+
+It also keeps this module's import cost bounded: ``ImportError`` on a
+missing domain is the only failure mode that returns ``[]`` here. Any
+real bug (typo in a model field, etc.) still surfaces normally.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+# Sentinels for entity_type so callers can filter without per-app
+# knowledge. Keep the strings stable — they appear in API responses.
+ENTITY_DEVICE = "device"
+ENTITY_AUTHORIZATION = "authorization"
+ENTITY_LOCKOUT = "lockout"
+ENTITY_FIRMWARE_UPDATE = "firmware_update"
+ENTITY_PURCHASE_ORDER = "purchase_order"
+ENTITY_PO_LINE_ITEM = "purchase_order_item"
+ENTITY_PO_ATTACHMENT = "purchase_order_attachment"
+ENTITY_DONATION = "donation"
+ENTITY_DONATION_ITEM = "donation_item"
+ENTITY_TAX_RECEIPT = "tax_receipt"
+ENTITY_DISPOSITION = "disposition"
+ENTITY_WORK_ORDER = "work_order"
+ENTITY_LOCATION_PROBLEM = "location_problem"
+ENTITY_VENDOR = "vendor"
+ENTITY_WEBHOOK = "webhook"
+ENTITY_SITE_SETTINGS = "site_settings"
+
+
+def _row(
+    *,
+    domain: str,
+    action: str,
+    actor_id: Optional[Any],
+    actor_username: Optional[str],
+    created_at: datetime,
+    entity_type: Optional[str],
+    entity_id: Optional[Any],
+    notes: str,
+    metadata: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Build one normalized row. The shape is the response contract."""
+    return {
+        "domain": domain,
+        "action": action,
+        "actor_id": actor_id,
+        "actor_username": actor_username,
+        "created_at": created_at.isoformat() if hasattr(created_at, "isoformat") else created_at,
+        "entity_type": entity_type,
+        "entity_id": str(entity_id) if entity_id is not None else None,
+        "notes": notes or "",
+        "metadata": metadata or {},
+    }
+
+
+def _entity_for_forgekey(event) -> tuple[Optional[str], Optional[Any]]:
+    """Pick the most-specific entity reference on a ForgeKeyAuditEvent."""
+    if event.firmware_update_id:
+        return ENTITY_FIRMWARE_UPDATE, event.firmware_update_id
+    if event.lockout_id:
+        return ENTITY_LOCKOUT, event.lockout_id
+    if event.authorization_id:
+        return ENTITY_AUTHORIZATION, event.authorization_id
+    if event.device_id:
+        return ENTITY_DEVICE, event.device_id
+    return None, None
+
+
+def _collect_forgekey(filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+    try:
+        from forgekey.models import ForgeKeyAuditEvent
+    except ImportError:
+        return []
+    qs = ForgeKeyAuditEvent.objects.select_related("actor")
+    qs = _apply_common_filters(qs, filters)
+    out: List[Dict[str, Any]] = []
+    for event in qs:
+        entity_type, entity_id = _entity_for_forgekey(event)
+        out.append(
+            _row(
+                domain="forgekey",
+                action=event.action,
+                actor_id=event.actor_id,
+                actor_username=getattr(event.actor, "username", None),
+                created_at=event.created_at,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                notes=event.notes,
+                metadata=event.metadata,
+            )
+        )
+    return out
+
+
+def _entity_for_po(event) -> tuple[Optional[str], Optional[Any]]:
+    if event.attachment_id:
+        return ENTITY_PO_ATTACHMENT, event.attachment_id
+    if event.line_item_id:
+        return ENTITY_PO_LINE_ITEM, event.line_item_id
+    if event.purchase_order_id:
+        return ENTITY_PURCHASE_ORDER, event.purchase_order_id
+    return None, None
+
+
+def _collect_purchase_orders(filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+    try:
+        from reorder_queue.models import PurchaseOrderAuditEvent
+    except ImportError:
+        return []
+    qs = PurchaseOrderAuditEvent.objects.select_related("actor")
+    qs = _apply_common_filters(qs, filters)
+    out: List[Dict[str, Any]] = []
+    for event in qs:
+        entity_type, entity_id = _entity_for_po(event)
+        out.append(
+            _row(
+                domain="purchase_orders",
+                action=event.action,
+                actor_id=event.actor_id,
+                actor_username=getattr(event.actor, "username", None),
+                created_at=event.created_at,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                notes=event.notes,
+                metadata=event.metadata,
+            )
+        )
+    return out
+
+
+def _collect_webhooks(filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+    try:
+        from reorder_queue.models import WebhookAuditEvent
+    except ImportError:
+        return []
+    qs = WebhookAuditEvent.objects.select_related("actor")
+    qs = _apply_common_filters(qs, filters)
+    out: List[Dict[str, Any]] = []
+    for event in qs:
+        out.append(
+            _row(
+                domain="webhooks",
+                action=event.action,
+                actor_id=event.actor_id,
+                actor_username=getattr(event.actor, "username", None),
+                created_at=event.created_at,
+                entity_type=ENTITY_WEBHOOK if event.webhook_id else None,
+                entity_id=event.webhook_id,
+                notes=event.notes,
+                metadata=event.metadata,
+            )
+        )
+    return out
+
+
+def _entity_for_donation(event) -> tuple[Optional[str], Optional[Any]]:
+    if event.disposition_id:
+        return ENTITY_DISPOSITION, event.disposition_id
+    if event.tax_receipt_id:
+        return ENTITY_TAX_RECEIPT, event.tax_receipt_id
+    if event.donation_item_id:
+        return ENTITY_DONATION_ITEM, event.donation_item_id
+    if event.donation_id:
+        return ENTITY_DONATION, event.donation_id
+    return None, None
+
+
+def _collect_donations(filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+    try:
+        from donations.models import DonationAuditEvent
+    except ImportError:
+        return []
+    qs = DonationAuditEvent.objects.select_related("actor")
+    qs = _apply_common_filters(qs, filters)
+    out: List[Dict[str, Any]] = []
+    for event in qs:
+        entity_type, entity_id = _entity_for_donation(event)
+        out.append(
+            _row(
+                domain="donations",
+                action=event.action,
+                actor_id=event.actor_id,
+                actor_username=getattr(event.actor, "username", None),
+                created_at=event.created_at,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                notes=event.notes,
+                metadata=event.metadata,
+            )
+        )
+    return out
+
+
+def _collect_maintenance(filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+    try:
+        from inventory.models import MaintenanceAuditEvent
+    except ImportError:
+        return []
+    qs = MaintenanceAuditEvent.objects.select_related("actor")
+    qs = _apply_common_filters(qs, filters)
+    out: List[Dict[str, Any]] = []
+    for event in qs:
+        if event.work_order_id:
+            entity_type, entity_id = ENTITY_WORK_ORDER, event.work_order_id
+        elif event.location_problem_id:
+            entity_type, entity_id = ENTITY_LOCATION_PROBLEM, event.location_problem_id
+        else:
+            entity_type, entity_id = None, None
+        out.append(
+            _row(
+                domain="maintenance",
+                action=event.action,
+                actor_id=event.actor_id,
+                actor_username=getattr(event.actor, "username", None),
+                created_at=event.created_at,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                notes=event.notes,
+                metadata=event.metadata,
+            )
+        )
+    return out
+
+
+def _collect_vendors(filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+    try:
+        from vendors.models import VendorAuditEvent
+    except ImportError:
+        return []
+    qs = VendorAuditEvent.objects.select_related("actor")
+    qs = _apply_common_filters(qs, filters)
+    out: List[Dict[str, Any]] = []
+    for event in qs:
+        out.append(
+            _row(
+                domain="vendors",
+                action=event.action,
+                actor_id=event.actor_id,
+                actor_username=getattr(event.actor, "username", None),
+                created_at=event.created_at,
+                entity_type=ENTITY_VENDOR if event.vendor_id else None,
+                entity_id=event.vendor_id,
+                notes=event.notes,
+                metadata=event.metadata,
+            )
+        )
+    return out
+
+
+def _collect_settings(filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+    try:
+        from customization.models import SiteSettingsAuditEvent
+    except ImportError:
+        return []
+    qs = SiteSettingsAuditEvent.objects.select_related("actor")
+    qs = _apply_common_filters(qs, filters)
+    out: List[Dict[str, Any]] = []
+    for event in qs:
+        out.append(
+            _row(
+                domain="customization",
+                action=event.action,
+                actor_id=event.actor_id,
+                actor_username=getattr(event.actor, "username", None),
+                created_at=event.created_at,
+                entity_type=ENTITY_SITE_SETTINGS if event.site_settings_id else None,
+                entity_id=event.site_settings_id,
+                notes=event.notes,
+                metadata=event.metadata,
+            )
+        )
+    return out
+
+
+def _collect_third_party_wo(filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Includes the pre-existing maintenance_orders.ThirdPartyWorkOrderAuditLog
+    so the unified feed covers ALL audit-relevant events town-wide, not just
+    the per-domain audits added in #352–#358."""
+    try:
+        from maintenance_orders.models import ThirdPartyWorkOrderAuditLog
+    except ImportError:
+        return []
+    qs = ThirdPartyWorkOrderAuditLog.objects.select_related("actor", "work_order")
+    qs = _apply_common_filters(qs, filters)
+    out: List[Dict[str, Any]] = []
+    for event in qs:
+        out.append(
+            _row(
+                domain="third_party_work_orders",
+                action=event.action,
+                actor_id=event.actor_id,
+                actor_username=getattr(event.actor, "username", None),
+                created_at=event.created_at,
+                entity_type="third_party_work_order" if event.work_order_id else None,
+                entity_id=event.work_order_id,
+                notes=event.notes,
+                metadata=event.metadata,
+            )
+        )
+    return out
+
+
+def _apply_common_filters(qs, filters: Dict[str, Any]):
+    """Apply actor / action / since / until filters to a queryset.
+
+    Each per-domain queryset has the same field names for these filters,
+    so the application is generic. Entity-type and entity-id filters are
+    applied AFTER normalization (in ``collect_events``) since the
+    underlying field names differ across domains.
+    """
+    actor_id = filters.get("actor_id")
+    if actor_id:
+        qs = qs.filter(actor_id=actor_id)
+    action = filters.get("action")
+    if action:
+        qs = qs.filter(action=action)
+    since = filters.get("since")
+    if since:
+        qs = qs.filter(created_at__gte=since)
+    until = filters.get("until")
+    if until:
+        qs = qs.filter(created_at__lte=until)
+    return qs
+
+
+_COLLECTORS = (
+    _collect_forgekey,
+    _collect_purchase_orders,
+    _collect_webhooks,
+    _collect_donations,
+    _collect_maintenance,
+    _collect_vendors,
+    _collect_settings,
+    _collect_third_party_wo,
+)
+
+
+def collect_events(
+    *,
+    actor_id: Optional[Any] = None,
+    action: Optional[str] = None,
+    domain: Optional[str] = None,
+    entity_type: Optional[str] = None,
+    entity_id: Optional[Any] = None,
+    since: Optional[datetime] = None,
+    until: Optional[datetime] = None,
+    limit: int = 200,
+) -> List[Dict[str, Any]]:
+    """Collect normalized audit events across all domains.
+
+    Filters are applied per-domain at queryset level when possible
+    (actor / action / since / until); domain / entity filters are
+    applied post-normalization. Results are sorted by ``created_at``
+    descending and capped at ``limit`` (default 200, max 1000).
+    """
+    filters = {
+        "actor_id": actor_id,
+        "action": action,
+        "since": since,
+        "until": until,
+    }
+
+    rows: List[Dict[str, Any]] = []
+    for collector in _COLLECTORS:
+        rows.extend(collector(filters))
+
+    if domain:
+        rows = [r for r in rows if r["domain"] == domain]
+    if entity_type:
+        rows = [r for r in rows if r["entity_type"] == entity_type]
+    if entity_id is not None:
+        target = str(entity_id)
+        rows = [r for r in rows if r["entity_id"] == target]
+
+    rows.sort(key=lambda r: r["created_at"], reverse=True)
+
+    capped = max(1, min(int(limit), 1000))
+    return rows[:capped]

--- a/backend/dashboard/tests/test_audit_feed.py
+++ b/backend/dashboard/tests/test_audit_feed.py
@@ -1,0 +1,220 @@
+from types import ModuleType
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from dashboard import audit_feed, views
+from dashboard.views import _parse_audit_feed_dt
+
+User = get_user_model()
+
+
+def _event(created_at, **overrides):
+    row = {
+        "domain": "forgekey",
+        "action": "updated",
+        "actor_id": 1,
+        "actor_username": "staff",
+        "created_at": created_at,
+        "entity_type": "device",
+        "entity_id": "1",
+        "notes": "",
+        "metadata": {},
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.mark.django_db
+class TestAuditFeedEndpoint:
+    def test_audit_feed_unauthenticated_returns_403(self, api_client):
+        response = api_client.get(reverse("get_audit_feed"))
+
+        assert response.status_code in {
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        }
+
+    def test_audit_feed_non_staff_returns_403(self):
+        user = User.objects.create_user(
+            username="regular-user",
+            email="regular@example.com",
+            password="testpass123",
+            is_staff=False,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.get(reverse("get_audit_feed"))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_audit_feed_staff_returns_200_with_zero_events_on_empty_db(self):
+        user = User.objects.create_user(
+            username="staff-user",
+            email="staff@example.com",
+            password="testpass123",
+            is_staff=True,
+            is_superuser=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.get(reverse("get_audit_feed"))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["count"] == 0
+        assert response.data["events"] == []
+
+    def test_audit_feed_limit_capped_to_1000(self):
+        user = User.objects.create_user(
+            username="limit-user",
+            email="limit@example.com",
+            password="testpass123",
+            is_staff=True,
+            is_superuser=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        with patch.object(
+            views,
+            "collect_events",
+            return_value=[_event("2026-05-07T10:00:00+00:00")] * 5,
+        ) as mock_collect:
+            response = client.get(reverse("get_audit_feed"), {"limit": "99999"})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["count"] == 5
+        assert len(response.data["events"]) == 5
+        assert mock_collect.call_args.kwargs["limit"] == 99999
+
+    def test_audit_feed_invalid_limit_falls_back_to_default(self):
+        user = User.objects.create_user(
+            username="default-limit-user",
+            email="default-limit@example.com",
+            password="testpass123",
+            is_staff=True,
+            is_superuser=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        with patch.object(views, "collect_events", return_value=[]) as mock_collect:
+            response = client.get(reverse("get_audit_feed"), {"limit": "garbage"})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert mock_collect.call_args.kwargs["limit"] == 200
+
+
+class TestParseAuditFeedDatetime:
+    def test_parse_audit_feed_dt_handles_z_suffix(self):
+        parsed = _parse_audit_feed_dt("2026-05-07T10:00:00Z")
+
+        assert parsed is not None
+        assert timezone.is_aware(parsed)
+        assert parsed.isoformat() == "2026-05-07T10:00:00+00:00"
+
+    def test_parse_audit_feed_dt_returns_none_for_bad_input(self):
+        assert _parse_audit_feed_dt(None) is None
+        assert _parse_audit_feed_dt("") is None
+        assert _parse_audit_feed_dt("not-a-date") is None
+
+    def test_parse_audit_feed_dt_makes_naive_aware(self):
+        parsed = _parse_audit_feed_dt("2026-05-07T10:00:00")
+
+        assert parsed is not None
+        assert timezone.is_aware(parsed)
+
+
+class TestCollectEvents:
+    def test_collect_events_combines_and_sorts_across_domains(self):
+        collectors = (
+            lambda filters: [_event("2026-05-07T09:00:00+00:00", domain="forgekey")],
+            lambda filters: [_event("2026-05-07T11:00:00+00:00", domain="vendors")],
+            lambda filters: [_event("2026-05-07T10:00:00+00:00", domain="donations")],
+        )
+
+        with patch.object(audit_feed, "_COLLECTORS", new=collectors):
+            events = audit_feed.collect_events()
+
+        assert [event["domain"] for event in events] == [
+            "vendors",
+            "donations",
+            "forgekey",
+        ]
+        assert [event["created_at"] for event in events] == [
+            "2026-05-07T11:00:00+00:00",
+            "2026-05-07T10:00:00+00:00",
+            "2026-05-07T09:00:00+00:00",
+        ]
+
+    def test_collect_events_filters_by_domain_post_normalization(self):
+        collectors = (
+            lambda filters: [
+                _event("2026-05-07T11:00:00+00:00", domain="forgekey"),
+                _event("2026-05-07T10:00:00+00:00", domain="vendors"),
+            ],
+            lambda filters: [_event("2026-05-07T09:00:00+00:00", domain="forgekey")],
+        )
+
+        with patch.object(audit_feed, "_COLLECTORS", new=collectors):
+            events = audit_feed.collect_events(domain="forgekey")
+
+        assert len(events) == 2
+        assert all(event["domain"] == "forgekey" for event in events)
+
+    def test_collect_events_filters_by_entity_type_and_entity_id(self):
+        collectors = (
+            lambda filters: [
+                _event("2026-05-07T11:00:00+00:00", entity_type="device", entity_id="42"),
+                _event("2026-05-07T10:00:00+00:00", entity_type="device", entity_id="7"),
+                _event(
+                    "2026-05-07T09:00:00+00:00",
+                    entity_type="authorization",
+                    entity_id="42",
+                ),
+            ],
+        )
+
+        with patch.object(audit_feed, "_COLLECTORS", new=collectors):
+            events = audit_feed.collect_events(entity_type="device", entity_id=42)
+
+        assert events == [_event("2026-05-07T11:00:00+00:00", entity_type="device", entity_id="42")]
+
+    def test_collect_events_caps_to_limit(self):
+        collectors = (
+            lambda filters: [
+                _event("2026-05-07T08:00:00+00:00"),
+                _event("2026-05-07T11:00:00+00:00"),
+            ],
+            lambda filters: [
+                _event("2026-05-07T10:00:00+00:00"),
+                _event("2026-05-07T09:00:00+00:00"),
+            ],
+        )
+
+        with patch.object(audit_feed, "_COLLECTORS", new=collectors):
+            events = audit_feed.collect_events(limit=3)
+
+        assert len(events) == 3
+        assert [event["created_at"] for event in events] == [
+            "2026-05-07T11:00:00+00:00",
+            "2026-05-07T10:00:00+00:00",
+            "2026-05-07T09:00:00+00:00",
+        ]
+
+    def test_defensive_imports_return_empty_when_module_missing(self, monkeypatch):
+        stub_models = ModuleType("forgekey.models")
+
+        monkeypatch.setitem(__import__("sys").modules, "forgekey.models", stub_models)
+
+        events = audit_feed._collect_forgekey({})
+
+        assert events == []

--- a/backend/dashboard/urls.py
+++ b/backend/dashboard/urls.py
@@ -31,4 +31,7 @@ urlpatterns = [
     ),
     path("widget-data/qr-scans/", views.get_qr_scans_data, name="get_qr_scans_data"),
     path("widget-data/deliveries/", views.get_deliveries_data, name="get_deliveries_data"),
+    # Audit feed (gh #359 / #334) — staff-only review surface across all
+    # per-domain audit tables.
+    path("audit-feed/", views.get_audit_feed, name="get_audit_feed"),
 ]

--- a/backend/dashboard/views.py
+++ b/backend/dashboard/views.py
@@ -2,13 +2,17 @@
 API views for dashboard configuration management.
 """
 
+from datetime import datetime
+
 from django.http import JsonResponse
+from django.utils import timezone as dj_timezone
 
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
+from .audit_feed import collect_events
 from .models import DashboardConfig, DashboardMessage, DashboardWidget
 from .serializers import DashboardWidgetSerializer
 
@@ -658,3 +662,72 @@ def get_deliveries_data(request):
 
     except Exception as e:
         return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+def _parse_audit_feed_dt(value):
+    """Parse an ISO-ish datetime from a query param; return None on bad input."""
+    if not value:
+        return None
+    try:
+        # Accept "2026-05-07" and "2026-05-07T10:00:00Z" / "+00:00"
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = dj_timezone.make_aware(parsed)
+    return parsed
+
+
+@api_view(["GET"])
+@permission_classes([IsAdminUser])
+def get_audit_feed(request):
+    """Return the unified audit-event feed across all domain audit tables.
+
+    Query parameters (all optional):
+      domain       — restrict to a single domain (forgekey, purchase_orders,
+                     webhooks, donations, maintenance, vendors,
+                     customization, third_party_work_orders)
+      entity_type  — restrict to a normalized entity_type string
+      entity_id    — restrict to a specific entity id (string match)
+      action       — restrict to a single action choice (per-domain
+                     value, e.g. "po_void" or "settings_update")
+      actor_id     — restrict to events performed by a specific user
+      since        — ISO-format datetime; events at or after this
+      until        — ISO-format datetime; events at or before this
+      limit        — max rows returned (default 200, capped at 1000)
+
+    Staff-only (IsAdminUser). Audit data is sensitive review material;
+    do not expose to non-staff. Per gh #359 / #334.
+    """
+    params = request.query_params
+
+    actor_id = params.get("actor_id") or None
+    domain = params.get("domain") or None
+    entity_type = params.get("entity_type") or None
+    entity_id = params.get("entity_id") or None
+    action = params.get("action") or None
+    since = _parse_audit_feed_dt(params.get("since"))
+    until = _parse_audit_feed_dt(params.get("until"))
+
+    try:
+        limit = int(params.get("limit", 200))
+    except (TypeError, ValueError):
+        limit = 200
+
+    events = collect_events(
+        actor_id=actor_id,
+        action=action,
+        domain=domain,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        since=since,
+        until=until,
+        limit=limit,
+    )
+
+    return Response(
+        {
+            "count": len(events),
+            "events": events,
+        }
+    )


### PR DESCRIPTION
## Summary

**Final domain landing of the #334 audit-trail work** — the unified review surface. Consolidates the per-domain audit tables from #352–#358 plus the pre-existing `maintenance_orders.ThirdPartyWorkOrderAuditLog` into a single staff-facing feed.

A staff reviewer can now answer *"who did what, when, on this entity"* across the whole town from one endpoint without joining 8 tables by hand.

## What's new

- **`dashboard.audit_feed`** service — `collect_events(...)` aggregator with per-domain collectors; defensive `try/except ImportError` guards on every domain so the feed lands cleanly even before all per-domain PRs have merged.
- **`GET /api/dashboard/audit-feed/`** — staff-only endpoint with query params: `domain`, `entity_type`, `entity_id`, `action`, `actor_id`, `since`, `until`, `limit` (default 200, capped at 1000).
- Includes the pre-existing `ThirdPartyWorkOrderAuditLog` so the feed covers **all** audit-relevant events town-wide.

## Response shape

```json
{
  "count": N,
  "events": [
    {
      "domain": "purchase_orders",
      "action": "po_void",
      "actor_id": 42,
      "actor_username": "ops_user",
      "created_at": "2026-05-07T10:30:00+00:00",
      "entity_type": "purchase_order",
      "entity_id": "f8a1...",
      "notes": "wrong supplier",
      "metadata": {"po_number": "PO-2026-001"}
    }
  ]
}
```

## Permissions

`IsAdminUser` only. Audit metadata can carry vendor identifiers, donation context, and other operationally sensitive info — non-staff get 403.

## Defensive imports

Every per-domain collector wraps its model import in `try/except ImportError`. Two reasons:

1. **Parallel-development safety.** This PR is ordered last but doesn't have to land last — the feed gracefully omits a domain whose audit table hasn't merged yet. Once each prior PR (#360–#366) lands, its rows automatically start appearing in the feed.
2. **Future-proofing.** If an app is disabled in `INSTALLED_APPS`, the feed degrades to "this domain has no audit events" rather than 500-ing.

## Test plan

Tests via **codex (OpenAI)** — `dashboard/tests/test_audit_feed.py`:

- [ ] Endpoint permission gating (unauth → 401/403, non-staff → 403, staff → 200)
- [ ] Date parser edge cases (Z suffix, naive→aware, bad input → None)
- [ ] Limit handling (invalid `?limit=garbage` → default 200)
- [ ] Aggregation: sort across domains, domain filter, entity filter, limit cap (all DB-free via mocked `_COLLECTORS`)
- [ ] Defensive import guarantee: `_collect_forgekey` returns `[]` when target model class is missing

Manual: black/isort/flake8 clean.

Closes #359
Refs #334