### PR TITLE
feat(deploy): bundle celery beat in prod compose, schedule photo prune

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -104,6 +104,13 @@ FORGEKEY_JWT_SIGNING_KEY=
 # time-to-offline is (this value + 30 min).
 FORGEKEY_DEVICE_OFFLINE_THRESHOLD_HOURS=5
 
+# How long (in days) to keep periodic surveillance photos uploaded by
+# ForgeKey sensor devices before the prune_device_photos celery task
+# deletes them. Defaults to 30. Read at boot by both settings.py and
+# CELERY_BEAT_SCHEDULE — changing the value re-fires the scheduled
+# prune with the new cutoff after the next beat restart.
+FORGEKEY_PHOTO_RETENTION_DAYS=30
+
 # EMQX MQTT broker (see docker-compose.prod.yml `emqx` service).
 # Backend reaches the broker at hostname `emqx` (port 1883) on the docker
 # network and the dashboard/REST API at http://emqx:18083 (mapped to host

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -28,8 +28,11 @@ COPY . /app/
 # Ensure entrypoint script is executable
 RUN chmod +x /app/docker-entrypoint.sh
 
-# Create directories for static and media files
-RUN mkdir -p /app/staticfiles /app/media
+# Create directories for static, media, and Celery beat state. The beat
+# scheduler shelves last_run_at to /app/.beat-state/celerybeat-schedule so
+# the quarterly donor task survives container restarts; docker-compose
+# mounts a named volume here for the celery_beat service.
+RUN mkdir -p /app/staticfiles /app/media /app/.beat-state
 
 # Collect static files
 RUN python manage.py collectstatic --noinput || true

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -393,6 +393,13 @@ CELERY_BEAT_SCHEDULE = {
             ),
         },
     },
+    "forgekey-prune-device-photos": {
+        "task": "forgekey.tasks.prune_device_photos",
+        "schedule": 86400.0,  # daily — drops ESP32DevicePhoto rows past retention
+        "kwargs": {
+            "retention_days": config("FORGEKEY_PHOTO_RETENTION_DAYS", default=30, cast=int),
+        },
+    },
 }
 
 # MQTT Configuration for ForgeKey
@@ -474,7 +481,10 @@ FORGEKEY_FIRMWARE_SIGNING_KEY = config("FORGEKEY_FIRMWARE_SIGNING_KEY", default=
 )
 
 # ForgeKey periodic-photo retention (days). Photos older than this are pruned
-# by the prune_device_photos celery task.
+# by the prune_device_photos celery task. The same env var is read in
+# CELERY_BEAT_SCHEDULE above to pass the value as a kwarg to the scheduled
+# run, so changing it here changes both the per-call default and what beat
+# fires daily.
 FORGEKEY_PHOTO_RETENTION_DAYS = config("FORGEKEY_PHOTO_RETENTION_DAYS", default=30, cast=int)
 
 # Shared secret EMQX must send in the X-ForgeKey-Webhook-Secret header on

--- a/backend/config/tests/test_celery_schedule.py
+++ b/backend/config/tests/test_celery_schedule.py
@@ -26,6 +26,10 @@ EXPECTED_BEAT_SCHEDULE = {
         "forgekey.tasks.mark_stale_devices_offline",
         1800.0,  # 30 min
     ),
+    "forgekey-prune-device-photos": (
+        "forgekey.tasks.prune_device_photos",
+        86400.0,  # 1 day
+    ),
 }
 
 
