### PR TITLE
feat(analytics): dashboard UI + signed-URL share (PR2 of 3)

### DIFF
--- a/backend/analytics/permissions.py
+++ b/backend/analytics/permissions.py
@@ -1,18 +1,47 @@
 """DRF permissions for analytics endpoints.
 
-Reuses ``membership.is_staff_or_sig_admin`` for the role gate so analytics
-follows the same access surface as work-order writes (gh #374). PR2 will
-extend this with a signed-URL bypass for board members without OMS
-accounts.
+Two access modes:
+
+1. **Authenticated role gate** — staff, superuser, Logistics, or any SIG
+   admin (matches the WO-write rule from gh #374).
+2. **Signed-URL bypass** — a valid ``?token=<signed>`` query parameter
+   lets even unauthenticated callers read the dashboard. Used to share
+   the analytics view with board members who don't have OMS accounts.
+   Tokens are minted by the staff-gated ``/api/analytics/share/`` endpoint.
+
+The token bypass applies only to read endpoints. Writes (e.g. minting a
+new token) still require the authenticated role gate.
 """
 
 from rest_framework.permissions import BasePermission
 
 from membership.utils import is_staff_or_sig_admin
 
+from .services.share_token import InvalidShareToken, verify_share_token
+
+
+def _has_valid_share_token(request) -> bool:
+    token = request.query_params.get("token")
+    if not token:
+        return False
+    try:
+        verify_share_token(token)
+    except InvalidShareToken:
+        return False
+    return True
+
 
 class IsAnalyticsViewer(BasePermission):
-    """Allow staff, superuser, Logistics, or any SIG admin to view analytics."""
+    """Authenticated staff/SIG admin OR a valid signed share token."""
+
+    def has_permission(self, request, view):
+        if is_staff_or_sig_admin(request.user):
+            return True
+        return _has_valid_share_token(request)
+
+
+class IsAnalyticsSharer(BasePermission):
+    """Only authenticated staff / SIG admins may mint share tokens."""
 
     def has_permission(self, request, view):
         return is_staff_or_sig_admin(request.user)

