### PR TITLE
feat(config): observability redaction utility (AC-27)

### DIFF
--- a/backend/config/api_errors.py
+++ b/backend/config/api_errors.py
@@ -43,6 +43,8 @@ from rest_framework.exceptions import (
 from rest_framework.response import Response
 from rest_framework.views import exception_handler as drf_exception_handler
 
+from .observability_redaction import redact as _redact_for_logs
+
 
 class ErrorCode:
     """Stable machine-readable error codes returned at ``error.code``."""
@@ -202,7 +204,12 @@ def standardized_exception_handler(exc, context):
 
     body: dict[str, Any] = {"code": code, "message": message}
     if details is not None and details != message:
-        body["details"] = details
+        # Scrub sensitive keys and value-shape secrets from the details
+        # payload before they leave the process. AC-27: error envelopes
+        # are an observability surface; details can carry user-supplied
+        # field maps (e.g. validation errors over a registration form
+        # that includes a password field). Redact before serialization.
+        body["details"] = _redact_for_logs(details)
 
     response.data = {"error": body}
     return response

--- a/backend/config/observability_redaction.py
+++ b/backend/config/observability_redaction.py
@@ -1,0 +1,146 @@
+"""Observability redaction utility (gh #333 / AC-27).
+
+Centralized helper for scrubbing secrets and PII from log payloads,
+error envelopes, and other observability surfaces before they leave
+the process.
+
+## Principles
+
+1. **Default-deny on key names.** Any dict key matching a known
+   sensitive pattern (``token``, ``secret``, ``password``,
+   ``api_key``, ``signature``, ``private_key``, ``csrf``, etc.) is
+   redacted regardless of its value type. We err on the side of
+   over-redaction — operators can always re-emit a debug field with
+   a non-sensitive name when they need value-level visibility.
+2. **Value-shape scrubbing.** Some values carry secrets even when
+   the key name is innocuous (e.g. a ``message`` field that contains
+   a stringified JWT or PEM). The value pass redacts substrings
+   matching known secret shapes.
+3. **Recursive.** Redaction descends into nested dicts and lists so
+   audit metadata, exception details, and structured-log payloads
+   are scrubbed all the way down.
+4. **Stable output shape.** The redactor never adds, removes, or
+   reorders keys — only the values change. This keeps downstream
+   parsers and dashboards honest.
+
+## Usage
+
+```python
+from config.observability_redaction import redact
+
+logger.error(
+    "webhook delivery failed",
+    extra=redact({"webhook_id": ..., "url": ..., "headers": req.headers}),
+)
+```
+
+The module is intentionally dependency-free (pure stdlib) so it can
+be imported from any layer — middleware, signal handlers, Celery
+tasks — without circular-import risk.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable, Mapping, Pattern, Sequence
+
+REDACTED = "***REDACTED***"
+
+
+# Case-insensitive substring patterns matched against dict keys.
+# Order matters only for human readability; matching is OR.
+_KEY_PATTERNS: tuple[Pattern[str], ...] = (
+    re.compile(r"token", re.IGNORECASE),
+    re.compile(r"secret", re.IGNORECASE),
+    re.compile(r"password|passwd|pwd", re.IGNORECASE),
+    re.compile(r"api[_-]?key", re.IGNORECASE),
+    re.compile(r"signing[_-]?key", re.IGNORECASE),
+    re.compile(r"private[_-]?key", re.IGNORECASE),
+    re.compile(r"signature", re.IGNORECASE),
+    re.compile(r"csrf", re.IGNORECASE),
+    re.compile(r"session[_-]?key", re.IGNORECASE),
+    re.compile(r"bearer", re.IGNORECASE),
+    re.compile(r"^(authorization|x-authorization|cookie|set-cookie)$", re.IGNORECASE),
+)
+
+
+# Patterns that match secret shapes anywhere in a string value.
+# These run AFTER the key-based pass and replace the matched substring
+# with REDACTED. They intentionally do NOT match short low-entropy
+# values to avoid scrubbing legitimate words.
+_VALUE_PATTERNS: tuple[Pattern[str], ...] = (
+    # Bearer + JWT-shape token (any auth header value)
+    re.compile(r"Bearer\s+[A-Za-z0-9\-._~+/]{20,}=*", re.IGNORECASE),
+    # Generic JWT (three base64url segments separated by dots)
+    re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"),
+    # PEM private key block (multiline)
+    re.compile(
+        r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+        re.DOTALL,
+    ),
+    # Generic high-entropy hex / base64 token (>= 32 chars). Catches
+    # API keys + signed tokens that escape the key-name pass via
+    # generic field names like ``payload`` or ``headers``.
+    re.compile(r"\b[A-Za-z0-9+/]{32,}={0,2}\b"),
+)
+
+
+def _key_is_sensitive(key: Any) -> bool:
+    if not isinstance(key, str):
+        return False
+    return any(p.search(key) for p in _KEY_PATTERNS)
+
+
+def _scrub_value(value: str) -> str:
+    """Apply value-shape patterns to a string. Returns the (possibly
+    rewritten) string; substrings matching any pattern become REDACTED.
+    """
+    for pattern in _VALUE_PATTERNS:
+        value = pattern.sub(REDACTED, value)
+    return value
+
+
+def redact(payload: Any) -> Any:
+    """Return a redacted copy of ``payload`` safe for logs.
+
+    - dicts: recursed; sensitive keys → REDACTED, other values
+      recursively redacted.
+    - lists / tuples: each element redacted, container type preserved.
+    - strings: value-shape patterns applied.
+    - other scalars (numbers, bools, None, datetime, UUID, etc.):
+      returned as-is.
+
+    The function is pure: ``payload`` is not mutated; the returned
+    structure is a new object hierarchy where any non-scalar
+    container has been rebuilt.
+    """
+    if isinstance(payload, Mapping):
+        return {
+            key: REDACTED if _key_is_sensitive(key) else redact(value)
+            for key, value in payload.items()
+        }
+    if isinstance(payload, (list, tuple)):
+        rebuilt: Iterable[Any] = (redact(item) for item in payload)
+        return type(payload)(rebuilt) if isinstance(payload, tuple) else list(rebuilt)
+    if isinstance(payload, (set, frozenset)):
+        # Sets can't contain unhashable redacted dicts; redact the
+        # member representations as strings to avoid crashing.
+        return type(payload)(redact(item) if isinstance(item, str) else item for item in payload)
+    if isinstance(payload, str):
+        return _scrub_value(payload)
+    return payload
+
+
+def is_sensitive_key(key: Any) -> bool:
+    """Public alias of the key check — useful for callers that want to
+    integrate redaction into a custom log formatter without using the
+    full ``redact`` traversal.
+    """
+    return _key_is_sensitive(key)
+
+
+__all__: Sequence[str] = (
+    "REDACTED",
+    "redact",
+    "is_sensitive_key",
+)

--- a/backend/config/tests/test_observability_redaction.py
+++ b/backend/config/tests/test_observability_redaction.py
@@ -1,0 +1,179 @@
+"""Unit tests for observability redaction and error-envelope scrubbing."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+from rest_framework.exceptions import ValidationError
+from rest_framework.test import APIRequestFactory
+
+from config.api_errors import standardized_exception_handler
+from config.observability_redaction import REDACTED, is_sensitive_key, redact
+
+pytestmark = pytest.mark.unit
+
+
+def _drf_context():
+    request = APIRequestFactory().post("/api/_test/redaction/", {}, format="json")
+    return {
+        "view": SimpleNamespace(),
+        "request": request,
+        "args": (),
+        "kwargs": {},
+    }
+
+
+def test_redacts_token_key():
+    assert redact({"token": "secret-value"}) == {"token": REDACTED}
+
+
+def test_redacts_secret_key():
+    assert redact({"client_secret": "secret-value"}) == {"client_secret": REDACTED}
+
+
+@pytest.mark.parametrize("key", ["password", "passwd", "pwd"])
+def test_redacts_password_key_variants(key):
+    assert redact({key: "secret-value"}) == {key: REDACTED}
+
+
+@pytest.mark.parametrize("key", ["api_key", "api-key", "apikey"])
+def test_redacts_api_key_variants(key):
+    assert redact({key: "secret-value"}) == {key: REDACTED}
+
+    assert is_sensitive_key("apiKey") is False
+    assert redact({"apiKey": "secret-value"}) == {"apiKey": "secret-value"}
+
+
+def test_redacts_signature_key():
+    assert redact({"signature": "abc123"}) == {"signature": REDACTED}
+
+
+def test_redacts_private_key_pem_field():
+    pem = "-----BEGIN PRIVATE KEY-----\nabc123\n-----END PRIVATE KEY-----"
+    assert redact({"private_key": pem}) == {"private_key": REDACTED}
+
+
+@pytest.mark.parametrize("key", ["Authorization", "X-Authorization"])
+def test_redacts_authorization_header_key(key):
+    assert redact({key: "Bearer should-not-survive"}) == {key: REDACTED}
+
+
+@pytest.mark.parametrize("key", ["Cookie", "Set-Cookie"])
+def test_redacts_cookie_keys(key):
+    assert redact({key: "sessionid=abc"}) == {key: REDACTED}
+
+
+def test_does_not_redact_innocuous_keys():
+    payload = {
+        "name": "widget",
+        "count": 3,
+        "description": "safe text",
+        "item_id": "abc-123",
+    }
+
+    assert redact(payload) == payload
+
+
+def test_scrubs_bearer_token_in_string():
+    value = "Bearer abcdefghijklmnopqrstuvwxyz1234567890"
+
+    assert redact(value) == REDACTED
+
+
+def test_scrubs_jwt_in_string():
+    jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.c2lnbmF0dXJl"
+    value = f"Authorization failed for token {jwt} during webhook delivery."
+
+    assert redact(value) == (
+        "Authorization failed for token " f"{REDACTED} during webhook delivery."
+    )
+
+
+def test_scrubs_pem_private_key_block():
+    pem = (
+        "prefix\n"
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "supersecretmaterial\n"
+        "-----END RSA PRIVATE KEY-----\n"
+        "suffix"
+    )
+
+    assert redact(pem) == f"prefix\n{REDACTED}\nsuffix"
+
+
+def test_scrubs_high_entropy_token():
+    token = "0123456789abcdef0123456789abcdef01234567"
+    value = f"received token={token} from upstream"
+
+    assert redact(value) == f"received token={REDACTED} from upstream"
+    assert redact("received token=hello from upstream") == "received token=hello from upstream"
+
+
+def test_redacts_nested_dict():
+    payload = {"outer": {"inner": {"token": "secret-value"}}}
+
+    assert redact(payload) == {"outer": {"inner": {"token": REDACTED}}}
+
+
+def test_redacts_dict_in_list():
+    payload = [{"token": "one"}, {"token": "two"}]
+
+    assert redact(payload) == [{"token": REDACTED}, {"token": REDACTED}]
+
+
+def test_redacts_tuple_preserves_type():
+    payload = ("safe", {"token": "secret-value"})
+
+    result = redact(payload)
+
+    assert isinstance(result, tuple)
+    assert result == ("safe", {"token": REDACTED})
+
+
+def test_redacts_list_preserves_type():
+    payload = ["safe", {"token": "secret-value"}]
+
+    result = redact(payload)
+
+    assert isinstance(result, list)
+    assert result == ["safe", {"token": REDACTED}]
+
+
+def test_redact_does_not_mutate_input():
+    payload = {
+        "message": "Bearer abcdefghijklmnopqrstuvwxyz1234567890",
+        "nested": {"token": "secret-value"},
+        "items": [{"secret": "top-secret"}],
+    }
+    original = deepcopy(payload)
+
+    result = redact(payload)
+
+    assert payload == original
+    assert result == {
+        "message": REDACTED,
+        "nested": {"token": REDACTED},
+        "items": [{"secret": REDACTED}],
+    }
+
+
+def test_exception_handler_redacts_password_in_validation_details():
+    exc = ValidationError({"password": ["This field may not be blank."]})
+
+    response = standardized_exception_handler(exc, _drf_context())
+
+    assert response is not None
+    assert response.status_code == 400
+    assert response.data["error"]["details"]["password"] == REDACTED
+
+
+def test_exception_handler_preserves_innocuous_validation_details():
+    exc = ValidationError({"username": ["This field may not be blank."]})
+
+    response = standardized_exception_handler(exc, _drf_context())
+
+    assert response is not None
+    assert response.status_code == 400
+    assert response.data["error"]["details"] == {"username": ["This field may not be blank."]}

--- a/backend/config/tests/test_observability_redaction.py
+++ b/backend/config/tests/test_observability_redaction.py
@@ -38,12 +38,13 @@ def test_redacts_password_key_variants(key):
     assert redact({key: "secret-value"}) == {key: REDACTED}
 
 
-@pytest.mark.parametrize("key", ["api_key", "api-key", "apikey"])
+@pytest.mark.parametrize("key", ["api_key", "api-key", "apikey", "apiKey", "API_KEY"])
 def test_redacts_api_key_variants(key):
+    # The regex ``api[_-]?key`` runs with re.IGNORECASE, so camelCase
+    # and SHOUTING_CASE both match. Default-deny on key names — every
+    # spelling of "api key" lands as REDACTED.
+    assert is_sensitive_key(key) is True
     assert redact({key: "secret-value"}) == {key: REDACTED}
-
-    assert is_sensitive_key("apiKey") is False
-    assert redact({"apiKey": "secret-value"}) == {"apiKey": "secret-value"}
 
 
 def test_redacts_signature_key():

--- a/docs/OBSERVABILITY_PRIVACY.md
+++ b/docs/OBSERVABILITY_PRIVACY.md
@@ -1,0 +1,92 @@
+# Observability privacy posture (AC-27)
+
+OpenMakerSuite emits operator-visible observability data through several
+surfaces:
+
+| Surface | Producer | Consumer |
+|---------|----------|----------|
+| Django request logs | gunicorn + nginx | Container stdout, Highlight |
+| DRF error envelopes | `config.api_errors.standardized_exception_handler` | API clients, frontend toasts |
+| Celery task results | `django_celery_results` | Django admin (`/admin/django_celery_results/`) |
+| Webhook delivery audit | `WebHook.failure_count` + `last_error` | Admin webhook detail view |
+| Forgekey device logs | `forgekey/management/commands/mqtt_consumer.py` | Container stdout, Highlight |
+| Frontend error reporting | `@highlight-run/react` (when `HIGHLIGHT_PROJECT_ID` set) | Highlight |
+
+## Redaction policy
+
+All payloads that traverse one of these surfaces are scrubbed by
+`config.observability_redaction.redact()` before emission. The redactor
+applies two passes:
+
+### 1. Sensitive key names (default-deny)
+
+Any dict key whose name matches one of these patterns is replaced with
+`***REDACTED***` regardless of value type:
+
+- `token` (anywhere in the key)
+- `secret`
+- `password` / `passwd` / `pwd`
+- `api_key` / `api-key`
+- `signing_key`
+- `private_key`
+- `signature`
+- `csrf`
+- `session_key`
+- `bearer`
+- Whole-key match: `Authorization`, `X-Authorization`, `Cookie`, `Set-Cookie`
+
+This is a default-deny policy — operators add a non-sensitive sibling
+field when they need value-level visibility (e.g. log
+`token_fingerprint` instead of `token`).
+
+### 2. Sensitive value shapes
+
+Even when a key name is innocuous, the value is scanned for known
+secret shapes and matching substrings are replaced with
+`***REDACTED***`:
+
+- `Bearer <token>` (auth header values)
+- JWTs (`eyJ...` triple-segment base64url)
+- PEM private key blocks (`-----BEGIN ... PRIVATE KEY-----`)
+- High-entropy hex/base64 tokens (32+ chars)
+
+This catches secrets that escape the key-name pass via generic field
+names like `payload`, `headers`, or stringified `message`.
+
+## What does NOT get scrubbed
+
+The redactor is intentionally conservative — it does not remove member
+identifiers (usernames, email addresses, donor names) because these are
+operationally necessary for incident response. The audit-trail data
+layer (gh #352–#358) records actor identity by design.
+
+If a member-data scrubbing pass becomes necessary (e.g. for export to
+third-party telemetry), build a second helper —
+`redact_member_pii()` — that runs in addition to `redact()` for the
+specific surfaces that cross trust boundaries.
+
+## Wiring
+
+Reference call sites that already route through the redactor:
+
+- `config.api_errors.standardized_exception_handler` — DRF error
+  envelope `details` payload.
+
+Surfaces that should adopt `redact()` next (tracked as follow-ups):
+
+- Webhook delivery failure logging (`WebHook.record_failure` /
+  `last_error` field).
+- Celery task result `traceback` storage (sanitize before
+  `django_celery_results` writes the row).
+- ForgeKey MQTT consumer logger when an inbound message contains a
+  user payload.
+- Frontend error capture (Highlight integration) — sanitize React
+  error context before it ships to the collector.
+
+## Operator obligation
+
+When adding a new logging or telemetry call, treat the payload as
+untrusted: route it through `redact()` before `logger.info(...)` /
+`extra={...}` / structured-event emission. Tests for new audit and
+error code paths should assert that representative secret values are
+scrubbed before they reach the response/log.


### PR DESCRIPTION
## Summary

Centralized helper for scrubbing secrets and PII from log payloads, error envelopes, and other observability surfaces before they leave the process. Wired into the standardized exception handler as a reference call site; remaining surfaces are tracked as follow-ups in the new privacy doc.

## What's new

- **`config.observability_redaction`** module with `redact(payload)`, `is_sensitive_key(key)`, and `REDACTED` constant.
- **Two redaction passes**:
  1. **Key-name default-deny** — sensitive substrings (token, secret, password, api_key, signing_key, private_key, signature, csrf, session_key, bearer) + anchored Authorization / Cookie variants.
  2. **Value-shape scrub** — Bearer tokens, JWTs, PEM private-key blocks, high-entropy hex/base64 32+ chars.
- **Wired into `standardized_exception_handler`** — DRF error envelope `details` field is scrubbed before serialization. Stops `{"password": ["may not be blank"]}` from leaking the user-supplied value back to the client.
- **`docs/OBSERVABILITY_PRIVACY.md`** documents the posture and the surfaces still to wire.

## Out of scope (follow-ups, listed in the doc)

- Webhook delivery failure logging
- Celery task result `traceback` storage
- ForgeKey MQTT consumer payload logger
- Frontend Highlight error capture sanitization
- Member PII redaction (intentionally separate from secret redaction)

## Test plan

Tests via **codex (OpenAI)** — `config/tests/test_observability_redaction.py`:
- [ ] 18 redactor unit tests (key patterns, value shapes, recursive structures, non-mutation, container-type preservation)
- [ ] 2 integration tests on the exception handler (sensitive field scrubbed, innocuous field passes through)

Manual: black/isort/flake8 clean.

Fixes #333