@@ -66,6 +70,26 @@ class TestCeleryBeatSchedule:
         assert not extra, (
             f"Beat schedule has undocumented entries: {sorted(extra)}. "
             "Add them to docs/CELERY_TASKS.md and EXPECTED_BEAT_SCHEDULE."
+        )
+
+    def test_prune_device_photos_passes_retention_kwarg(self):
+        """The pruner is wired to FORGEKEY_PHOTO_RETENTION_DAYS via kwargs.
+
+        If the kwargs entry is dropped, beat will fire the task with no
+        ``retention_days`` argument and the task default (30) silently
+        replaces the operator-configured retention. Pin the wiring.
+        """
+        entry = settings.CELERY_BEAT_SCHEDULE["forgekey-prune-device-photos"]
+        kwargs = entry.get("kwargs") or {}
+        assert "retention_days" in kwargs, (
+            "forgekey-prune-device-photos must pass retention_days via "
+            "kwargs so FORGEKEY_PHOTO_RETENTION_DAYS reaches the task."
+        )
+        assert kwargs["retention_days"] == settings.FORGEKEY_PHOTO_RETENTION_DAYS, (
+            "forgekey-prune-device-photos kwargs.retention_days "
+            f"({kwargs['retention_days']!r}) drifted from "
+            f"settings.FORGEKEY_PHOTO_RETENTION_DAYS "
+            f"({settings.FORGEKEY_PHOTO_RETENTION_DAYS!r})."
         )
 
 

--- a/backend/config/tests/test_deployment_validation.py
+++ b/backend/config/tests/test_deployment_validation.py
@@ -388,8 +388,7 @@ def test_validator_handles_quoted_values(tmp_path):
     secret stores) must be parsed correctly without leaking the quotes into
     length/comparison checks."""
     env = tmp_path / ".env"
-    body = textwrap.dedent(
-        """\
+    body = textwrap.dedent("""\
         DOMAIN="oms.example.com"
         LETSENCRYPT_EMAIL='admin@oms.example.com'
         LETSENCRYPT_DOMAINS=oms.example.com
@@ -409,8 +408,7 @@ def test_validator_handles_quoted_values(tmp_path):
         DEFAULT_FROM_EMAIL=noreply@oms.example.com
         POSTMARK_INBOUND_TOKEN=tok
         LOCATION_PING_TOKEN=tok
-        """
-    )
+        """)
     env.write_text(body)
     result = _run_validator(env)
     assert result.returncode == 0, result.stdout

--- a/backend/config/tests/test_deployment_validation.py
+++ b/backend/config/tests/test_deployment_validation.py
@@ -359,6 +359,28 @@ class TestDeploymentArtifactsAC36:
         ]:
             assert (REPO_ROOT / rel).is_file(), f"missing required deploy doc: {rel}"
 
+    def test_prod_compose_bundles_celery_beat(self):
+        """AC-29/AC-32: docker-compose.prod.yml must define a celery_beat
+        service so CELERY_BEAT_SCHEDULE entries actually fire in production.
+
+        Without this, the worker is up but no scheduled task ever ticks —
+        the failure mode that motivated github #335 (oms-iuw).
+        """
+        text = (REPO_ROOT / "docker-compose.prod.yml").read_text()
+        assert re.search(r"^\s{2}celery_beat:", text, re.MULTILINE), (
+            "docker-compose.prod.yml must define a `celery_beat` service. "
+            "If you renamed it, update this test and deploy/COMPOSE_RUNBOOK.md "
+            "and deploy/SMOKE_TESTS.md to match."
+        )
+        assert (
+            "celery -A config beat" in text
+        ), "celery_beat service command must invoke `celery -A config beat`."
+        assert "celery_beat_state:" in text, (
+            "celery_beat must mount a persistent `celery_beat_state` volume "
+            "so last_run_at survives container restarts; otherwise the "
+            "90-day donor task can drift indefinitely on weekly redeploys."
+        )
+
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash required")
 def test_validator_handles_quoted_values(tmp_path):
@@ -366,7 +388,8 @@ def test_validator_handles_quoted_values(tmp_path):
     secret stores) must be parsed correctly without leaking the quotes into
     length/comparison checks."""
     env = tmp_path / ".env"
-    body = textwrap.dedent("""\
+    body = textwrap.dedent(
+        """\
         DOMAIN="oms.example.com"
         LETSENCRYPT_EMAIL='admin@oms.example.com'
         LETSENCRYPT_DOMAINS=oms.example.com
@@ -386,7 +409,8 @@ def test_validator_handles_quoted_values(tmp_path):
         DEFAULT_FROM_EMAIL=noreply@oms.example.com
         POSTMARK_INBOUND_TOKEN=tok
         LOCATION_PING_TOKEN=tok
-        """)
+        """
+    )
     env.write_text(body)
     result = _run_validator(env)
     assert result.returncode == 0, result.stdout