--- a/backend/analytics/services/share_token.py
+++ b/backend/analytics/services/share_token.py
@@ -1,0 +1,78 @@
+"""Signed-URL share tokens for the analytics dashboard.
+
+Built on Django's ``TimestampSigner`` so we can stamp an expiry without
+needing a database row per token. The signature is derived from
+``SECRET_KEY`` plus the salt below; rotating the salt invalidates every
+outstanding token (the kill-switch).
+
+Tokens are intentionally minimal: they carry only a ``v1`` marker so we
+can change the format later without breaking older URLs gracefully. They
+are *not* per-user — anyone with the URL can view the dashboard until it
+expires.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.conf import settings
+from django.core.signing import BadSignature, SignatureExpired, TimestampSigner
+
+SHARE_TOKEN_SALT_SETTING = "ANALYTICS_SHARE_SALT"
+DEFAULT_TTL_DAYS = 30
+MAX_TTL_DAYS = 365
+TOKEN_PAYLOAD_V1 = "v1"
+
+
+class InvalidShareToken(Exception):
+    """Raised when a token is malformed, tampered with, or expired."""
+
+
+def _signer() -> TimestampSigner:
+    salt = getattr(settings, SHARE_TOKEN_SALT_SETTING, "analytics-share-v1")
+    return TimestampSigner(salt=salt)
+
+
+def mint_share_token(ttl_days: int = DEFAULT_TTL_DAYS) -> str:
+    """Return a signed token good for ``ttl_days`` days.
+
+    Caller is responsible for clamping ``ttl_days`` to its desired range
+    before reaching here; we still cap at ``MAX_TTL_DAYS`` defensively.
+    """
+    if ttl_days <= 0:
+        raise ValueError("ttl_days must be positive")
+    if ttl_days > MAX_TTL_DAYS:
+        ttl_days = MAX_TTL_DAYS
+    return _signer().sign(f"{TOKEN_PAYLOAD_V1}:{ttl_days}")
+
+
+def verify_share_token(token: str) -> int:
+    """Return the original ttl_days when valid, else raise InvalidShareToken.
+
+    Validates both the signature and the embedded TTL — a token signed
+    yesterday with ``ttl_days=1`` will be rejected today even though the
+    signature itself is fine.
+    """
+    try:
+        unsigned = _signer().unsign(token, max_age=timedelta(days=MAX_TTL_DAYS))
+    except SignatureExpired as exc:
+        raise InvalidShareToken("token expired") from exc
+    except BadSignature as exc:
+        raise InvalidShareToken("invalid signature") from exc
+
+    try:
+        version, ttl_str = unsigned.split(":", 1)
+        ttl_days = int(ttl_str)
+    except (ValueError, AttributeError) as exc:
+        raise InvalidShareToken("malformed payload") from exc
+
+    if version != TOKEN_PAYLOAD_V1:
+        raise InvalidShareToken(f"unsupported token version {version!r}")
+
+    # Re-check the embedded TTL — TimestampSigner only enforces MAX_TTL_DAYS above.
+    try:
+        _signer().unsign(token, max_age=timedelta(days=ttl_days))
+    except SignatureExpired as exc:
+        raise InvalidShareToken("token expired") from exc
+
+    return ttl_days

--- a/backend/analytics/tests/test_share_token.py
+++ b/backend/analytics/tests/test_share_token.py
@@ -1,0 +1,92 @@
+"""Unit tests for the signed-URL share token utility."""
+
+from __future__ import annotations
+
+
+
+import pytest
+from freezegun import freeze_time
+
+from analytics.services.share_token import (
+    MAX_TTL_DAYS,
+    InvalidShareToken,
+    mint_share_token,
+    verify_share_token,
+)
+
+
+class TestMintAndVerify:
+    def test_round_trip(self):
+        token = mint_share_token(ttl_days=7)
+        assert verify_share_token(token) == 7
+
+    def test_default_ttl(self):
+        token = mint_share_token()
+        assert verify_share_token(token) == 30
+
+    def test_zero_ttl_rejected(self):
+        with pytest.raises(ValueError):
+            mint_share_token(ttl_days=0)
+
+    def test_negative_ttl_rejected(self):
+        with pytest.raises(ValueError):
+            mint_share_token(ttl_days=-5)
+
+    def test_clamped_at_max(self):
+        token = mint_share_token(ttl_days=MAX_TTL_DAYS + 100)
+        # Stored TTL should be MAX_TTL_DAYS, not the requested value.
+        assert verify_share_token(token) == MAX_TTL_DAYS
+
+
+class TestVerifyRejectsBadTokens:
+    def test_garbage_string(self):
+        with pytest.raises(InvalidShareToken):
+            verify_share_token("not-a-token")
+
+    def test_tampered_signature(self):
+        token = mint_share_token(ttl_days=7)
+        # Flip a character in the signature segment.
+        if token.endswith("a"):
+            tampered = token[:-1] + "b"
+        else:
+            tampered = token[:-1] + "a"
+        with pytest.raises(InvalidShareToken):
+            verify_share_token(tampered)
+
+    def test_empty_token(self):
+        with pytest.raises(InvalidShareToken):
+            verify_share_token("")
+
+
+class TestExpiry:
+    def test_expired_after_embedded_ttl(self):
+        with freeze_time("2026-01-01 12:00:00"):
+            token = mint_share_token(ttl_days=2)
+        # 3 days later: signature still valid (under MAX_TTL_DAYS) but
+        # embedded TTL has elapsed.
+        with freeze_time("2026-01-04 13:00:00"):
+            with pytest.raises(InvalidShareToken):
+                verify_share_token(token)
+
+    def test_still_valid_within_ttl(self):
+        with freeze_time("2026-01-01 12:00:00"):
+            token = mint_share_token(ttl_days=7)
+        with freeze_time("2026-01-05 12:00:00"):
+            assert verify_share_token(token) == 7
+
+    def test_signature_expired_past_max(self):
+        with freeze_time("2024-01-01"):
+            token = mint_share_token(ttl_days=MAX_TTL_DAYS)
+        # MAX_TTL_DAYS (365) + a buffer past the absolute cap.
+        with freeze_time("2026-01-02"):
+            with pytest.raises(InvalidShareToken):
+                verify_share_token(token)
+
+
+class TestSaltRotation:
+    def test_changing_salt_invalidates_existing_tokens(self, settings):
+        token = mint_share_token(ttl_days=7)
+        assert verify_share_token(token) == 7
+        settings.ANALYTICS_SHARE_SALT = "rotated-v2"
+        with pytest.raises(InvalidShareToken):
+            verify_share_token(token)

--- a/backend/analytics/tests/test_views.py
+++ b/backend/analytics/tests/test_views.py
@@ -1,4 +1,4 @@
-"""Tests for ``/api/analytics/pulse/``."""
+"""Tests for ``/api/analytics/pulse/`` and ``/api/analytics/share/``."""
 
 from datetime import date, datetime, timedelta
 from decimal import Decimal
@@ -12,6 +12,7 @@ from django.utils.crypto import get_random_string
 import pytest
 from rest_framework.test import APIClient
 
+from analytics.services.share_token import mint_share_token
 from inventory.models import MaintenanceItem, WorkOrder
 from inventory.tests.factories import AssetFactory
 from membership.models import SIGAdmin
@@ -150,3 +151,96 @@ class TestPulseCache:
         cache.clear()
         third = client.get(url)
         assert third.json()["summary"]["internal_completed_count"] == baseline_count + 1
+
+
+class TestPulseShareToken:
+    URL = "/api/analytics/pulse/"
+
+    def test_anonymous_with_valid_token_allowed(self):
+        token = mint_share_token(ttl_days=7)
+        resp = _client().get(f"{self.URL}?token={token}")
+        assert resp.status_code == 200
+        assert "summary" in resp.json()
+
+    def test_anonymous_with_invalid_token_denied(self):
+        resp = _client().get(f"{self.URL}?token=garbage")
+        assert resp.status_code in (401, 403)
+
+    def test_authenticated_without_token_still_works(self):
+        # Token is optional — the role gate continues to work.
+        resp = _client(_user("admin", is_staff=True)).get(self.URL)
+        assert resp.status_code == 200
+
+    def test_volunteer_with_valid_token_allowed(self):
+        # Even a volunteer (who would be denied by role) gets in with token.
+        token = mint_share_token(ttl_days=7)
+        resp = _client(_user("volunteer")).get(f"{self.URL}?token={token}")
+        assert resp.status_code == 200
+
+
+class TestPulseMonthlyBudget:
+    URL = "/api/analytics/pulse/"
+
+    def test_budget_null_when_unset(self, settings):
+        if hasattr(settings, "MONTHLY_BUDGET_TOTAL"):
+            del settings.MONTHLY_BUDGET_TOTAL
+        resp = _client(_user("admin", is_staff=True)).get(self.URL)
+        assert resp.json()["monthly_budget"] is None
+
+    def test_budget_returned_when_set(self, settings):
+        settings.MONTHLY_BUDGET_TOTAL = "5000.00"
+        resp = _client(_user("admin", is_staff=True)).get(self.URL)
+        assert resp.json()["monthly_budget"] == "5000.00"
+
+    def test_budget_invalid_value_returns_null(self, settings):
+        settings.MONTHLY_BUDGET_TOTAL = "not a number"
+        resp = _client(_user("admin", is_staff=True)).get(self.URL)
+        assert resp.json()["monthly_budget"] is None
+
+
+class TestShareEndpoint:
+    URL = "/api/analytics/share/"
+
+    def test_anonymous_denied(self):
+        resp = _client().post(self.URL, data={}, format="json")
+        assert resp.status_code in (401, 403)
+
+    def test_volunteer_denied(self):
+        resp = _client(_user("volunteer")).post(self.URL, data={}, format="json")
+        assert resp.status_code == 403
+
+    def test_staff_can_mint_default_ttl(self):
+        resp = _client(_user("admin", is_staff=True)).post(self.URL, data={}, format="json")
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["ttl_days"] == 30
+        assert body["token"]
+        assert body["expires_in_days"] == 30
+
+    def test_staff_can_mint_custom_ttl(self):
+        resp = _client(_user("admin", is_staff=True)).post(
+            self.URL, data={"ttl_days": 7}, format="json"
+        )
+        assert resp.status_code == 201
+        assert resp.json()["ttl_days"] == 7
+
+    def test_minted_token_unlocks_pulse(self):
+        share_resp = _client(_user("admin", is_staff=True)).post(
+            self.URL, data={"ttl_days": 14}, format="json"
+        )
+        token = share_resp.json()["token"]
+        # Anonymous client uses the token.
+        pulse_resp = _client().get(f"/api/analytics/pulse/?token={token}")
+        assert pulse_resp.status_code == 200
+
+    def test_invalid_ttl_rejected(self):
+        client = _client(_user("admin", is_staff=True))
+        for bad in ("hello", -5, 0, 9999):
+            resp = client.post(self.URL, data={"ttl_days": bad}, format="json")
+            assert resp.status_code == 400
+
+    def test_sig_admin_can_mint(self):
+        user = _user("sig_lead")
+        SIGAdmin.objects.create(user=user, group=Group.objects.create(name="Wood SIG"))
+        resp = _client(user).post(self.URL, data={}, format="json")
+        assert resp.status_code == 201

--- a/backend/analytics/urls.py
+++ b/backend/analytics/urls.py
@@ -2,10 +2,11 @@
 
 from django.urls import path
 
-from .views import AnalyticsPulseView
+from .views import AnalyticsPulseView, AnalyticsShareView
 
 app_name = "analytics"
 
 urlpatterns = [
     path("pulse/", AnalyticsPulseView.as_view(), name="pulse"),
+    path("share/", AnalyticsShareView.as_view(), name="share"),
 ]

--- a/backend/analytics/views.py
+++ b/backend/analytics/views.py
@@ -1,13 +1,17 @@
-"""Read-only analytics endpoint.
+"""Analytics endpoints.
 
-``/api/analytics/pulse/`` returns the full aggregate JSON used by both
-the dashboard (PR2) and the monthly email (PR3). Cached 60 minutes in
-django-redis to bound DB load when the dashboard is viewed concurrently.
+- ``GET /api/analytics/pulse/`` — full aggregate JSON used by the dashboard
+  (PR2) and the monthly email (PR3). Cached 60 minutes in django-redis to
+  bound DB load when the dashboard is viewed concurrently.
+- ``POST /api/analytics/share/`` — staff-only mint of a signed-URL token
+  that lets board members without OMS accounts view the dashboard.
 
-Query parameters:
+Query parameters on pulse:
 - ``start`` and ``end`` (ISO date) — summary window. Defaults to the last
   full calendar month.
 - ``bucket`` — ``"month"`` (default) or ``"quarter"`` for the trend series.
+- ``token`` — optional signed share token (alternative to authenticated
+  access; see ``analytics.permissions.IsAnalyticsViewer``).
 
 The 12-month trend series is independent of the summary window so the
 chart is stable as users zoom around.
@@ -16,7 +20,9 @@ chart is stable as users zoom around.
 from __future__ import annotations
 
 from datetime import date, timedelta
+from decimal import Decimal, InvalidOperation
 
+from django.conf import settings
 from django.core.cache import cache
 from django.utils.dateparse import parse_date
 
@@ -24,9 +30,10 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .permissions import IsAnalyticsViewer
+from .permissions import IsAnalyticsSharer, IsAnalyticsViewer
 from .services.aggregation import category_spend, top_users, utilization, value_summary, wo_volume
 from .services.forecast import maintenance_forecast
+from .services.share_token import DEFAULT_TTL_DAYS, MAX_TTL_DAYS, mint_share_token
 
 CACHE_TTL_SECONDS = 60 * 60
 CACHE_VERSION = "v1"
@@ -48,8 +55,23 @@ def _last_12_months_window() -> tuple[date, date]:
     return start, end
 
 
+def _monthly_budget() -> str | None:
+    """Return ``MONTHLY_BUDGET_TOTAL`` as a string Decimal, or None if unset.
+
+    Frontend hides the budget gauge when this is null. We serialize as a
+    string for parity with the other money fields in the summary.
+    """
+    raw = getattr(settings, "MONTHLY_BUDGET_TOTAL", None)
+    if raw in (None, ""):
+        return None
+    try:
+        return str(Decimal(str(raw)))
+    except InvalidOperation:
+        return None
+
+
 class AnalyticsPulseView(APIView):
-    """``GET /api/analytics/pulse/?start=YYYY-MM-DD&end=YYYY-MM-DD&bucket=month``"""
+    """``GET /api/analytics/pulse/?start=...&end=...&bucket=month&token=...``"""
 
     permission_classes = [IsAnalyticsViewer]
 
@@ -101,4 +123,43 @@ class AnalyticsPulseView(APIView):
                 "maintenance_forecast": maintenance_forecast(),
             }
             cache.set(cache_key, payload, CACHE_TTL_SECONDS)
+
+        # Budget is read fresh on every request so config changes take effect
+        # without waiting for the cache to expire.
+        payload = {**payload, "monthly_budget": _monthly_budget()}
         return Response(payload)
+
+
+class AnalyticsShareView(APIView):
+    """``POST /api/analytics/share/`` — mint a signed-URL token.
+
+    Body: ``{"ttl_days": <1..365>}`` (optional, defaults to 30).
+    Response: ``{"token": "...", "ttl_days": N, "expires_in_days": N}``.
+
+    The frontend composes the full shareable URL from the token. We
+    deliberately do not include the URL on the server because the public
+    base URL varies per deployment.
+    """
+
+    permission_classes = [IsAnalyticsSharer]
+
+    def post(self, request):
+        ttl_raw = request.data.get("ttl_days", DEFAULT_TTL_DAYS)
+        try:
+            ttl_days = int(ttl_raw)
+        except (TypeError, ValueError):
+            return Response(
+                {"detail": "ttl_days must be an integer"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if ttl_days <= 0 or ttl_days > MAX_TTL_DAYS:
+            return Response(
+                {"detail": f"ttl_days must be between 1 and {MAX_TTL_DAYS}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        token = mint_share_token(ttl_days=ttl_days)
+        return Response(
+            {"token": token, "ttl_days": ttl_days, "expires_in_days": ttl_days},
+            status=status.HTTP_201_CREATED,
+        )

--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -9,6 +9,9 @@ views:
   analytics.views.AnalyticsPulseView:
     permission_classes:
     - IsAnalyticsViewer
+  analytics.views.AnalyticsShareView:
+    permission_classes:
+    - IsAnalyticsSharer
   auth_views.create_test_membership:
     permission_classes:
     - AllowAny

--- a/docs/API_PERMISSION_MATRIX.md
+++ b/docs/API_PERMISSION_MATRIX.md
@@ -273,7 +273,8 @@ category spend, and a maintenance forecast.
 
 | Method | Path | Class | Purpose | Notes |
 | --- | --- | --- | --- | --- |
-| GET | `analytics/pulse/` | staff-or-sig-admin | `IsAnalyticsViewer` — returns the full aggregate JSON used by both the dashboard and the monthly email. | 60-min django-redis cache keyed by `(start, end, bucket)`. PR2 will add a signed-URL bypass for board members without OMS accounts. |
+| GET | `analytics/pulse/` | staff-or-sig-admin **or** signed-URL token | `IsAnalyticsViewer` — returns the full aggregate JSON used by both the dashboard and the monthly email. Authenticated staff/SIG admins are allowed; anyone presenting a valid `?token=...` minted by `analytics/share/` is also allowed (board-member bypass). | 60-min django-redis cache keyed by `(start, end, bucket)`. Token verifies signature + embedded TTL; rotating `ANALYTICS_SHARE_SALT` invalidates all outstanding tokens. |
+| POST | `analytics/share/` | staff-or-sig-admin | `IsAnalyticsSharer` — mints a signed token (`{"ttl_days": 1..365}`, defaults to 30). Returns the token + ttl; the frontend composes the shareable URL. | Pure HMAC-signed token (no DB row); authoritative kill-switch is the salt setting. |
 
 ## Flower (Celery monitoring)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { Navigate, Route, BrowserRouter as Router, Routes, useParams } from 'rea
 import ErrorFallback from './components/ErrorFallback';
 import WorkspaceLayout from './components/WorkspaceLayout';
 import AdminDashboard from './pages/AdminDashboard';
+import AnalyticsDashboardPage from './pages/AnalyticsDashboardPage';
 import AssetDetailPage from './pages/AssetDetailPage';
 import AssetFormPage from './pages/AssetFormPage';
 import MaintenanceItemFormPage from './pages/MaintenanceItemFormPage';
@@ -203,6 +204,10 @@ function AppContent() {
           <Route path="/facilities/electrical/light-switches/:id/edit" element={<WorkspaceLayout><LightSwitchFormPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/network-drops/new" element={<WorkspaceLayout><NetworkDropFormPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/network-drops/:id/edit" element={<WorkspaceLayout><NetworkDropFormPage /></WorkspaceLayout>} />
+
+          {/* Analytics dashboard */}
+          <Route path="/analytics" element={<WorkspaceLayout><AnalyticsDashboardPage /></WorkspaceLayout>} />
+          <Route path="/analytics/shared" element={<AnalyticsDashboardPage shared />} />
 
           {/* Preventive Maintenance */}
           <Route path="/maintenance" element={<WorkspaceLayout><MaintenanceDashboardPage /></WorkspaceLayout>} />

--- a/frontend/src/__tests__/pages/AnalyticsDashboardPage.test.tsx
+++ b/frontend/src/__tests__/pages/AnalyticsDashboardPage.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Smoke tests for AnalyticsDashboardPage. Covers:
+ * - happy path render with mocked pulse response
+ * - error path
+ * - shared mode forwards token from query param and hides Share button
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import AnalyticsDashboardPage from '../../pages/AnalyticsDashboardPage';
+import * as api from '../../services/api';
+
+jest.mock('../../services/api');
+
+// Recharts is heavy — render placeholders so the smoke test stays focused.
+jest.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
+  LineChart: () => <div data-testid="line-chart" />,
+  Line: () => null,
+  BarChart: () => <div data-testid="bar-chart" />,
+  Bar: () => null,
+  RadialBarChart: () => <div data-testid="radial-bar-chart" />,
+  RadialBar: () => null,
+  PolarAngleAxis: () => null,
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+}));
+
+const renderAt = (path: string) =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/analytics" element={<AnalyticsDashboardPage />} />
+          <Route path="/analytics/shared" element={<AnalyticsDashboardPage shared />} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>
+  );
+
+const mockPulse: api.AnalyticsPulseResponse = {
+  summary: {
+    period_start: '2026-04-01',
+    period_end: '2026-05-01',
+    internal_completed_count: 12,
+    internal_estimated_external_cost: '3000.00',
+    internal_estimated_internal_cost: '500.00',
+    internal_net_value: '2500.00',
+    external_closed_count: 2,
+    external_actual_cost: '950.00',
+    external_estimated_cost: '1200.00',
+    total_value_to_makerspace: '1550.00',
+  },
+  wo_volume_trend: [
+    { period: '2026-04-01', count: 12 },
+  ],
+  top_users: [
+    { user_id: 1, username: 'alice', display_name: 'Alice Wonder', completed_wo_count: 5 },
+  ],
+  utilization: [
+    { asset_id: 'a1', asset_name: 'CNC Mill', category: 'CNC', hours_used: 150, completed_wo_count: 3, status: 'active' },
+  ],
+  category_spend: [
+    { category_id: 1, category_name: 'CNC', internal_estimated: '300.00', external_estimated: '600.00', external_actual: '950.00', internal_wo_count: 2, external_wo_count: 1 },
+  ],
+  maintenance_forecast: [
+    { asset_id: 'a1', asset_name: 'CNC Mill', category: 'CNC', status: 'active', hours_used: 150, last_completed_wo_at: null, interval_hours: 100, interval_days: null, days_since_last_wo: null, due_reason: 'hours' },
+  ],
+  monthly_budget: '5000.00',
+};
+
+describe('AnalyticsDashboardPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all panels with mocked pulse data', async () => {
+    (api.pulseAPI.getPulse as jest.Mock).mockResolvedValue({ data: mockPulse });
+
+    renderAt('/analytics');
+
+    await waitFor(() => {
+      expect(screen.getByText('Makerspace pulse')).toBeInTheDocument();
+    });
+
+    // Summary stats
+    expect(screen.getByText('Net value created')).toBeInTheDocument();
+    // Panels rendered
+    expect(screen.getByTestId('budget-gauge')).toBeInTheDocument();
+    expect(screen.getByTestId('volume-trend-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('category-spend-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('top-users-table')).toBeInTheDocument();
+    expect(screen.getByTestId('maintenance-forecast-list')).toBeInTheDocument();
+    expect(screen.getByTestId('equipment-status-grid')).toBeInTheDocument();
+    // Top user surfaces
+    expect(screen.getByText('Alice Wonder')).toBeInTheDocument();
+    // Share button visible in default (non-shared) mode
+    expect(screen.getByRole('button', { name: /share with board/i })).toBeInTheDocument();
+  });
+
+  it('renders error state on API failure', async () => {
+    (api.pulseAPI.getPulse as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    renderAt('/analytics');
+
+    await waitFor(() => {
+      // Mantine Alert renders title + body. Pick whichever instance is present.
+      const matches = screen.getAllByText(/Could not load analytics/);
+      expect(matches.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('shared mode forwards token and hides share button', async () => {
+    (api.pulseAPI.getPulse as jest.Mock).mockResolvedValue({ data: mockPulse });
+
+    renderAt('/analytics/shared?token=signed.token.here');
+
+    await waitFor(() => {
+      expect(screen.getByText(/shared link/i)).toBeInTheDocument();
+    });
+
+    expect(api.pulseAPI.getPulse).toHaveBeenCalledWith({ token: 'signed.token.here' });
+    expect(screen.queryByRole('button', { name: /share with board/i })).not.toBeInTheDocument();
+  });
+
+  it('hides budget gauge when monthly_budget is null', async () => {
+    (api.pulseAPI.getPulse as jest.Mock).mockResolvedValue({
+      data: { ...mockPulse, monthly_budget: null },
+    });
+
+    renderAt('/analytics');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('budget-gauge-disabled')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('budget-gauge')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/analytics/BudgetGauge.tsx
+++ b/frontend/src/components/analytics/BudgetGauge.tsx
@@ -1,0 +1,52 @@
+import { Card, Group, Stack, Text, Title } from '@mantine/core';
+import React from 'react';
+import {
+  PolarAngleAxis,
+  RadialBar,
+  RadialBarChart,
+  ResponsiveContainer,
+} from 'recharts';
+
+interface BudgetGaugeProps {
+  budget: string | null;
+  externalActualCost: string;
+}
+
+const fmt = (n: number) =>
+  n.toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+
+export const BudgetGauge: React.FC<BudgetGaugeProps> = ({ budget, externalActualCost }) => {
+  if (!budget) {
+    return (
+      <Card withBorder p="md" radius="md" data-testid="budget-gauge-disabled">
+        <Title order={4}>Monthly budget</Title>
+        <Text size="sm" c="dimmed" mt="sm">
+          Set <code>MONTHLY_BUDGET_TOTAL</code> in backend settings to enable this gauge.
+        </Text>
+      </Card>
+    );
+  }
+
+  const budgetNum = Number(budget);
+  const spent = Number(externalActualCost);
+  const pct = budgetNum > 0 ? Math.min(100, Math.round((spent / budgetNum) * 100)) : 0;
+  const data = [{ name: 'spent', value: pct, fill: pct >= 90 ? 'var(--mantine-color-red-6)' : pct >= 70 ? 'var(--mantine-color-yellow-6)' : 'var(--mantine-color-green-6)' }];
+
+  return (
+    <Card withBorder p="md" radius="md" data-testid="budget-gauge">
+      <Title order={4}>Monthly budget</Title>
+      <Stack gap="xs" mt="sm">
+        <ResponsiveContainer width="100%" height={180}>
+          <RadialBarChart innerRadius="70%" outerRadius="100%" data={data} startAngle={180} endAngle={0}>
+            <PolarAngleAxis type="number" domain={[0, 100]} angleAxisId={0} tick={false} />
+            <RadialBar background dataKey="value" angleAxisId={0} />
+          </RadialBarChart>
+        </ResponsiveContainer>
+        <Group justify="space-between">
+          <Text size="sm" c="dimmed">Spent</Text>
+          <Text fw={600}>{fmt(spent)} / {fmt(budgetNum)} ({pct}%)</Text>
+        </Group>
+      </Stack>
+    </Card>
+  );
+};

--- a/frontend/src/components/analytics/CategorySpendChart.tsx
+++ b/frontend/src/components/analytics/CategorySpendChart.tsx
@@ -1,0 +1,50 @@
+import { Card, Text, Title } from '@mantine/core';
+import React from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { AnalyticsCategorySpendRow } from '../../services/api';
+
+interface CategorySpendChartProps {
+  data: AnalyticsCategorySpendRow[];
+}
+
+const fmtMoney = (n: number) =>
+  n.toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+
+export const CategorySpendChart: React.FC<CategorySpendChartProps> = ({ data }) => {
+  const chartData = data.map((row) => ({
+    category: row.category_name ?? 'Uncategorized',
+    'Internal estimated': Number(row.internal_estimated),
+    'External actual': Number(row.external_actual),
+  }));
+
+  return (
+    <Card withBorder p="md" radius="md" data-testid="category-spend-chart">
+      <Title order={4}>Spend by category</Title>
+      {chartData.length === 0 ? (
+        <Text size="sm" c="dimmed" mt="sm">No work orders attributed to a category in this window.</Text>
+      ) : (
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart data={chartData} margin={{ top: 16, right: 16, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="category" />
+            <YAxis tickFormatter={fmtMoney} />
+            <Tooltip formatter={(value: number) => fmtMoney(value)} />
+            <Legend />
+            <Bar dataKey="Internal estimated" fill="var(--mantine-color-blue-5)" />
+            <Bar dataKey="External actual" fill="var(--mantine-color-orange-6)" />
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </Card>
+  );
+};

--- a/frontend/src/components/analytics/EquipmentStatusGrid.tsx
+++ b/frontend/src/components/analytics/EquipmentStatusGrid.tsx
@@ -1,0 +1,54 @@
+import { Badge, Card, Table, Text, Title } from '@mantine/core';
+import React from 'react';
+
+import type { AnalyticsUtilizationRow } from '../../services/api';
+
+interface EquipmentStatusGridProps {
+  rows: AnalyticsUtilizationRow[];
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  active: 'green',
+  maintenance: 'yellow',
+  testing: 'blue',
+  implementing: 'cyan',
+  retired: 'gray',
+  lost: 'red',
+  donated_out: 'gray',
+};
+
+export const EquipmentStatusGrid: React.FC<EquipmentStatusGridProps> = ({ rows }) => (
+  <Card withBorder p="md" radius="md" data-testid="equipment-status-grid">
+    <Title order={4}>Equipment touched this period</Title>
+    {rows.length === 0 ? (
+      <Text size="sm" c="dimmed" mt="sm">No assets had completed work orders in this window.</Text>
+    ) : (
+      <Table mt="sm" striped highlightOnHover>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Asset</Table.Th>
+            <Table.Th>Category</Table.Th>
+            <Table.Th>Status</Table.Th>
+            <Table.Th ta="right">Hours used</Table.Th>
+            <Table.Th ta="right">Completed WOs</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {rows.map((r) => (
+            <Table.Tr key={r.asset_id}>
+              <Table.Td>{r.asset_name}</Table.Td>
+              <Table.Td>{r.category ?? '—'}</Table.Td>
+              <Table.Td>
+                <Badge color={STATUS_COLORS[r.status] ?? 'gray'} variant="light">
+                  {r.status}
+                </Badge>
+              </Table.Td>
+              <Table.Td ta="right">{r.hours_used}</Table.Td>
+              <Table.Td ta="right">{r.completed_wo_count}</Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    )}
+  </Card>
+);

--- a/frontend/src/components/analytics/MaintenanceForecastList.tsx
+++ b/frontend/src/components/analytics/MaintenanceForecastList.tsx
@@ -1,0 +1,60 @@
+import { Badge, Card, Table, Text, Title } from '@mantine/core';
+import React from 'react';
+
+import type { AnalyticsForecastEntry } from '../../services/api';
+
+interface MaintenanceForecastListProps {
+  entries: AnalyticsForecastEntry[];
+}
+
+const REASON_COLORS: Record<string, string> = {
+  both: 'red',
+  days: 'orange',
+  hours: 'yellow',
+};
+
+const REASON_LABELS: Record<string, string> = {
+  both: 'Hours + days',
+  days: 'Days',
+  hours: 'Hours',
+};
+
+export const MaintenanceForecastList: React.FC<MaintenanceForecastListProps> = ({ entries }) => (
+  <Card withBorder p="md" radius="md" data-testid="maintenance-forecast-list">
+    <Title order={4}>Maintenance forecast</Title>
+    {entries.length === 0 ? (
+      <Text size="sm" c="dimmed" mt="sm">No assets are due for service.</Text>
+    ) : (
+      <Table mt="sm" striped highlightOnHover>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Asset</Table.Th>
+            <Table.Th>Trigger</Table.Th>
+            <Table.Th ta="right">Hours used</Table.Th>
+            <Table.Th ta="right">Days since last WO</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {entries.map((e) => (
+            <Table.Tr key={e.asset_id}>
+              <Table.Td>{e.asset_name}</Table.Td>
+              <Table.Td>
+                <Badge color={REASON_COLORS[e.due_reason] ?? 'gray'} variant="light">
+                  {REASON_LABELS[e.due_reason] ?? e.due_reason}
+                </Badge>
+              </Table.Td>
+              <Table.Td ta="right">
+                {e.hours_used}
+                {e.interval_hours !== null && <Text component="span" size="xs" c="dimmed"> / {e.interval_hours}</Text>}
+              </Table.Td>
+              <Table.Td ta="right">
+                {e.days_since_last_wo ?? '—'}
+                {e.interval_days !== null && <Text component="span" size="xs" c="dimmed"> / {e.interval_days}</Text>}
+              </Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    )}
+  </Card>
+);

--- a/frontend/src/components/analytics/ShareLinkButton.tsx
+++ b/frontend/src/components/analytics/ShareLinkButton.tsx
@@ -1,0 +1,108 @@
+import { Button, CopyButton, Group, Modal, NumberInput, Stack, Text, TextInput, Tooltip } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { IconCheck, IconCopy, IconShare } from '@tabler/icons-react';
+import React, { useState } from 'react';
+
+import { pulseAPI } from '../../services/api';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
+
+interface ShareLinkButtonProps {
+  /** Origin URL to compose into the share link, e.g. window.location.origin. */
+  baseUrl: string;
+}
+
+export const ShareLinkButton: React.FC<ShareLinkButtonProps> = ({ baseUrl }) => {
+  const [opened, { open, close }] = useDisclosure(false);
+  const [ttlDays, setTtlDays] = useState<number | string>(30);
+  const [submitting, setSubmitting] = useState(false);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+
+  const reset = () => {
+    setTtlDays(30);
+    setShareUrl(null);
+  };
+
+  const onClose = () => {
+    close();
+    reset();
+  };
+
+  const onMint = async () => {
+    setSubmitting(true);
+    try {
+      const ttl = typeof ttlDays === 'number' ? ttlDays : parseInt(String(ttlDays), 10);
+      const resp = await pulseAPI.createShare(ttl);
+      const url = `${baseUrl}/analytics/shared?token=${encodeURIComponent(resp.data.token)}`;
+      setShareUrl(url);
+    } catch (err) {
+      notifications.show({
+        color: 'red',
+        title: 'Could not create share link',
+        message: extractErrorMessage(err) ?? 'Unknown error',
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Button leftSection={<IconShare size={16} />} variant="light" onClick={open}>
+        Share with board
+      </Button>
+      <Modal opened={opened} onClose={onClose} title="Share analytics dashboard" size="md">
+        <Stack>
+          <Text size="sm">
+            Generates a signed URL that anyone can use to view the dashboard read-only,
+            even without an OMS account. The URL expires after the chosen number of days.
+          </Text>
+          {shareUrl ? (
+            <Stack gap="xs">
+              <TextInput
+                label="Shareable URL"
+                value={shareUrl}
+                readOnly
+                onFocus={(e) => e.currentTarget.select()}
+                rightSection={
+                  <CopyButton value={shareUrl} timeout={2000}>
+                    {({ copied, copy }) => (
+                      <Tooltip label={copied ? 'Copied' : 'Copy'} withArrow>
+                        <Button size="xs" variant="subtle" onClick={copy} aria-label="Copy share URL">
+                          {copied ? <IconCheck size={16} /> : <IconCopy size={16} />}
+                        </Button>
+                      </Tooltip>
+                    )}
+                  </CopyButton>
+                }
+                rightSectionWidth={48}
+              />
+              <Text size="xs" c="dimmed">
+                Treat this URL as sensitive. Anyone with the link can view the dashboard until it expires.
+                To revoke a leaked link before expiry, rotate <code>ANALYTICS_SHARE_SALT</code> in backend settings.
+              </Text>
+            </Stack>
+          ) : (
+            <NumberInput
+              label="Expires after"
+              description="Days from now (1–365)"
+              value={ttlDays}
+              onChange={setTtlDays}
+              min={1}
+              max={365}
+              data-testid="share-ttl-input"
+            />
+          )}
+          <Group justify="flex-end" mt="sm">
+            <Button variant="subtle" onClick={onClose}>Close</Button>
+            {!shareUrl && (
+              <Button onClick={onMint} loading={submitting} data-testid="share-mint-button">
+                Generate URL
+              </Button>
+            )}
+          </Group>
+        </Stack>
+      </Modal>
+    </>
+  );
+};

--- a/frontend/src/components/analytics/TopUsersTable.tsx
+++ b/frontend/src/components/analytics/TopUsersTable.tsx
@@ -1,0 +1,34 @@
+import { Card, Table, Text, Title } from '@mantine/core';
+import React from 'react';
+
+import type { AnalyticsTopUser } from '../../services/api';
+
+interface TopUsersTableProps {
+  users: AnalyticsTopUser[];
+}
+
+export const TopUsersTable: React.FC<TopUsersTableProps> = ({ users }) => (
+  <Card withBorder p="md" radius="md" data-testid="top-users-table">
+    <Title order={4}>Top contributors</Title>
+    {users.length === 0 ? (
+      <Text size="sm" c="dimmed" mt="sm">No completed work orders in this window.</Text>
+    ) : (
+      <Table mt="sm" striped highlightOnHover>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Member</Table.Th>
+            <Table.Th ta="right">Completed WOs</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {users.map((u) => (
+            <Table.Tr key={u.user_id}>
+              <Table.Td>{u.display_name}</Table.Td>
+              <Table.Td ta="right">{u.completed_wo_count}</Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    )}
+  </Card>
+);

--- a/frontend/src/components/analytics/VolumeTrendChart.tsx
+++ b/frontend/src/components/analytics/VolumeTrendChart.tsx
@@ -1,0 +1,41 @@
+import { Card, Text, Title } from '@mantine/core';
+import React from 'react';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { AnalyticsTrendPoint } from '../../services/api';
+
+interface VolumeTrendChartProps {
+  data: AnalyticsTrendPoint[];
+}
+
+const formatPeriodLabel = (iso: string) => {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, { month: 'short', year: '2-digit' });
+};
+
+export const VolumeTrendChart: React.FC<VolumeTrendChartProps> = ({ data }) => (
+  <Card withBorder p="md" radius="md" data-testid="volume-trend-chart">
+    <Title order={4}>Work order volume — last 12 months</Title>
+    {data.length === 0 ? (
+      <Text size="sm" c="dimmed" mt="sm">No completed work orders in the trend window.</Text>
+    ) : (
+      <ResponsiveContainer width="100%" height={260}>
+        <LineChart data={data} margin={{ top: 16, right: 16, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="period" tickFormatter={formatPeriodLabel} />
+          <YAxis allowDecimals={false} />
+          <Tooltip labelFormatter={formatPeriodLabel} />
+          <Line type="monotone" dataKey="count" stroke="var(--mantine-color-blue-6)" strokeWidth={2} dot={{ r: 3 }} />
+        </LineChart>
+      </ResponsiveContainer>
+    )}
+  </Card>
+);

--- a/frontend/src/pages/AnalyticsDashboardPage.tsx
+++ b/frontend/src/pages/AnalyticsDashboardPage.tsx
@@ -1,0 +1,168 @@
+import {
+  Alert,
+  Card,
+  Container,
+  Grid,
+  Group,
+  Loader,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import { BudgetGauge } from '../components/analytics/BudgetGauge';
+import { CategorySpendChart } from '../components/analytics/CategorySpendChart';
+import { EquipmentStatusGrid } from '../components/analytics/EquipmentStatusGrid';
+import { MaintenanceForecastList } from '../components/analytics/MaintenanceForecastList';
+import { ShareLinkButton } from '../components/analytics/ShareLinkButton';
+import { TopUsersTable } from '../components/analytics/TopUsersTable';
+import { VolumeTrendChart } from '../components/analytics/VolumeTrendChart';
+import { pulseAPI, AnalyticsPulseResponse } from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+interface AnalyticsDashboardPageProps {
+  /**
+   * When true, the page renders the board-shareable view: no share button,
+   * a notice that this is a read-only snapshot, and the token from the URL
+   * is forwarded on the API call. Wired by the parent Route.
+   */
+  shared?: boolean;
+}
+
+const fmtMoney = (raw: string) => {
+  const n = Number(raw);
+  if (!isFinite(n)) return raw;
+  return n.toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 2 });
+};
+
+const SummaryStat: React.FC<{ label: string; value: string; hint?: string; emphasis?: boolean }> = ({
+  label,
+  value,
+  hint,
+  emphasis,
+}) => (
+  <Card withBorder p="md" radius="md">
+    <Text size="sm" c="dimmed" fw={500}>{label}</Text>
+    <Text size="1.6rem" fw={700} c={emphasis ? 'green.7' : undefined}>{value}</Text>
+    {hint && <Text size="xs" c="dimmed" mt={2}>{hint}</Text>}
+  </Card>
+);
+
+export const AnalyticsDashboardPage: React.FC<AnalyticsDashboardPageProps> = ({ shared = false }) => {
+  const [searchParams] = useSearchParams();
+  const [data, setData] = useState<AnalyticsPulseResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const token = shared ? searchParams.get('token') ?? undefined : undefined;
+    setLoading(true);
+    setError(null);
+    pulseAPI
+      .getPulse({ token })
+      .then((resp) => {
+        if (!cancelled) {
+          setData(resp.data);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(extractErrorMessage(err) ?? 'Could not load analytics.');
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [shared, searchParams]);
+
+  if (loading) {
+    return (
+      <Container size="xl" py="xl">
+        <Group justify="center"><Loader /></Group>
+      </Container>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <Container size="xl" py="xl">
+        <Alert color="red" icon={<IconAlertTriangle size={16} />} title="Could not load analytics">
+          {error ?? 'Unknown error'}
+        </Alert>
+      </Container>
+    );
+  }
+
+  const { summary } = data;
+
+  return (
+    <Container size="xl" py="lg">
+      <Group justify="space-between" mb="lg">
+        <Stack gap={2}>
+          <Title order={1}>Makerspace pulse</Title>
+          <Text size="sm" c="dimmed">
+            {summary.period_start} → {summary.period_end}
+            {shared && ' · shared link (read-only)'}
+          </Text>
+        </Stack>
+        {!shared && <ShareLinkButton baseUrl={window.location.origin} />}
+      </Group>
+
+      <Stack gap="lg">
+        <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="md">
+          <SummaryStat
+            label="Net value created"
+            value={fmtMoney(summary.internal_net_value)}
+            hint="External estimate − internal cost"
+            emphasis
+          />
+          <SummaryStat
+            label="External spend (closed)"
+            value={fmtMoney(summary.external_actual_cost)}
+            hint={`${summary.external_closed_count} third-party WO${summary.external_closed_count === 1 ? '' : 's'}`}
+          />
+          <SummaryStat
+            label="Internal WOs completed"
+            value={String(summary.internal_completed_count)}
+          />
+          <SummaryStat
+            label="Total to makerspace"
+            value={fmtMoney(summary.total_value_to_makerspace)}
+            hint="Net internal − external spent"
+          />
+        </SimpleGrid>
+
+        <Grid>
+          <Grid.Col span={{ base: 12, lg: 4 }}>
+            <BudgetGauge budget={data.monthly_budget} externalActualCost={summary.external_actual_cost} />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, lg: 8 }}>
+            <VolumeTrendChart data={data.wo_volume_trend} />
+          </Grid.Col>
+        </Grid>
+
+        <CategorySpendChart data={data.category_spend} />
+
+        <Grid>
+          <Grid.Col span={{ base: 12, lg: 6 }}>
+            <TopUsersTable users={data.top_users} />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, lg: 6 }}>
+            <MaintenanceForecastList entries={data.maintenance_forecast} />
+          </Grid.Col>
+        </Grid>
+
+        <EquipmentStatusGrid rows={data.utilization} />
+      </Stack>
+    </Container>
+  );
+};
+
+export default AnalyticsDashboardPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2140,4 +2140,86 @@ export const thirdPartyMaintenanceAPI = {
   }) => api.post<ThirdPartyQuoteDto>('/maintenance-orders/quotes/', payload),
 };
 
+// Analytics API
+export interface AnalyticsValueSummary {
+  period_start: string;
+  period_end: string;
+  internal_completed_count: number;
+  internal_estimated_external_cost: string;
+  internal_estimated_internal_cost: string;
+  internal_net_value: string;
+  external_closed_count: number;
+  external_actual_cost: string;
+  external_estimated_cost: string;
+  total_value_to_makerspace: string;
+}
+
+export interface AnalyticsTrendPoint {
+  period: string;
+  count: number;
+}
+
+export interface AnalyticsTopUser {
+  user_id: number;
+  username: string;
+  display_name: string;
+  completed_wo_count: number;
+}
+
+export interface AnalyticsUtilizationRow {
+  asset_id: string;
+  asset_name: string;
+  category: string | null;
+  hours_used: number;
+  completed_wo_count: number;
+  status: string;
+}
+
+export interface AnalyticsCategorySpendRow {
+  category_id: number | null;
+  category_name: string | null;
+  internal_estimated: string;
+  external_estimated: string;
+  external_actual: string;
+  internal_wo_count: number;
+  external_wo_count: number;
+}
+
+export interface AnalyticsForecastEntry {
+  asset_id: string;
+  asset_name: string;
+  category: string | null;
+  status: string;
+  hours_used: number;
+  last_completed_wo_at: string | null;
+  interval_hours: number | null;
+  interval_days: number | null;
+  days_since_last_wo: number | null;
+  due_reason: 'hours' | 'days' | 'both';
+}
+
+export interface AnalyticsPulseResponse {
+  summary: AnalyticsValueSummary;
+  wo_volume_trend: AnalyticsTrendPoint[];
+  top_users: AnalyticsTopUser[];
+  utilization: AnalyticsUtilizationRow[];
+  category_spend: AnalyticsCategorySpendRow[];
+  maintenance_forecast: AnalyticsForecastEntry[];
+  monthly_budget: string | null;
+}
+
+export interface AnalyticsShareResponse {
+  token: string;
+  ttl_days: number;
+  expires_in_days: number;
+}
+
+export const pulseAPI = {
+  getPulse: (params?: { start?: string; end?: string; bucket?: 'month' | 'quarter'; token?: string }) =>
+    api.get<AnalyticsPulseResponse>('/analytics/pulse/', { params }),
+
+  createShare: (ttlDays?: number) =>
+    api.post<AnalyticsShareResponse>('/analytics/share/', ttlDays ? { ttl_days: ttlDays } : {}),
+};
+
 export default api;


### PR DESCRIPTION
## Summary

Second of three PRs for the executive analytics work. Layers a React dashboard and a signed-URL bypass on top of PR1's data layer; the monthly email task lands in PR3.

> **Stacked on #387.** This PR's base is `oms-mayor/analytics-pulse-phase-1` so the diff stays focused on PR2 changes. Once #387 merges, the base will auto-rebase to `main`.

## What's in here

### Backend
- **`analytics/services/share_token.py`** — TimestampSigner-based mint+verify. Tokens carry an embedded TTL (default 30 days, max 365). Rotating `ANALYTICS_SHARE_SALT` is the kill-switch for outstanding links. No DB row per token.
- **`analytics/permissions.py`** — `IsAnalyticsViewer` extended to accept `?token=...` alongside the role gate. Added `IsAnalyticsSharer` for the mint endpoint.
- **`analytics/views.py`**:
  - `GET /api/analytics/pulse/` now accepts `?token=...` and includes `monthly_budget` on the summary (read fresh on every request so config changes don't wait for cache expiry).
  - `POST /api/analytics/share/` — staff/SIG-admin only. Mints a token and returns it; the frontend composes the URL.
- **`MONTHLY_BUDGET_TOTAL`** Django setting drives the budget gauge; null when unset.

### Frontend
- New routes:
  - `/analytics` — staff view with `WorkspaceLayout` chrome + Share button.
  - `/analytics/shared` — token-mode view (no chrome) for board members reaching the URL via a signed link.
- **`pages/AnalyticsDashboardPage.tsx`** orchestrator: loading / error / shared modes; forwards `?token=` when shared.
- **`components/analytics/`** — one component per panel:
  - `BudgetGauge` (Recharts RadialBar)
  - `VolumeTrendChart` (Recharts LineChart, last 12 months)
  - `CategorySpendChart` (Recharts BarChart, internal vs external)
  - `TopUsersTable`, `EquipmentStatusGrid`, `MaintenanceForecastList` (Mantine Table)
- **`ShareLinkButton`** — modal that calls `POST /share/`, shows the URL with one-click copy + sensitivity warning.
- **`pulseAPI`** in `services/api.ts` — hand-written types matching the backend JSON. Named distinctly from the existing `analyticsAPI` symbol (which serves the reorder-queue surface).

## Test plan

- [x] Backend: 73 tests in the analytics + log-hours suites pass. New coverage:
  - Token round-trip, signature tampering, expiry by embedded TTL, salt rotation
  - Share endpoint: anonymous denied, volunteer denied, staff/SIG-admin allowed, invalid TTL rejected
  - Pulse: token bypass for anonymous + volunteer; `monthly_budget` set / unset / invalid value
  - Permission matrix drift test green after regenerating YAML + Markdown
- [x] Frontend: Jest smoke test — happy path renders all panels, error path shows alert, shared mode forwards token + hides Share button, budget gauge disabled when null
- [x] `pre-commit run` on touched files: all hooks pass (black, isort, ruff, bandit, django-upgrade, TypeScript compile, npm test)
- [ ] Manual smoke: `/analytics` as staff, `/analytics/shared?token=…` as anonymous in a separate browser

## Out of scope (PR3)

- Celery Beat monthly email task with matplotlib PNG charts
- `analytics-recipients` Django group + `BOARD_REPORT_EMAILS` env recipient resolution
- Dry-run management command for ops/testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)