### PR TITLE
chore(deps): upgrade Node.js to 24 across builds + dev

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
       "installTools": true
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "18",
+      "version": "24",
       "nodeGypDependencies": true,
       "installYarnUsingApt": true
     },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,10 +235,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Node.js 20
+      - name: Set up Node.js 24
         uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 
@@ -263,10 +263,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Node.js 20
+      - name: Set up Node.js 24
         uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -235,7 +235,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:24-alpine
 
 WORKDIR /app
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,6 @@
         "@testing-library/react": "^14.3.1",
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.5.2",
-        "@types/node": "^16.18.68",
         "@types/react": "^18.2.42",
         "@types/react-dom": "^18.2.17",
         "axios": "^1.16.0",
@@ -49,6 +48,7 @@
         "@commitlint/cli": "^19.6.1",
         "@commitlint/config-conventional": "^19.6.0",
         "@playwright/test": "^1.56.1",
+        "@types/node": "^24.12.3",
         "@types/react-grid-layout": "^1.3.6",
         "husky": "^8.0.3",
         "iconv-lite": "^0.7.0",
@@ -56,6 +56,9 @@
         "patch-package": "^8.0.1",
         "playwright": "^1.56.1",
         "postinstall-postinstall": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -5502,10 +5505,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "16.18.126",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
-      "license": "MIT"
+      "version": "24.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.3.tgz",
+      "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.14",
@@ -19824,6 +19830,12 @@
       "version": "1.13.8",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,11 @@
   "name": "makerspace-inventory-frontend",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "dependencies": {
+    "@highlight-run/react": "^17.0.0",
     "@hookform/resolvers": "^3.3.4",
     "@mantine/core": "^7.11.0",
     "@mantine/dates": "^7.11.0",
@@ -11,13 +15,11 @@
     "@mantine/hooks": "^7.11.0",
     "@mantine/modals": "^7.17.8",
     "@mantine/notifications": "^7.17.8",
-    "@highlight-run/react": "^17.0.0",
     "@tabler/icons-react": "^3.35.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.3.1",
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.5.2",
-    "@types/node": "^16.18.68",
     "@types/react": "^18.2.42",
     "@types/react-dom": "^18.2.17",
     "axios": "^1.16.0",
@@ -123,6 +125,7 @@
     "@commitlint/cli": "^19.6.1",
     "@commitlint/config-conventional": "^19.6.0",
     "@playwright/test": "^1.56.1",
+    "@types/node": "^24.12.3",
     "@types/react-grid-layout": "^1.3.6",
     "husky": "^8.0.3",
     "iconv-lite": "^0.7.0",


### PR DESCRIPTION
## Summary

Bumps Node.js from 20 (and 18 in the devcontainer) to **24** across every pinned location:

| File | From → To |
|------|-----------|
| `frontend/Dockerfile.prod` | `node:20-alpine` → `node:24-alpine` |
| `frontend/Dockerfile` | `node:20-alpine` → `node:24-alpine` |
| `.github/workflows/ci.yml` | `node-version: "20"` → `"24"` (×2 jobs) |
| `.github/workflows/docker-build.yml` | `node-version: '20'` → `'24'` |
| `.devcontainer/devcontainer.json` | feature `version: "18"` → `"24"` |
| `frontend/package.json` | adds `engines.node: ">=24.0.0"` |
| `frontend/package.json` | `@types/node ^16` → `^24` |

Lockfile re-resolved cleanly (22 lines of diff in `package-lock.json` — just the new `@types/node` and a couple of transitives).

## Why this is scoped tightly

Other dependency majors (`typescript` 4→5, `react` 18→19, `testing-library` 5→6, `@types/jest` 27→29, etc.) are deliberately **left for separate follow-up PRs** — those are major-version bumps with their own breaking changes that need targeted migration work, and folding them into the Node upgrade would couple two unrelated risks.

## Test plan

- `npm run lint` clean locally (0 errors, only pre-existing warnings)
- CI runs `npm ci` against the new Node 24 + the regenerated lockfile
- Docker build CI rebuilds both `Dockerfile` and `Dockerfile.prod` against `node:24-alpine`

If anything in the React 18 / typescript 4.9 / react-scripts 5 stack proves incompatible with Node 24's V8 (e.g. node-gyp native deps, deprecated APIs in webpack 5), CI will surface it on this PR rather than silently in production.

Fixes #371