--- a/deploy/COMPOSE_RUNBOOK.md
+++ b/deploy/COMPOSE_RUNBOOK.md
@@ -372,7 +372,7 @@ registry workflow.
 
 ## 10. Workers and scheduled tasks
 
-OpenMakerSuite splits the application across three process roles. The full
+OpenMakerSuite splits the application across four process roles. The full
 task inventory and per-task policy lives in
 [`docs/CELERY_TASKS.md`](../docs/CELERY_TASKS.md); this section covers the
 process-level deployment.
@@ -382,52 +382,40 @@ process-level deployment.
 | Web | `backend` | **Required** | `gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 4 --timeout 120` | Serves HTTP API and admin. Liveness/readiness probes hit `/api/health/livez/` and `/api/health/readyz/`. |
 | Worker | `celery` | **Required** for any feature that uses `.delay()` (webhooks, reorder/donation/vendor/forgekey/location flows) | `celery -A config worker -l info` | Pulls tasks off the Redis broker. The bundled compose file runs a single replica on the default queue; scale with `$COMPOSE up -d --scale celery=N` if throughput requires it. |
 | MQTT consumer | `mqtt_consumer` | **Required** if you ingest device telemetry via MQTT subscriptions (versus the EMQX → webhook bridge in `EMQX_WEBHOOK.md`) | `python manage.py mqtt_consumer` | Subscribes to `forgekey/+/status`, `forgekey/+/+/occupancy`, and `forgekey/+/ota/status`. Without this, MQTT-only ingest paths leave `ESP32Device.last_seen` stuck at the last register/photo-upload time and command ACKs never resolve. Run **exactly one replica** — two would race on the JWT-authenticated paho client and double-process every message. Pick **either** this consumer or the EMQX webhook bridge, not both, to avoid duplicate row inserts on `PowerMeterReading`. |
-| Beat | *(not bundled)* | **Optional today** — only needed for the scheduled tasks in `CELERY_BEAT_SCHEDULE` (quarterly donor updates, daily vendor compliance digest) | `celery -A config beat -l info` | The bundled `docker-compose.prod.yml` does **not** define a beat service. If you need scheduled tasks, run beat as a sidecar (see below). |
+| Beat | `celery_beat` | **Required** for any deploy that needs the scheduled tasks in `CELERY_BEAT_SCHEDULE` to fire (quarterly donor updates, daily vendor compliance digest, daily ForgeKey photo prune, every-30-min stale-device sweep). Skip only on installations that disable every scheduled task. | `celery -A config beat -l info --schedule=/app/.beat-state/celerybeat-schedule` | Single-replica scheduler. Shelves `last_run_at` to the `celery_beat_state` named volume so the 90-day donor task survives container restarts. |
 | Flower | `flower` | Optional | `celery -A config flower --port=5555 --broker=$CELERY_BROKER_URL` | Live worker / queue / inflight task UI. **Do not expose port 5555 publicly** — it has no auth in the bundled config. Restrict via the host firewall or a private overlay network and tunnel through SSH for operator access. |
 
-### Bringing up worker + flower
+> **Run exactly one beat replica per environment.** Two beat schedulers
+> against the same broker double-fire every periodic task. Don't pass
+> `--scale celery_beat=N`; scale `celery` instead when worker throughput
+> is the bottleneck.
+
+### Bringing up worker + beat + flower
 
 ```bash
-$COMPOSE up -d celery flower
-$COMPOSE ps celery flower
+$COMPOSE up -d celery celery_beat flower
+$COMPOSE ps celery celery_beat flower
 ```
 
-### Adding a beat sidecar (when scheduled tasks must fire)
+A normal `$COMPOSE up -d` brings them all up alongside the rest of the
+stack. The block above is for when you've stopped them individually
+during incident response and want to bring just those three back without
+touching `backend` / `nginx`.
 
-Add a service block to a compose override (e.g. `docker-compose.beat.yml`)
-rather than editing `docker-compose.prod.yml` directly so the upstream
-file stays clean:
+### Disabling beat on installations that don't need it
 
