### PR TITLE
feat(nav): capability-showcase homepage + landing primitives (PR2 of 2)

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,6 +9,17 @@
       content="Makerspace Inventory Management System"
     />
     <title>Makerspace Inventory</title>
+    <!--
+      Display + mono faces used by the landing primitives. Body type stays
+      on the system stack so workspace pages keep their existing rhythm.
+      See frontend/src/styles/landing.css for usage rules.
+    -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/__tests__/components/landing/CapabilityCard.test.tsx
+++ b/frontend/src/__tests__/components/landing/CapabilityCard.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Smoke tests for the shared CapabilityCard primitive (AC-2).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import CapabilityCard from '../../../components/landing/CapabilityCard';
+
+const renderCard = (props: Partial<React.ComponentProps<typeof CapabilityCard>> = {}) =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <CapabilityCard
+          to="/inventory"
+          title="Inventory"
+          description="Items, suppliers, locations."
+          icon={<svg data-testid="card-icon" />}
+          {...props}
+        />
+      </MemoryRouter>
+    </MantineProvider>
+  );
+
+describe('CapabilityCard', () => {
+  it('renders title, description, and icon', () => {
+    renderCard();
+    expect(screen.getByRole('heading', { level: 3, name: /inventory/i })).toBeInTheDocument();
+    expect(screen.getByText(/items, suppliers/i)).toBeInTheDocument();
+    expect(screen.getByTestId('card-icon')).toBeInTheDocument();
+  });
+
+  it('renders the eyebrow when provided', () => {
+    renderCard({ eyebrow: 'Workspace' });
+    expect(screen.getByText(/workspace/i)).toBeInTheDocument();
+  });
+
+  it('renders the staff badge when provided', () => {
+    renderCard({ badge: 'Staff' });
+    expect(screen.getByText('Staff')).toBeInTheDocument();
+  });
+
+  it('uses the custom CTA label when provided', () => {
+    renderCard({ ctaLabel: 'Launch' });
+    expect(screen.getByText(/launch/i)).toBeInTheDocument();
+  });
+
+  it('whole card is a single link to the destination', () => {
+    renderCard({ to: '/inventory/scan' });
+    const link = screen.getByRole('link', { name: /inventory/i });
+    expect(link).toHaveAttribute('href', '/inventory/scan');
+  });
+
+  it('uses the override testId when provided', () => {
+    renderCard({ testId: 'custom-id' });
+    expect(screen.getByTestId('custom-id')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/landing/PageHero.test.tsx
+++ b/frontend/src/__tests__/components/landing/PageHero.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Smoke tests for the shared PageHero primitive (AC-2).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import PageHero from '../../../components/landing/PageHero';
+
+const renderHero = (props: Partial<React.ComponentProps<typeof PageHero>> = {}) =>
+  render(
+    <MantineProvider>
+      <PageHero title="Run the shop." {...props} />
+    </MantineProvider>
+  );
+
+describe('PageHero', () => {
+  it('renders the title as an h1', () => {
+    renderHero();
+    expect(screen.getByRole('heading', { level: 1, name: /run the shop/i })).toBeInTheDocument();
+  });
+
+  it('renders the eyebrow when provided', () => {
+    renderHero({ eyebrow: 'OpenMakerSuite' });
+    expect(screen.getByTestId('page-hero-eyebrow')).toHaveTextContent('OpenMakerSuite');
+  });
+
+  it('omits the eyebrow when not provided', () => {
+    renderHero();
+    expect(screen.queryByTestId('page-hero-eyebrow')).not.toBeInTheDocument();
+  });
+
+  it('renders the description when provided', () => {
+    renderHero({ description: 'One operations layer.' });
+    expect(screen.getByText(/one operations layer/i)).toBeInTheDocument();
+  });
+
+  it('renders the action slot when provided', () => {
+    renderHero({ action: <button>Share</button> });
+    expect(screen.getByTestId('page-hero-action')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /share/i })).toBeInTheDocument();
+  });
+
+  it('omits the action slot when not provided', () => {
+    renderHero();
+    expect(screen.queryByTestId('page-hero-action')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/navigation/routeNavigation.test.tsx
+++ b/frontend/src/__tests__/navigation/routeNavigation.test.tsx
@@ -34,7 +34,7 @@ describe('Workspace overview pages (AC-3, AC-7)', () => {
       expect(screen.getByRole('heading', { level: 1, name: /purchasing/i })).toBeInTheDocument();
       const links = screen.getAllByRole('link');
       expect(links.length).toBeGreaterThanOrEqual(2);
-      expect(screen.getByRole('heading', { level: 4, name: /purchase orders/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /purchase orders/i })).toBeInTheDocument();
     });
   });
 
@@ -42,9 +42,9 @@ describe('Workspace overview pages (AC-3, AC-7)', () => {
     it('renders title + the major child entry points', () => {
       renderWithProviders(<FacilitiesOverviewPage />);
       expect(screen.getByRole('heading', { level: 1, name: /facilities/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /tv dashboard/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /logistics/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /^electrical$/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /tv dashboard/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /logistics/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /^electrical$/i })).toBeInTheDocument();
       const links = screen.getAllByRole('link');
       expect(links.length).toBeGreaterThanOrEqual(5);
     });
@@ -56,10 +56,10 @@ describe('Workspace overview pages (AC-3, AC-7)', () => {
       expect(screen.getByRole('heading', { level: 1, name: /reports/i })).toBeInTheDocument();
       // Use heading role (the card titles) so we don't collide with the
       // accessible-name text inside Link-wrapped cards.
-      expect(screen.getByRole('heading', { level: 4, name: /analytics pulse/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /inventory report/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /purchasing report/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /asset report/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /analytics pulse/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /inventory report/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /purchasing report/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /asset report/i })).toBeInTheDocument();
     });
   });
 
@@ -67,10 +67,10 @@ describe('Workspace overview pages (AC-3, AC-7)', () => {
     it('renders profile + site + webhooks + tax-receipt links', () => {
       renderWithProviders(<SettingsOverviewPage />);
       expect(screen.getByRole('heading', { level: 1, name: /settings/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /^profile$/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /site settings/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /^webhooks$/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /tax receipt lookup/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /^profile$/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /site settings/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /^webhooks$/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /tax receipt lookup/i })).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/__tests__/pages/HomePage.test.tsx
+++ b/frontend/src/__tests__/pages/HomePage.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * HomePage tests (AC-1).
+ *
+ * Asserts every spec-listed capability area is enumerated on the
+ * homepage with an actionable link, and that the Common workflows row
+ * is present. Catches regressions where a workspace silently disappears
+ * from the homepage capability grid.
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import HomePage from '../../pages/HomePage';
+
+// AuthSection talks to the API and renders auth UI. The homepage tests
+// don't need to exercise that surface; render a stub instead.
+jest.mock('../../components/AuthSection', () => () => <div data-testid="auth-section-stub" />);
+// Footer pulls in Mantine + assets we don't care about for these tests.
+jest.mock('../../components/Footer', () => () => <div data-testid="footer-stub" />);
+
+const renderHome = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    </MantineProvider>
+  );
+
+describe('HomePage (AC-1)', () => {
+  it('renders the hero and Common workflows row', () => {
+    renderHome();
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/run the shop/i);
+    expect(screen.getByTestId('home-quick-workflows')).toBeInTheDocument();
+  });
+
+  it('Common workflows row links to scan, dashboard, and maintenance', () => {
+    renderHome();
+    const row = screen.getByTestId('home-quick-workflows');
+    expect(within(row).getByRole('link', { name: /scan a qr code/i }))
+      .toHaveAttribute('href', '/inventory/scan');
+    expect(within(row).getByRole('link', { name: /operations dashboard/i }))
+      .toHaveAttribute('href', '/dashboard');
+    expect(within(row).getByRole('link', { name: /maintenance/i }))
+      .toHaveAttribute('href', '/maintenance');
+  });
+
+  describe('every spec-listed workspace has a CapabilityCard', () => {
+    // Path → expected card title (used to disambiguate when multiple
+    // sections mention the same word).
+    const expected: Array<[string, RegExp]> = [
+      ['/inventory', /^inventory$/i],
+      ['/purchasing', /^purchasing$/i],
+      ['/assets', /^assets$/i],
+      ['/facilities', /^facilities$/i],
+      ['/maintenance', /^maintenance$/i],
+      ['/sigs/dashboard', /^sigs$/i],
+      ['/reports', /^reports$/i],
+      ['/analytics', /analytics pulse/i],
+      ['/settings', /settings/i],
+    ];
+    it.each(expected)('links to %s with title matching %s', (href, _titleRe) => {
+      renderHome();
+      const grid = screen.getByTestId('home-workspaces');
+      const link = within(grid).getByRole('link', { name: _titleRe });
+      expect(link).toHaveAttribute('href', href);
+    });
+  });
+
+  it('badges Analytics Pulse as Staff', () => {
+    renderHome();
+    const grid = screen.getByTestId('home-workspaces');
+    const analyticsCard = within(grid).getByTestId('home-workspace-/analytics');
+    expect(within(analyticsCard).getByText(/staff/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/landing/CapabilityCard.tsx
+++ b/frontend/src/components/landing/CapabilityCard.tsx
@@ -1,0 +1,96 @@
+/**
+ * CapabilityCard — single grid item used on the homepage and every
+ * workspace overview page. Composes:
+ *   - Optional eyebrow (mono caps): a numbered or category label
+ *   - Icon "instrument chip" (Tabler icon on a dark square)
+ *   - Title (sans, semibold)
+ *   - Description (1-3 lines, muted)
+ *   - Optional badge (e.g. "Staff" for gated capabilities)
+ *   - "Open →" affordance that animates on hover
+ *
+ * The whole card is the link (single click target — no accessibility
+ * footgun where the title and the arrow are separate links).
+ *
+ * AC-2: every workspace overview page uses this component, so card
+ * styling stays consistent without per-page duplication.
+ */
+import { Badge, Box, Group, Stack, Text } from '@mantine/core';
+import { IconArrowNarrowRight } from '@tabler/icons-react';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import '../../styles/landing.css';
+
+export interface CapabilityCardProps {
+  /** Destination path. Use absolute paths (e.g. "/inventory/scan"). */
+  to: string;
+  /** Required: card title in body sans. */
+  title: string;
+  /** Required: 1-3 line description shown beneath the title. */
+  description: string;
+  /** Tabler icon component (rendered at 22px on a dark chip). */
+  icon: React.ReactNode;
+  /** Optional eyebrow (mono caps). Use for capability numbering or category. */
+  eyebrow?: string;
+  /** Optional pill badge (e.g. "Staff") shown above the title. */
+  badge?: string;
+  /** Override the call-to-action label; defaults to "Open". */
+  ctaLabel?: string;
+  /** Stable test selector. Defaults to `capability-card-${to}`. */
+  testId?: string;
+}
+
+const CapabilityCard: React.FC<CapabilityCardProps> = ({
+  to,
+  title,
+  description,
+  icon,
+  eyebrow,
+  badge,
+  ctaLabel = 'Open',
+  testId,
+}) => (
+  <Link
+    to={to}
+    className="landing-capability-card"
+    data-testid={testId ?? `capability-card-${to}`}
+    aria-label={title}
+    style={{ padding: '1.4rem' }}
+  >
+    <Stack gap="md" style={{ height: '100%' }}>
+      <Group justify="space-between" align="flex-start" wrap="nowrap">
+        <Box className="landing-icon-chip" aria-hidden>
+          {icon}
+        </Box>
+        {badge && (
+          <Badge color="blue" variant="light" size="sm" radius="sm">
+            {badge}
+          </Badge>
+        )}
+      </Group>
+
+      <Stack gap={6} style={{ flex: 1 }}>
+        {eyebrow && (
+          <Text component="span" className="landing-eyebrow">
+            {eyebrow}
+          </Text>
+        )}
+        <Text component="h3" fw={600} size="lg" style={{ margin: 0, lineHeight: 1.25 }}>
+          {title}
+        </Text>
+        <Text size="sm" c="dimmed" style={{ lineHeight: 1.5 }}>
+          {description}
+        </Text>
+      </Stack>
+
+      <Box>
+        <span className="landing-arrow">
+          {ctaLabel}
+          <IconArrowNarrowRight size={16} stroke={2.4} />
+        </span>
+      </Box>
+    </Stack>
+  </Link>
+);
+
+export default CapabilityCard;

--- a/frontend/src/components/landing/PageHero.tsx
+++ b/frontend/src/components/landing/PageHero.tsx
@@ -1,0 +1,68 @@
+/**
+ * PageHero — the top-of-page banner for the homepage and workspace
+ * overview pages. Renders an optional eyebrow (mono caps), a display
+ * title, an optional description, and an optional action slot
+ * (right-aligned on wide viewports, stacked under the description on
+ * narrow ones).
+ *
+ * Usage:
+ *   <PageHero
+ *     eyebrow="Reports"
+ *     title="Operational + executive reporting"
+ *     description="Pulse, inventory, purchasing, and asset reports."
+ *     action={<ShareLinkButton ... />}
+ *   />
+ *
+ * AC-2: this is the canonical hero used by the homepage and every
+ * workspace landing page so typography + spacing stay consistent.
+ */
+import { Box, Group, Stack, Text } from '@mantine/core';
+import React from 'react';
+
+import '../../styles/landing.css';
+
+export interface PageHeroProps {
+  eyebrow?: string;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  action?: React.ReactNode;
+}
+
+const PageHero: React.FC<PageHeroProps> = ({ eyebrow, title, description, action }) => (
+  <Box component="header" data-testid="page-hero" mb="xl">
+    <Group justify="space-between" align="flex-end" wrap="wrap" gap="md">
+      <Stack gap="xs" style={{ flex: '1 1 360px' }}>
+        {eyebrow && (
+          <Text component="span" className="landing-eyebrow" data-testid="page-hero-eyebrow">
+            {eyebrow}
+          </Text>
+        )}
+        <Text
+          component="h1"
+          className="landing-display"
+          data-testid="page-hero-title"
+          style={{ fontSize: 'clamp(1.9rem, 3.4vw, 2.7rem)', margin: 0 }}
+        >
+          {title}
+        </Text>
+        {description && (
+          <Text
+            size="md"
+            c="dimmed"
+            data-testid="page-hero-description"
+            style={{ maxWidth: 64 * 8 }}
+          >
+            {description}
+          </Text>
+        )}
+      </Stack>
+      {action && (
+        <Box data-testid="page-hero-action" style={{ flexShrink: 0 }}>
+          {action}
+        </Box>
+      )}
+    </Group>
+  </Box>
+);
+
+export default PageHero;

--- a/frontend/src/components/landing/WorkspaceLanding.tsx
+++ b/frontend/src/components/landing/WorkspaceLanding.tsx
@@ -1,0 +1,67 @@
+/**
+ * WorkspaceLanding — page shell composed of <PageHero> + a card grid +
+ * an optional footer slot. Used by every workspace overview page so
+ * spacing, typography, and card rhythm stay identical (AC-2).
+ *
+ * Pass capability cards as `children`; this component handles the
+ * SimpleGrid layout and the warm-paper landing surface. If a workspace
+ * needs more bespoke content beneath the grid (e.g. a list of recent
+ * activity), put it in `footer`.
+ *
+ * Usage:
+ *   <WorkspaceLanding
+ *     hero={{ eyebrow: "Reports", title: "...", description: "..." }}
+ *   >
+ *     <CapabilityCard ... />
+ *     <CapabilityCard ... />
+ *   </WorkspaceLanding>
+ */
+import { Box, Container, SimpleGrid, Stack } from '@mantine/core';
+import React from 'react';
+
+import '../../styles/landing.css';
+import PageHero, { PageHeroProps } from './PageHero';
+
+export interface WorkspaceLandingProps {
+  /** Hero props passed straight to <PageHero>. */
+  hero: PageHeroProps;
+  /**
+   * Capability cards to lay out in a responsive grid. The grid is 1/2/3
+   * columns at base/sm/lg breakpoints — matches the existing dashboard
+   * stat-card pattern so workspaces feel rhythmically consistent.
+   */
+  children?: React.ReactNode;
+  /**
+   * Optional content rendered below the capability grid (e.g. recent
+   * activity, "what changed last month" callouts).
+   */
+  footer?: React.ReactNode;
+  /** Override the column count if the workspace has fewer cards. */
+  cols?: { base?: number; sm?: number; lg?: number };
+  /** Stable test selector. */
+  testId?: string;
+}
+
+const WorkspaceLanding: React.FC<WorkspaceLandingProps> = ({
+  hero,
+  children,
+  footer,
+  cols = { base: 1, sm: 2, lg: 3 },
+  testId = 'workspace-landing',
+}) => (
+  <Box className="landing-surface" data-testid={testId}>
+    <Container size="xl" py="xl">
+      <Stack gap="xl">
+        <PageHero {...hero} />
+        {children && (
+          <SimpleGrid cols={cols} spacing="md" verticalSpacing="md">
+            {children}
+          </SimpleGrid>
+        )}
+        {footer && <Box>{footer}</Box>}
+      </Stack>
+    </Container>
+  </Box>
+);
+
+export default WorkspaceLanding;

--- a/frontend/src/pages/AnalyticsDashboardPage.tsx
+++ b/frontend/src/pages/AnalyticsDashboardPage.tsx
@@ -8,7 +8,6 @@ import {
   SimpleGrid,
   Stack,
   Text,
-  Title,
 } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
@@ -21,6 +20,7 @@ import { MaintenanceForecastList } from '../components/analytics/MaintenanceFore
 import { ShareLinkButton } from '../components/analytics/ShareLinkButton';
 import { TopUsersTable } from '../components/analytics/TopUsersTable';
 import { VolumeTrendChart } from '../components/analytics/VolumeTrendChart';
+import PageHero from '../components/landing/PageHero';
 import { pulseAPI, AnalyticsPulseResponse } from '../services/api';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
 
@@ -104,16 +104,12 @@ export const AnalyticsDashboardPage: React.FC<AnalyticsDashboardPageProps> = ({ 
 
   return (
     <Container size="xl" py="lg">
-      <Group justify="space-between" mb="lg">
-        <Stack gap={2}>
-          <Title order={1}>Makerspace pulse</Title>
-          <Text size="sm" c="dimmed">
-            {summary.period_start} → {summary.period_end}
-            {shared && ' · shared link (read-only)'}
-          </Text>
-        </Stack>
-        {!shared && <ShareLinkButton baseUrl={window.location.origin} />}
-      </Group>
+      <PageHero
+        eyebrow="Analytics pulse"
+        title="Makerspace pulse"
+        description={`${summary.period_start} → ${summary.period_end}${shared ? ' · shared link (read-only)' : ''}`}
+        action={!shared ? <ShareLinkButton baseUrl={window.location.origin} /> : undefined}
+      />
 
       <Stack gap="lg">
         <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="md">

--- a/frontend/src/pages/FacilitiesOverviewPage.tsx
+++ b/frontend/src/pages/FacilitiesOverviewPage.tsx
@@ -1,10 +1,8 @@
 /**
- * Landing page for the Facilities workspace. Same shape as the other
- * overview pages added in this PR: a card grid with one entry per major
- * child route. Lives at `/facilities/` so breadcrumb clicks have a real
- * destination (was previously a 404).
+ * Landing page for the Facilities workspace, mounted at `/facilities/`.
+ * Refactored in nav-cohesion PR2 to use the shared <WorkspaceLanding>
+ * + <CapabilityCard> primitives.
  */
-import { Card, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import {
   IconBolt,
   IconBox,
@@ -15,90 +13,77 @@ import {
   IconTruck,
 } from '@tabler/icons-react';
 import React from 'react';
-import { Link } from 'react-router-dom';
 
-interface OverviewItem {
-  to: string;
-  title: string;
-  description: string;
-  icon: React.ReactNode;
-}
-
-const ITEMS: OverviewItem[] = [
-  {
-    to: '/facilities/tv-dashboard',
-    title: 'TV dashboard',
-    description: 'Full-screen status board for shop displays.',
-    icon: <IconDeviceTv size={28} />,
-  },
-  {
-    to: '/facilities/logistics',
-    title: 'Logistics dashboard',
-    description: 'Logistics view of open work, reorders, and location problems.',
-    icon: <IconTruck size={28} />,
-  },
-  {
-    to: '/facilities/screens',
-    title: 'Screens',
-    description: 'Configure kiosk and display screens.',
-    icon: <IconScreenshot size={28} />,
-  },
-  {
-    to: '/facilities/maker-boxes',
-    title: 'Maker boxes',
-    description: 'Inventory and check-out activity for member maker boxes.',
-    icon: <IconBox size={28} />,
-  },
-  {
-    to: '/facilities/electrical',
-    title: 'Electrical',
-    description: 'Breakers, outlets, light switches, and network drops.',
-    icon: <IconBolt size={28} />,
-  },
-  {
-    to: '/facilities/forgekey-devices',
-    title: 'ForgeKey devices',
-    description: 'Door, locker, and equipment-control devices on the ForgeKey bus.',
-    icon: <IconKey size={28} />,
-  },
-  {
-    to: '/facilities/checklist',
-    title: 'Checklists',
-    description: 'Recurring opening, closing, and safety walk-through checklists.',
-    icon: <IconChecklist size={28} />,
-  },
-];
+import CapabilityCard from '../components/landing/CapabilityCard';
+import WorkspaceLanding from '../components/landing/WorkspaceLanding';
 
 const FacilitiesOverviewPage: React.FC = () => (
-  <Container size="xl" py="lg">
-    <Stack gap="xl">
-      <Stack gap={4}>
-        <Title order={1}>Facilities</Title>
-        <Text c="dimmed">Operations dashboards, kiosks, and the physical-plant systems that keep the shop running.</Text>
-      </Stack>
-
-      <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
-        {ITEMS.map((item) => (
-          <Card
-            key={item.to}
-            withBorder
-            radius="md"
-            p="lg"
-            component={Link}
-            to={item.to}
-            data-testid={`facilities-overview-card-${item.to}`}
-            style={{ textDecoration: 'none', color: 'inherit' }}
-          >
-            <Stack gap="sm">
-              <Text c="blue.7">{item.icon}</Text>
-              <Title order={4}>{item.title}</Title>
-              <Text size="sm" c="dimmed">{item.description}</Text>
-            </Stack>
-          </Card>
-        ))}
-      </SimpleGrid>
-    </Stack>
-  </Container>
+  <WorkspaceLanding
+    testId="facilities-overview"
+    hero={{
+      eyebrow: 'Facilities',
+      title: 'Facilities',
+      description:
+        'Operations dashboards, kiosks, and the physical-plant systems that keep the shop running.',
+    }}
+  >
+    <CapabilityCard
+      to="/facilities/tv-dashboard"
+      title="TV dashboard"
+      description="Full-screen status board for shop displays."
+      icon={<IconDeviceTv size={22} stroke={1.8} />}
+      eyebrow="Display"
+      testId="facilities-overview-card-/facilities/tv-dashboard"
+    />
+    <CapabilityCard
+      to="/facilities/logistics"
+      title="Logistics dashboard"
+      description="Logistics view of open work, reorders, and location problems."
+      icon={<IconTruck size={22} stroke={1.8} />}
+      eyebrow="Display"
+      testId="facilities-overview-card-/facilities/logistics"
+    />
+    <CapabilityCard
+      to="/facilities/screens"
+      title="Screens"
+      description="Configure kiosk and display screens."
+      icon={<IconScreenshot size={22} stroke={1.8} />}
+      eyebrow="Setup"
+      testId="facilities-overview-card-/facilities/screens"
+    />
+    <CapabilityCard
+      to="/facilities/maker-boxes"
+      title="Maker boxes"
+      description="Inventory and check-out activity for member maker boxes."
+      icon={<IconBox size={22} stroke={1.8} />}
+      eyebrow="Members"
+      testId="facilities-overview-card-/facilities/maker-boxes"
+    />
+    <CapabilityCard
+      to="/facilities/electrical"
+      title="Electrical"
+      description="Breakers, outlets, light switches, and network drops."
+      icon={<IconBolt size={22} stroke={1.8} />}
+      eyebrow="Plant"
+      testId="facilities-overview-card-/facilities/electrical"
+    />
+    <CapabilityCard
+      to="/facilities/forgekey-devices"
+      title="ForgeKey devices"
+      description="Door, locker, and equipment-control devices on the ForgeKey bus."
+      icon={<IconKey size={22} stroke={1.8} />}
+      eyebrow="Access"
+      testId="facilities-overview-card-/facilities/forgekey-devices"
+    />
+    <CapabilityCard
+      to="/facilities/checklist"
+      title="Checklists"
+      description="Recurring opening, closing, and safety walk-through checklists."
+      icon={<IconChecklist size={22} stroke={1.8} />}
+      eyebrow="Routine"
+      testId="facilities-overview-card-/facilities/checklist"
+    />
+  </WorkspaceLanding>
 );
 
 export default FacilitiesOverviewPage;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,17 +1,149 @@
 /**
- * Home Page
- * Landing page with links to scan items, admin dashboard, and authentication
+ * Home Page (`/`).
+ *
+ * Capability-showcase landing for OpenMakerSuite (AC-1). Lists every
+ * top-level workspace as a CapabilityCard with a 1-line value prop and
+ * a deep link, plus a "Common workflows" quick-action row at the top
+ * for the highest-traffic flows (scan, dashboard, work orders).
+ *
+ * Uses the same PageHero + CapabilityCard primitives the workspace
+ * overview pages use, so visuals stay continuous across the app (AC-2).
  */
+import { Box, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import {
+  IconAdjustments,
+  IconBoxSeam,
+  IconBuildingFactory2,
+  IconChartBar,
+  IconChartLine,
+  IconClipboardList,
+  IconLayoutDashboard,
+  IconQrcode,
+  IconReceipt,
+  IconShoppingCart,
+  IconStack2,
+  IconUsersGroup,
+  IconTool,
+} from '@tabler/icons-react';
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+
 import AuthSection from '../components/AuthSection';
 import Footer from '../components/Footer';
-import '../styles/HomePage.css';
+import CapabilityCard from '../components/landing/CapabilityCard';
+import PageHero from '../components/landing/PageHero';
+import '../styles/landing.css';
+
+interface Capability {
+  to: string;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  eyebrow: string;
+  badge?: string;
+}
+
+/**
+ * Most-used workflows surfaced above the workspace grid. Kept short so
+ * a member arriving at /, with a phone in hand, can act in one tap.
+ */
+const QUICK_WORKFLOWS: Capability[] = [
+  {
+    to: '/inventory/scan',
+    title: 'Scan a QR code',
+    description: 'Look up a shelf, asset, or fixture from a printed label.',
+    icon: <IconQrcode size={22} stroke={1.8} />,
+    eyebrow: '01 / Quick',
+  },
+  {
+    to: '/dashboard',
+    title: 'Operations dashboard',
+    description: 'Live status across reorders, deliveries, and asset problems.',
+    icon: <IconLayoutDashboard size={22} stroke={1.8} />,
+    eyebrow: '02 / Quick',
+  },
+  {
+    to: '/maintenance',
+    title: 'Maintenance + work orders',
+    description: 'Open the PM dashboard, queue up scheduled work, log completions.',
+    icon: <IconClipboardList size={22} stroke={1.8} />,
+    eyebrow: '03 / Quick',
+  },
+];
+
+/**
+ * Every top-level workspace. Order matches the sidebar so navigation
+ * patterns are reinforced rather than competing.
+ */
+const WORKSPACES: Capability[] = [
+  {
+    to: '/inventory',
+    title: 'Inventory',
+    description: 'Items, suppliers, locations, and the QR-coded scan workflows the shop runs on.',
+    icon: <IconBoxSeam size={22} stroke={1.8} />,
+    eyebrow: 'Inventory',
+  },
+  {
+    to: '/purchasing',
+    title: 'Purchasing',
+    description: 'Purchase orders, suggested reorders, and the public transparency ledger.',
+    icon: <IconShoppingCart size={22} stroke={1.8} />,
+    eyebrow: 'Purchasing',
+  },
+  {
+    to: '/assets',
+    title: 'Assets',
+    description: 'Equipment register: lifecycle, ownership, maintenance plans, and parts.',
+    icon: <IconStack2 size={22} stroke={1.8} />,
+    eyebrow: 'Assets',
+  },
+  {
+    to: '/facilities',
+    title: 'Facilities',
+    description: 'Operations dashboards, kiosks, electrical, ForgeKey devices, and checklists.',
+    icon: <IconBuildingFactory2 size={22} stroke={1.8} />,
+    eyebrow: 'Facilities',
+  },
+  {
+    to: '/maintenance',
+    title: 'Maintenance',
+    description: 'Preventive maintenance, work orders, and third-party vendor coordination.',
+    icon: <IconTool size={22} stroke={1.8} />,
+    eyebrow: 'Maintenance',
+  },
+  {
+    to: '/sigs/dashboard',
+    title: 'SIGs',
+    description: 'Special Interest Group operations: members, assets, and SIG-owned inventory.',
+    icon: <IconUsersGroup size={22} stroke={1.8} />,
+    eyebrow: 'Community',
+  },
+  {
+    to: '/reports',
+    title: 'Reports',
+    description: 'Operational reports across inventory, purchasing, and assets.',
+    icon: <IconChartBar size={22} stroke={1.8} />,
+    eyebrow: 'Reports',
+  },
+  {
+    to: '/analytics',
+    title: 'Analytics pulse',
+    description: 'Executive dashboard: ROI, utilization, category spend, and the maintenance forecast.',
+    icon: <IconChartLine size={22} stroke={1.8} />,
+    eyebrow: 'Reports',
+    badge: 'Staff',
+  },
+  {
+    to: '/settings',
+    title: 'Settings + integrations',
+    description: 'Profile, organization configuration, webhooks, and tax-receipt tooling.',
+    icon: <IconAdjustments size={22} stroke={1.8} />,
+    eyebrow: 'Admin',
+  },
+];
 
 const HomePage: React.FC = () => {
-  const navigate = useNavigate();
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [username, setUsername] = useState('');
+  const [, setIsLoggedIn] = useState(false);
+  const [, setUsername] = useState('');
 
   const handleAuthChange = (loggedIn: boolean, user?: string) => {
     setIsLoggedIn(loggedIn);
@@ -19,106 +151,70 @@ const HomePage: React.FC = () => {
   };
 
   return (
-    <div className="home-page">
-      <div className="hero">
-        <h1> Dallas Makerspace Inventory Management</h1>
-        <p className="tagline">Scan. Track. Reorder. Simple.</p>
-      </div>
+    <Box className="landing-surface" data-testid="home-page">
+      <Container size="xl" py="xl">
+        <Stack gap="xl">
+          <PageHero
+            eyebrow="OpenMakerSuite"
+            title="Run the shop."
+            description="One operations layer for the makerspace — inventory, equipment, maintenance, purchasing, and the analytics that show your members what they get back from the room."
+          />
 
-      <AuthSection onAuthChange={handleAuthChange} />
+          <Box>
+            <AuthSection onAuthChange={handleAuthChange} />
+          </Box>
 
-      <div className="card-grid">
-        <div className="feature-card">
-          <div className="icon">📱</div>
-          <h2>Scan QR Code</h2>
-          <p>
-            Scan the QR code on any item shelf label to view details and submit
-            reorder requests.
-          </p>
-          <p className="instruction">
-            Use your phone camera to scan the QR codes on inventory labels.
-          </p>
-        </div>
+          <Stack gap="md" data-testid="home-quick-workflows">
+            <Stack gap={2}>
+              <Text component="span" className="landing-eyebrow">Common workflows</Text>
+              <Title order={2} className="landing-display" style={{ fontSize: '1.4rem', margin: 0 }}>
+                Start here
+              </Title>
+            </Stack>
+            <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
+              {QUICK_WORKFLOWS.map((c) => (
+                <CapabilityCard
+                  key={c.to}
+                  to={c.to}
+                  title={c.title}
+                  description={c.description}
+                  icon={c.icon}
+                  eyebrow={c.eyebrow}
+                  testId={`home-quick-${c.to}`}
+                  ctaLabel="Go"
+                />
+              ))}
+            </SimpleGrid>
+          </Stack>
 
-        <div className="feature-card" onClick={() => navigate('/inventory/admin')}>
-          <div className="icon">⚙️</div>
-          <h2>{isLoggedIn ? 'Admin Dashboard' : 'Admin Dashboard'}</h2>
-          <p>
-            {isLoggedIn
-              ? 'Manage reorder queue, approve requests, and process bulk orders by supplier.'
-              : 'View pending reorder requests and manage inventory workflow (login for enhanced features).'
-            }
-          </p>
-          <button className="card-button">
-            {isLoggedIn ? `Go to Dashboard (${username})` : 'Go to Dashboard'}
-          </button>
-        </div>
+          <hr className="landing-rule" />
 
-        <div className="feature-card">
-          <div className="icon">📊</div>
-          <h2>Features</h2>
-          <ul className="feature-list">
-            <li>Automatic QR code generation</li>
-            <li>3x5" printable index cards</li>
-            <li>Lead time tracking</li>
-            <li>Multi-supplier support</li>
-            <li>Stock level monitoring</li>
-          </ul>
-        </div>
-
-        <div className="feature-card" onClick={() => navigate('/facilities/tv-dashboard')}>
-          <div className="icon">📺</div>
-          <h2>TV Dashboard</h2>
-          <p>
-            Large-screen display optimized for Chromecast and TV viewing.
-            Shows items that have been reordered and are in progress with delivery tracking.
-          </p>
-          <button className="card-button">
-            Open TV Dashboard
-          </button>
-        </div>
-
-        <div className="feature-card" onClick={() => navigate('/facilities/logistics')}>
-          <div className="icon">🚛</div>
-          <h2>Logistics Display</h2>
-          <p>
-            FireTV-friendly board for the logistics bay. Highlights refill requests, open purchase orders,
-            and progress toward delivery.
-          </p>
-          <button className="card-button">
-            Launch Logistics Dashboard
-          </button>
-        </div>
-      </div>
-
-      <div className="info-section">
-        <h2>How It Works</h2>
-        <div className="steps">
-          <div className="step">
-            <div className="step-number">1</div>
-            <h3>Create Item</h3>
-            <p>Add inventory items via Django admin with photos, descriptions, and reorder quantities.</p>
-          </div>
-          <div className="step">
-            <div className="step-number">2</div>
-            <h3>Generate Labels</h3>
-            <p>Print 3x5" index cards with QR codes to laminate and hang from shelves.</p>
-          </div>
-          <div className="step">
-            <div className="step-number">3</div>
-            <h3>Scan & Request</h3>
-            <p>Users scan QR codes when items run low and submit reorder requests.</p>
-          </div>
-          <div className="step">
-            <div className="step-number">4</div>
-            <h3>Admin Review</h3>
-            <p>Admins review requests, generate supplier cart links, and track deliveries.</p>
-          </div>
-        </div>
-      </div>
-
+          <Stack gap="md" data-testid="home-workspaces">
+            <Stack gap={2}>
+              <Text component="span" className="landing-eyebrow">Workspaces</Text>
+              <Title order={2} className="landing-display" style={{ fontSize: '1.4rem', margin: 0 }}>
+                Everything OpenMakerSuite covers
+              </Title>
+            </Stack>
+            <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
+              {WORKSPACES.map((w) => (
+                <CapabilityCard
+                  key={w.to}
+                  to={w.to}
+                  title={w.title}
+                  description={w.description}
+                  icon={w.icon}
+                  eyebrow={w.eyebrow}
+                  badge={w.badge}
+                  testId={`home-workspace-${w.to}`}
+                />
+              ))}
+            </SimpleGrid>
+          </Stack>
+        </Stack>
+      </Container>
       <Footer />
-    </div>
+    </Box>
   );
 };
 

--- a/frontend/src/pages/PurchasingOverviewPage.tsx
+++ b/frontend/src/pages/PurchasingOverviewPage.tsx
@@ -1,74 +1,49 @@
 /**
- * Landing page for the Purchasing workspace. Listed under
- * `/purchasing/` so breadcrumb clicks on the "Purchasing" segment have
- * a real destination (was previously a 404).
- *
- * Layout uses Mantine primitives directly; PR2 will refactor onto the
- * shared <CapabilityCard> / <PageHero> / <WorkspaceLanding> components.
+ * Landing page for the Purchasing workspace, mounted at `/purchasing/`.
+ * Refactored in nav-cohesion PR2 to use the shared <WorkspaceLanding>
+ * + <CapabilityCard> primitives so it matches the homepage rhythm.
  */
-import { Card, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import { IconClipboardList, IconPlus, IconReceipt } from '@tabler/icons-react';
 import React from 'react';
-import { Link } from 'react-router-dom';
 
-interface OverviewItem {
-  to: string;
-  title: string;
-  description: string;
-  icon: React.ReactNode;
-}
-
-const ITEMS: OverviewItem[] = [
-  {
-    to: '/purchasing/orders',
-    title: 'Purchase orders',
-    description: 'Open the queue of pending and recent purchase orders.',
-    icon: <IconClipboardList size={28} />,
-  },
-  {
-    to: '/purchasing/orders/new',
-    title: 'New purchase order',
-    description: 'Start a new purchase order from suggested reorders or a blank template.',
-    icon: <IconPlus size={28} />,
-  },
-  {
-    to: '/inventory/transparency',
-    title: 'Transparency ledger',
-    description: 'Public-facing view of recent reorder activity for membership transparency.',
-    icon: <IconReceipt size={28} />,
-  },
-];
+import CapabilityCard from '../components/landing/CapabilityCard';
+import WorkspaceLanding from '../components/landing/WorkspaceLanding';
 
 const PurchasingOverviewPage: React.FC = () => (
-  <Container size="xl" py="lg">
-    <Stack gap="xl">
-      <Stack gap={4}>
-        <Title order={1}>Purchasing</Title>
-        <Text c="dimmed">Manage purchase orders, reorder requests, and vendor transparency.</Text>
-      </Stack>
-
-      <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
-        {ITEMS.map((item) => (
-          <Card
-            key={item.to}
-            withBorder
-            radius="md"
-            p="lg"
-            component={Link}
-            to={item.to}
-            data-testid={`purchasing-overview-card-${item.to}`}
-            style={{ textDecoration: 'none', color: 'inherit' }}
-          >
-            <Stack gap="sm">
-              <Text c="blue.7">{item.icon}</Text>
-              <Title order={4}>{item.title}</Title>
-              <Text size="sm" c="dimmed">{item.description}</Text>
-            </Stack>
-          </Card>
-        ))}
-      </SimpleGrid>
-    </Stack>
-  </Container>
+  <WorkspaceLanding
+    testId="purchasing-overview"
+    hero={{
+      eyebrow: 'Purchasing',
+      title: 'Purchasing',
+      description:
+        'Manage purchase orders, reorder requests, and the public transparency ledger.',
+    }}
+  >
+    <CapabilityCard
+      to="/purchasing/orders"
+      title="Purchase orders"
+      description="Open the queue of pending and recent purchase orders."
+      icon={<IconClipboardList size={22} stroke={1.8} />}
+      eyebrow="Workflow"
+      testId="purchasing-overview-card-/purchasing/orders"
+    />
+    <CapabilityCard
+      to="/purchasing/orders/new"
+      title="New purchase order"
+      description="Start a new purchase order from suggested reorders or a blank template."
+      icon={<IconPlus size={22} stroke={1.8} />}
+      eyebrow="Action"
+      testId="purchasing-overview-card-/purchasing/orders/new"
+    />
+    <CapabilityCard
+      to="/inventory/transparency"
+      title="Transparency ledger"
+      description="Public-facing view of recent reorder activity for membership transparency."
+      icon={<IconReceipt size={22} stroke={1.8} />}
+      eyebrow="Public"
+      testId="purchasing-overview-card-/inventory/transparency"
+    />
+  </WorkspaceLanding>
 );
 
 export default PurchasingOverviewPage;

--- a/frontend/src/pages/ReportsOverviewPage.tsx
+++ b/frontend/src/pages/ReportsOverviewPage.tsx
@@ -1,9 +1,8 @@
 /**
- * Landing page for the Reports workspace. Same shape as the other
- * overview pages added in this PR. Includes the new Analytics Pulse
- * dashboard so it is reachable through breadcrumb + sidebar navigation.
+ * Landing page for the Reports workspace, mounted at `/reports/`.
+ * Refactored in nav-cohesion PR2 to use the shared <WorkspaceLanding>
+ * + <CapabilityCard> primitives.
  */
-import { Card, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import {
   IconChartBar,
   IconReportAnalytics,
@@ -11,73 +10,54 @@ import {
   IconStack,
 } from '@tabler/icons-react';
 import React from 'react';
-import { Link } from 'react-router-dom';
 
-interface OverviewItem {
-  to: string;
-  title: string;
-  description: string;
-  icon: React.ReactNode;
-}
-
-const ITEMS: OverviewItem[] = [
-  {
-    to: '/analytics',
-    title: 'Analytics pulse',
-    description:
-      'Executive dashboard: ROI, utilization, category spend, and the maintenance forecast. Source for the monthly board email.',
-    icon: <IconChartBar size={28} />,
-  },
-  {
-    to: '/reports/inventory',
-    title: 'Inventory report',
-    description: 'Stock levels, low-stock alerts, and item-level activity.',
-    icon: <IconStack size={28} />,
-  },
-  {
-    to: '/reports/purchasing',
-    title: 'Purchasing report',
-    description: 'Spend by supplier, vendor performance, and reorder cycle metrics.',
-    icon: <IconShoppingCart size={28} />,
-  },
-  {
-    to: '/reports/assets',
-    title: 'Asset report',
-    description: 'Asset roster, lifecycle status, and maintenance history.',
-    icon: <IconReportAnalytics size={28} />,
-  },
-];
+import CapabilityCard from '../components/landing/CapabilityCard';
+import WorkspaceLanding from '../components/landing/WorkspaceLanding';
 
 const ReportsOverviewPage: React.FC = () => (
-  <Container size="xl" py="lg">
-    <Stack gap="xl">
-      <Stack gap={4}>
-        <Title order={1}>Reports</Title>
-        <Text c="dimmed">Operational and executive reports across inventory, purchasing, assets, and the analytics pulse.</Text>
-      </Stack>
-
-      <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
-        {ITEMS.map((item) => (
-          <Card
-            key={item.to}
-            withBorder
-            radius="md"
-            p="lg"
-            component={Link}
-            to={item.to}
-            data-testid={`reports-overview-card-${item.to}`}
-            style={{ textDecoration: 'none', color: 'inherit' }}
-          >
-            <Stack gap="sm">
-              <Text c="blue.7">{item.icon}</Text>
-              <Title order={4}>{item.title}</Title>
-              <Text size="sm" c="dimmed">{item.description}</Text>
-            </Stack>
-          </Card>
-        ))}
-      </SimpleGrid>
-    </Stack>
-  </Container>
+  <WorkspaceLanding
+    testId="reports-overview"
+    hero={{
+      eyebrow: 'Reports',
+      title: 'Reports',
+      description:
+        'Operational and executive reports across inventory, purchasing, assets, and the analytics pulse.',
+    }}
+  >
+    <CapabilityCard
+      to="/analytics"
+      title="Analytics pulse"
+      description="Executive dashboard: ROI, utilization, category spend, and the maintenance forecast. Source for the monthly board email."
+      icon={<IconChartBar size={22} stroke={1.8} />}
+      eyebrow="Executive"
+      badge="Staff"
+      testId="reports-overview-card-/analytics"
+    />
+    <CapabilityCard
+      to="/reports/inventory"
+      title="Inventory report"
+      description="Stock levels, low-stock alerts, and item-level activity."
+      icon={<IconStack size={22} stroke={1.8} />}
+      eyebrow="Operational"
+      testId="reports-overview-card-/reports/inventory"
+    />
+    <CapabilityCard
+      to="/reports/purchasing"
+      title="Purchasing report"
+      description="Spend by supplier, vendor performance, and reorder cycle metrics."
+      icon={<IconShoppingCart size={22} stroke={1.8} />}
+      eyebrow="Operational"
+      testId="reports-overview-card-/reports/purchasing"
+    />
+    <CapabilityCard
+      to="/reports/assets"
+      title="Asset report"
+      description="Asset roster, lifecycle status, and maintenance history."
+      icon={<IconReportAnalytics size={22} stroke={1.8} />}
+      eyebrow="Operational"
+      testId="reports-overview-card-/reports/assets"
+    />
+  </WorkspaceLanding>
 );
 
 export default ReportsOverviewPage;

--- a/frontend/src/pages/SettingsOverviewPage.tsx
+++ b/frontend/src/pages/SettingsOverviewPage.tsx
@@ -1,76 +1,56 @@
 /**
- * Landing page for the Settings workspace. Same shape as the other
- * overview pages added in this PR.
+ * Landing page for the Settings workspace, mounted at `/settings/`.
+ * Refactored in nav-cohesion PR2 to use the shared <WorkspaceLanding>
+ * + <CapabilityCard> primitives.
  */
-import { Card, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import { IconAdjustments, IconReceipt, IconUser, IconWebhook } from '@tabler/icons-react';
 import React from 'react';
-import { Link } from 'react-router-dom';
 
-interface OverviewItem {
-  to: string;
-  title: string;
-  description: string;
-  icon: React.ReactNode;
-}
-
-const ITEMS: OverviewItem[] = [
-  {
-    to: '/settings/profile',
-    title: 'Profile',
-    description: 'Manage your account, contact info, and notification preferences.',
-    icon: <IconUser size={28} />,
-  },
-  {
-    to: '/settings/site',
-    title: 'Site settings',
-    description: 'Organization-wide configuration for OpenMakerSuite.',
-    icon: <IconAdjustments size={28} />,
-  },
-  {
-    to: '/settings/webhooks',
-    title: 'Webhooks',
-    description: 'Outbound webhook endpoints and delivery history.',
-    icon: <IconWebhook size={28} />,
-  },
-  {
-    to: '/settings/tax-receipt/lookup',
-    title: 'Tax receipt lookup',
-    description: 'Look up an issued donor tax receipt by donation reference.',
-    icon: <IconReceipt size={28} />,
-  },
-];
+import CapabilityCard from '../components/landing/CapabilityCard';
+import WorkspaceLanding from '../components/landing/WorkspaceLanding';
 
 const SettingsOverviewPage: React.FC = () => (
-  <Container size="xl" py="lg">
-    <Stack gap="xl">
-      <Stack gap={4}>
-        <Title order={1}>Settings</Title>
-        <Text c="dimmed">Account, organization, and integration configuration.</Text>
-      </Stack>
-
-      <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
-        {ITEMS.map((item) => (
-          <Card
-            key={item.to}
-            withBorder
-            radius="md"
-            p="lg"
-            component={Link}
-            to={item.to}
-            data-testid={`settings-overview-card-${item.to}`}
-            style={{ textDecoration: 'none', color: 'inherit' }}
-          >
-            <Stack gap="sm">
-              <Text c="blue.7">{item.icon}</Text>
-              <Title order={4}>{item.title}</Title>
-              <Text size="sm" c="dimmed">{item.description}</Text>
-            </Stack>
-          </Card>
-        ))}
-      </SimpleGrid>
-    </Stack>
-  </Container>
+  <WorkspaceLanding
+    testId="settings-overview"
+    hero={{
+      eyebrow: 'Settings',
+      title: 'Settings',
+      description: 'Account, organization, and integration configuration.',
+    }}
+  >
+    <CapabilityCard
+      to="/settings/profile"
+      title="Profile"
+      description="Manage your account, contact info, and notification preferences."
+      icon={<IconUser size={22} stroke={1.8} />}
+      eyebrow="Account"
+      testId="settings-overview-card-/settings/profile"
+    />
+    <CapabilityCard
+      to="/settings/site"
+      title="Site settings"
+      description="Organization-wide configuration for OpenMakerSuite."
+      icon={<IconAdjustments size={22} stroke={1.8} />}
+      eyebrow="Org"
+      testId="settings-overview-card-/settings/site"
+    />
+    <CapabilityCard
+      to="/settings/webhooks"
+      title="Webhooks"
+      description="Outbound webhook endpoints and delivery history."
+      icon={<IconWebhook size={22} stroke={1.8} />}
+      eyebrow="Integrations"
+      testId="settings-overview-card-/settings/webhooks"
+    />
+    <CapabilityCard
+      to="/settings/tax-receipt/lookup"
+      title="Tax receipt lookup"
+      description="Look up an issued donor tax receipt by donation reference."
+      icon={<IconReceipt size={22} stroke={1.8} />}
+      eyebrow="Tools"
+      testId="settings-overview-card-/settings/tax-receipt/lookup"
+    />
+  </WorkspaceLanding>
 );
 
 export default SettingsOverviewPage;

--- a/frontend/src/styles/landing.css
+++ b/frontend/src/styles/landing.css
@@ -1,0 +1,130 @@
+/**
+ * Design tokens for the homepage + workspace overview pages.
+ *
+ * Aesthetic direction: refined editorial × industrial control panel.
+ * - Display: DM Serif Display gives section titles weight without
+ *   shouting; pairs with the system sans body to keep workspace pages
+ *   continuous with everything else in the app.
+ * - Mono accents (IBM Plex Mono) for eyebrow labels — channels the
+ *   "instrument label" feel without dressing every page in monospace.
+ *
+ * Tokens are scoped to .landing-surface so workspace pages that opt out
+ * (e.g. data-grid pages) don't pick them up by accident.
+ */
+
+:root {
+  --landing-display-font: 'DM Serif Display', 'Iowan Old Style', 'Cambria',
+    'Georgia', serif;
+  --landing-mono-font: 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo,
+    Consolas, monospace;
+
+  --landing-surface-bg: #faf8f4;
+  --landing-card-bg: #ffffff;
+  --landing-card-border: rgba(15, 23, 42, 0.08);
+  --landing-card-border-hover: rgba(25, 113, 194, 0.45);
+  --landing-card-shadow-hover: 0 18px 40px -28px rgba(15, 23, 42, 0.4);
+
+  --landing-eyebrow: #6b7280;
+  --landing-text: #111827;
+  --landing-muted: #4b5563;
+  --landing-rule: rgba(15, 23, 42, 0.08);
+
+  --landing-accent: #1971c2;
+  --landing-accent-soft: #e7f1fb;
+  --landing-chip-bg: #1a1a1a;
+  --landing-chip-fg: #f5f1e8;
+
+  --landing-radius: 14px;
+}
+
+/*
+ * Apply the warm-paper background only when a page opts in by wrapping
+ * its content in `.landing-surface`. Workspace pages already on white
+ * Mantine cards stay unchanged.
+ */
+.landing-surface {
+  background: var(--landing-surface-bg);
+  min-height: 100%;
+}
+
+/* Display headings inside landing surfaces. */
+.landing-display {
+  font-family: var(--landing-display-font);
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  line-height: 1.05;
+  color: var(--landing-text);
+}
+
+.landing-eyebrow {
+  font-family: var(--landing-mono-font);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--landing-eyebrow);
+}
+
+/* Capability card hover — subtle lift, no parallax tricks. */
+.landing-capability-card {
+  background: var(--landing-card-bg);
+  border: 1px solid var(--landing-card-border);
+  border-radius: var(--landing-radius);
+  transition: border-color 160ms ease, transform 160ms ease,
+    box-shadow 160ms ease;
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.landing-capability-card:hover {
+  border-color: var(--landing-card-border-hover);
+  transform: translateY(-2px);
+  box-shadow: var(--landing-card-shadow-hover);
+}
+
+.landing-capability-card:focus-visible {
+  outline: 2px solid var(--landing-accent);
+  outline-offset: 3px;
+}
+
+.landing-icon-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: var(--landing-chip-bg);
+  color: var(--landing-chip-fg);
+}
+
+.landing-arrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--landing-accent);
+  font-weight: 500;
+  font-size: 0.9rem;
+  transition: gap 160ms ease;
+}
+
+.landing-capability-card:hover .landing-arrow {
+  gap: 10px;
+}
+
+.landing-rule {
+  border: 0;
+  border-top: 1px solid var(--landing-rule);
+  margin: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .landing-capability-card,
+  .landing-arrow {
+    transition: none;
+  }
+  .landing-capability-card:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary

Final PR of the **navigation cohesion + homepage capability showcase** epic. Closes **AC-1, AC-2**, and the remaining **AC-6** surface. Builds on PR1's route-correctness foundation (#391).

> **Stacked on #391** so the new homepage / overview-page primitives sit cleanly on top of the route map + 4 overview pages PR1 introduced.

## Three reusable primitives — `components/landing/`

| Component | Role |
|---|---|
| **`<PageHero>`** | Eyebrow + display title + description + optional action slot. Right-aligned action on wide viewports, stacks under description on narrow. |
| **`<CapabilityCard>`** | Single grid item: icon "instrument chip" + optional eyebrow / staff badge + title (h3) + description + animated CTA arrow. Whole card is one `<Link>`. |
| **`<WorkspaceLanding>`** | `<PageHero>` + responsive `SimpleGrid` + optional footer slot. Every workspace overview page composes this. |

## Aesthetic — refined editorial × industrial control panel

- **Display**: DM Serif Display for hero / section titles. Pairs with the system sans body so workspace pages still feel continuous.
- **Mono accents**: IBM Plex Mono for eyebrow caps (`INVENTORY`, `01 / QUICK`). Channels "instrument label" feel without dressing every page in monospace.
- **Surface**: warm-paper background (`#faf8f4`) only on `.landing-surface`-wrapped pages; data-grid pages stay on the existing Mantine white-card baseline.
- **No npm deps added** — fonts loaded via preconnected `<link>`s in `index.html`.

## Homepage redesign

Replaces the previous 5-emoji-card + step-by-step layout with:
1. `<PageHero>` — bold "Run the shop." headline
2. `<AuthSection>` (unchanged — login/logout)
3. **Common workflows** quick-action row: scan, ops dashboard, maintenance
4. **Workspaces** grid — 9 capability cards covering inventory, purchasing, assets, facilities, maintenance, SIGs, reports, **analytics pulse** (staff-badged), settings

Each card has a 1-line value prop and an actionable `<Link>` to its workspace overview page.

## Workspace pages refactored onto the new primitives

- `PurchasingOverviewPage`, `FacilitiesOverviewPage`, `ReportsOverviewPage`, `SettingsOverviewPage` — now `<WorkspaceLanding>` + N `<CapabilityCard>`s instead of rolling their own Mantine `Container` + `Title` + `Card` grids.
- **`AnalyticsDashboardPage`** swaps its bespoke hero for `<PageHero>` with the `ShareLinkButton` wired into the action slot. Visually matches the homepage now without touching data-fetching / panel composition.

That's **6 pages** sharing the same primitives — well past AC-2's "homepage + at least 2 workspace landing pages" minimum.

## Test plan

- [x] **16 new tests** + migration of existing nav tests:
  - `__tests__/components/landing/PageHero.test.tsx` — eyebrow/title/description/action slot rendering
  - `__tests__/components/landing/CapabilityCard.test.tsx` — title/desc/icon/eyebrow/badge/CTA/whole-card-link
  - `__tests__/pages/HomePage.test.tsx` — every spec-listed workspace appears in the capability grid with the correct href; Common workflows row points at scan/dashboard/maintenance; Analytics is staff-badged
  - `__tests__/navigation/routeNavigation.test.tsx` — migrated from `level: 4` heading queries to `level: 3` to match `CapabilityCard`'s title element
- [x] **Full frontend suite**: 559 passed, 73 suites, 0 TypeScript errors in `src/`
- [x] `pre-commit run` on touched files — TypeScript compile + npm test gates green
- [ ] Manual smoke: `/` renders new homepage, capability cards click through to overview pages, Analytics card lands on the live dashboard

## AC coverage (full epic)

| AC | Status | Where |
|----|--------|-------|
| AC-1 Homepage capability sections | ✅ this PR | New `HomePage.tsx` |
| AC-2 Consistent design system | ✅ this PR | 3 primitives + 6 pages composed |
| AC-3 Breadcrumbs never lead to blank pages | ✅ #391 | New overview pages + `clickable: false` flag |
| AC-4 Only routable ancestors clickable | ✅ #391 | `routeMap.ts` + Breadcrumbs span fallback |
| AC-5 Canonical labels | ✅ #391 | Route map covers all workspaces |
| AC-6 Encoded as tests | ✅ both PRs | 73 nav-related cases across both PRs |
| AC-7 Dead-link prevention | ✅ both PRs | `entryPoints.test.tsx` + new overview pages + new homepage |

🤖 Generated with [Claude Code](https://claude.com/claude-code)