### PR TITLE
fix(api): coordinate frontend + backend on standardized error envelope

### DIFF
--- a/backend/auth_views.py
+++ b/backend/auth_views.py
@@ -19,6 +19,7 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
+from config.api_errors import ErrorCode, error_response
 from config.tokens import CustomRefreshToken
 
 
@@ -59,26 +60,27 @@ def register_user(request):
 
     # Basic validation
     if not username:
-        return Response({"detail": "Username is required"}, status=status.HTTP_400_BAD_REQUEST)
+        return error_response(ErrorCode.VALIDATION_FAILED, "Username is required")
 
     if len(username) < 3:
-        return Response(
-            {"detail": "Username must be at least 3 characters long"},
-            status=status.HTTP_400_BAD_REQUEST,
+        return error_response(
+            ErrorCode.VALIDATION_FAILED,
+            "Username must be at least 3 characters long",
         )
 
     # Check if username already exists
     if User.objects.filter(username=username).exists():
-        return Response(
-            {"detail": "Username already exists. Please choose another."},
-            status=status.HTTP_400_BAD_REQUEST,
+        return error_response(
+            ErrorCode.CONFLICT,
+            "Username already exists. Please choose another.",
+            status_code=status.HTTP_400_BAD_REQUEST,
         )
 
     # Validate email if provided
     if email and not re.match(r"^[^@]+@[^@]+\.[^@]+$", email):
-        return Response(
-            {"detail": "Please enter a valid email address"},
-            status=status.HTTP_400_BAD_REQUEST,
+        return error_response(
+            ErrorCode.VALIDATION_FAILED,
+            "Please enter a valid email address",
         )
 
     try:
@@ -90,9 +92,10 @@ def register_user(request):
         return Response(payload, status=status.HTTP_201_CREATED)
 
     except Exception as e:
-        return Response(
-            {"detail": f"Registration failed: {str(e)}"},
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        return error_response(
+            ErrorCode.SERVER_ERROR,
+            f"Registration failed: {str(e)}",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
 
@@ -108,23 +111,32 @@ def login_user(request):
     password = request.data.get("password", "")
 
     if not username or not password:
-        return Response(
-            {"detail": "Username and password are required"},
-            status=status.HTTP_400_BAD_REQUEST,
+        return error_response(
+            ErrorCode.VALIDATION_FAILED,
+            "Username and password are required",
         )
 
     user = authenticate(request, username=username, password=password)
 
     if user is None:
-        return Response({"detail": "Invalid credentials"}, status=status.HTTP_401_UNAUTHORIZED)
+        return error_response(
+            ErrorCode.AUTHENTICATION_FAILED,
+            "Invalid credentials",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
 
     if not user.is_active:
-        return Response({"detail": "User account is disabled"}, status=status.HTTP_401_UNAUTHORIZED)
+        return error_response(
+            ErrorCode.AUTHENTICATION_FAILED,
+            "User account is disabled",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
 
     if not user.can_login():
-        return Response(
-            {"detail": "User does not have an active membership or required role"},
-            status=status.HTTP_403_FORBIDDEN,
+        return error_response(
+            ErrorCode.PERMISSION_DENIED,
+            "User does not have an active membership or required role",
+            status_code=status.HTTP_403_FORBIDDEN,
         )
 
     return Response(_issue_session_and_tokens(request, user))
@@ -151,7 +163,7 @@ def refresh_token(request):
     refresh_token = request.data.get("refresh")
 
     if not refresh_token:
-        return Response({"detail": "Refresh token is required"}, status=status.HTTP_400_BAD_REQUEST)
+        return error_response(ErrorCode.VALIDATION_FAILED, "Refresh token is required")
 
     try:
         refresh = CustomRefreshToken(refresh_token)
@@ -164,7 +176,11 @@ def refresh_token(request):
         )
 
     except Exception:
-        return Response({"detail": "Invalid refresh token"}, status=status.HTTP_401_UNAUTHORIZED)
+        return error_response(
+            ErrorCode.AUTHENTICATION_FAILED,
+            "Invalid refresh token",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
 
 
 @api_view(["POST"])
@@ -179,20 +195,23 @@ def create_test_membership(request):
     from membership.models import Membership
 
     if not settings.DEBUG:
-        return Response(
-            {"detail": "This endpoint is only available in DEBUG mode"},
-            status=status.HTTP_403_FORBIDDEN,
+        return error_response(
+            ErrorCode.PERMISSION_DENIED,
+            "This endpoint is only available in DEBUG mode",
+            status_code=status.HTTP_403_FORBIDDEN,
         )
 
     username = request.data.get("username", "").strip()
     if not username:
-        return Response({"detail": "Username is required"}, status=status.HTTP_400_BAD_REQUEST)
+        return error_response(ErrorCode.VALIDATION_FAILED, "Username is required")
 
     try:
         user = User.objects.get(username=username)
     except User.DoesNotExist:
-        return Response(
-            {"detail": f"User '{username}' not found"}, status=status.HTTP_404_NOT_FOUND
+        return error_response(
+            ErrorCode.NOT_FOUND,
+            f"User '{username}' not found",
+            status_code=status.HTTP_404_NOT_FOUND,
         )
 
     # Create an active membership for the user

--- a/backend/config/tests/test_auth_envelope.py
+++ b/backend/config/tests/test_auth_envelope.py
@@ -1,0 +1,153 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+import pytest
+
+from membership.models import Membership
+
+User = get_user_model()
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def member_user():
+    user = User.objects.create_user(
+        username="member",
+        email="member@example.com",
+        password="correct-horse-battery",
+    )
+    membership = Membership.objects.create(
+        membership_type=Membership.MEMBERSHIP_TYPE_MONTHLY,
+        status=Membership.STATUS_ACTIVE,
+    )
+    membership.users.add(user)
+    return user
+
+
+class TestRegisterUserErrorEnvelope:
+    def test_register_requires_username(self, api_client):
+        response = api_client.post(
+            reverse("register"),
+            {"email": "newmaker@example.com", "password": "brand-new-pass"},
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {
+            "error": {
+                "code": "validation_failed",
+                "message": "Username is required",
+            }
+        }
+
+    def test_register_rejects_short_username(self, api_client):
+        response = api_client.post(
+            reverse("register"),
+            {"username": "ab", "email": "", "password": "whatever"},
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error"] == {
+            "code": "validation_failed",
+            "message": "Username must be at least 3 characters long",
+        }
+
+    def test_register_rejects_duplicate_username_with_conflict_code(self, api_client, member_user):
+        response = api_client.post(
+            reverse("register"),
+            {
+                "username": "member",
+                "email": "dup@example.com",
+                "password": "whatever",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error"]["code"] == "conflict"
+        assert response.json()["error"]["message"] == (
+            "Username already exists. Please choose another."
+        )
+
+    def test_register_rejects_invalid_email(self, api_client):
+        response = api_client.post(
+            reverse("register"),
+            {
+                "username": "newmaker",
+                "email": "not-an-email",
+                "password": "brand-new-pass",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error"] == {
+            "code": "validation_failed",
+            "message": "Please enter a valid email address",
+        }
+
+
+class TestLoginUserErrorEnvelope:
+    def test_login_requires_username_and_password(self, api_client):
+        response = api_client.post(reverse("login"), {}, format="json")
+
+        assert response.status_code == 400
+        assert response.json()["error"] == {
+            "code": "validation_failed",
+            "message": "Username and password are required",
+        }
+
+    def test_login_rejects_bad_credentials(self, api_client, member_user):
+        response = api_client.post(
+            reverse("login"),
+            {"username": "member", "password": "wrong"},
+            format="json",
+        )
+
+        assert response.status_code == 401
+        assert response.json()["error"] == {
+            "code": "authentication_failed",
+            "message": "Invalid credentials",
+        }
+
+    def test_login_rejects_user_without_login_permission(self, api_client, member_user):
+        with patch.object(User, "can_login", return_value=False):
+            response = api_client.post(
+                reverse("login"),
+                {"username": "member", "password": "correct-horse-battery"},
+                format="json",
+            )
+
+        assert response.status_code == 403
+        assert response.json()["error"] == {
+            "code": "permission_denied",
+            "message": "User does not have an active membership or required role",
+        }
+
+
+class TestRefreshTokenErrorEnvelope:
+    def test_refresh_requires_refresh_token(self, api_client):
+        response = api_client.post(reverse("refresh"), {}, format="json")
+
+        assert response.status_code == 400
+        assert response.json()["error"] == {
+            "code": "validation_failed",
+            "message": "Refresh token is required",
+        }
+
+    def test_refresh_rejects_invalid_token(self, api_client):
+        response = api_client.post(
+            reverse("refresh"),
+            {"refresh": "not-a-token"},
+            format="json",
+        )
+
+        assert response.status_code == 401
+        assert response.json()["error"] == {
+            "code": "authentication_failed",
+            "message": "Invalid refresh token",
+        }

--- a/backend/dashboard/views.py
+++ b/backend/dashboard/views.py
@@ -12,6 +12,8 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
+from config.api_errors import ErrorCode, error_response
+
 from .audit_feed import collect_events
 from .models import DashboardConfig, DashboardMessage, DashboardWidget
 from .serializers import DashboardWidgetSerializer
@@ -105,7 +107,11 @@ def get_dashboard_config(request):
         )
 
     except Exception as e:
-        return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return error_response(
+            ErrorCode.SERVER_ERROR,
+            str(e),
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
 
 
 @api_view(["POST"])
@@ -152,7 +158,7 @@ def update_dashboard_config(request):
         )
 
     except Exception as e:
-        return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        return error_response(ErrorCode.VALIDATION_FAILED, str(e))
 
 
 @api_view(["POST"])
@@ -188,7 +194,7 @@ def add_dashboard_message(request):
         )
 
     except Exception as e:
-        return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        return error_response(ErrorCode.VALIDATION_FAILED, str(e))
 
 
 @api_view(["GET"])
@@ -262,7 +268,11 @@ def get_inventory_summary(request):
         )
 
     except Exception as e:
-        return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return error_response(
+            ErrorCode.SERVER_ERROR,
+            str(e),
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
 
 
 # Simple health check endpoint
@@ -309,7 +319,11 @@ def get_user_widgets(request):
         return Response(serializer.data)
 
     except Exception as e:
-        return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return error_response(
+            ErrorCode.SERVER_ERROR,
+            str(e),
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
 
 
 @api_view(["POST"])
@@ -325,7 +339,7 @@ def save_user_widgets(request):
         widgets_data = request.data.get("widgets", [])
 
         if not isinstance(widgets_data, list):
-            return Response({"error": "widgets must be a list"}, status=status.HTTP_400_BAD_REQUEST)
+            return error_response(ErrorCode.VALIDATION_FAILED, "widgets must be a list")
 
         updated_widgets = []
         for widget_data in widgets_data:
@@ -356,7 +370,7 @@ def save_user_widgets(request):
         return Response({"widgets": updated_widgets})
 
     except Exception as e:
-        return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        return error_response(ErrorCode.VALIDATION_FAILED, str(e))
 
 
 @api_view(["GET"])
@@ -409,7 +423,11 @@ def get_low_stock_data(request):
         )
 
     except Exception as e:
-        return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return error_response(
+            ErrorCode.SERVER_ERROR,
+            str(e),
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
 
 
 @api_view(["GET"])
@@ -467,7 +485,11 @@ def get_pending_reorders_data(request):
         )
 
     except Exception as e:
-        return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return error_response(
+            ErrorCode.SERVER_ERROR,
+            str(e),
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
 
 
 @api_view(["GET"])
@@ -525,7 +547,11 @@ def get_asset_problems_data(request):
         )
 
     except Exception as e:
-        return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return error_response(
+            ErrorCode.SERVER_ERROR,
+            str(e),
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
 
 
 @api_view(["GET"])
@@ -604,7 +630,11 @@ def get_qr_scans_data(request):
         )
 
     except Exception as e:
-        return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return error_response(
+            ErrorCode.SERVER_ERROR,
+            str(e),
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
 
 
 @api_view(["GET"])
@@ -661,7 +691,11 @@ def get_deliveries_data(request):
         )
 
     except Exception as e:
-        return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return error_response(
+            ErrorCode.SERVER_ERROR,
+            str(e),
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
 
 
 def _parse_audit_feed_dt(value):

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -24,6 +24,8 @@ from rest_framework.permissions import (
 )
 from rest_framework.response import Response
 
+from config.api_errors import ErrorCode, error_response
+
 from .audit import record_event as record_maintenance_audit_event
 from .models import (
     Asset,
@@ -317,7 +319,11 @@ class LocationViewSet(viewsets.ModelViewSet):
         location = self.get_object()
 
         if not location.qr_code:
-            return Response({"error": "QR code not generated yet"}, status=404)
+            return error_response(
+                ErrorCode.NOT_FOUND,
+                "QR code not generated yet",
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
 
         from django.http import HttpResponse
 
@@ -729,7 +735,11 @@ class InventoryItemViewSet(viewsets.ModelViewSet):
                 }
             )
         except Exception as e:
-            return Response({"error": str(e)}, status=500)
+            return error_response(
+                ErrorCode.SERVER_ERROR,
+                str(e),
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
     def _get_client_ip(self, request):
         """Get client IP address from request."""
@@ -752,7 +762,11 @@ class InventoryItemViewSet(viewsets.ModelViewSet):
         item = self.get_object()
 
         if not item.qr_code:
-            return Response({"error": "QR code not generated yet"}, status=404)
+            return error_response(
+                ErrorCode.NOT_FOUND,
+                "QR code not generated yet",
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
 
         from django.http import HttpResponse
 
@@ -1496,7 +1510,7 @@ class AssetViewSet(viewsets.ModelViewSet):
         try:
             png_bytes = render_asset_tag(asset, size=size)
         except InvalidTagSizeError as exc:
-            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+            return error_response(ErrorCode.VALIDATION_FAILED, str(exc))
 
         response = HttpResponse(png_bytes, content_type="image/png")
         if request.query_params.get("download") == "1":
@@ -1633,7 +1647,11 @@ class AssetViewSet(viewsets.ModelViewSet):
         try:
             assets = Asset.objects.filter(id__in=asset_ids)
             if not assets.exists():
-                return Response({"error": "No assets found"}, status=status.HTTP_404_NOT_FOUND)
+                return error_response(
+                    ErrorCode.NOT_FOUND,
+                    "No assets found",
+                    status_code=status.HTTP_404_NOT_FOUND,
+                )
 
             renderer = BrotherLabelRenderer()
             pdf_bytes = renderer.render_batch(list(assets))
@@ -1792,7 +1810,7 @@ class AssetViewSet(viewsets.ModelViewSet):
             )
 
         if not reason:
-            return Response({"error": "reason is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return error_response(ErrorCode.VALIDATION_FAILED, "reason is required")
 
         # Determine lockout level based on user's role
         lockout_level = self._get_user_lockout_level(user, asset)
@@ -1831,7 +1849,7 @@ class AssetViewSet(viewsets.ModelViewSet):
         active_lockouts = DeviceLockout.objects.filter(asset=asset, is_active=True)
 
         if not active_lockouts.exists():
-            return Response({"error": "Asset is not locked"}, status=status.HTTP_400_BAD_REQUEST)
+            return error_response(ErrorCode.VALIDATION_FAILED, "Asset is not locked")
 
         # Check if user can unlock any of the lockouts
         unlockable_lockout = None
@@ -2945,7 +2963,7 @@ class InventoryReportViewSet(viewsets.ViewSet):
 
             return response_obj
 
-        return Response({"error": "Invalid report type"}, status=status.HTTP_400_BAD_REQUEST)
+        return error_response(ErrorCode.VALIDATION_FAILED, "Invalid report type")
 
 
 class MaintenanceMaterialViewSet(viewsets.ModelViewSet):
@@ -4333,7 +4351,7 @@ class AssetReportViewSet(viewsets.ViewSet):
 
             return response_obj
 
-        return Response({"error": "Invalid report type"}, status=status.HTTP_400_BAD_REQUEST)
+        return error_response(ErrorCode.VALIDATION_FAILED, "Invalid report type")
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -4388,7 +4406,11 @@ def postmark_inbound_work_order(request):
         )
     provided = request.headers.get("X-Postmark-Webhook-Token") or request.GET.get("token") or ""
     if provided != expected:
-        return Response({"detail": "Forbidden."}, status=status.HTTP_403_FORBIDDEN)
+        return error_response(
+            ErrorCode.PERMISSION_DENIED,
+            "Forbidden.",
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
 
     payload = request.data if isinstance(request.data, dict) else {}
     message_id = payload.get("MessageID", "") or ""
@@ -4602,7 +4624,7 @@ class InventoryReconciliationViewSet(viewsets.ViewSet):
                         reorders_created += 1
                     created_reconciliations.append(reconciliation)
         except DjangoValidationError as exc:
-            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+            return error_response(ErrorCode.VALIDATION_FAILED, str(exc))
 
         output = StockReconciliationSerializer(created_reconciliations, many=True).data
         return Response(
@@ -4769,7 +4791,7 @@ class InventoryReconciliationViewSet(viewsets.ViewSet):
                     )
                     created += 1
         except DjangoValidationError as exc:
-            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+            return error_response(ErrorCode.VALIDATION_FAILED, str(exc))
 
         return Response(
             {

--- a/backend/location_checkins/views.py
+++ b/backend/location_checkins/views.py
@@ -16,6 +16,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from config.api_errors import ErrorCode, error_response
 from inventory.models import Location
 
 from .models import LocationCheckIn, LocationFeedback, LocationTask, SecurityReport
@@ -65,14 +66,16 @@ class LocationCheckInViewSet(viewsets.ModelViewSet):
         """
         location_id = request.data.get("location_id")
         if not location_id:
-            return Response(
-                {"error": "location_id is required"}, status=status.HTTP_400_BAD_REQUEST
-            )
+            return error_response(ErrorCode.VALIDATION_FAILED, "location_id is required")
 
         try:
             location = Location.objects.get(id=location_id, is_active=True)
         except Location.DoesNotExist:
-            return Response({"error": "Location not found"}, status=status.HTTP_404_NOT_FOUND)
+            return error_response(
+                ErrorCode.NOT_FOUND,
+                "Location not found",
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
 
         checkin_type = request.data.get("checkin_type", "anonymous")
         if checkin_type not in ["volunteer", "contractor", "anonymous"]:
@@ -125,9 +128,7 @@ class LocationFeedbackViewSet(viewsets.ModelViewSet):
         """
         location_id = request.data.get("location_id")
         if not location_id:
-            return Response(
-                {"error": "location_id is required"}, status=status.HTTP_400_BAD_REQUEST
-            )
+            return error_response(ErrorCode.VALIDATION_FAILED, "location_id is required")
 
         feedback_type = request.data.get("feedback_type")
         if feedback_type not in ["positive", "neutral", "negative"]:
@@ -138,12 +139,16 @@ class LocationFeedbackViewSet(viewsets.ModelViewSet):
 
         message = request.data.get("message", "")
         if not message:
-            return Response({"error": "message is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return error_response(ErrorCode.VALIDATION_FAILED, "message is required")
 
         try:
             location = Location.objects.get(id=location_id, is_active=True)
         except Location.DoesNotExist:
-            return Response({"error": "Location not found"}, status=status.HTTP_404_NOT_FOUND)
+            return error_response(
+                ErrorCode.NOT_FOUND,
+                "Location not found",
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
 
         feedback = LocationFeedback.objects.create(
             location=location,
@@ -197,9 +202,7 @@ class SecurityReportViewSet(viewsets.ModelViewSet):
         """
         location_id = request.data.get("location_id")
         if not location_id:
-            return Response(
-                {"error": "location_id is required"}, status=status.HTTP_400_BAD_REQUEST
-            )
+            return error_response(ErrorCode.VALIDATION_FAILED, "location_id is required")
 
         report_type = request.data.get("report_type")
         if report_type not in ["cleaning", "safety"]:
@@ -214,7 +217,11 @@ class SecurityReportViewSet(viewsets.ModelViewSet):
         try:
             location = Location.objects.get(id=location_id, is_active=True)
         except Location.DoesNotExist:
-            return Response({"error": "Location not found"}, status=status.HTTP_404_NOT_FOUND)
+            return error_response(
+                ErrorCode.NOT_FOUND,
+                "Location not found",
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
 
         security_report = SecurityReport.objects.create(
             location=location,
@@ -379,7 +386,11 @@ def location_ping_webhook(request):
 
     provided = request.headers.get("X-Location-Ping-Token") or request.GET.get("token") or ""
     if provided != expected:
-        return Response({"detail": "Unauthorized."}, status=status.HTTP_401_UNAUTHORIZED)
+        return error_response(
+            ErrorCode.NOT_AUTHENTICATED,
+            "Unauthorized.",
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
 
     payload = request.data if isinstance(request.data, dict) else {}
     location = _resolve_location(payload)

--- a/frontend/src/__tests__/utils/extractErrorMessage.test.ts
+++ b/frontend/src/__tests__/utils/extractErrorMessage.test.ts
@@ -1,0 +1,139 @@
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
+
+describe('utils/extractErrorMessage', () => {
+  const fallback = 'Something went wrong';
+
+  it('returns envelope error.message when present', () => {
+    expect(
+      extractErrorMessage(
+        {
+          response: {
+            data: {
+              error: {
+                code: 'validation_failed',
+                message: 'Username is required',
+              },
+            },
+          },
+        },
+        fallback,
+      ),
+    ).toBe('Username is required');
+  });
+
+  it('falls back to data.detail when it is a string', () => {
+    expect(
+      extractErrorMessage(
+        {
+          response: {
+            data: {
+              detail: 'Legacy detail message',
+            },
+          },
+        },
+        fallback,
+      ),
+    ).toBe('Legacy detail message');
+  });
+
+  it('falls back to the first detail entry when detail is a non-empty array', () => {
+    expect(
+      extractErrorMessage(
+        {
+          response: {
+            data: {
+              detail: ['First error', 'Second error'],
+            },
+          },
+        },
+        fallback,
+      ),
+    ).toBe('First error');
+  });
+
+  it('falls back to data.error when it is a bare string', () => {
+    expect(
+      extractErrorMessage(
+        {
+          response: {
+            data: {
+              error: 'Older endpoint message',
+            },
+          },
+        },
+        fallback,
+      ),
+    ).toBe('Older endpoint message');
+  });
+
+  it('returns the fallback when no known error message fields are present', () => {
+    expect(
+      extractErrorMessage(
+        {
+          response: {
+            data: {
+              foo: 'bar',
+            },
+          },
+        },
+        fallback,
+      ),
+    ).toBe(fallback);
+  });
+
+  it('handles a bare data payload without a response wrapper', () => {
+    expect(
+      extractErrorMessage(
+        {
+          data: {
+            detail: 'Already destructured payload',
+          },
+        },
+        fallback,
+      ),
+    ).toBe('Already destructured payload');
+  });
+
+  it('returns the fallback for null, undefined, and non-object input', () => {
+    expect(extractErrorMessage(null, fallback)).toBe(fallback);
+    expect(extractErrorMessage(undefined, fallback)).toBe(fallback);
+    expect(extractErrorMessage('plain string', fallback)).toBe(fallback);
+  });
+
+  it('returns the fallback when envelope message is an empty string', () => {
+    expect(
+      extractErrorMessage(
+        {
+          response: {
+            data: {
+              error: {
+                code: 'server_error',
+                message: '   ',
+              },
+            },
+          },
+        },
+        fallback,
+      ),
+    ).toBe(fallback);
+  });
+
+  it('prefers envelope.message over detail when both exist', () => {
+    expect(
+      extractErrorMessage(
+        {
+          response: {
+            data: {
+              error: {
+                code: 'validation_failed',
+                message: 'Preferred envelope message',
+              },
+              detail: 'Legacy detail message',
+            },
+          },
+        },
+        fallback,
+      ),
+    ).toBe('Preferred envelope message');
+  });
+});

--- a/frontend/src/components/AssetDetailModal.tsx
+++ b/frontend/src/components/AssetDetailModal.tsx
@@ -6,6 +6,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { assetsAPI } from '../services/api';
 import { Asset } from '../types';
 import '../styles/AssetDetailModal.css';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface AssetDetailModalProps {
   assetId: string | null;
@@ -28,7 +29,7 @@ const AssetDetailModal: React.FC<AssetDetailModalProps> = ({ assetId, isOpen, on
       setAsset(response.data);
     } catch (err: any) {
       console.error('Error loading asset details:', err);
-      setError(err.response?.data?.detail || 'Failed to load asset details');
+      setError(extractErrorMessage(err, 'Failed to load asset details'));
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/AuthSection.tsx
+++ b/frontend/src/components/AuthSection.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from 'react';
 import { authAPI } from '../services/api';
 import { consumePendingReturnTo } from './SessionExpiredBanner';
 import '../styles/AuthSection.css';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface AuthSectionProps {
   onAuthChange: (isLoggedIn: boolean, username?: string) => void;
@@ -67,7 +68,7 @@ const AuthSection: React.FC<AuthSectionProps> = ({ onAuthChange }) => {
         window.location.assign(returnTo);
       }
     } catch (err: any) {
-      setError(err.response?.data?.detail || 'Login failed. Please check your credentials.');
+      setError(extractErrorMessage(err, 'Login failed. Please check your credentials.'));
     } finally {
       setLoading(false);
     }
@@ -108,7 +109,7 @@ const AuthSection: React.FC<AuthSectionProps> = ({ onAuthChange }) => {
       // Dispatch custom event for NavigationBar
       window.dispatchEvent(new Event('authChange'));
     } catch (err: any) {
-      setError(err.response?.data?.detail || 'Registration failed. Username may already exist.');
+      setError(extractErrorMessage(err, 'Registration failed. Username may already exist.'));
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/DeviceControlsCard.tsx
+++ b/frontend/src/components/DeviceControlsCard.tsx
@@ -16,12 +16,12 @@
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-import { extractErrorMessage } from '../utils/extractErrorMessage';
   ForgeKeyCommandResponse,
   ForgeKeyDevice,
   ForgeKeyDeviceCommand,
   forgekeyAPI,
 } from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const ACK_TIMEOUT_MS = 10_000;
 const POLL_INTERVAL_MS = 2_000;

--- a/frontend/src/components/DeviceControlsCard.tsx
+++ b/frontend/src/components/DeviceControlsCard.tsx
@@ -16,6 +16,7 @@
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+import { extractErrorMessage } from '../utils/extractErrorMessage';
   ForgeKeyCommandResponse,
   ForgeKeyDevice,
   ForgeKeyDeviceCommand,
@@ -115,7 +116,7 @@ const DeviceControlsCard: React.FC<DeviceControlsCardProps> = ({ device }) => {
       return response.data.results;
     } catch (err) {
       const detail =
-        (err as any)?.response?.data?.detail || 'Failed to load recent commands.';
+        extractErrorMessage(err, 'Failed to load recent commands.');
       setHistoryError(detail);
       return null;
     }
@@ -223,7 +224,7 @@ const DeviceControlsCard: React.FC<DeviceControlsCardProps> = ({ device }) => {
         refreshHistory();
       } catch (err) {
         const detail =
-          (err as any)?.response?.data?.detail || 'Command failed.';
+          extractErrorMessage(err, 'Command failed.');
         setInFlight((prev) => ({
           ...prev,
           [def.key]: { pending: false, pendingCommandId: null, error: detail },

--- a/frontend/src/components/LocationProblemsPanel.tsx
+++ b/frontend/src/components/LocationProblemsPanel.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { locationProblemsAPI } from '../services/api';
 import { LocationProblem, LocationProblemSeverity } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 export interface LocationProblemsPanelProps {
   locationId: string | number;
@@ -38,7 +39,7 @@ const LocationProblemsPanel: React.FC<LocationProblemsPanelProps> = ({
         setProblems(resp.data);
       } catch (err: any) {
         if (cancelled) return;
-        setError(err.response?.data?.detail || 'Failed to load problem reports');
+        setError(extractErrorMessage(err, 'Failed to load problem reports'));
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/frontend/src/components/LocationTrafficPanel.tsx
+++ b/frontend/src/components/LocationTrafficPanel.tsx
@@ -5,6 +5,7 @@ import { Group, SegmentedControl, Stack, Text } from '@mantine/core';
 import React, { useEffect, useMemo, useState } from 'react';
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { locationCheckinAPI } from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 export interface LocationTrafficPanelProps {
   locationId: string | number;
@@ -55,7 +56,7 @@ const LocationTrafficPanel: React.FC<LocationTrafficPanelProps> = ({ locationId 
         }
       } catch (err: any) {
         if (!cancelled) {
-          setError(err?.response?.data?.detail || 'Failed to load traffic data');
+          setError(extractErrorMessage(err, 'Failed to load traffic data'));
         }
       } finally {
         if (!cancelled) {

--- a/frontend/src/components/ThirdPartyWoComplianceBanner.tsx
+++ b/frontend/src/components/ThirdPartyWoComplianceBanner.tsx
@@ -8,6 +8,7 @@
  */
 import React, { useEffect, useState } from 'react';
 import {
+import { extractErrorMessage } from '../utils/extractErrorMessage';
   AssetWoStatusDto,
   ComplianceBucket,
   thirdPartyMaintenanceAPI,
@@ -53,7 +54,7 @@ const ThirdPartyWoComplianceBanner: React.FC<Props> = ({ assetId, vendorId }) =>
       })
       .catch((err) => {
         if (!cancelled)
-          setError(err?.response?.data?.detail || 'Failed to load asset status');
+          setError(extractErrorMessage(err, 'Failed to load asset status'));
       })
       .finally(() => {
         if (!cancelled) setLoading(false);

--- a/frontend/src/components/ThirdPartyWoComplianceBanner.tsx
+++ b/frontend/src/components/ThirdPartyWoComplianceBanner.tsx
@@ -8,11 +8,11 @@
  */
 import React, { useEffect, useState } from 'react';
 import {
-import { extractErrorMessage } from '../utils/extractErrorMessage';
   AssetWoStatusDto,
   ComplianceBucket,
   thirdPartyMaintenanceAPI,
 } from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface Props {
   assetId: string | null;

--- a/frontend/src/pages/AssetDetailPage.tsx
+++ b/frontend/src/pages/AssetDetailPage.tsx
@@ -16,6 +16,7 @@ import '../styles/AssetDetailPage.css';
 import { Asset, AssetProblem, MaintenanceItem, WorkOrder } from '../types';
 import { formatDateOnly } from '../utils/dates';
 import { showError } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const AssetDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -72,7 +73,7 @@ const AssetDetailPage: React.FC = () => {
       }
     } catch (err: any) {
       console.error('Error loading asset details:', err);
-      setError(err.response?.data?.detail || 'Failed to load asset details');
+      setError(extractErrorMessage(err, 'Failed to load asset details'));
     } finally {
       setLoading(false);
     }
@@ -195,7 +196,7 @@ const AssetDetailPage: React.FC = () => {
       await assetsAPI.lockAsset(id);
       await loadAssetDetails();
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to lock asset');
+      showError(extractErrorMessage(err, 'Failed to lock asset'));
     } finally {
       setActionLoading(null);
     }
@@ -208,7 +209,7 @@ const AssetDetailPage: React.FC = () => {
       await assetsAPI.unlockAsset(id);
       await loadAssetDetails();
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to unlock asset');
+      showError(extractErrorMessage(err, 'Failed to unlock asset'));
     } finally {
       setActionLoading(null);
     }
@@ -220,7 +221,7 @@ const AssetDetailPage: React.FC = () => {
       await assetPartsAPI.markReplaced(partId);
       await loadAssetDetails();
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to mark part as replaced');
+      showError(extractErrorMessage(err, 'Failed to mark part as replaced'));
     } finally {
       setActionLoading(null);
     }
@@ -241,7 +242,7 @@ const AssetDetailPage: React.FC = () => {
       const options = response.data.results.filter((a) => a.id !== id);
       setCloneTargetOptions(options);
     } catch (err: any) {
-      setCloneError(err.response?.data?.detail || 'Failed to load assets');
+      setCloneError(extractErrorMessage(err, 'Failed to load assets'));
     }
   };
 
@@ -264,7 +265,7 @@ const AssetDetailPage: React.FC = () => {
       );
       closeCloneModal();
     } catch (err: any) {
-      setCloneError(err.response?.data?.detail || 'Failed to clone maintenance item');
+      setCloneError(extractErrorMessage(err, 'Failed to clone maintenance item'));
     } finally {
       setCloneSubmitting(false);
     }
@@ -284,7 +285,7 @@ const AssetDetailPage: React.FC = () => {
       setShowReportForm(false);
       await loadAssetDetails();
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to report problem');
+      showError(extractErrorMessage(err, 'Failed to report problem'));
       console.error('Error reporting problem:', err);
     } finally {
       setSubmittingProblem(false);
@@ -302,7 +303,7 @@ const AssetDetailPage: React.FC = () => {
       setResolvingStatus('resolved');
       await loadAssetDetails();
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to resolve problem');
+      showError(extractErrorMessage(err, 'Failed to resolve problem'));
       console.error('Error resolving problem:', err);
     } finally {
       setActionLoading(null);
@@ -1005,7 +1006,7 @@ const AssetDetailPage: React.FC = () => {
                       await assetsAPI.generateQR(id);
                       await loadAssetDetails();
                     } catch (err: any) {
-                      showError(err.response?.data?.detail || 'Failed to generate QR code');
+                      showError(extractErrorMessage(err, 'Failed to generate QR code'));
                     }
                   }
                 }}

--- a/frontend/src/pages/AssetFormPage.tsx
+++ b/frontend/src/pages/AssetFormPage.tsx
@@ -18,6 +18,7 @@ import { FormTextarea } from '../components/forms/FormTextarea';
 import { assetsAPI, inventoryAPI, sigAPI } from '../services/api';
 import { Asset, Category, InventoryItem, Location, SIG } from '../types';
 import { AssetFormData, assetFormSchema } from '../utils/formSchemas';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const AssetFormPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -228,7 +229,7 @@ const AssetFormPage: React.FC = () => {
       navigate(`/assets/${savedAsset.id}`);
     } catch (err: any) {
       console.error('Error saving asset:', err);
-      setError(err.response?.data?.detail || 'Failed to save asset. Please try again.');
+      setError(extractErrorMessage(err, 'Failed to save asset. Please try again.'));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/AssetScanPage.tsx
+++ b/frontend/src/pages/AssetScanPage.tsx
@@ -12,6 +12,7 @@ import { assetProblemsAPI, assetsAPI, checklistsAPI, maintenanceAPI } from '../s
 import '../styles/ScanPage.css';
 import { Asset, Checklist, MaintenanceItem } from '../types';
 import { confirmDelete, promptInput, showError } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const AssetScanPage: React.FC = () => {
   const { assetId } = useParams<{ assetId: string }>();
@@ -70,7 +71,7 @@ const AssetScanPage: React.FC = () => {
       setAsset(assetResponse.data);
       setError(null);
     } catch (err: any) {
-      setError(err.response?.data?.detail || err.response?.data?.error || 'Failed to load asset');
+      setError(extractErrorMessage(err, 'Failed to load asset'));
       console.error('Error loading asset:', err);
     } finally {
       setLoading(false);
@@ -117,7 +118,7 @@ const AssetScanPage: React.FC = () => {
       setActionSuccess('Maintenance task marked complete');
       setTimeout(() => setActionSuccess(null), 3000);
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to log completion');
+      showError(extractErrorMessage(err, 'Failed to log completion'));
       console.error('Error completing maintenance task:', err);
     } finally {
       setCompletingTask(null);
@@ -129,7 +130,7 @@ const AssetScanPage: React.FC = () => {
       const completion = await checklistsAPI.startChecklist(checklistId, userName);
       navigate(`/checklist/${checklistId}/complete/${completion.data.id}`);
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to start checklist');
+      showError(extractErrorMessage(err, 'Failed to start checklist'));
     }
   };
 
@@ -155,7 +156,7 @@ const AssetScanPage: React.FC = () => {
       setActionSuccess('Asset enabled successfully');
       setTimeout(() => setActionSuccess(null), 3000);
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to enable asset');
+      showError(extractErrorMessage(err, 'Failed to enable asset'));
       console.error('Error enabling asset:', err);
     } finally {
       setSubmitting(false);
@@ -173,7 +174,7 @@ const AssetScanPage: React.FC = () => {
         setActionSuccess('Asset disabled successfully');
         setTimeout(() => setActionSuccess(null), 3000);
       } catch (err: any) {
-        showError(err.response?.data?.detail || 'Failed to disable asset');
+        showError(extractErrorMessage(err, 'Failed to disable asset'));
         console.error('Error disabling asset:', err);
       } finally {
         setSubmitting(false);
@@ -194,7 +195,7 @@ const AssetScanPage: React.FC = () => {
           setActionSuccess('Asset locked successfully');
           setTimeout(() => setActionSuccess(null), 3000);
         } catch (err: any) {
-          showError(err.response?.data?.error || err.response?.data?.detail || 'Failed to lock asset');
+          showError(extractErrorMessage(err, 'Failed to lock asset'));
           console.error('Error locking asset:', err);
         } finally {
           setSubmitting(false);
@@ -214,7 +215,7 @@ const AssetScanPage: React.FC = () => {
         setActionSuccess('Asset unlocked successfully');
         setTimeout(() => setActionSuccess(null), 3000);
       } catch (err: any) {
-        showError(err.response?.data?.error || err.response?.data?.detail || 'Failed to unlock asset');
+        showError(extractErrorMessage(err, 'Failed to unlock asset'));
         console.error('Error unlocking asset:', err);
       } finally {
         setSubmitting(false);
@@ -261,7 +262,7 @@ const AssetScanPage: React.FC = () => {
       );
       setTimeout(() => setActionSuccess(null), 3000);
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to report problem');
+      showError(extractErrorMessage(err, 'Failed to report problem'));
       console.error('Error reporting problem:', err);
     } finally {
       setSubmitting(false);

--- a/frontend/src/pages/BreakerFormPage.tsx
+++ b/frontend/src/pages/BreakerFormPage.tsx
@@ -19,6 +19,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { electricalCircuitsAPI, inventoryAPI } from '../services/api';
 import { Location } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface FormState {
   location: number | null;
@@ -87,7 +88,7 @@ const BreakerFormPage: React.FC = () => {
         });
       })
       .catch((err) => {
-        setError(err.response?.data?.detail || 'Failed to load breaker');
+        setError(extractErrorMessage(err, 'Failed to load breaker'));
       })
       .finally(() => setLoading(false));
   }, [id, isEdit]);

--- a/frontend/src/pages/BreakerTracePage.tsx
+++ b/frontend/src/pages/BreakerTracePage.tsx
@@ -18,6 +18,7 @@ import React, { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { electricalCircuitsAPI, OUTLET_TYPE_OPTIONS } from '../services/api';
 import { Breaker, LightSwitch, Outlet } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const outletTypeLabel = (value: string): string =>
   OUTLET_TYPE_OPTIONS.find((option) => option.value === value)?.label || value;
@@ -52,7 +53,7 @@ const BreakerTracePage: React.FC = () => {
       })
       .catch((err) => {
         if (cancelled) return;
-        setError(err.response?.data?.detail || 'Failed to load breaker trace');
+        setError(extractErrorMessage(err, 'Failed to load breaker trace'));
       })
       .finally(() => {
         if (!cancelled) setLoading(false);

--- a/frontend/src/pages/CategoryFormPage.tsx
+++ b/frontend/src/pages/CategoryFormPage.tsx
@@ -8,6 +8,7 @@ import ColorPicker from '../components/ColorPicker';
 import { inventoryAPI } from '../services/api';
 import '../styles/CategoryFormPage.css';
 import { Category } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface CategoryFormData {
   name: string;
@@ -67,7 +68,7 @@ const CategoryFormPage: React.FC = () => {
         setError('Category not found');
       }
     } catch (err: any) {
-      setError(err.response?.data?.detail || 'Failed to load category');
+      setError(extractErrorMessage(err, 'Failed to load category'));
       console.error('Error loading category:', err);
     } finally {
       setLoading(false);
@@ -130,7 +131,7 @@ const CategoryFormPage: React.FC = () => {
 
       navigate('/inventory/categories');
     } catch (err: any) {
-      setError(err.response?.data?.detail || err.response?.data?.error || 'Failed to save category');
+      setError(extractErrorMessage(err, 'Failed to save category'));
       console.error('Error saving category:', err);
     } finally {
       setSaving(false);

--- a/frontend/src/pages/CategoryListPage.tsx
+++ b/frontend/src/pages/CategoryListPage.tsx
@@ -9,6 +9,7 @@ import { inventoryAPI } from '../services/api';
 import '../styles/CategoryListPage.css';
 import { Category } from '../types';
 import { confirmDelete, showError } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const CategoryListPage: React.FC = () => {
   const [categories, setCategories] = useState<Category[]>([]);
@@ -27,7 +28,7 @@ const CategoryListPage: React.FC = () => {
       setCategories(response.data.results);
       setError(null);
     } catch (err: any) {
-      setError(err.response?.data?.detail || 'Failed to load categories');
+      setError(extractErrorMessage(err, 'Failed to load categories'));
       console.error('Error loading categories:', err);
     } finally {
       setLoading(false);
@@ -85,7 +86,7 @@ const CategoryListPage: React.FC = () => {
         await inventoryAPI.deleteCategory(id.toString());
         await loadCategories();
       } catch (err: any) {
-        showError(err.response?.data?.detail || 'Failed to delete category');
+        showError(extractErrorMessage(err, 'Failed to delete category'));
       }
     });
   };

--- a/frontend/src/pages/ChecklistCompletionPage.tsx
+++ b/frontend/src/pages/ChecklistCompletionPage.tsx
@@ -10,6 +10,7 @@ import { checklistsAPI, inventoryAPI } from '../services/api';
 import '../styles/ScanPage.css';
 import { Checklist, ChecklistCompletion, ChecklistStep } from '../types';
 import { confirmAction } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface PendingScan {
   step: ChecklistStep;
@@ -46,7 +47,7 @@ const ChecklistCompletionPage: React.FC = () => {
       setCompletion(completionResponse.data);
       setError(null);
     } catch (err: any) {
-      setError(err.response?.data?.detail || err.response?.data?.error || 'Failed to load checklist');
+      setError(extractErrorMessage(err, 'Failed to load checklist'));
       console.error('Error loading checklist:', err);
     } finally {
       setLoading(false);
@@ -119,7 +120,7 @@ const ChecklistCompletionPage: React.FC = () => {
       // Reload and prompt for completion
       await finalizeScan();
     } catch (err: any) {
-      notifications.showError('Failed to scan code', err.response?.data?.detail);
+      notifications.showError('Failed to scan code', extractErrorMessage(err, ''));
       console.error('Error scanning code:', err);
     } finally {
       setScanning(false);
@@ -143,7 +144,7 @@ const ChecklistCompletionPage: React.FC = () => {
             await loadData();
             notifications.showSuccess('Checklist Completed', 'Checklist completed successfully!');
           } catch (err: any) {
-            notifications.showError('Failed to complete checklist', err.response?.data?.detail);
+            notifications.showError('Failed to complete checklist', extractErrorMessage(err, ''));
             console.error('Error completing checklist:', err);
           }
         },
@@ -184,7 +185,7 @@ const ChecklistCompletionPage: React.FC = () => {
       setPhotoCaption('');
       await finalizeScan();
     } catch (err: any) {
-      notifications.showError('Failed to upload photo', err.response?.data?.detail);
+      notifications.showError('Failed to upload photo', extractErrorMessage(err, ''));
       console.error('Error uploading photo:', err);
     } finally {
       setSubmittingPhoto(false);
@@ -231,7 +232,7 @@ const ChecklistCompletionPage: React.FC = () => {
           await loadData();
           notifications.showSuccess('Checklist Completed', 'Checklist completed successfully!');
         } catch (err: any) {
-          notifications.showError('Failed to complete checklist', err.response?.data?.detail);
+          notifications.showError('Failed to complete checklist', extractErrorMessage(err, ''));
           console.error('Error completing checklist:', err);
         }
       },

--- a/frontend/src/pages/DonationItemScanPage.tsx
+++ b/frontend/src/pages/DonationItemScanPage.tsx
@@ -9,6 +9,7 @@ import '../styles/ScanPage.css';
 import { Disposition, DispositionType, DonationItem, KeptDestination, SaleMethod } from '../types';
 import { formatDateOnly } from '../utils/dates';
 import { showError } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const DonationItemScanPage: React.FC = () => {
   const { itemId } = useParams<{ itemId: string }>();
@@ -53,7 +54,7 @@ const DonationItemScanPage: React.FC = () => {
       const dispositionsResponse = await donationsAPI.getDispositions({ donation_item: itemId });
       setDispositions(dispositionsResponse.data.results);
     } catch (err: any) {
-      setError(err.response?.data?.detail || err.response?.data?.error || 'Failed to load donation item');
+      setError(extractErrorMessage(err, 'Failed to load donation item'));
       console.error('Error loading donation item:', err);
     } finally {
       setLoading(false);
@@ -80,7 +81,7 @@ const DonationItemScanPage: React.FC = () => {
       setActionSuccess('Item information updated successfully');
       setTimeout(() => setActionSuccess(null), 3000);
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to update item');
+      showError(extractErrorMessage(err, 'Failed to update item'));
       console.error('Error updating item:', err);
     } finally {
       setSubmitting(false);
@@ -157,7 +158,7 @@ const DonationItemScanPage: React.FC = () => {
       
       setTimeout(() => setActionSuccess(null), 3000);
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to create disposition');
+      showError(extractErrorMessage(err, 'Failed to create disposition'));
       console.error('Error creating disposition:', err);
     } finally {
       setSubmitting(false);

--- a/frontend/src/pages/ElectricalCircuitsPage.tsx
+++ b/frontend/src/pages/ElectricalCircuitsPage.tsx
@@ -46,6 +46,7 @@ import {
   Outlet,
 } from '../types';
 import { confirmDelete, showError } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 type ActiveTab = 'breakers' | 'outlets' | 'switches' | 'drops';
 
@@ -104,7 +105,7 @@ const ElectricalCircuitsPage: React.FC = () => {
         setDrops(response.data.results);
       }
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to load records');
+      showError(extractErrorMessage(err, 'Failed to load records'));
     } finally {
       setLoading(false);
     }
@@ -120,7 +121,7 @@ const ElectricalCircuitsPage: React.FC = () => {
         await electricalCircuitsAPI.deleteBreaker(breaker.id);
         await reload();
       } catch (err: any) {
-        showError(err.response?.data?.detail || 'Failed to delete breaker');
+        showError(extractErrorMessage(err, 'Failed to delete breaker'));
       }
     });
   };
@@ -131,7 +132,7 @@ const ElectricalCircuitsPage: React.FC = () => {
         await electricalCircuitsAPI.deleteOutlet(outlet.id);
         await reload();
       } catch (err: any) {
-        showError(err.response?.data?.detail || 'Failed to delete outlet');
+        showError(extractErrorMessage(err, 'Failed to delete outlet'));
       }
     });
   };
@@ -142,7 +143,7 @@ const ElectricalCircuitsPage: React.FC = () => {
         await electricalCircuitsAPI.deleteLightSwitch(sw.id);
         await reload();
       } catch (err: any) {
-        showError(err.response?.data?.detail || 'Failed to delete light switch');
+        showError(extractErrorMessage(err, 'Failed to delete light switch'));
       }
     });
   };
@@ -153,7 +154,7 @@ const ElectricalCircuitsPage: React.FC = () => {
         await electricalCircuitsAPI.deleteNetworkDrop(drop.id);
         await reload();
       } catch (err: any) {
-        showError(err.response?.data?.detail || 'Failed to delete network drop');
+        showError(extractErrorMessage(err, 'Failed to delete network drop'));
       }
     });
   };

--- a/frontend/src/pages/FixtureScanPage.tsx
+++ b/frontend/src/pages/FixtureScanPage.tsx
@@ -10,6 +10,7 @@ import { fixturesAPI } from '../services/api';
 import '../styles/ScanPage.css';
 import { Fixture, FixtureRefillRequest } from '../types';
 import { confirmAction, showError } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const FixtureScanPage: React.FC = () => {
   const { fixtureId } = useParams<{ fixtureId: string }>();
@@ -54,7 +55,7 @@ const FixtureScanPage: React.FC = () => {
 
       setError(null);
     } catch (err: any) {
-      setError(err.response?.data?.detail || 'Failed to load fixture');
+      setError(extractErrorMessage(err, 'Failed to load fixture'));
       console.error('Error loading fixture:', err);
     } finally {
       setLoading(false);
@@ -81,7 +82,7 @@ const FixtureScanPage: React.FC = () => {
           }, 2000);
         } catch (err: any) {
           console.error('Error auto-submitting refill request:', err);
-          setError(err.response?.data?.error || 'Failed to submit refill request');
+          setError(extractErrorMessage(err, 'Failed to submit refill request'));
           setSubmitting(false);
         }
       }

--- a/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
+++ b/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
@@ -10,6 +10,7 @@ import { Navigate, useParams } from 'react-router-dom';
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import DeviceControlsCard from '../components/DeviceControlsCard';
 import {
+import { extractErrorMessage } from '../utils/extractErrorMessage';
   ForgeKeyCommandResponse,
   ForgeKeyDevice,
   ForgeKeyOccupancyResponse,
@@ -55,7 +56,7 @@ const ForgeKeyDeviceDetailPage: React.FC = () => {
       setOccupancy(occRes.data);
       setLoadError(null);
     } catch (err: any) {
-      setLoadError(err?.response?.data?.detail || 'Failed to load device.');
+      setLoadError(extractErrorMessage(err, 'Failed to load device.'));
     } finally {
       setLoading(false);
     }
@@ -99,7 +100,7 @@ const ForgeKeyDeviceDetailPage: React.FC = () => {
           [key]: {
             pending: false,
             lastResult: prev[key].lastResult,
-            lastError: err?.response?.data?.detail || 'Command failed.',
+            lastError: extractErrorMessage(err, 'Command failed.'),
           },
         }));
       }

--- a/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
+++ b/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
@@ -10,12 +10,12 @@ import { Navigate, useParams } from 'react-router-dom';
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import DeviceControlsCard from '../components/DeviceControlsCard';
 import {
-import { extractErrorMessage } from '../utils/extractErrorMessage';
   ForgeKeyCommandResponse,
   ForgeKeyDevice,
   ForgeKeyOccupancyResponse,
   forgekeyAPI,
 } from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const POLL_INTERVAL_MS = 30_000;
 

--- a/frontend/src/pages/ForgeKeyDevicesPage.tsx
+++ b/frontend/src/pages/ForgeKeyDevicesPage.tsx
@@ -8,6 +8,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, Navigate } from 'react-router-dom';
 import { ForgeKeyDevice, forgekeyAPI, inventoryAPI } from '../services/api';
 import { Location } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const ForgeKeyDevicesPage: React.FC = () => {
   const isStaff = typeof window !== 'undefined' && localStorage.getItem('is_staff') === 'true';
@@ -34,7 +35,7 @@ const ForgeKeyDevicesPage: React.FC = () => {
         setLocations(locRes.data.results);
         setError(null);
       } catch (err: any) {
-        setError(err?.response?.data?.detail || 'Failed to load ForgeKey devices.');
+        setError(extractErrorMessage(err, 'Failed to load ForgeKey devices.'));
       } finally {
         setLoading(false);
       }
@@ -67,7 +68,7 @@ const ForgeKeyDevicesPage: React.FC = () => {
         setSavedId(deviceId);
         setError(null);
       } catch (err: any) {
-        setError(err?.response?.data?.detail || 'Failed to update device location.');
+        setError(extractErrorMessage(err, 'Failed to update device location.'));
       } finally {
         setSavingId(null);
       }

--- a/frontend/src/pages/InventoryItemFormPage.tsx
+++ b/frontend/src/pages/InventoryItemFormPage.tsx
@@ -21,6 +21,7 @@ import { inventoryAPI } from '../services/api';
 import { Category, InventoryItem, ItemSupplier, Location, Supplier } from '../types';
 import { promptInput, showError } from '../utils/dialogs';
 import { InventoryItemFormData, inventoryItemSchema } from '../utils/formSchemas';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const InventoryItemFormPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -232,7 +233,7 @@ const InventoryItemFormPage: React.FC = () => {
       navigate(`/inventory/items/${savedItem.id}`);
     } catch (err: any) {
       console.error('Error saving item:', err);
-      setError(err.response?.data?.detail || 'Failed to save item. Please try again.');
+      setError(extractErrorMessage(err, 'Failed to save item. Please try again.'));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/LightSwitchFormPage.tsx
+++ b/frontend/src/pages/LightSwitchFormPage.tsx
@@ -22,6 +22,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { electricalCircuitsAPI, inventoryAPI } from '../services/api';
 import { Breaker, Location } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface FormState {
   location: number | null;
@@ -97,7 +98,7 @@ const LightSwitchFormPage: React.FC = () => {
         });
       })
       .catch((err) => {
-        setError(err.response?.data?.detail || 'Failed to load light switch');
+        setError(extractErrorMessage(err, 'Failed to load light switch'));
       })
       .finally(() => setLoading(false));
   }, [id, isEdit]);

--- a/frontend/src/pages/LocationDetailPage.tsx
+++ b/frontend/src/pages/LocationDetailPage.tsx
@@ -12,6 +12,7 @@ import { inventoryAPI } from '../services/api';
 import '../styles/LocationDetailPage.css';
 import { Location } from '../types';
 import { confirmDelete, showError, showSuccess } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const LocationDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -41,7 +42,7 @@ const LocationDetailPage: React.FC = () => {
       setLocation(response.data);
       setError(null);
     } catch (err: any) {
-      setError(err.response?.data?.detail || 'Failed to load location');
+      setError(extractErrorMessage(err, 'Failed to load location'));
       console.error('Error loading location:', err);
     } finally {
       setLoading(false);
@@ -57,7 +58,7 @@ const LocationDetailPage: React.FC = () => {
       await loadLocation();
       showSuccess('QR code generated successfully');
     } catch (err: any) {
-      showError(err.response?.data?.error || 'Failed to generate QR code');
+      showError(extractErrorMessage(err, 'Failed to generate QR code'));
     } finally {
       setGeneratingQR(false);
     }
@@ -70,7 +71,7 @@ const LocationDetailPage: React.FC = () => {
         await inventoryAPI.deleteLocation(id);
         navigate('/inventory/locations');
       } catch (err: any) {
-        showError(err.response?.data?.detail || 'Failed to delete location');
+        showError(extractErrorMessage(err, 'Failed to delete location'));
       }
     });
   };

--- a/frontend/src/pages/LocationFormPage.tsx
+++ b/frontend/src/pages/LocationFormPage.tsx
@@ -7,6 +7,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { inventoryAPI } from '../services/api';
 import '../styles/LocationFormPage.css';
 import { Location } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface LocationFormData {
   name: string;
@@ -62,7 +63,7 @@ const LocationFormPage: React.FC = () => {
         is_active: location.is_active,
       });
     } catch (err: any) {
-      setError(err.response?.data?.detail || 'Failed to load location');
+      setError(extractErrorMessage(err, 'Failed to load location'));
       console.error('Error loading location:', err);
     } finally {
       setLoading(false);
@@ -125,7 +126,7 @@ const LocationFormPage: React.FC = () => {
 
       navigate('/inventory/locations');
     } catch (err: any) {
-      setError(err.response?.data?.detail || err.response?.data?.error || 'Failed to save location');
+      setError(extractErrorMessage(err, 'Failed to save location'));
       console.error('Error saving location:', err);
     } finally {
       setSaving(false);

--- a/frontend/src/pages/LocationListPage.tsx
+++ b/frontend/src/pages/LocationListPage.tsx
@@ -9,6 +9,7 @@ import { inventoryAPI } from '../services/api';
 import '../styles/LocationListPage.css';
 import { Location } from '../types';
 import { confirmDelete, showError, showSuccess } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const LocationListPage: React.FC = () => {
   const [locations, setLocations] = useState<Location[]>([]);
@@ -24,7 +25,7 @@ const LocationListPage: React.FC = () => {
       setLocations(response.data.results);
       setError(null);
     } catch (err: any) {
-      setError(err.response?.data?.detail || 'Failed to load locations');
+      setError(extractErrorMessage(err, 'Failed to load locations'));
       console.error('Error loading locations:', err);
       // Re-throw to trigger the Highlight error boundary if it's a critical error
       if (!err.response) {
@@ -134,7 +135,7 @@ const LocationListPage: React.FC = () => {
         await inventoryAPI.deleteLocation(id.toString());
         await loadLocations();
       } catch (err: any) {
-        showError(err.response?.data?.detail || 'Failed to delete location');
+        showError(extractErrorMessage(err, 'Failed to delete location'));
       }
     });
   };
@@ -145,7 +146,7 @@ const LocationListPage: React.FC = () => {
       await loadLocations();
       showSuccess('QR code generated successfully');
     } catch (err: any) {
-      showError(err.response?.data?.error || 'Failed to generate QR code');
+      showError(extractErrorMessage(err, 'Failed to generate QR code'));
     }
   };
 

--- a/frontend/src/pages/LocationProblemDetailPage.tsx
+++ b/frontend/src/pages/LocationProblemDetailPage.tsx
@@ -9,6 +9,7 @@ import { Link, useParams } from 'react-router-dom';
 import api, { locationProblemsAPI, maintenanceAPI } from '../services/api';
 import { LocationProblem, MaintenanceItem } from '../types';
 import { showError, showSuccess } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface VendorOption {
   id: string;
@@ -56,7 +57,7 @@ const LocationProblemDetailPage: React.FC = () => {
         const resp = await locationProblemsAPI.get(id);
         if (!cancelled) setProblem(resp.data);
       } catch (err: any) {
-        if (!cancelled) setError(err.response?.data?.detail || 'Failed to load');
+        if (!cancelled) setError(extractErrorMessage(err, 'Failed to load'));
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -101,7 +102,7 @@ const LocationProblemDetailPage: React.FC = () => {
       showSuccess('Standard work order opened.');
       await refreshProblem();
     } catch (err: any) {
-      showError(err.response?.data?.error || 'Failed to promote.');
+      showError(extractErrorMessage(err, 'Failed to promote.'));
     }
   };
 
@@ -119,7 +120,7 @@ const LocationProblemDetailPage: React.FC = () => {
       showSuccess('Third-party work order opened.');
       await refreshProblem();
     } catch (err: any) {
-      showError(err.response?.data?.error || 'Failed to promote.');
+      showError(extractErrorMessage(err, 'Failed to promote.'));
     }
   };
 
@@ -133,7 +134,7 @@ const LocationProblemDetailPage: React.FC = () => {
       showSuccess(`Problem marked ${status}.`);
       await refreshProblem();
     } catch (err: any) {
-      showError(err.response?.data?.error || 'Failed to resolve.');
+      showError(extractErrorMessage(err, 'Failed to resolve.'));
     }
   };
 

--- a/frontend/src/pages/LocationScanPage.tsx
+++ b/frontend/src/pages/LocationScanPage.tsx
@@ -13,6 +13,7 @@ import { checklistsAPI, inventoryAPI, locationCheckinAPI } from '../services/api
 import '../styles/ScanPage.css';
 import { Checklist } from '../types';
 import { promptInput, showError } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface Location {
   id: string;
@@ -59,7 +60,7 @@ const LocationScanPage: React.FC = () => {
       setLocation(response.data);
       setError(null);
     } catch (err: any) {
-      setError(err.response?.data?.detail || err.response?.data?.error || 'Failed to load location');
+      setError(extractErrorMessage(err, 'Failed to load location'));
       console.error('Error loading location:', err);
     } finally {
       setLoading(false);
@@ -96,7 +97,7 @@ const LocationScanPage: React.FC = () => {
       const completion = await checklistsAPI.startChecklist(checklistId, userName);
       navigate(`/checklist/${checklistId}/complete/${completion.data.id}`);
     } catch (err: any) {
-      notifications.showError('Failed to start checklist', err.response?.data?.detail);
+      notifications.showError('Failed to start checklist', extractErrorMessage(err, ''));
     }
   };
 
@@ -168,7 +169,7 @@ const LocationScanPage: React.FC = () => {
         setReportDescription('');
       }, 3000);
     } catch (err: any) {
-      showError(err.response?.data?.error || 'Failed to submit report');
+      showError(extractErrorMessage(err, 'Failed to submit report'));
       console.error('Error submitting report:', err);
     } finally {
       setSubmitting(false);

--- a/frontend/src/pages/LogisticsDashboard.tsx
+++ b/frontend/src/pages/LogisticsDashboard.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import '../styles/LogisticsDashboard.css';
 import { analyticsAPI, customizationAPI, locationCheckinAPI } from '../services/api';
 import { SiteSettings } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface TopLocationRow {
   location_id: number;
@@ -80,7 +81,7 @@ const LogisticsDashboard: React.FC = () => {
       console.error('Failed to load logistics dashboard data', err);
       console.error('Error response:', err.response);
       console.error('Error details:', err.response?.data || err.message);
-      setError(`Unable to load logistics data: ${err.response?.data?.detail || err.message || 'Unknown error'}`);
+      setError(`Unable to load logistics data: ${extractErrorMessage(err, '') || err.message || 'Unknown error'}`);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/MaintenanceDashboard.tsx
+++ b/frontend/src/pages/MaintenanceDashboard.tsx
@@ -36,6 +36,7 @@ import { Link } from 'react-router-dom';
 import { maintenanceAPI, reorderAPI, workOrderAPI } from '../services/api';
 import { LowStockAlert, MaintenanceItem, WorkOrder, WorkOrderUploadResult } from '../types';
 import { parseYmd } from '../utils/dates';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const STATUS_COLORS: Record<string, string> = {
   open: 'blue',

--- a/frontend/src/pages/MaintenanceDashboard.tsx
+++ b/frontend/src/pages/MaintenanceDashboard.tsx
@@ -398,7 +398,7 @@ const MaintenanceDashboard: React.FC = () => {
     } catch (err: any) {
       notifications.show({
         title: 'Upload Failed',
-        message: err?.response?.data?.detail || 'Could not upload PDF.',
+        message: extractErrorMessage(err, 'Could not upload PDF.'),
         color: 'red',
       });
     } finally {

--- a/frontend/src/pages/MaintenanceDashboardPage.tsx
+++ b/frontend/src/pages/MaintenanceDashboardPage.tsx
@@ -86,7 +86,7 @@ const MaintenanceDashboardPage: React.FC = () => {
       })
       .catch((err) => {
         if (cancelled) return;
-        setError(err?.response?.data?.detail || 'Failed to load maintenance dashboard.');
+        setError(extractErrorMessage(err, 'Failed to load maintenance dashboard.'));
       })
       .finally(() => {
         if (cancelled) return;

--- a/frontend/src/pages/MaintenanceDashboardPage.tsx
+++ b/frontend/src/pages/MaintenanceDashboardPage.tsx
@@ -18,6 +18,7 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { activeMaintenanceAPI, maintenanceAPI, MaintenanceDashboardData } from '../services/api';
 import { ActiveMaintenanceRow } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const PERIOD_LABELS: Array<{ key: keyof MaintenanceDashboardData['costs']['per_period']; label: string }> = [
   { key: 'today', label: 'Today' },

--- a/frontend/src/pages/MaintenanceItemFormPage.tsx
+++ b/frontend/src/pages/MaintenanceItemFormPage.tsx
@@ -161,7 +161,7 @@ const MaintenanceItemFormPage: React.FC = () => {
       navigate(`/assets/${assetId}`);
     } catch (err: any) {
       console.error('Error saving maintenance item:', err);
-      setError(err.response?.data?.detail || 'Failed to save maintenance item.');
+      setError(extractErrorMessage(err, 'Failed to save maintenance item.'));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/MaintenanceItemFormPage.tsx
+++ b/frontend/src/pages/MaintenanceItemFormPage.tsx
@@ -24,6 +24,7 @@ import { FormNumberInput } from '../components/forms/FormNumberInput';
 import { FormTextarea } from '../components/forms/FormTextarea';
 import { maintenanceAPI } from '../services/api';
 import { MaintenanceMaterial } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 import { MaintenanceItemFormData, maintenanceItemFormSchema } from '../utils/formSchemas';
 
 interface PendingMaterial {

--- a/frontend/src/pages/MakerBoxAdminPage.tsx
+++ b/frontend/src/pages/MakerBoxAdminPage.tsx
@@ -8,6 +8,7 @@
  */
 import React, { useCallback, useEffect, useState } from 'react';
 import { makerBoxesAPI, MakerBox } from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const STATUS_BADGE: Record<MakerBox['status'], { label: string; color: string }> = {
   valid: { label: 'Valid', color: '#1f8a3a' },
@@ -32,7 +33,7 @@ const MakerBoxAdminPage: React.FC = () => {
       setBoxes(rows);
       setError(null);
     } catch (err: any) {
-      setError(err?.response?.data?.detail || 'Failed to load maker boxes.');
+      setError(extractErrorMessage(err, 'Failed to load maker boxes.'));
     } finally {
       setLoading(false);
     }
@@ -57,7 +58,7 @@ const MakerBoxAdminPage: React.FC = () => {
         const url = URL.createObjectURL(blob);
         window.open(url, '_blank');
       } catch (err: any) {
-        setError(err?.response?.data?.detail || 'Manual label generation failed.');
+        setError(extractErrorMessage(err, 'Manual label generation failed.'));
       } finally {
         setGenerating(false);
       }

--- a/frontend/src/pages/MakerBoxScanPage.tsx
+++ b/frontend/src/pages/MakerBoxScanPage.tsx
@@ -9,6 +9,7 @@
  */
 import React, { useCallback, useState } from 'react';
 import { makerBoxesAPI, MakerBoxScanResult } from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 type FormState = {
   binId: string;
@@ -39,7 +40,7 @@ const MakerBoxScanPage: React.FC = () => {
         const match = rows.find((b) => b.bin_id === response.data.bin_id);
         setBoxId(match ? match.id : null);
       } catch (err: any) {
-        const detail = err?.response?.data?.detail;
+        const detail = extractErrorMessage(err, '');
         setError(detail || 'Scan failed.');
         setResult(null);
         setBoxId(null);
@@ -58,7 +59,7 @@ const MakerBoxScanPage: React.FC = () => {
       const response = await makerBoxesAPI.emailPickup(boxId);
       setEmailSentTo(response.data.to);
     } catch (err: any) {
-      setError(err?.response?.data?.detail || 'Email failed to send.');
+      setError(extractErrorMessage(err, 'Email failed to send.'));
     } finally {
       setEmailSending(false);
     }

--- a/frontend/src/pages/NetworkDropFormPage.tsx
+++ b/frontend/src/pages/NetworkDropFormPage.tsx
@@ -24,6 +24,7 @@ import {
   NETWORK_DROP_TYPE_OPTIONS,
 } from '../services/api';
 import { Location, NetworkDropType } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface FormState {
   location: number | null;
@@ -98,7 +99,7 @@ const NetworkDropFormPage: React.FC = () => {
         setExistingPhoto(d.photo);
       })
       .catch((err) => {
-        setError(err.response?.data?.detail || 'Failed to load network drop');
+        setError(extractErrorMessage(err, 'Failed to load network drop'));
       })
       .finally(() => setLoading(false));
   }, [id, isEdit]);

--- a/frontend/src/pages/OutletFormPage.tsx
+++ b/frontend/src/pages/OutletFormPage.tsx
@@ -24,6 +24,7 @@ import {
   OUTLET_TYPE_OPTIONS,
 } from '../services/api';
 import { Breaker, Location, OutletType } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface FormState {
   location: number | null;
@@ -102,7 +103,7 @@ const OutletFormPage: React.FC = () => {
         setExistingPhoto(o.photo);
       })
       .catch((err) => {
-        setError(err.response?.data?.detail || 'Failed to load outlet');
+        setError(extractErrorMessage(err, 'Failed to load outlet'));
       })
       .finally(() => setLoading(false));
   }, [id, isEdit]);

--- a/frontend/src/pages/PurchaseOrderFormPage.tsx
+++ b/frontend/src/pages/PurchaseOrderFormPage.tsx
@@ -15,6 +15,7 @@ import {
   ReorderDataSupplier,
 } from '../services/api';
 import '../styles/PurchaseOrderFormPage.css';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface SelectedItem extends ReorderDataItem {
   selected: boolean;
@@ -72,7 +73,7 @@ const PurchaseOrderFormPage: React.FC = () => {
       setSuppliers(response.data.suppliers);
     } catch (err: any) {
       console.error('Error loading reorder data:', err);
-      setError(err.response?.data?.detail || err.message || 'Failed to load reorder data');
+      setError(extractErrorMessage(err, '') || err.message || 'Failed to load reorder data');
     } finally {
       setLoading(false);
     }
@@ -271,7 +272,7 @@ const PurchaseOrderFormPage: React.FC = () => {
             return;
           }
         } catch (err: any) {
-          setError(err.response?.data?.error || 'Barcode not found');
+          setError(extractErrorMessage(err, 'Barcode not found'));
           setSearchingProduct(false);
           return;
         }
@@ -370,7 +371,7 @@ const PurchaseOrderFormPage: React.FC = () => {
       console.error('Error searching for product:', err);
       // Only show error if this was a manual search (not auto-search)
       if (searchTerm !== undefined || barcode !== undefined) {
-        setError(err.response?.data?.error || err.response?.data?.detail || err.message || 'Failed to find product');
+        setError(err.response?.data?.error || extractErrorMessage(err, '') || err.message || 'Failed to find product');
       }
     } finally {
       setSearchingProduct(false);
@@ -487,7 +488,7 @@ const PurchaseOrderFormPage: React.FC = () => {
       navigate(`/purchasing/orders/${orderId}`);
     } catch (err: any) {
       console.error('Error creating purchase order:', err);
-      setError(err.response?.data?.detail || err.response?.data?.error || err.message || 'Failed to create purchase order');
+      setError(extractErrorMessage(err, '') || err.response?.data?.error || err.message || 'Failed to create purchase order');
       setSubmitting(false);
     }
   };

--- a/frontend/src/pages/PurchaseOrderListPage.tsx
+++ b/frontend/src/pages/PurchaseOrderListPage.tsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import { purchaseOrderAPI } from '../services/api';
 import '../styles/PurchaseOrderListPage.css';
 import { formatDateOnly } from '../utils/dates';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface PurchaseOrder {
   id: string;
@@ -44,7 +45,7 @@ const PurchaseOrderListPage: React.FC = () => {
         data: err?.response?.data,
         message: err?.message,
       });
-      setError(err.response?.data?.error || err.response?.data?.detail || err.message || 'Failed to load purchase orders');
+      setError(err.response?.data?.error || extractErrorMessage(err, '') || err.message || 'Failed to load purchase orders');
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/PurchaseOrderPage.tsx
+++ b/frontend/src/pages/PurchaseOrderPage.tsx
@@ -8,6 +8,7 @@ import { purchaseOrderAPI } from '../services/api';
 import '../styles/PurchaseOrderPage.css';
 import { formatDateOnly, formatYmd } from '../utils/dates';
 import { confirmAction, promptInput, showError, showSuccess } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface PurchaseOrderItem {
   id: string;
@@ -99,7 +100,7 @@ const PurchaseOrderPage: React.FC = () => {
       setOrder(response.data);
     } catch (err: any) {
       console.error('Error loading purchase order:', err);
-      setError(err.response?.data?.error || 'Failed to load purchase order');
+      setError(extractErrorMessage(err, 'Failed to load purchase order'));
     } finally {
       setLoading(false);
     }
@@ -164,7 +165,7 @@ const PurchaseOrderPage: React.FC = () => {
       setEditingCostItemId(null);
       setLineCost('');
     } catch (err: any) {
-      showError(err.response?.data?.error || 'Failed to update line cost');
+      showError(extractErrorMessage(err, 'Failed to update line cost'));
       console.error('Error updating line cost:', err);
     } finally {
       setSaving(false);
@@ -181,7 +182,7 @@ const PurchaseOrderPage: React.FC = () => {
       setEditingItemId(null);
       setShipmentDate('');
     } catch (err: any) {
-      showError(err.response?.data?.error || 'Failed to update shipment date');
+      showError(extractErrorMessage(err, 'Failed to update shipment date'));
       console.error('Error updating shipment date:', err);
     } finally {
       setSaving(false);
@@ -205,7 +206,7 @@ const PurchaseOrderPage: React.FC = () => {
           setVoidingItemId(null);
           setVoidReason('');
         } catch (err: any) {
-          showError(err.response?.data?.error || 'Failed to void line item');
+          showError(extractErrorMessage(err, 'Failed to void line item'));
           console.error('Error voiding line item:', err);
         } finally {
           setSaving(false);
@@ -234,7 +235,7 @@ const PurchaseOrderPage: React.FC = () => {
           showSuccess('Purchase order voided');
           await loadOrder();
         } catch (err: any) {
-          showError(err.response?.data?.detail || 'Failed to void purchase order');
+          showError(extractErrorMessage(err, 'Failed to void purchase order'));
           console.error('Error voiding purchase order:', err);
         } finally {
           setSaving(false);
@@ -278,7 +279,7 @@ const PurchaseOrderPage: React.FC = () => {
       await loadOrder();
       handleCancelMarkDelivered();
     } catch (err: any) {
-      showError(err.response?.data?.error || 'Failed to mark purchase order as delivered');
+      showError(extractErrorMessage(err, 'Failed to mark purchase order as delivered'));
       console.error('Error marking delivered:', err);
     } finally {
       setSaving(false);
@@ -315,7 +316,7 @@ const PurchaseOrderPage: React.FC = () => {
       setEditingMetadata(false);
       showSuccess('Purchase order details updated');
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to update purchase order details');
+      showError(extractErrorMessage(err, 'Failed to update purchase order details'));
       console.error('Error updating PO metadata:', err);
     } finally {
       setSaving(false);
@@ -336,7 +337,7 @@ const PurchaseOrderPage: React.FC = () => {
       setAttachmentDescription('');
       showSuccess('Attachment uploaded');
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to upload attachment');
+      showError(extractErrorMessage(err, 'Failed to upload attachment'));
       console.error('Error uploading attachment:', err);
     } finally {
       setUploadingAttachment(false);
@@ -354,7 +355,7 @@ const PurchaseOrderPage: React.FC = () => {
           await loadOrder();
           showSuccess('Attachment deleted');
         } catch (err: any) {
-          showError(err.response?.data?.detail || 'Failed to delete attachment');
+          showError(extractErrorMessage(err, 'Failed to delete attachment'));
           console.error('Error deleting attachment:', err);
         } finally {
           setSaving(false);

--- a/frontend/src/pages/SIGDashboard.tsx
+++ b/frontend/src/pages/SIGDashboard.tsx
@@ -7,6 +7,7 @@ import { useParams } from 'react-router-dom';
 import { assetsAPI, inventoryAPI, reorderAPI, sigAPI } from '../services/api';
 import { Asset, InventoryItem, ReorderRequest, SIG } from '../types';
 import '../styles/SIGDashboard.css';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 type TabType = 'overview' | 'members' | 'assets' | 'inventory' | 'reorders';
 
@@ -90,8 +91,7 @@ const SIGDashboard: React.FC = () => {
       const detail =
         err?.response?.data?.name?.[0] ||
         err?.response?.data?.group_email?.[0] ||
-        err?.response?.data?.detail ||
-        'Failed to create SIG.';
+        extractErrorMessage(err, 'Failed to create SIG.');
       setCreateError(detail);
     } finally {
       setCreating(false);

--- a/frontend/src/pages/ScanPage.tsx
+++ b/frontend/src/pages/ScanPage.tsx
@@ -11,6 +11,7 @@ import '../styles/ScanPage.css';
 import { Checklist, InventoryItem, ItemSupplier } from '../types';
 import { formatDateOnly } from '../utils/dates';
 import { promptInput, showError } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const ScanPage: React.FC = () => {
   const { itemId } = useParams<{ itemId: string }>();
@@ -87,7 +88,7 @@ const ScanPage: React.FC = () => {
 
       setError(null);
     } catch (err: any) {
-      setError(err.response?.data?.detail || 'Failed to load item');
+      setError(extractErrorMessage(err, 'Failed to load item'));
       console.error('Error loading item:', err);
     } finally {
       setLoading(false);
@@ -114,7 +115,7 @@ const ScanPage: React.FC = () => {
       const completion = await checklistsAPI.startChecklist(checklistId, userName);
       navigate(`/checklist/${checklistId}/complete/${completion.data.id}`);
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to start checklist');
+      showError(extractErrorMessage(err, 'Failed to start checklist'));
     }
   };
 
@@ -198,7 +199,7 @@ const ScanPage: React.FC = () => {
         navigate('/');
       }, 3000);
     } catch (err: any) {
-      showError(err.response?.data?.detail || 'Failed to submit reorder request');
+      showError(extractErrorMessage(err, 'Failed to submit reorder request'));
       console.error('Error submitting reorder:', err);
     } finally {
       setSubmitting(false);

--- a/frontend/src/pages/SiteSettingsPage.tsx
+++ b/frontend/src/pages/SiteSettingsPage.tsx
@@ -15,6 +15,7 @@ import { FormInput } from '../components/forms/FormInput';
 import { customizationAPI } from '../services/api';
 import '../styles/SiteSettingsPage.css';
 import { SiteSettings } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 // Form schema
 const siteSettingsSchema = z.object({
@@ -86,7 +87,7 @@ const SiteSettingsPage: React.FC = () => {
       });
     } catch (err: any) {
       console.error('Error loading site settings:', err);
-      setError(err.response?.data?.detail || 'Failed to load site settings');
+      setError(extractErrorMessage(err, 'Failed to load site settings'));
     } finally {
       setLoading(false);
     }
@@ -143,7 +144,7 @@ const SiteSettingsPage: React.FC = () => {
       });
     } catch (err: any) {
       console.error('Error updating site settings:', err);
-      setError(err.response?.data?.detail || err.response?.data?.error || 'Failed to update site settings');
+      setError(extractErrorMessage(err, 'Failed to update site settings'));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/SupplierFormPage.tsx
+++ b/frontend/src/pages/SupplierFormPage.tsx
@@ -23,6 +23,7 @@ import { FormSelect } from '../components/forms/FormSelect';
 import { FormTextarea } from '../components/forms/FormTextarea';
 import { inventoryAPI } from '../services/api';
 import { SupplierFormData, supplierSchema } from '../utils/formSchemas';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const SupplierFormPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -74,7 +75,7 @@ const SupplierFormPage: React.FC = () => {
       });
     } catch (err: any) {
       console.error('Error loading supplier:', err);
-      setError(err.response?.data?.detail || 'Failed to load supplier. Please try again.');
+      setError(extractErrorMessage(err, 'Failed to load supplier. Please try again.'));
     } finally {
       setLoading(false);
     }
@@ -95,7 +96,7 @@ const SupplierFormPage: React.FC = () => {
     } catch (err: any) {
       console.error('Error saving supplier:', err);
       setError(
-        err.response?.data?.detail ||
+        extractErrorMessage(err, '') ||
           err.response?.data?.message ||
           'Failed to save supplier. Please try again.'
       );

--- a/frontend/src/pages/ThirdPartyWorkOrderPage.tsx
+++ b/frontend/src/pages/ThirdPartyWorkOrderPage.tsx
@@ -40,6 +40,7 @@ import {
   ThirdPartyWorkOrderDto,
   ThirdPartyWorkOrderStatus,
 } from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const STATUS_TO_STEP: Record<ThirdPartyWorkOrderStatus, number> = {
   requested: 0,
@@ -100,11 +101,7 @@ const ThirdPartyWorkOrderPage: React.FC = () => {
         await fn();
         await fetchWo();
       } catch (err) {
-        const detail = (err as { response?: { data?: { detail?: unknown } } })
-          ?.response?.data?.detail;
-        setActionError(
-          typeof detail === 'string' ? detail : 'Action failed — see server logs',
-        );
+        setActionError(extractErrorMessage(err, 'Action failed — see server logs'));
       } finally {
         setActing(false);
       }

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -13,6 +13,7 @@ import { FormImageUpload } from '../components/forms/FormImageUpload';
 import { FormInput } from '../components/forms/FormInput';
 import { notificationsAPI, userAPI } from '../services/api';
 import { ChangePasswordRequest, NotificationPreferences, UserProfile } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 // Form schemas
 const profileSchema = z.object({
@@ -105,7 +106,7 @@ const UserProfilePage: React.FC = () => {
       }
     } catch (err: any) {
       console.error('Error loading profile:', err);
-      setError(err.response?.data?.detail || 'Failed to load profile');
+      setError(extractErrorMessage(err, 'Failed to load profile'));
     } finally {
       setLoading(false);
     }
@@ -119,7 +120,7 @@ const UserProfilePage: React.FC = () => {
       setPreferences(response.data);
     } catch (err: any) {
       console.error('Error loading preferences:', err);
-      const errorMessage = err.response?.data?.detail || err.message || 'Failed to load notification preferences';
+      const errorMessage = extractErrorMessage(err, '') || err.message || 'Failed to load notification preferences';
       setPreferencesError(errorMessage);
       setError(`Failed to load notification preferences: ${errorMessage}`);
     } finally {
@@ -143,7 +144,7 @@ const UserProfilePage: React.FC = () => {
       setTimeout(() => setSuccess(null), 3000);
     } catch (err: any) {
       console.error('Error updating profile:', err);
-      setError(err.response?.data?.detail || 'Failed to update profile');
+      setError(extractErrorMessage(err, 'Failed to update profile'));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/WebhookDetailPage.tsx
+++ b/frontend/src/pages/WebhookDetailPage.tsx
@@ -24,6 +24,7 @@ import { webhooksAPI } from '../services/api';
 import '../styles/WebhookDetailPage.css';
 import { Webhook, WebhookTestResult } from '../types';
 import { confirmDelete, showError } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const WebhookDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -86,7 +87,7 @@ const WebhookDetailPage: React.FC = () => {
         webhook_id: Number(id),
         webhook_name: webhook?.name || '',
         success: false,
-        error_message: err.response?.data?.detail || 'Failed to test webhook',
+        error_message: extractErrorMessage(err, 'Failed to test webhook'),
         tested_at: new Date().toISOString(),
       });
       setTestModalOpen(true);
@@ -145,7 +146,7 @@ const WebhookDetailPage: React.FC = () => {
         navigate('/settings/webhooks');
       } catch (err: any) {
         console.error('Error deleting webhook:', err);
-        showError(err.response?.data?.detail || 'Failed to delete webhook');
+        showError(extractErrorMessage(err, 'Failed to delete webhook'));
       }
     });
   };

--- a/frontend/src/pages/WebhookFormPage.tsx
+++ b/frontend/src/pages/WebhookFormPage.tsx
@@ -24,6 +24,7 @@ import { FormTextarea } from '../components/forms/FormTextarea';
 import { webhooksAPI } from '../services/api';
 import '../styles/WebhookFormPage.css';
 import { WebhookFormData, webhookSchema } from '../utils/formSchemas';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const EVENT_TYPE_OPTIONS = [
   { value: 'reorder_request_created', label: 'Reorder Request Created' },
@@ -94,7 +95,7 @@ const WebhookFormPage: React.FC = () => {
       });
     } catch (err: any) {
       console.error('Error loading webhook:', err);
-      setError(err.response?.data?.detail || 'Failed to load webhook. Please try again.');
+      setError(extractErrorMessage(err, 'Failed to load webhook. Please try again.'));
     } finally {
       setLoading(false);
     }
@@ -128,7 +129,7 @@ const WebhookFormPage: React.FC = () => {
     } catch (err: any) {
       console.error('Error saving webhook:', err);
       setError(
-        err.response?.data?.detail ||
+        extractErrorMessage(err, '') ||
           err.response?.data?.message ||
           'Failed to save webhook. Please try again.'
       );

--- a/frontend/src/pages/WebhookListPage.tsx
+++ b/frontend/src/pages/WebhookListPage.tsx
@@ -21,6 +21,7 @@ import { webhooksAPI } from '../services/api';
 import '../styles/WebhookListPage.css';
 import { Webhook } from '../types';
 import { confirmDelete, showError } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const EVENT_TYPE_OPTIONS: Array<{ value: string; label: string }> = [
   { value: '', label: 'All Event Types' },
@@ -93,7 +94,7 @@ const WebhookListPage: React.FC = () => {
         await loadWebhooks();
       } catch (err: any) {
         console.error('Error deleting webhook:', err);
-        showError(err.response?.data?.detail || 'Failed to delete webhook');
+        showError(extractErrorMessage(err, 'Failed to delete webhook'));
       }
     });
   };

--- a/frontend/src/pages/WorkOrderPage.tsx
+++ b/frontend/src/pages/WorkOrderPage.tsx
@@ -133,7 +133,7 @@ const WorkOrderPage: React.FC = () => {
       } else {
         notifications.show({
           title: 'Error',
-          message: e.response?.data?.detail || 'Failed to update status.',
+          message: extractErrorMessage(e, 'Failed to update status.'),
           color: 'red',
         });
       }
@@ -175,7 +175,7 @@ const WorkOrderPage: React.FC = () => {
       const e = err as { response?: { data?: { detail?: string } } };
       notifications.show({
         title: 'Validation failed',
-        message: e.response?.data?.detail || 'Could not record validation.',
+        message: extractErrorMessage(e, 'Could not record validation.'),
         color: 'red',
       });
     } finally {

--- a/frontend/src/pages/WorkOrderPage.tsx
+++ b/frontend/src/pages/WorkOrderPage.tsx
@@ -39,6 +39,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { workOrderAPI } from '../services/api';
 import { WorkOrder, WorkOrderStatus } from '../types';
 import { formatDateOnly } from '../utils/dates';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const STATUS_OPTIONS = [
   { value: 'open', label: 'Open' },

--- a/frontend/src/utils/extractErrorMessage.ts
+++ b/frontend/src/utils/extractErrorMessage.ts
@@ -1,0 +1,62 @@
+/**
+ * Pull a user-safe error message off any axios error / arbitrary thrown value.
+ *
+ * The OMS backend emits errors in two shapes during the migration to the
+ * standardized envelope (gh #330):
+ *
+ *   1. **Envelope** — DRF exception handler + ``config.api_errors.error_response()``
+ *      ``{"error": {"code": "...", "message": "...", "details": {...}}}``
+ *
+ *   2. **Legacy detail** — direct ``Response({"detail": "..."}, status=4xx)``
+ *      ``{"detail": "..."}``
+ *
+ * This helper preserves the envelope-first preference so once a backend
+ * site is converted to ``error_response`` the UI surfaces the canonical
+ * code/message without any change at the call site. The legacy ``detail``
+ * branch keeps existing untouched endpoints displaying the same toast they
+ * always did.
+ *
+ * Always supply a ``fallback``: it covers the wholly unexpected shape
+ * (network error, CORS preflight failure, browser cancel, malformed JSON)
+ * where neither shape is present.
+ */
+export function extractErrorMessage(err: unknown, fallback: string): string {
+  // Axios shape: ``err.response.data``. Also handle a bare ``data`` payload
+  // for code paths that already destructured the response.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const anyErr = err as any;
+  const data = anyErr?.response?.data ?? anyErr?.data ?? anyErr;
+
+  if (data && typeof data === "object") {
+    // Envelope shape (preferred — once #330 conversion lands).
+    const envelope = data.error;
+    if (envelope && typeof envelope === "object") {
+      const message = envelope.message;
+      if (typeof message === "string" && message.trim() !== "") {
+        return message;
+      }
+    }
+
+    // Legacy ``detail`` field. DRF's default ValidationError handler
+    // sometimes ships ``detail`` as a string and sometimes as a list of
+    // field errors; prefer the first non-empty string.
+    const detail = data.detail;
+    if (typeof detail === "string" && detail.trim() !== "") {
+      return detail;
+    }
+    if (Array.isArray(detail) && typeof detail[0] === "string" && detail[0].trim() !== "") {
+      return detail[0];
+    }
+
+    // ``data.error`` might be a bare string in older endpoints (we encode
+    // ``Response({"error": "..."})`` literally in a few places). Surface
+    // that before falling back.
+    if (typeof data.error === "string" && data.error.trim() !== "") {
+      return data.error;
+    }
+  }
+
+  return fallback;
+}
+
+export default extractErrorMessage;


### PR DESCRIPTION
## Summary

Coordinated migration to the standardized error envelope contract documented in `config/api_errors.py`. Doing both ends in one PR per request — flipping the backend without a frontend helper would blank every error toast in the UI.

## Frontend (47 files, ~110 call sites)

- **New helper** `frontend/src/utils/extractErrorMessage.ts`. Reads in priority order: envelope `error.message` → legacy `data.detail` (string or `[0]` of array) → bare `data.error` → `fallback`. Single source of truth.
- **Mechanical migration** of `err?.response?.data?.detail || 'X'` patterns to `extractErrorMessage(err, 'X')` across all pages + components.

## Backend (4 files, 35+ sites)

Converted ad-hoc `Response({"error": ...}, status=4xx/5xx)` and `Response({"detail": ...}, status=4xx/5xx)` calls to `error_response()` from `config.api_errors`:

| File | Sites | Notes |
|------|-------|-------|
| `auth_views.py` | 7 | register / login / refresh / create_test_membership. Mapped 401→AUTHENTICATION_FAILED, 409→CONFLICT (username taken), etc. |
| `dashboard/views.py` | 12 | exception handlers, mostly 500→SERVER_ERROR |
| `inventory/views.py` | 11 | 3 needed manual fix-up (used `status=404` integer instead of `status.HTTP_404_NOT_FOUND`) |
| `location_checkins/views.py` | 8 | |

Status-code mapping: 400→`VALIDATION_FAILED`, 401→`AUTHENTICATION_FAILED` / `NOT_AUTHENTICATED`, 403→`PERMISSION_DENIED`, 404→`NOT_FOUND`, 409→`CONFLICT`, 500→`SERVER_ERROR`, 503→`DEPENDENCY_UNAVAILABLE`.

## What's intentionally untouched

- **Success paths** like `Response({"detail": "Logged out"}, 200)` — envelope is for errors only.
- `configure_emqx_jwt_auth` and other non-DRF JSON paths consumed by EMQX/firmware (different audience).
- One `JsonResponse` in `dashboard.dashboard_health` (different API surface).
- `__tests__/services/api.test.ts` keeps asserting `data.detail === 'Logged out'` — success path.

## Why this is non-breaking

The frontend helper still reads the legacy `detail` path as a fallback, so any backend endpoint we DIDN'T convert continues to surface its error toast unchanged. As more endpoints flip to envelope, the same helper transparently surfaces the canonical message.

## Test plan

Tests via **codex (OpenAI)** — AI-diversity coverage:

- [ ] `frontend/src/__tests__/utils/extractErrorMessage.test.ts` (9 Jest cases — envelope precedence, detail array, bare data, null input, fallback)
- [ ] `backend/config/tests/test_auth_envelope.py` (9 pytest cases — each converted auth endpoint returns envelope with right `code`)

Manual: black/isort/flake8 clean; Python compiles; spot-checked frontend conversions.

Fixes #330