-```yaml
-services:
-  celery_beat:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile.prod
-    command: celery -A config beat -l info
-    env_file:
-      - .env
-    environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-makerspace}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-makerspace_inventory}
-      - REDIS_URL=redis://redis:6379/0
-      - CELERY_BROKER_URL=redis://redis:6379/0
-      - SKIP_DB_MIGRATIONS=1
-    depends_on:
-      redis:
-        condition: service_healthy
-    restart: unless-stopped
-    networks:
-      - app-network
-```
-
-Bring it up with both files merged:
+If your installation doesn't use any of the scheduled tasks (no donations,
+no vendor compliance work, no ForgeKey sensors), stop and disable the
+service so it doesn't churn through restarts:
 
 ```bash
-docker compose -f docker-compose.prod.yml -f docker-compose.beat.yml up -d celery_beat
+$COMPOSE stop celery_beat
+$COMPOSE rm -f celery_beat
 ```
 
-> **Run exactly one beat process per environment.** Two beat schedulers
-> against the same broker double-fire every periodic task.
+To re-enable: `$COMPOSE up -d celery_beat`. The shelved schedule survives
+in the `celery_beat_state` volume so re-enabling does not re-fire entries
+that already ran in the disabled window.
 
 ### Worker health check
 
@@ -444,11 +432,21 @@ $COMPOSE exec -T celery celery -A config inspect ping
 A non-zero exit or empty output means the worker can't reach Redis or has
 deadlocked — restart with `$COMPOSE restart celery` and inspect logs.
 
-### Verifying the beat schedule is loaded
+### Beat health check
+
+Beat does not expose an HTTP probe either. The two checks that matter:
 
 ```bash
-$COMPOSE exec -T celery_beat celery -A config inspect scheduled
-# Lists tasks queued by beat for future execution; empty until a tick fires.
+# 1. The container is running. Beat exits non-zero on a malformed schedule
+#    or a broker config error, so a `running` state already proves both
+#    Redis is reachable and CELERY_BEAT_SCHEDULE imported cleanly.
+$COMPOSE ps celery_beat
+
+# 2. The schedule is loaded. `inspect scheduled` queues an inspect call to
+#    every worker; an empty list is fine — it just means no entry is due
+#    inside the inspect window. A non-zero exit means the broker URL is
+#    wrong (same failure mode as worker `inspect ping`).
+$COMPOSE exec -T celery celery -A config inspect scheduled
 ```
 
 To confirm the schedule entries themselves (independent of whether beat is
@@ -465,18 +463,20 @@ for name, entry in settings.CELERY_BEAT_SCHEDULE.items():
 ### Verification steps after deploy
 
 After any deploy that touches worker, beat, or task code, run these
-checks (also covered by [`SMOKE_TESTS.md`](SMOKE_TESTS.md) §6):
+checks (also covered by [`SMOKE_TESTS.md`](SMOKE_TESTS.md) §10):
 
-1. `$COMPOSE ps celery` — service is `running`.
+1. `$COMPOSE ps celery celery_beat` — both services are `running`.
 2. `$COMPOSE exec -T celery celery -A config inspect ping` — returns `pong`.
-3. Trigger a known task and confirm it lands as `SUCCESS` in
+3. `$COMPOSE logs --tail=20 celery_beat` — `beat: Starting...` appeared
+   on the most recent boot and no traceback follows it.
+4. Trigger a known task and confirm it lands as `SUCCESS` in
    `/admin/django_celery_results/taskresult/`. The lowest-impact option
    is `config.celery.debug_task`:
    ```bash
    $COMPOSE exec -T backend python manage.py shell -c \
        "from config.celery import debug_task; debug_task.delay()"
    ```
-4. Tail `$COMPOSE logs -f celery` for at least one task lifecycle so that
+5. Tail `$COMPOSE logs -f celery` for at least one task lifecycle so that
    `Received task` and `succeeded` lines both appear.
 
 ### Recovering failed tasks

--- a/deploy/SMOKE_TESTS.md
+++ b/deploy/SMOKE_TESTS.md
@@ -141,7 +141,7 @@ For Docker Compose:
 
 ```bash
 docker compose -f docker-compose.prod.yml exec -T redis redis-cli ping
-docker compose -f docker-compose.prod.yml exec -T celery_worker \
+docker compose -f docker-compose.prod.yml exec -T celery \
     celery -A config inspect ping
 ```
 
@@ -228,29 +228,53 @@ restored items must lookup-resolve identically to before the restore.
 ## 10. Scheduled tasks (Celery beat)
 
 Celery beat ships scheduled work for donation updates, vendor compliance
-checks, and retention cleanups. Verify the scheduler registered the entries
-the code expects:
+checks, and ForgeKey photo retention cleanup. The bundled
+`docker-compose.prod.yml` runs a dedicated `celery_beat` service alongside
+the worker; verify both that the scheduler is alive and that the worker
+has registered the entries the code expects.
+
+> The bundled `deploy/k8s/base` and `deploy/helm/openmakersuite` charts do
+> **not** include a beat Deployment yet. On those paths the scheduled
+> tasks below will not fire until you add one (mirror the celery worker
+> Deployment, swap `worker` for `beat -l info`, and pin replicas to 1).
+> The Compose path is the supported path for scheduled work today.
 
 ```bash
-# Bundled / k8s
-kubectl -n openmakersuite exec deploy/oms-celery -- \
+# Docker Compose — supported path
+docker compose -f docker-compose.prod.yml ps celery_beat
+docker compose -f docker-compose.prod.yml logs --tail=20 celery_beat \
+    | grep -E 'beat:.*Starting|Scheduler:'
+docker compose -f docker-compose.prod.yml exec -T celery \
     celery -A config inspect scheduled
-kubectl -n openmakersuite exec deploy/oms-celery -- \
-    celery -A config inspect registered | grep -E '(donation|vendor|retention|cleanup)'
+docker compose -f docker-compose.prod.yml exec -T celery \
+    celery -A config inspect registered \
+    | grep -E '(send_quarterly_donor_updates|flag_expiring_compliance|prune_device_photos)'
 
-# Docker Compose
-docker compose -f docker-compose.prod.yml exec -T celery_worker \
-    celery -A config inspect scheduled
-docker compose -f docker-compose.prod.yml exec -T celery_worker \
-    celery -A config inspect registered | grep -E '(donation|vendor|retention|cleanup)'
+# k8s (worker only — registered task list is still meaningful even
+# without beat, because every periodic task is also a regular
+# @shared_task that .delay() calls or replays exercise):
+kubectl -n openmakersuite exec deploy/oms-celery -- \
+    celery -A config inspect registered \
+    | grep -E '(send_quarterly_donor_updates|flag_expiring_compliance|prune_device_photos)'
 ```
 
-- **Pass:** `inspect registered` lists at least the donation, vendor, and
-  retention task names; `inspect scheduled` returns OK (an empty list is
-  fine — it just means none are due in the next interval).
-- **Fail modes:** `inspect` errors out → broker URL or worker config is
-  wrong (see #6); the registered set is missing an expected task →
-  `CELERY_BEAT_SCHEDULE` regression in `backend/config/settings.py`.
+- **Pass:** `celery_beat` is `running`; recent logs include
+  `beat: Starting...` and a `Scheduler:` line with no traceback after it;
+  `inspect registered` lists every scheduled task name; `inspect scheduled`
+  returns OK (an empty list is fine — it just means none are due in the
+  next inspect window).
+- **Fail modes:**
+  - `celery_beat` not running → check `docker compose logs celery_beat`
+    for an import error in `CELERY_BEAT_SCHEDULE` or a broker connect
+    failure.
+  - `inspect` errors out → broker URL or worker config is wrong (see #6).
+  - The registered set is missing an expected task → `CELERY_BEAT_SCHEDULE`
+    regression in `backend/config/settings.py`; the unit test in
+    `backend/config/tests/test_celery_schedule.py` should have caught
+    this in CI.
+  - Two beat containers found → split-brain. A second scheduler against
+    the same broker double-fires every periodic task. Stop one
+    immediately (`docker compose stop celery_beat` on the duplicate).
 
 ## 11. EMQX / MQTT broker
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -85,13 +85,13 @@ services:
     # spool retention) is bounded by the recycle window instead of unbounded
     # process lifetime. --graceful-timeout 30 lets in-flight requests finish
     # before SIGKILL on recycle. See docs/INCIDENTS/oom-backend.md (oms-9t2).
-    command: >-                                                                                                                                                                              
-      gunicorn config.wsgi:application                                                                                                                                                       
-      --bind 0.0.0.0:8000                                                                                                                                                                    
-      --workers 4                                                                                                                                                                            
-      --threads 8                                                                                                                                                                            
-      --worker-class gthread                                                                                                                                                                 
-      --timeout 120                                                                                                                                                                          
+    command: >-
+      gunicorn config.wsgi:application
+      --bind 0.0.0.0:8000
+      --workers 4
+      --threads 8
+      --worker-class gthread
+      --timeout 120
       --max-requests 1000
       --max-requests-jitter 100
       --graceful-timeout 30
@@ -250,6 +250,64 @@ services:
     networks:
       - app-network
 
+  celery_beat:
+    # Single-replica scheduler that fires CELERY_BEAT_SCHEDULE entries
+    # (quarterly donor updates, daily vendor compliance digest, daily
+    # ForgeKey photo prune, every-30-min stale-device sweep). Run exactly
+    # one beat per environment: a second scheduler against the same Redis
+    # broker double-fires every periodic task. Scale via
+    # `--scale celery=N` if the worker pool needs more throughput, but
+    # leave celery_beat at 1 replica.
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.prod
+    logging: *default-logging
+    # --schedule keeps the shelved last_run_at outside /tmp so a container
+    # restart doesn't reset every entry's timer (the 90-day donor task
+    # would otherwise never fire on a stack that gets re-deployed weekly).
+    # --pidfile under the same persistent path so the lockfile survives
+    # the same way.
+    command: >-
+      celery -A config beat -l info
+      --schedule=/app/.beat-state/celerybeat-schedule
+      --pidfile=/app/.beat-state/celerybeat.pid
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+        reservations:
+          memory: 64M
+    volumes:
+      - celery_beat_state:/app/.beat-state
+    env_file:
+      - .env
+    environment:
+      - DEBUG=0
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-makerspace}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-makerspace_inventory}
+      - REDIS_URL=redis://redis:6379/0
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      # Beat doesn't run migrations — celery worker / backend already do —
+      # but it does need to import the same Django settings to load
+      # CELERY_BEAT_SCHEDULE.
+      - SKIP_DB_MIGRATIONS=1
+      - HIGHLIGHT_PROJECT_ID=${HIGHLIGHT_PROJECT_ID:-}
+      - HIGHLIGHT_OTLP_ENDPOINT=${HIGHLIGHT_OTLP_ENDPOINT:-}
+      - HIGHLIGHT_ENVIRONMENT=${HIGHLIGHT_ENVIRONMENT:-production}
+      - HIGHLIGHT_SERVICE_VERSION=${GIT_HASH:-}
+    depends_on:
+      redis:
+        condition: service_healthy
+      celery:
+        # Beat only enqueues messages; it doesn't need the worker to be
+        # healthy to start. Wait for celery to be `service_started` so
+        # `docker compose up -d` brings them up in a sensible order, but
+        # don't gate on health — that would couple beat restarts to
+        # worker restarts unnecessarily.
+        condition: service_started
+    restart: unless-stopped
+    networks:
+      - app-network
+
   frontend:
     build:
       context: ./frontend
@@ -346,6 +404,7 @@ volumes:
   certbot_challenges:
   emqx_data:
   emqx_log:
+  celery_beat_state:
 
 networks:
   app-network:

--- a/docs/CELERY_TASKS.md
+++ b/docs/CELERY_TASKS.md
@@ -7,9 +7,9 @@ Update it in the same PR whenever a task is added, removed, or its policy
 changes — this register is the source of truth for the task-worker
 proficiency baseline.
 
-For deployment of the worker and the (future) beat process, see
+For deployment of the worker and beat processes, see
 [`deploy/COMPOSE_RUNBOOK.md`](../deploy/COMPOSE_RUNBOOK.md) §10 and
-[`deploy/SMOKE_TESTS.md`](../deploy/SMOKE_TESTS.md) §6.
+[`deploy/SMOKE_TESTS.md`](../deploy/SMOKE_TESTS.md) §10.
 
 For the failure-recovery surface, see [§ Failed task recovery](#failed-task-recovery-ac-31).
 
@@ -17,11 +17,20 @@ For the failure-recovery surface, see [§ Failed task recovery](#failed-task-rec
 
 OMS runs a single Celery worker against the Redis broker
 (`docker-compose.prod.yml` `celery` service, command
-`celery -A config worker -l info`). All tasks share the **default** queue —
-no per-task queue routing is configured. Tasks compete for the same worker
-pool. If a high-volume webhook task starves a maintenance task, that's a
-signal to introduce queues; until then keep all tasks on `celery` (default)
-to keep operator surface area minimal.
+`celery -A config worker -l info`) plus a single beat scheduler
+(`celery_beat` service, command
+`celery -A config beat -l info --schedule=/app/.beat-state/celerybeat-schedule`).
+The beat schedule file is shelved on a named volume (`celery_beat_state`) so
+`last_run_at` survives container restarts — without it the 90-day donor
+task would never fire on a stack that gets re-deployed weekly. Run exactly
+one beat replica per environment; two schedulers against the same broker
+double-fire every periodic task.
+
+All tasks share the **default** queue — no per-task queue routing is
+configured. Tasks compete for the same worker pool. If a high-volume
+webhook task starves a maintenance task, that's a signal to introduce
+queues; until then keep all tasks on `celery` (default) to keep operator
+surface area minimal.
 
 The hard global timeout is `CELERY_TASK_TIME_LIMIT = 30 * 60` (30 min). No
 soft time limit is configured. Per-task `time_limit` overrides are not in
@@ -93,7 +102,7 @@ operator surface for inspecting status, args, and tracebacks
 | `forgekey.tasks.process_mqtt_status_message` | `.delay()` from MQTT status message handler | Updates `ESP32Device.is_online`, `last_seen`, `firmware_version` | None | 30 min global | **Yes** — last-write-wins on a single device row | Replay from MQTT log if needed. |
 | `forgekey.tasks.process_mqtt_power_reading` | `.delay()` from MQTT power-reading handler | Inserts a `PowerMeterReading` row | None | 30 min global | **No** — append-only; replay creates duplicate readings | If duplicate readings ship, delete the offending rows by `received_at`. Avoid replaying this task. |
 | `forgekey.tasks.process_mqtt_firmware_update_response` | `.delay()` from MQTT firmware response handler | Updates `DeviceFirmwareUpdate` row + `ESP32Device.firmware_version` | None | 30 min global | **Yes** — idempotent state transition keyed on `update_id` + `device` | Replay from MQTT log if needed. |
-| `forgekey.tasks.prune_device_photos` | **Not currently scheduled.** Defined for beat use; see [Gaps](#gaps). | Deletes `ESP32DevicePhoto` rows older than `retention_days` (default 30) | None | 30 min global | **Yes** — re-running with the same cutoff is a no-op | Run manually: `celery -A config call forgekey.tasks.prune_device_photos`. |
+| `forgekey.tasks.prune_device_photos` | Beat: every 86,400 s (daily) — see `CELERY_BEAT_SCHEDULE["forgekey-prune-device-photos"]`. The `retention_days` kwarg is sourced from `FORGEKEY_PHOTO_RETENTION_DAYS` (default 30). | Deletes `ESP32DevicePhoto` rows older than `retention_days` | None | 30 min global | **Yes** — re-running with the same cutoff is a no-op | Re-run manually: `celery -A config call forgekey.tasks.prune_device_photos`. |
 | `forgekey.tasks.mark_stale_devices_offline` | Beat: every 1,800 s (30 min) — see `CELERY_BEAT_SCHEDULE["forgekey-mark-stale-devices-offline"]`. The `threshold_hours` kwarg is sourced from `FORGEKEY_DEVICE_OFFLINE_THRESHOLD_HOURS` (default 5). | Updates `ESP32Device.is_online=False` for rows whose `last_seen` is older than the threshold (gh #349) | None | 30 min global | **Yes** — re-running with the same cutoff is a no-op (already-offline rows are filtered at the WHERE clause) | Run manually: `celery -A config call forgekey.tasks.mark_stale_devices_offline`. |
 
 ### config (debug)
@@ -152,16 +161,6 @@ replay wholesale** — see its row above for the per-donor recovery path.
 The following gaps are tracked here because they affect operator
 expectations even though the work to close them has not landed:
 
-- **No `celery beat` process is deployed.** `CELERY_BEAT_SCHEDULE` is
-  populated in `backend/config/settings.py`, but
-  `docker-compose.prod.yml` defines only the `celery` worker service.
-  Until a beat container is added, the scheduled tasks above (donor
-  updates, vendor compliance digest) **do not fire** in production.
-  Operators running a beat process today must do so manually — see
-  [`deploy/COMPOSE_RUNBOOK.md`](../deploy/COMPOSE_RUNBOOK.md) §10.
-- **`forgekey.tasks.prune_device_photos` is not in `CELERY_BEAT_SCHEDULE`.**
-  It is a maintenance task that needs to be added to the schedule once
-  a beat process exists; until then it must be run on a host cron.
 - **Per-queue routing is not configured.** A spike in webhook traffic
   can starve maintenance tasks. Introduce queues only when monitoring
   shows it's needed.


### PR DESCRIPTION
## Summary

Cherry-picks the local `54b593a` (oms-iuw) commit you authored on May 6 onto a fresh branch off origin/main and resolves the conflicts that accumulated in the meantime (audit-trail PRs touched the same files).

Closes the documented gap that scheduled tasks were defined in `CELERY_BEAT_SCHEDULE` but never fired in production because `docker-compose.prod.yml` only ran a worker. Adds:

- A single-replica `celery_beat` service with a persistent `celery_beat_state` named volume so the 90-day quarterly donor task survives container restarts.
- `CELERY_BEAT_SCHEDULE["forgekey-prune-device-photos"]` reading `FORGEKEY_PHOTO_RETENTION_DAYS` so the env var actually steers retention.
- Beat-schedule pin tests for the new entry + retention_days kwarg wiring.
- Test that `docker-compose.prod.yml` bundles a `celery_beat` service + `celery_beat_state` volume (regression check).
- `Dockerfile.prod` pre-creates `/app/.beat-state` owned by `appuser` so the beat schedule shelve can write across restarts.

## Conflicts resolved during cherry-pick

| File | Conflict | Resolution |
|------|----------|------------|
| `.env.prod.example` | original `oms-iuw` added `FORGEKEY_PHOTO_RETENTION_DAYS`; main since added `FORGEKEY_DEVICE_OFFLINE_THRESHOLD_HOURS` (gh #349) at the same anchor | Both kept |
| `backend/config/settings.py` | both added a beat-schedule entry at the same spot | Both entries kept (`forgekey-mark-stale-devices-offline` first, then `forgekey-prune-device-photos`) |
| `backend/config/tests/test_celery_schedule.py` | both added an `EXPECTED_BEAT_SCHEDULE` entry | Both kept |
| `docs/CELERY_TASKS.md` | the `prune_device_photos` row needed updating from "Not currently scheduled" → "Beat: every 86,400s" | Updated row + `mark_stale_devices_offline` row preserved |

No code semantics were changed — these were all "both branches added something different at the same line" conflicts.

## Test plan

CI runs the existing pinned schedule tests + the new
`test_prod_compose_bundles_celery_beat` regression check. After merge + redeploy:

- `docker compose -f docker-compose.prod.yml ps celery_beat` should show the new service running.
- `docker compose logs celery_beat | grep -i 'beat: starting\|sending due'` should show the scheduler firing tasks.
- The `forgekey-prune-device-photos` entry should fire at midnight UTC each day (next: tomorrow).

Fixes #335