### PR TITLE
chore(restack): land the 4 stranded PRs (#388, #389, #391, #392) onto main

### DIFF
--- a/backend/analytics/management/commands/send_monthly_pulse.py
+++ b/backend/analytics/management/commands/send_monthly_pulse.py
@@ -1,0 +1,95 @@
+"""``manage.py send_monthly_pulse`` — fire (or dry-run) the monthly pulse email.
+
+The Celery Beat schedule auto-runs ``send_monthly_pulse_email`` at 09:00 on
+the 1st of each month over the prior calendar month. This command lets ops
+staff run the same body manually for testing, backfill, or to verify
+recipient resolution after changing ``BOARD_REPORT_EMAILS`` /
+``analytics-recipients`` group membership.
+
+Examples:
+    python manage.py send_monthly_pulse --dry-run
+    python manage.py send_monthly_pulse --month=2026-04
+    python manage.py send_monthly_pulse --month=2026-04 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+
+from django.core.management.base import BaseCommand, CommandError
+
+from analytics.tasks import send_monthly_pulse
+
+
+def _month_arg(value: str) -> tuple[date, date]:
+    try:
+        year_str, month_str = value.split("-", 1)
+        year = int(year_str)
+        month = int(month_str)
+    except (ValueError, AttributeError) as exc:
+        raise argparse.ArgumentTypeError(f"--month must be YYYY-MM, got {value!r}") from exc
+    if not (1 <= month <= 12):
+        raise argparse.ArgumentTypeError(f"--month month must be 1-12, got {month}")
+    start = date(year, month, 1)
+    # End is exclusive: first of the following month.
+    end = date(year + 1, 1, 1) if month == 12 else date(year, month + 1, 1)
+    return start, end
+
+
+class Command(BaseCommand):
+    help = "Send the monthly analytics pulse email (or preview with --dry-run)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--month",
+            type=_month_arg,
+            default=None,
+            help="Override the reporting window in YYYY-MM. Defaults to the prior calendar month.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Resolve recipients + render the email but do not send.",
+        )
+
+    def handle(self, *args, **options):
+        period_start = period_end = None
+        if options["month"]:
+            period_start, period_end = options["month"]
+
+        try:
+            result = send_monthly_pulse(
+                period_start=period_start,
+                period_end=period_end,
+                dry_run=options["dry_run"],
+            )
+        except Exception as exc:
+            raise CommandError(str(exc)) from exc
+
+        recipients = result["recipients"]
+        if not recipients:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"No recipients resolved (BOARD_REPORT_EMAILS empty + analytics-recipients group empty). "
+                    f"Window {result['period_start']}..{result['period_end']}."
+                )
+            )
+            return
+
+        if result["sent"]:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Sent monthly pulse for {result['period_start']}..{result['period_end']} "
+                    f"to {len(recipients)} recipient(s)."
+                )
+            )
+        else:
+            self.stdout.write(
+                self.style.NOTICE(
+                    f"Dry-run: rendered monthly pulse for {result['period_start']}..{result['period_end']} "
+                    f"for {len(recipients)} recipient(s) ({result['reason']})."
+                )
+            )
+            for addr in recipients:
+                self.stdout.write(f"  - {addr}")

--- a/backend/analytics/permissions.py
+++ b/backend/analytics/permissions.py
@@ -1,18 +1,47 @@
 """DRF permissions for analytics endpoints.
 
-Reuses ``membership.is_staff_or_sig_admin`` for the role gate so analytics
-follows the same access surface as work-order writes (gh #374). PR2 will
-extend this with a signed-URL bypass for board members without OMS
-accounts.
+Two access modes:
+
+1. **Authenticated role gate** — staff, superuser, Logistics, or any SIG
+   admin (matches the WO-write rule from gh #374).
+2. **Signed-URL bypass** — a valid ``?token=<signed>`` query parameter
+   lets even unauthenticated callers read the dashboard. Used to share
+   the analytics view with board members who don't have OMS accounts.
+   Tokens are minted by the staff-gated ``/api/analytics/share/`` endpoint.
+
+The token bypass applies only to read endpoints. Writes (e.g. minting a
+new token) still require the authenticated role gate.
 """
 
 from rest_framework.permissions import BasePermission
 
 from membership.utils import is_staff_or_sig_admin
 
+from .services.share_token import InvalidShareToken, verify_share_token
+
+
+def _has_valid_share_token(request) -> bool:
+    token = request.query_params.get("token")
+    if not token:
+        return False
+    try:
+        verify_share_token(token)
+    except InvalidShareToken:
+        return False
+    return True
+
 
 class IsAnalyticsViewer(BasePermission):
-    """Allow staff, superuser, Logistics, or any SIG admin to view analytics."""
+    """Authenticated staff/SIG admin OR a valid signed share token."""
+
+    def has_permission(self, request, view):
+        if is_staff_or_sig_admin(request.user):
+            return True
+        return _has_valid_share_token(request)
+
+
+class IsAnalyticsSharer(BasePermission):
+    """Only authenticated staff / SIG admins may mint share tokens."""
 
     def has_permission(self, request, view):
         return is_staff_or_sig_admin(request.user)

--- a/backend/analytics/services/email_charts.py
+++ b/backend/analytics/services/email_charts.py
@@ -1,0 +1,119 @@
+"""Server-side PNG chart generation for the monthly pulse email.
+
+We use matplotlib's headless ``Agg`` backend so this runs in worker
+containers without GUI deps. Each function returns ``bytes`` ready to
+attach inline via the ``cid:`` reference in the HTML template.
+
+Charts are deliberately simple:
+- Email clients are a hostile rendering target; rich interactivity
+  belongs on the live dashboard, which the email links to.
+- Fonts are matplotlib defaults (DejaVu) — no external font dependency.
+- Color palette mirrors the dashboard so screenshots feel familiar.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Sequence
+
+import matplotlib
+
+matplotlib.use("Agg")  # noqa: E402 — must precede pyplot import.
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+CHART_DPI = 110
+CHART_FIGSIZE = (7.0, 3.2)  # inches; renders ~770x352 at 110 DPI
+COLOR_INTERNAL = "#1971C2"  # Mantine blue-7
+COLOR_EXTERNAL = "#E8590C"  # Mantine orange-7
+COLOR_VOLUME = "#1864AB"
+
+
+def _figure_to_png_bytes(fig) -> bytes:
+    fig.tight_layout()
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=CHART_DPI, bbox_inches="tight")
+    plt.close(fig)
+    return buf.getvalue()
+
+
+def render_volume_trend_png(trend: Sequence[dict]) -> bytes:
+    """Return PNG bytes for the 12-month WO volume line chart."""
+    fig, ax = plt.subplots(figsize=CHART_FIGSIZE, dpi=CHART_DPI)
+    if not trend:
+        ax.text(
+            0.5,
+            0.5,
+            "No completed work orders in the trend window.",
+            ha="center",
+            va="center",
+            color="#888",
+        )
+        ax.axis("off")
+        return _figure_to_png_bytes(fig)
+
+    labels = [_short_period(row["period"]) for row in trend]
+    counts = [int(row["count"]) for row in trend]
+
+    ax.plot(labels, counts, color=COLOR_VOLUME, marker="o", linewidth=2)
+    ax.fill_between(range(len(counts)), counts, alpha=0.1, color=COLOR_VOLUME)
+    ax.set_title("Work order volume — last 12 months", fontsize=12, color="#222")
+    ax.set_ylabel("Completed WOs")
+    ax.grid(True, axis="y", linestyle="--", alpha=0.5)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    fig.autofmt_xdate(rotation=30, ha="right")
+    return _figure_to_png_bytes(fig)
+
+
+def render_category_spend_png(rows: Sequence[dict]) -> bytes:
+    """Return PNG bytes for the grouped-bar 'Spend by category' chart."""
+    fig, ax = plt.subplots(figsize=CHART_FIGSIZE, dpi=CHART_DPI)
+    if not rows:
+        ax.text(
+            0.5,
+            0.5,
+            "No work orders attributed to a category in this window.",
+            ha="center",
+            va="center",
+            color="#888",
+        )
+        ax.axis("off")
+        return _figure_to_png_bytes(fig)
+
+    labels = [row["category_name"] or "Uncategorized" for row in rows]
+    internal = [float(row["internal_estimated"]) for row in rows]
+    external = [float(row["external_actual"]) for row in rows]
+
+    x = list(range(len(labels)))
+    width = 0.4
+    ax.bar(
+        [i - width / 2 for i in x],
+        internal,
+        width,
+        label="Internal estimated",
+        color=COLOR_INTERNAL,
+    )
+    ax.bar(
+        [i + width / 2 for i in x], external, width, label="External actual", color=COLOR_EXTERNAL
+    )
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, rotation=20, ha="right")
+    ax.set_ylabel("USD")
+    ax.set_title("Spend by category", fontsize=12, color="#222")
+    ax.grid(True, axis="y", linestyle="--", alpha=0.5)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.legend(loc="upper right", frameon=False, fontsize=9)
+    return _figure_to_png_bytes(fig)
+
+
+def _short_period(iso_date: str) -> str:
+    """``2026-04-01`` → ``Apr '26`` for compact x-axis ticks."""
+    from datetime import date
+
+    try:
+        d = date.fromisoformat(iso_date)
+    except (TypeError, ValueError):
+        return iso_date
+    return d.strftime("%b '%y")

--- a/backend/analytics/services/recipients.py
+++ b/backend/analytics/services/recipients.py
@@ -1,0 +1,85 @@
+"""Recipient resolution for the monthly analytics pulse email.
+
+Two sources, deduped on lowercase address:
+
+1. ``settings.BOARD_REPORT_EMAILS`` — comma-separated list of addresses
+   for board members or stakeholders without OMS accounts.
+2. ``analytics-recipients`` Django ``Group`` — staff or members who opted
+   in via their profile and have a valid email on the user record.
+
+The group is created on first read (``Group.objects.get_or_create``) so
+admins can immediately assign users to it without a separate seed step.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+
+ANALYTICS_GROUP_NAME = "analytics-recipients"
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+User = get_user_model()
+
+
+def _split_env_emails(raw) -> list[str]:
+    if not raw:
+        return []
+    if isinstance(raw, (list, tuple, set)):
+        items = raw
+    else:
+        items = re.split(r"[,;\s]+", str(raw))
+    return [s.strip() for s in items if s and s.strip()]
+
+
+def _is_valid_email(value: str) -> bool:
+    return bool(_EMAIL_RE.match(value))
+
+
+def _ensure_group() -> Group:
+    group, _ = Group.objects.get_or_create(name=ANALYTICS_GROUP_NAME)
+    return group
+
+
+def get_analytics_group() -> Group:
+    """Return the ``analytics-recipients`` group, creating it if absent."""
+    return _ensure_group()
+
+
+def _group_member_emails() -> Iterable[str]:
+    group = _ensure_group()
+    return (
+        User.objects.filter(groups=group, is_active=True)
+        .exclude(email="")
+        .values_list("email", flat=True)
+    )
+
+
+def resolve_pulse_recipients() -> list[str]:
+    """Return the deduped list of pulse-email recipients.
+
+    Comparison is case-insensitive; the returned addresses preserve the
+    *first* casing seen so admin-set addresses look how the admin typed
+    them. Invalid addresses are silently dropped.
+    """
+    env_raw = getattr(settings, "BOARD_REPORT_EMAILS", "")
+
+    seen: dict[str, str] = {}  # lowercase → original
+
+    def _add(addr: str) -> None:
+        if not _is_valid_email(addr):
+            return
+        key = addr.lower()
+        if key not in seen:
+            seen[key] = addr
+
+    for addr in _split_env_emails(env_raw):
+        _add(addr)
+    for addr in _group_member_emails():
+        _add(addr)
+
+    return list(seen.values())

--- a/backend/analytics/services/share_token.py
+++ b/backend/analytics/services/share_token.py
@@ -1,0 +1,78 @@
+"""Signed-URL share tokens for the analytics dashboard.
+
+Built on Django's ``TimestampSigner`` so we can stamp an expiry without
+needing a database row per token. The signature is derived from
+``SECRET_KEY`` plus the salt below; rotating the salt invalidates every
+outstanding token (the kill-switch).
+
+Tokens are intentionally minimal: they carry only a ``v1`` marker so we
+can change the format later without breaking older URLs gracefully. They
+are *not* per-user — anyone with the URL can view the dashboard until it
+expires.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.conf import settings
+from django.core.signing import BadSignature, SignatureExpired, TimestampSigner
+
+SHARE_TOKEN_SALT_SETTING = "ANALYTICS_SHARE_SALT"
+DEFAULT_TTL_DAYS = 30
+MAX_TTL_DAYS = 365
+TOKEN_PAYLOAD_V1 = "v1"
+
+
+class InvalidShareToken(Exception):
+    """Raised when a token is malformed, tampered with, or expired."""
+
+
+def _signer() -> TimestampSigner:
+    salt = getattr(settings, SHARE_TOKEN_SALT_SETTING, "analytics-share-v1")
+    return TimestampSigner(salt=salt)
+
+
+def mint_share_token(ttl_days: int = DEFAULT_TTL_DAYS) -> str:
+    """Return a signed token good for ``ttl_days`` days.
+
+    Caller is responsible for clamping ``ttl_days`` to its desired range
+    before reaching here; we still cap at ``MAX_TTL_DAYS`` defensively.
+    """
+    if ttl_days <= 0:
+        raise ValueError("ttl_days must be positive")
+    if ttl_days > MAX_TTL_DAYS:
+        ttl_days = MAX_TTL_DAYS
+    return _signer().sign(f"{TOKEN_PAYLOAD_V1}:{ttl_days}")
+
+
+def verify_share_token(token: str) -> int:
+    """Return the original ttl_days when valid, else raise InvalidShareToken.
+
+    Validates both the signature and the embedded TTL — a token signed
+    yesterday with ``ttl_days=1`` will be rejected today even though the
+    signature itself is fine.
+    """
+    try:
+        unsigned = _signer().unsign(token, max_age=timedelta(days=MAX_TTL_DAYS))
+    except SignatureExpired as exc:
+        raise InvalidShareToken("token expired") from exc
+    except BadSignature as exc:
+        raise InvalidShareToken("invalid signature") from exc
+
+    try:
+        version, ttl_str = unsigned.split(":", 1)
+        ttl_days = int(ttl_str)
+    except (ValueError, AttributeError) as exc:
+        raise InvalidShareToken("malformed payload") from exc
+
+    if version != TOKEN_PAYLOAD_V1:
+        raise InvalidShareToken(f"unsupported token version {version!r}")
+
+    # Re-check the embedded TTL — TimestampSigner only enforces MAX_TTL_DAYS above.
+    try:
+        _signer().unsign(token, max_age=timedelta(days=ttl_days))
+    except SignatureExpired as exc:
+        raise InvalidShareToken("token expired") from exc
+
+    return ttl_days

--- a/backend/analytics/services/share_token.py
+++ b/backend/analytics/services/share_token.py
@@ -18,10 +18,13 @@ from datetime import timedelta
 from django.conf import settings
 from django.core.signing import BadSignature, SignatureExpired, TimestampSigner
 
-SHARE_TOKEN_SALT_SETTING = "ANALYTICS_SHARE_SALT"
+# Both constants below are *names* (a Django settings key + a payload
+# version marker), not secrets. ``# nosec B105`` quiets bandit's
+# hardcoded-password heuristic.
+SHARE_TOKEN_SALT_SETTING = "ANALYTICS_SHARE_SALT"  # nosec B105
 DEFAULT_TTL_DAYS = 30
 MAX_TTL_DAYS = 365
-TOKEN_PAYLOAD_V1 = "v1"
+TOKEN_PAYLOAD_V1 = "v1"  # nosec B105
 
 
 class InvalidShareToken(Exception):

--- a/backend/analytics/tasks.py
+++ b/backend/analytics/tasks.py
@@ -1,0 +1,226 @@
+"""Celery tasks for the analytics app.
+
+The monthly pulse task is scheduled by Celery Beat to fire at 09:00 on the
+1st of each month (see ``CELERY_BEAT_SCHEDULE`` in ``config.settings``).
+The same body powers the ``send_monthly_pulse`` management command for
+ad-hoc / dry-run use.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from decimal import Decimal, InvalidOperation
+from email.mime.image import MIMEImage
+from typing import Iterable
+
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+from django.template.loader import render_to_string
+
+from celery import shared_task
+
+from .services.aggregation import category_spend, top_users, value_summary, wo_volume
+from .services.email_charts import render_category_spend_png, render_volume_trend_png
+from .services.forecast import maintenance_forecast
+from .services.recipients import resolve_pulse_recipients
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TREND_MONTHS = 12
+
+DUE_REASON_LABELS = {
+    "both": "Hours + days",
+    "days": "Days",
+    "hours": "Hours",
+}
+
+
+def previous_month_window(today: date | None = None) -> tuple[date, date]:
+    """Return ``(start, end)`` for the calendar month *before* ``today``.
+
+    End is exclusive; start is the first of that month.
+    """
+    today = today or date.today()
+    end = today.replace(day=1)  # exclusive bound: first of current month
+    start = (end - timedelta(days=1)).replace(day=1)
+    return start, end
+
+
+def trend_window_ending(end: date, months: int = DEFAULT_TREND_MONTHS) -> tuple[date, date]:
+    start = end
+    for _ in range(months):
+        start = (start - timedelta(days=1)).replace(day=1)
+    return start, end
+
+
+def _fmt_money(raw: str) -> str:
+    try:
+        n = Decimal(str(raw))
+    except (InvalidOperation, TypeError):
+        return str(raw)
+    return f"${n:,.2f}"
+
+
+def _enriched_summary(summary: dict) -> dict:
+    """Add ``*_fmt`` USD-formatted strings on top of the raw summary."""
+    enriched = dict(summary)
+    for key in (
+        "internal_estimated_external_cost",
+        "internal_estimated_internal_cost",
+        "internal_net_value",
+        "external_actual_cost",
+        "external_estimated_cost",
+        "total_value_to_makerspace",
+    ):
+        enriched[f"{key}_fmt"] = _fmt_money(summary[key])
+    return enriched
+
+
+def _enriched_forecast(forecast_entries: Iterable[dict]) -> list[dict]:
+    return [
+        {
+            **entry,
+            "due_reason_label": DUE_REASON_LABELS.get(entry["due_reason"], entry["due_reason"]),
+        }
+        for entry in forecast_entries
+    ]
+
+
+def _build_payload(period_start: date, period_end: date) -> dict:
+    """Pull the same aggregates the live dashboard uses, for one window."""
+    trend_start, trend_end = trend_window_ending(period_end)
+    return {
+        "summary": value_summary(period_start, period_end),
+        "trend": wo_volume(trend_start, trend_end, bucket="month"),
+        "top_users": top_users(period_start, period_end, limit=5),
+        "category_spend": category_spend(period_start, period_end),
+        "forecast": maintenance_forecast(),
+    }
+
+
+def _period_label(start: date) -> str:
+    return start.strftime("%B %Y")
+
+
+def _build_email(
+    *,
+    recipients: list[str],
+    period_start: date,
+    period_end: date,
+    payload: dict,
+) -> EmailMultiAlternatives:
+    context = {
+        "period_label": _period_label(period_start),
+        "period_start": period_start,
+        "period_end": period_end,
+        "summary": _enriched_summary(payload["summary"]),
+        "top_users": payload["top_users"],
+        "forecast": _enriched_forecast(payload["forecast"]),
+        "dashboard_url": getattr(settings, "ANALYTICS_DASHBOARD_URL", ""),
+    }
+    subject = f"Makerspace pulse — {context['period_label']}"
+    text_body = render_to_string("emails/monthly_pulse.txt", context)
+    html_body = render_to_string("emails/monthly_pulse.html", context)
+
+    message = EmailMultiAlternatives(
+        subject=subject,
+        body=text_body,
+        from_email=getattr(settings, "DEFAULT_FROM_EMAIL", None),
+        to=recipients,
+    )
+    message.attach_alternative(html_body, "text/html")
+    message.mixed_subtype = "related"  # so cid: refs work in HTML
+
+    for cid, png_bytes in (
+        ("volume_trend.png", render_volume_trend_png(payload["trend"])),
+        ("category_spend.png", render_category_spend_png(payload["category_spend"])),
+    ):
+        img = MIMEImage(png_bytes, _subtype="png")
+        img.add_header("Content-ID", f"<{cid}>")
+        img.add_header("Content-Disposition", "inline", filename=cid)
+        message.attach(img)
+
+    return message
+
+
+def send_monthly_pulse(
+    *,
+    period_start: date | None = None,
+    period_end: date | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Render and (optionally) send the monthly pulse email.
+
+    Returns a dict with ``recipients``, ``period_start``, ``period_end``,
+    ``sent`` (bool), and ``reason`` when not sent. Used directly by the
+    management command and indirectly by the Celery task.
+    """
+    if (period_start is None) != (period_end is None):
+        raise ValueError("Provide both period_start and period_end, or neither")
+    if period_start is None or period_end is None:
+        period_start, period_end = previous_month_window()
+
+    recipients = resolve_pulse_recipients()
+    if not recipients:
+        logger.warning(
+            "Monthly pulse not sent for %s..%s — no recipients configured",
+            period_start,
+            period_end,
+        )
+        return {
+            "recipients": [],
+            "period_start": period_start.isoformat(),
+            "period_end": period_end.isoformat(),
+            "sent": False,
+            "reason": "no recipients configured",
+        }
+
+    payload = _build_payload(period_start, period_end)
+    message = _build_email(
+        recipients=recipients,
+        period_start=period_start,
+        period_end=period_end,
+        payload=payload,
+    )
+
+    if dry_run:
+        logger.info(
+            "Dry-run: would send monthly pulse for %s..%s to %d recipient(s)",
+            period_start,
+            period_end,
+            len(recipients),
+        )
+        return {
+            "recipients": recipients,
+            "period_start": period_start.isoformat(),
+            "period_end": period_end.isoformat(),
+            "sent": False,
+            "reason": "dry-run",
+        }
+
+    sent_count = message.send(fail_silently=False)
+    logger.info(
+        "Sent monthly pulse for %s..%s to %d recipient(s)",
+        period_start,
+        period_end,
+        sent_count,
+    )
+    return {
+        "recipients": recipients,
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+        "sent": True,
+        "reason": None,
+    }
+
+
+@shared_task(bind=True, ignore_result=True, name="analytics.send_monthly_pulse_email")
+def send_monthly_pulse_email(self):
+    """Celery entry-point fired by Beat at 09:00 on the 1st of each month."""
+    try:
+        return send_monthly_pulse()
+    except Exception:
+        logger.exception("send_monthly_pulse_email failed")
+        # Re-raise so the Celery result backend records the failure.
+        raise

--- a/backend/analytics/templates/emails/monthly_pulse.html
+++ b/backend/analytics/templates/emails/monthly_pulse.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Monthly pulse — {{ period_label }}</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; color: #222; line-height: 1.5; max-width: 720px; margin: 0 auto; padding: 1em;">
+
+  <h1 style="margin-bottom: 0.25em; color: #1864ab;">Makerspace pulse</h1>
+  <p style="margin-top: 0; color: #555;">{{ period_label }}</p>
+
+  <h2 style="border-bottom: 1px solid #eee; padding-bottom: 0.25em;">Headline</h2>
+  <table cellpadding="8" cellspacing="0" style="border-collapse: collapse; width: 100%; margin-bottom: 1.5em;">
+    <tr>
+      <td style="background:#f1f8ff; border-radius:4px;">
+        <div style="font-size:12px; color:#555; text-transform: uppercase; letter-spacing: 0.05em;">Net value created</div>
+        <div style="font-size:1.6em; font-weight:700; color:#2f9e44;">{{ summary.internal_net_value_fmt }}</div>
+        <div style="font-size:11px; color:#888;">External estimate − internal cost</div>
+      </td>
+      <td style="background:#fff4e6; border-radius:4px;">
+        <div style="font-size:12px; color:#555; text-transform: uppercase; letter-spacing: 0.05em;">External spend (closed)</div>
+        <div style="font-size:1.6em; font-weight:700; color:#e8590c;">{{ summary.external_actual_cost_fmt }}</div>
+        <div style="font-size:11px; color:#888;">{{ summary.external_closed_count }} third-party WO{{ summary.external_closed_count|pluralize }}</div>
+      </td>
+    </tr>
+    <tr>
+      <td style="background:#e7f5ff; border-radius:4px;">
+        <div style="font-size:12px; color:#555; text-transform: uppercase; letter-spacing: 0.05em;">Internal WOs completed</div>
+        <div style="font-size:1.6em; font-weight:700; color:#1864ab;">{{ summary.internal_completed_count }}</div>
+      </td>
+      <td style="background:#f8f9fa; border-radius:4px;">
+        <div style="font-size:12px; color:#555; text-transform: uppercase; letter-spacing: 0.05em;">Total to makerspace</div>
+        <div style="font-size:1.6em; font-weight:700; color:#222;">{{ summary.total_value_to_makerspace_fmt }}</div>
+        <div style="font-size:11px; color:#888;">Net internal − external spent</div>
+      </td>
+    </tr>
+  </table>
+
+  <h2 style="border-bottom: 1px solid #eee; padding-bottom: 0.25em;">Work order volume</h2>
+  <p style="text-align:center; margin: 0;">
+    <img src="cid:volume_trend.png" alt="Work order volume — last 12 months" style="max-width: 100%; border-radius: 4px;">
+  </p>
+
+  <h2 style="border-bottom: 1px solid #eee; padding-bottom: 0.25em;">Spend by category</h2>
+  <p style="text-align:center; margin: 0;">
+    <img src="cid:category_spend.png" alt="Spend by category" style="max-width: 100%; border-radius: 4px;">
+  </p>
+
+  {% if top_users %}
+  <h2 style="border-bottom: 1px solid #eee; padding-bottom: 0.25em;">Top contributors</h2>
+  <table cellpadding="6" cellspacing="0" style="border-collapse: collapse; width: 100%; margin-bottom: 1.5em;">
+    <tr style="background:#f8f9fa;">
+      <th align="left" style="padding:8px; color:#555; font-size:12px; text-transform:uppercase;">Member</th>
+      <th align="right" style="padding:8px; color:#555; font-size:12px; text-transform:uppercase;">Completed WOs</th>
+    </tr>
+    {% for user in top_users %}
+    <tr style="{% if not forloop.last %}border-bottom:1px solid #eee;{% endif %}">
+      <td style="padding:8px;">{{ user.display_name }}</td>
+      <td style="padding:8px;" align="right"><strong>{{ user.completed_wo_count }}</strong></td>
+    </tr>
+    {% endfor %}
+  </table>
+  {% endif %}
+
+  {% if forecast %}
+  <h2 style="border-bottom: 1px solid #eee; padding-bottom: 0.25em;">Maintenance forecast</h2>
+  <p style="margin-top: 0; color: #555;">{{ forecast|length }} asset{{ forecast|length|pluralize }} due for service.</p>
+  <table cellpadding="6" cellspacing="0" style="border-collapse: collapse; width: 100%; margin-bottom: 1.5em;">
+    <tr style="background:#f8f9fa;">
+      <th align="left" style="padding:8px; color:#555; font-size:12px; text-transform:uppercase;">Asset</th>
+      <th align="left" style="padding:8px; color:#555; font-size:12px; text-transform:uppercase;">Trigger</th>
+    </tr>
+    {% for entry in forecast %}
+    <tr style="{% if not forloop.last %}border-bottom:1px solid #eee;{% endif %}">
+      <td style="padding:8px;">{{ entry.asset_name }}</td>
+      <td style="padding:8px; color:#e8590c;">{{ entry.due_reason_label }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+  {% endif %}
+
+  <hr style="border: none; border-top: 1px solid #eee; margin-top: 2em;">
+  {% if dashboard_url %}
+  <p style="margin: 1em 0;">
+    <a href="{{ dashboard_url }}" style="background:#1971c2; color:#fff; padding:10px 16px; text-decoration:none; border-radius:4px; display:inline-block;">
+      Open the live dashboard
+    </a>
+  </p>
+  {% endif %}
+  <p style="color:#888; font-size: 12px;">Sent automatically by OpenMakerSuite on the 1st of each month.</p>
+</body>
+</html>

--- a/backend/analytics/templates/emails/monthly_pulse.txt
+++ b/backend/analytics/templates/emails/monthly_pulse.txt
@@ -1,0 +1,21 @@
+Makerspace pulse — {{ period_label }}
+======================================
+
+Headline
+--------
+Net value created:        {{ summary.internal_net_value_fmt }}
+External spend (closed):  {{ summary.external_actual_cost_fmt }} ({{ summary.external_closed_count }} third-party WO{{ summary.external_closed_count|pluralize }})
+Internal WOs completed:   {{ summary.internal_completed_count }}
+Total to makerspace:      {{ summary.total_value_to_makerspace_fmt }}
+
+{% if top_users %}Top contributors
+----------------
+{% for user in top_users %}- {{ user.display_name }}: {{ user.completed_wo_count }} completed WO{{ user.completed_wo_count|pluralize }}
+{% endfor %}
+{% endif %}{% if forecast %}Maintenance forecast ({{ forecast|length }} asset{{ forecast|length|pluralize }} due)
+{% for entry in forecast %}- {{ entry.asset_name }}: {{ entry.due_reason_label }}
+{% endfor %}
+{% endif %}{% if dashboard_url %}
+Live dashboard: {{ dashboard_url }}
+{% endif %}
+Sent automatically by OpenMakerSuite on the 1st of each month.

--- a/backend/analytics/tests/test_email_charts.py
+++ b/backend/analytics/tests/test_email_charts.py
@@ -1,0 +1,59 @@
+"""Smoke tests for the matplotlib PNG renderers.
+
+We assert byte-level basics (PNG signature, non-empty) rather than visual
+properties — the email layout is the integration test.
+"""
+
+from __future__ import annotations
+
+from analytics.services.email_charts import render_category_spend_png, render_volume_trend_png
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+class TestVolumeTrend:
+    def test_returns_png_bytes(self):
+        out = render_volume_trend_png(
+            [
+                {"period": "2026-04-01", "count": 5},
+                {"period": "2026-05-01", "count": 8},
+            ]
+        )
+        assert out.startswith(PNG_MAGIC)
+        assert len(out) > 200
+
+    def test_handles_empty_input(self):
+        out = render_volume_trend_png([])
+        assert out.startswith(PNG_MAGIC)
+
+
+class TestCategorySpend:
+    def test_returns_png_bytes(self):
+        out = render_category_spend_png(
+            [
+                {
+                    "category_name": "CNC",
+                    "internal_estimated": "30.00",
+                    "external_actual": "800.00",
+                },
+                {
+                    "category_name": "3D Printers",
+                    "internal_estimated": "120.00",
+                    "external_actual": "0.00",
+                },
+            ]
+        )
+        assert out.startswith(PNG_MAGIC)
+        assert len(out) > 200
+
+    def test_handles_empty_input(self):
+        out = render_category_spend_png([])
+        assert out.startswith(PNG_MAGIC)
+
+    def test_uncategorized_label(self):
+        out = render_category_spend_png(
+            [
+                {"category_name": None, "internal_estimated": "10.00", "external_actual": "20.00"},
+            ]
+        )
+        assert out.startswith(PNG_MAGIC)

--- a/backend/analytics/tests/test_recipients.py
+++ b/backend/analytics/tests/test_recipients.py
@@ -1,0 +1,78 @@
+"""Tests for ``analytics.services.recipients``."""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+
+import pytest
+
+from analytics.services.recipients import (
+    ANALYTICS_GROUP_NAME,
+    get_analytics_group,
+    resolve_pulse_recipients,
+)
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def _user(username, email, **flags):
+    return User.objects.create_user(
+        username=username,
+        email=email,
+        password="x" * 24,
+        **flags,
+    )
+
+
+class TestResolvePulseRecipients:
+    def test_empty_when_nothing_configured(self, settings):
+        if hasattr(settings, "BOARD_REPORT_EMAILS"):
+            del settings.BOARD_REPORT_EMAILS
+        assert resolve_pulse_recipients() == []
+
+    def test_env_only(self, settings):
+        settings.BOARD_REPORT_EMAILS = "alice@example.com,bob@example.com"
+        assert sorted(resolve_pulse_recipients()) == ["alice@example.com", "bob@example.com"]
+
+    def test_group_only(self, settings):
+        settings.BOARD_REPORT_EMAILS = ""
+        group = get_analytics_group()
+        u = _user("carol", "carol@example.com")
+        u.groups.add(group)
+        assert resolve_pulse_recipients() == ["carol@example.com"]
+
+    def test_dedupes_case_insensitive(self, settings):
+        settings.BOARD_REPORT_EMAILS = "Alice@Example.com"
+        group = get_analytics_group()
+        u = _user("alice_user", "alice@example.com")
+        u.groups.add(group)
+        result = resolve_pulse_recipients()
+        # Env address is preserved (first seen), group duplicate dropped.
+        assert result == ["Alice@Example.com"]
+
+    def test_group_inactive_user_excluded(self, settings):
+        settings.BOARD_REPORT_EMAILS = ""
+        group = get_analytics_group()
+        u = _user("inactive", "inactive@example.com", is_active=False)
+        u.groups.add(group)
+        assert resolve_pulse_recipients() == []
+
+    def test_group_user_without_email_excluded(self, settings):
+        settings.BOARD_REPORT_EMAILS = ""
+        group = get_analytics_group()
+        u = _user("noemail", "")
+        u.groups.add(group)
+        assert resolve_pulse_recipients() == []
+
+    def test_invalid_env_address_dropped(self, settings):
+        settings.BOARD_REPORT_EMAILS = "not-an-email,real@example.com,also bad"
+        assert resolve_pulse_recipients() == ["real@example.com"]
+
+    def test_creates_group_lazily(self, settings):
+        settings.BOARD_REPORT_EMAILS = ""
+        Group.objects.filter(name=ANALYTICS_GROUP_NAME).delete()
+        # Calling resolve creates the group on first read.
+        resolve_pulse_recipients()
+        assert Group.objects.filter(name=ANALYTICS_GROUP_NAME).exists()

--- a/backend/analytics/tests/test_share_token.py
+++ b/backend/analytics/tests/test_share_token.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-
-
 import pytest
 from freezegun import freeze_time
 

--- a/backend/analytics/tests/test_share_token.py
+++ b/backend/analytics/tests/test_share_token.py
@@ -1,0 +1,92 @@
+"""Unit tests for the signed-URL share token utility."""
+
+from __future__ import annotations
+
+
+
+import pytest
+from freezegun import freeze_time
+
+from analytics.services.share_token import (
+    MAX_TTL_DAYS,
+    InvalidShareToken,
+    mint_share_token,
+    verify_share_token,
+)
+
+
+class TestMintAndVerify:
+    def test_round_trip(self):
+        token = mint_share_token(ttl_days=7)
+        assert verify_share_token(token) == 7
+
+    def test_default_ttl(self):
+        token = mint_share_token()
+        assert verify_share_token(token) == 30
+
+    def test_zero_ttl_rejected(self):
+        with pytest.raises(ValueError):
+            mint_share_token(ttl_days=0)
+
+    def test_negative_ttl_rejected(self):
+        with pytest.raises(ValueError):
+            mint_share_token(ttl_days=-5)
+
+    def test_clamped_at_max(self):
+        token = mint_share_token(ttl_days=MAX_TTL_DAYS + 100)
+        # Stored TTL should be MAX_TTL_DAYS, not the requested value.
+        assert verify_share_token(token) == MAX_TTL_DAYS
+
+
+class TestVerifyRejectsBadTokens:
+    def test_garbage_string(self):
+        with pytest.raises(InvalidShareToken):
+            verify_share_token("not-a-token")
+
+    def test_tampered_signature(self):
+        token = mint_share_token(ttl_days=7)
+        # Flip a character in the signature segment.
+        if token.endswith("a"):
+            tampered = token[:-1] + "b"
+        else:
+            tampered = token[:-1] + "a"
+        with pytest.raises(InvalidShareToken):
+            verify_share_token(tampered)
+
+    def test_empty_token(self):
+        with pytest.raises(InvalidShareToken):
+            verify_share_token("")
+
+
+class TestExpiry:
+    def test_expired_after_embedded_ttl(self):
+        with freeze_time("2026-01-01 12:00:00"):
+            token = mint_share_token(ttl_days=2)
+        # 3 days later: signature still valid (under MAX_TTL_DAYS) but
+        # embedded TTL has elapsed.
+        with freeze_time("2026-01-04 13:00:00"):
+            with pytest.raises(InvalidShareToken):
+                verify_share_token(token)
+
+    def test_still_valid_within_ttl(self):
+        with freeze_time("2026-01-01 12:00:00"):
+            token = mint_share_token(ttl_days=7)
+        with freeze_time("2026-01-05 12:00:00"):
+            assert verify_share_token(token) == 7
+
+    def test_signature_expired_past_max(self):
+        with freeze_time("2024-01-01"):
+            token = mint_share_token(ttl_days=MAX_TTL_DAYS)
+        # MAX_TTL_DAYS (365) + a buffer past the absolute cap.
+        with freeze_time("2026-01-02"):
+            with pytest.raises(InvalidShareToken):
+                verify_share_token(token)
+
+
+class TestSaltRotation:
+    def test_changing_salt_invalidates_existing_tokens(self, settings):
+        token = mint_share_token(ttl_days=7)
+        assert verify_share_token(token) == 7
+        settings.ANALYTICS_SHARE_SALT = "rotated-v2"
+        with pytest.raises(InvalidShareToken):
+            verify_share_token(token)

--- a/backend/analytics/tests/test_tasks.py
+++ b/backend/analytics/tests/test_tasks.py
@@ -1,0 +1,148 @@
+"""Tests for the monthly pulse task + management command."""
+
+from __future__ import annotations
+
+from datetime import date
+from io import StringIO
+
+from django.contrib.auth import get_user_model
+from django.core import mail
+from django.core.management import call_command
+
+import pytest
+
+from analytics.services.recipients import get_analytics_group
+from analytics.tasks import previous_month_window, send_monthly_pulse
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def _user_in_group(username: str, email: str):
+    user = User.objects.create_user(username=username, email=email, password="x" * 24)
+    user.groups.add(get_analytics_group())
+    return user
+
+
+class TestPreviousMonthWindow:
+    def test_typical_day(self):
+        start, end = previous_month_window(today=date(2026, 5, 15))
+        assert start == date(2026, 4, 1)
+        assert end == date(2026, 5, 1)
+
+    def test_first_of_month(self):
+        # On the 1st, "previous month" is the month two before only at extremes;
+        # for the 1st of Feb, prior is January.
+        start, end = previous_month_window(today=date(2026, 2, 1))
+        assert start == date(2026, 1, 1)
+        assert end == date(2026, 2, 1)
+
+    def test_january_rolls_to_december(self):
+        start, end = previous_month_window(today=date(2026, 1, 10))
+        assert start == date(2025, 12, 1)
+        assert end == date(2026, 1, 1)
+
+
+class TestSendMonthlyPulse:
+    def test_no_recipients_short_circuits(self, settings):
+        settings.BOARD_REPORT_EMAILS = ""
+        result = send_monthly_pulse(period_start=date(2026, 4, 1), period_end=date(2026, 5, 1))
+        assert result["sent"] is False
+        assert result["reason"] == "no recipients configured"
+        assert result["recipients"] == []
+        assert len(mail.outbox) == 0
+
+    def test_dry_run_does_not_send(self, settings):
+        settings.BOARD_REPORT_EMAILS = "board@example.com"
+        result = send_monthly_pulse(
+            period_start=date(2026, 4, 1),
+            period_end=date(2026, 5, 1),
+            dry_run=True,
+        )
+        assert result["sent"] is False
+        assert result["reason"] == "dry-run"
+        assert result["recipients"] == ["board@example.com"]
+        assert len(mail.outbox) == 0
+
+    def test_real_send_uses_recipient_union(self, settings):
+        settings.BOARD_REPORT_EMAILS = "board@example.com"
+        _user_in_group("carol", "carol@example.com")
+        result = send_monthly_pulse(period_start=date(2026, 4, 1), period_end=date(2026, 5, 1))
+        assert result["sent"] is True
+        assert sorted(result["recipients"]) == ["board@example.com", "carol@example.com"]
+        assert len(mail.outbox) == 1
+        sent = mail.outbox[0]
+        assert sorted(sent.to) == ["board@example.com", "carol@example.com"]
+        assert "Makerspace pulse" in sent.subject
+        assert "April 2026" in sent.subject
+
+    def test_inline_chart_attachments_present(self, settings):
+        settings.BOARD_REPORT_EMAILS = "board@example.com"
+        send_monthly_pulse(period_start=date(2026, 4, 1), period_end=date(2026, 5, 1))
+        sent = mail.outbox[0]
+        # EmailMultiAlternatives attaches the alternative HTML body as an
+        # alternative; chart PNGs attach as MIMEImage parts. Verify both
+        # cid headers landed on the message.
+        cids = [
+            att.get("Content-ID", "").strip("<>") if hasattr(att, "get") else None
+            for att in sent.attachments
+        ]
+        assert "volume_trend.png" in cids
+        assert "category_spend.png" in cids
+
+    def test_partial_window_args_rejected(self):
+        with pytest.raises(ValueError):
+            send_monthly_pulse(period_start=date(2026, 4, 1), period_end=None)
+        with pytest.raises(ValueError):
+            send_monthly_pulse(period_start=None, period_end=date(2026, 5, 1))
+
+    def test_default_window_is_previous_month(self, settings, monkeypatch):
+        settings.BOARD_REPORT_EMAILS = "board@example.com"
+        result = send_monthly_pulse(dry_run=True)
+        # Just assert the result is a sane prior-month window (start before end,
+        # both first-of-month). Avoids depending on today's actual date.
+        start = date.fromisoformat(result["period_start"])
+        end = date.fromisoformat(result["period_end"])
+        assert start.day == 1
+        assert end.day == 1
+        assert start < end
+
+
+class TestManagementCommand:
+    def test_dry_run_with_recipients(self, settings):
+        settings.BOARD_REPORT_EMAILS = "board@example.com"
+        out = StringIO()
+        call_command(
+            "send_monthly_pulse",
+            "--month=2026-04",
+            "--dry-run",
+            stdout=out,
+        )
+        output = out.getvalue()
+        assert "Dry-run" in output
+        assert "board@example.com" in output
+        assert len(mail.outbox) == 0
+
+    def test_no_recipients_warns(self, settings):
+        settings.BOARD_REPORT_EMAILS = ""
+        out = StringIO()
+        call_command("send_monthly_pulse", "--dry-run", stdout=out)
+        assert "No recipients resolved" in out.getvalue()
+
+    def test_real_send(self, settings):
+        settings.BOARD_REPORT_EMAILS = "board@example.com"
+        out = StringIO()
+        call_command("send_monthly_pulse", "--month=2026-04", stdout=out)
+        assert "Sent monthly pulse" in out.getvalue()
+        assert len(mail.outbox) == 1
+
+    def test_invalid_month_arg(self, settings):
+        settings.BOARD_REPORT_EMAILS = "board@example.com"
+        with pytest.raises(Exception):
+            call_command("send_monthly_pulse", "--month=garbage")
+
+    def test_month_december_handled(self, settings):
+        settings.BOARD_REPORT_EMAILS = "board@example.com"
+        out = StringIO()
+        call_command("send_monthly_pulse", "--month=2025-12", "--dry-run", stdout=out)
+        assert "Dry-run" in out.getvalue()

--- a/backend/analytics/tests/test_views.py
+++ b/backend/analytics/tests/test_views.py
@@ -1,4 +1,4 @@
-"""Tests for ``/api/analytics/pulse/``."""
+"""Tests for ``/api/analytics/pulse/`` and ``/api/analytics/share/``."""
 
 from datetime import date, datetime, timedelta
 from decimal import Decimal
@@ -12,6 +12,7 @@ from django.utils.crypto import get_random_string
 import pytest
 from rest_framework.test import APIClient
 
+from analytics.services.share_token import mint_share_token
 from inventory.models import MaintenanceItem, WorkOrder
 from inventory.tests.factories import AssetFactory
 from membership.models import SIGAdmin
@@ -150,3 +151,96 @@ class TestPulseCache:
         cache.clear()
         third = client.get(url)
         assert third.json()["summary"]["internal_completed_count"] == baseline_count + 1
+
+
+class TestPulseShareToken:
+    URL = "/api/analytics/pulse/"
+
+    def test_anonymous_with_valid_token_allowed(self):
+        token = mint_share_token(ttl_days=7)
+        resp = _client().get(f"{self.URL}?token={token}")
+        assert resp.status_code == 200
+        assert "summary" in resp.json()
+
+    def test_anonymous_with_invalid_token_denied(self):
+        resp = _client().get(f"{self.URL}?token=garbage")
+        assert resp.status_code in (401, 403)
+
+    def test_authenticated_without_token_still_works(self):
+        # Token is optional — the role gate continues to work.
+        resp = _client(_user("admin", is_staff=True)).get(self.URL)
+        assert resp.status_code == 200
+
+    def test_volunteer_with_valid_token_allowed(self):
+        # Even a volunteer (who would be denied by role) gets in with token.
+        token = mint_share_token(ttl_days=7)
+        resp = _client(_user("volunteer")).get(f"{self.URL}?token={token}")
+        assert resp.status_code == 200
+
+
+class TestPulseMonthlyBudget:
+    URL = "/api/analytics/pulse/"
+
+    def test_budget_null_when_unset(self, settings):
+        if hasattr(settings, "MONTHLY_BUDGET_TOTAL"):
+            del settings.MONTHLY_BUDGET_TOTAL
+        resp = _client(_user("admin", is_staff=True)).get(self.URL)
+        assert resp.json()["monthly_budget"] is None
+
+    def test_budget_returned_when_set(self, settings):
+        settings.MONTHLY_BUDGET_TOTAL = "5000.00"
+        resp = _client(_user("admin", is_staff=True)).get(self.URL)
+        assert resp.json()["monthly_budget"] == "5000.00"
+
+    def test_budget_invalid_value_returns_null(self, settings):
+        settings.MONTHLY_BUDGET_TOTAL = "not a number"
+        resp = _client(_user("admin", is_staff=True)).get(self.URL)
+        assert resp.json()["monthly_budget"] is None
+
+
+class TestShareEndpoint:
+    URL = "/api/analytics/share/"
+
+    def test_anonymous_denied(self):
+        resp = _client().post(self.URL, data={}, format="json")
+        assert resp.status_code in (401, 403)
+
+    def test_volunteer_denied(self):
+        resp = _client(_user("volunteer")).post(self.URL, data={}, format="json")
+        assert resp.status_code == 403
+
+    def test_staff_can_mint_default_ttl(self):
+        resp = _client(_user("admin", is_staff=True)).post(self.URL, data={}, format="json")
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["ttl_days"] == 30
+        assert body["token"]
+        assert body["expires_in_days"] == 30
+
+    def test_staff_can_mint_custom_ttl(self):
+        resp = _client(_user("admin", is_staff=True)).post(
+            self.URL, data={"ttl_days": 7}, format="json"
+        )
+        assert resp.status_code == 201
+        assert resp.json()["ttl_days"] == 7
+
+    def test_minted_token_unlocks_pulse(self):
+        share_resp = _client(_user("admin", is_staff=True)).post(
+            self.URL, data={"ttl_days": 14}, format="json"
+        )
+        token = share_resp.json()["token"]
+        # Anonymous client uses the token.
+        pulse_resp = _client().get(f"/api/analytics/pulse/?token={token}")
+        assert pulse_resp.status_code == 200
+
+    def test_invalid_ttl_rejected(self):
+        client = _client(_user("admin", is_staff=True))
+        for bad in ("hello", -5, 0, 9999):
+            resp = client.post(self.URL, data={"ttl_days": bad}, format="json")
+            assert resp.status_code == 400
+
+    def test_sig_admin_can_mint(self):
+        user = _user("sig_lead")
+        SIGAdmin.objects.create(user=user, group=Group.objects.create(name="Wood SIG"))
+        resp = _client(user).post(self.URL, data={}, format="json")
+        assert resp.status_code == 201

--- a/backend/analytics/urls.py
+++ b/backend/analytics/urls.py
@@ -2,10 +2,11 @@
 
 from django.urls import path
 
-from .views import AnalyticsPulseView
+from .views import AnalyticsPulseView, AnalyticsShareView
 
 app_name = "analytics"
 
 urlpatterns = [
     path("pulse/", AnalyticsPulseView.as_view(), name="pulse"),
+    path("share/", AnalyticsShareView.as_view(), name="share"),
 ]

--- a/backend/analytics/views.py
+++ b/backend/analytics/views.py
@@ -1,13 +1,17 @@
-"""Read-only analytics endpoint.
+"""Analytics endpoints.
 
-``/api/analytics/pulse/`` returns the full aggregate JSON used by both
-the dashboard (PR2) and the monthly email (PR3). Cached 60 minutes in
-django-redis to bound DB load when the dashboard is viewed concurrently.
+- ``GET /api/analytics/pulse/`` — full aggregate JSON used by the dashboard
+  (PR2) and the monthly email (PR3). Cached 60 minutes in django-redis to
+  bound DB load when the dashboard is viewed concurrently.
+- ``POST /api/analytics/share/`` — staff-only mint of a signed-URL token
+  that lets board members without OMS accounts view the dashboard.
 
-Query parameters:
+Query parameters on pulse:
 - ``start`` and ``end`` (ISO date) — summary window. Defaults to the last
   full calendar month.
 - ``bucket`` — ``"month"`` (default) or ``"quarter"`` for the trend series.
+- ``token`` — optional signed share token (alternative to authenticated
+  access; see ``analytics.permissions.IsAnalyticsViewer``).
 
 The 12-month trend series is independent of the summary window so the
 chart is stable as users zoom around.
@@ -16,7 +20,9 @@ chart is stable as users zoom around.
 from __future__ import annotations
 
 from datetime import date, timedelta
+from decimal import Decimal, InvalidOperation
 
+from django.conf import settings
 from django.core.cache import cache
 from django.utils.dateparse import parse_date
 
@@ -24,9 +30,10 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .permissions import IsAnalyticsViewer
+from .permissions import IsAnalyticsSharer, IsAnalyticsViewer
 from .services.aggregation import category_spend, top_users, utilization, value_summary, wo_volume
 from .services.forecast import maintenance_forecast
+from .services.share_token import DEFAULT_TTL_DAYS, MAX_TTL_DAYS, mint_share_token
 
 CACHE_TTL_SECONDS = 60 * 60
 CACHE_VERSION = "v1"
@@ -48,8 +55,23 @@ def _last_12_months_window() -> tuple[date, date]:
     return start, end
 
 
+def _monthly_budget() -> str | None:
+    """Return ``MONTHLY_BUDGET_TOTAL`` as a string Decimal, or None if unset.
+
+    Frontend hides the budget gauge when this is null. We serialize as a
+    string for parity with the other money fields in the summary.
+    """
+    raw = getattr(settings, "MONTHLY_BUDGET_TOTAL", None)
+    if raw in (None, ""):
+        return None
+    try:
+        return str(Decimal(str(raw)))
+    except InvalidOperation:
+        return None
+
+
 class AnalyticsPulseView(APIView):
-    """``GET /api/analytics/pulse/?start=YYYY-MM-DD&end=YYYY-MM-DD&bucket=month``"""
+    """``GET /api/analytics/pulse/?start=...&end=...&bucket=month&token=...``"""
 
     permission_classes = [IsAnalyticsViewer]
 
@@ -101,4 +123,43 @@ class AnalyticsPulseView(APIView):
                 "maintenance_forecast": maintenance_forecast(),
             }
             cache.set(cache_key, payload, CACHE_TTL_SECONDS)
+
+        # Budget is read fresh on every request so config changes take effect
+        # without waiting for the cache to expire.
+        payload = {**payload, "monthly_budget": _monthly_budget()}
         return Response(payload)
+
+
+class AnalyticsShareView(APIView):
+    """``POST /api/analytics/share/`` — mint a signed-URL token.
+
+    Body: ``{"ttl_days": <1..365>}`` (optional, defaults to 30).
+    Response: ``{"token": "...", "ttl_days": N, "expires_in_days": N}``.
+
+    The frontend composes the full shareable URL from the token. We
+    deliberately do not include the URL on the server because the public
+    base URL varies per deployment.
+    """
+
+    permission_classes = [IsAnalyticsSharer]
+
+    def post(self, request):
+        ttl_raw = request.data.get("ttl_days", DEFAULT_TTL_DAYS)
+        try:
+            ttl_days = int(ttl_raw)
+        except (TypeError, ValueError):
+            return Response(
+                {"detail": "ttl_days must be an integer"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if ttl_days <= 0 or ttl_days > MAX_TTL_DAYS:
+            return Response(
+                {"detail": f"ttl_days must be between 1 and {MAX_TTL_DAYS}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        token = mint_share_token(ttl_days=ttl_days)
+        return Response(
+            {"token": token, "ttl_days": ttl_days, "expires_in_days": ttl_days},
+            status=status.HTTP_201_CREATED,
+        )

--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -9,6 +9,9 @@ views:
   analytics.views.AnalyticsPulseView:
     permission_classes:
     - IsAnalyticsViewer
+  analytics.views.AnalyticsShareView:
+    permission_classes:
+    - IsAnalyticsSharer
   auth_views.create_test_membership:
     permission_classes:
     - AllowAny

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import dj_database_url
 import highlight_io
+from celery.schedules import crontab
 from decouple import config
 from highlight_io.integrations.django import DjangoIntegration
 
@@ -405,6 +406,13 @@ CELERY_BEAT_SCHEDULE = {
         "kwargs": {
             "retention_days": config("FORGEKEY_PHOTO_RETENTION_DAYS", default=30, cast=int),
         },
+    },
+    # Monthly board / staff pulse email — covers the prior calendar month.
+    # Uses crontab so we land at 09:00 on the 1st regardless of how the
+    # worker scheduler restarted during the month.
+    "analytics-send-monthly-pulse": {
+        "task": "analytics.send_monthly_pulse_email",
+        "schedule": crontab(minute=0, hour=9, day_of_month=1),
     },
 }
 

--- a/backend/config/tests/test_celery_schedule.py
+++ b/backend/config/tests/test_celery_schedule.py
@@ -11,9 +11,12 @@ from django.conf import settings
 
 import pytest
 from celery import current_app
+from celery.schedules import crontab
 
 EXPECTED_BEAT_SCHEDULE = {
-    # name in CELERY_BEAT_SCHEDULE -> (task path, schedule seconds)
+    # name in CELERY_BEAT_SCHEDULE -> (task path, schedule)
+    # Schedule is float seconds for periodic interval tasks, or a celery
+    # crontab() instance for calendar-aligned tasks.
     "send-quarterly-donor-updates": (
         "donations.tasks.send_quarterly_donor_updates",
         7776000.0,  # 90 days
@@ -30,6 +33,10 @@ EXPECTED_BEAT_SCHEDULE = {
         "forgekey.tasks.prune_device_photos",
         86400.0,  # 1 day
     ),
+    "analytics-send-monthly-pulse": (
+        "analytics.send_monthly_pulse_email",
+        crontab(minute=0, hour=9, day_of_month=1),  # 09:00 on the 1st
+    ),
 }
 
 
@@ -45,17 +52,17 @@ class TestCeleryBeatSchedule:
             )
 
     @pytest.mark.parametrize(
-        "name, task_path, schedule_seconds",
+        "name, task_path, schedule",
         [(name, *cfg) for name, cfg in EXPECTED_BEAT_SCHEDULE.items()],
     )
-    def test_entry_targets_expected_task_and_cadence(self, name, task_path, schedule_seconds):
+    def test_entry_targets_expected_task_and_cadence(self, name, task_path, schedule):
         entry = settings.CELERY_BEAT_SCHEDULE[name]
         assert (
             entry["task"] == task_path
         ), f"Beat entry {name!r} points at {entry['task']!r}, expected {task_path!r}."
-        assert entry["schedule"] == schedule_seconds, (
+        assert entry["schedule"] == schedule, (
             f"Beat entry {name!r} schedule changed to {entry['schedule']!r} "
-            f"(expected {schedule_seconds!r})."
+            f"(expected {schedule!r})."
         )
 
     def test_no_undocumented_entries(self):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,6 +16,9 @@ flower==2.0.1
 qrcode[pil]==7.4.2
 reportlab==4.2.0
 Pillow==12.2.0
+# Server-side PNG charts for the monthly analytics pulse email (analytics app).
+# Forced to the headless Agg backend in code so this does not pull GUI deps.
+matplotlib==3.10.9
 pyzbar==0.1.9  # Optional: for QR code validation (requires system zbar library)
 pypdf==6.10.2   # PDF text/form extraction for inbound work-order ingestion
 opencv-python-headless==4.13.0.92  # cv2.QRCodeDetector for image-based PDF ingestion

--- a/docs/API_PERMISSION_MATRIX.md
+++ b/docs/API_PERMISSION_MATRIX.md
@@ -273,7 +273,8 @@ category spend, and a maintenance forecast.
 
 | Method | Path | Class | Purpose | Notes |
 | --- | --- | --- | --- | --- |
-| GET | `analytics/pulse/` | staff-or-sig-admin | `IsAnalyticsViewer` — returns the full aggregate JSON used by both the dashboard and the monthly email. | 60-min django-redis cache keyed by `(start, end, bucket)`. PR2 will add a signed-URL bypass for board members without OMS accounts. |
+| GET | `analytics/pulse/` | staff-or-sig-admin **or** signed-URL token | `IsAnalyticsViewer` — returns the full aggregate JSON used by both the dashboard and the monthly email. Authenticated staff/SIG admins are allowed; anyone presenting a valid `?token=...` minted by `analytics/share/` is also allowed (board-member bypass). | 60-min django-redis cache keyed by `(start, end, bucket)`. Token verifies signature + embedded TTL; rotating `ANALYTICS_SHARE_SALT` invalidates all outstanding tokens. |
+| POST | `analytics/share/` | staff-or-sig-admin | `IsAnalyticsSharer` — mints a signed token (`{"ttl_days": 1..365}`, defaults to 30). Returns the token + ttl; the frontend composes the shareable URL. | Pure HMAC-signed token (no DB row); authoritative kill-switch is the salt setting. |
 
 ## Flower (Celery monitoring)
 

--- a/docs/CELERY_TASKS.md
+++ b/docs/CELERY_TASKS.md
@@ -105,6 +105,12 @@ operator surface for inspecting status, args, and tracebacks
 | `forgekey.tasks.prune_device_photos` | Beat: every 86,400 s (daily) — see `CELERY_BEAT_SCHEDULE["forgekey-prune-device-photos"]`. The `retention_days` kwarg is sourced from `FORGEKEY_PHOTO_RETENTION_DAYS` (default 30). | Deletes `ESP32DevicePhoto` rows older than `retention_days` | None | 30 min global | **Yes** — re-running with the same cutoff is a no-op | Re-run manually: `celery -A config call forgekey.tasks.prune_device_photos`. |
 | `forgekey.tasks.mark_stale_devices_offline` | Beat: every 1,800 s (30 min) — see `CELERY_BEAT_SCHEDULE["forgekey-mark-stale-devices-offline"]`. The `threshold_hours` kwarg is sourced from `FORGEKEY_DEVICE_OFFLINE_THRESHOLD_HOURS` (default 5). | Updates `ESP32Device.is_online=False` for rows whose `last_seen` is older than the threshold (gh #349) | None | 30 min global | **Yes** — re-running with the same cutoff is a no-op (already-offline rows are filtered at the WHERE clause) | Run manually: `celery -A config call forgekey.tasks.mark_stale_devices_offline`. |
 
+### analytics
+
+| Task | Trigger | Side effects | Retries | Timeout | Idempotency | Recovery |
+| --- | --- | --- | --- | --- | --- | --- |
+| `analytics.send_monthly_pulse_email` | Beat: `crontab(minute=0, hour=9, day_of_month=1)` — see `CELERY_BEAT_SCHEDULE["analytics-send-monthly-pulse"]`. Covers the prior calendar month. | Resolves recipients (env `BOARD_REPORT_EMAILS` ∪ `analytics-recipients` Django group), renders the HTML+text monthly-pulse email with two inline matplotlib PNG charts, sends via the configured email backend (Postmark via `django-anymail` in prod). Short-circuits with a logged warning when no recipients are configured. | None (`@shared_task` defaults) | 30 min global | **No** — running twice in the same window double-emails recipients. | Manual replay: `python manage.py send_monthly_pulse --month=YYYY-MM` (with `--dry-run` to preview without sending). The management command shares the same body so it stays in lockstep with the Beat task. |
+
 ### config (debug)
 
 | Task | Trigger | Side effects | Retries | Timeout | Idempotency | Recovery |

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,6 +9,17 @@
       content="Makerspace Inventory Management System"
     />
     <title>Makerspace Inventory</title>
+    <!--
+      Display + mono faces used by the landing primitives. Body type stays
+      on the system stack so workspace pages keep their existing rhythm.
+      See frontend/src/styles/landing.css for usage rules.
+    -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,10 +22,14 @@ import CodeEntryPage from './pages/CodeEntryPage';
 import DashboardPage from './pages/DashboardPage';
 import DonationItemScanPage from './pages/DonationItemScanPage';
 import ElectricalCircuitsPage from './pages/ElectricalCircuitsPage';
+import FacilitiesOverviewPage from './pages/FacilitiesOverviewPage';
 import FixtureScanPage from './pages/FixtureScanPage';
 import ForgeKeyDeviceDetailPage from './pages/ForgeKeyDeviceDetailPage';
 import ForgeKeyDevicesPage from './pages/ForgeKeyDevicesPage';
 import HomePage from './pages/HomePage';
+import PurchasingOverviewPage from './pages/PurchasingOverviewPage';
+import ReportsOverviewPage from './pages/ReportsOverviewPage';
+import SettingsOverviewPage from './pages/SettingsOverviewPage';
 import LightSwitchFormPage from './pages/LightSwitchFormPage';
 import InventoryItemDetailPage from './pages/InventoryItemDetailPage';
 import InventoryItemFormPage from './pages/InventoryItemFormPage';
@@ -171,6 +175,7 @@ function AppContent() {
           <Route path="/inventory/categories/:id/edit" element={<WorkspaceLayout><CategoryFormPage /></WorkspaceLayout>} />
 
           {/* Purchasing Workspace */}
+          <Route path="/purchasing" element={<WorkspaceLayout><PurchasingOverviewPage /></WorkspaceLayout>} />
           <Route path="/purchasing/orders" element={<WorkspaceLayout><PurchaseOrderListPage /></WorkspaceLayout>} />
           <Route path="/purchasing/orders/new" element={<WorkspaceLayout><PurchaseOrderFormPage /></WorkspaceLayout>} />
           <Route path="/purchasing/orders/:orderId" element={<WorkspaceLayout><PurchaseOrderPage /></WorkspaceLayout>} />
@@ -184,6 +189,7 @@ function AppContent() {
           <Route path="/assets/:assetId/maintenance/:id/edit" element={<WorkspaceLayout><MaintenanceItemFormPage /></WorkspaceLayout>} />
 
           {/* Facilities Workspace */}
+          <Route path="/facilities" element={<WorkspaceLayout><FacilitiesOverviewPage /></WorkspaceLayout>} />
           <Route path="/facilities/tv-dashboard" element={<TVDashboard />} />
           <Route path="/facilities/tv-dashboard/:location" element={<TVDashboard />} />
           <Route path="/facilities/screens" element={<WorkspaceLayout><ScreensListPage /></WorkspaceLayout>} />
@@ -224,11 +230,13 @@ function AppContent() {
           <Route path="/sigs/dashboard/:sigId" element={<WorkspaceLayout><SIGDashboard /></WorkspaceLayout>} />
 
           {/* Reports Workspace */}
+          <Route path="/reports" element={<WorkspaceLayout><ReportsOverviewPage /></WorkspaceLayout>} />
           <Route path="/reports/inventory" element={<WorkspaceLayout><InventoryReportPage /></WorkspaceLayout>} />
           <Route path="/reports/purchasing" element={<WorkspaceLayout><PurchasingReportPage /></WorkspaceLayout>} />
           <Route path="/reports/assets" element={<WorkspaceLayout><AssetReportPage /></WorkspaceLayout>} />
 
           {/* Settings Workspace */}
+          <Route path="/settings" element={<WorkspaceLayout><SettingsOverviewPage /></WorkspaceLayout>} />
           <Route path="/settings/profile" element={<WorkspaceLayout><UserProfilePage /></WorkspaceLayout>} />
           <Route path="/settings/site" element={<WorkspaceLayout><SiteSettingsPage /></WorkspaceLayout>} />
           <Route path="/settings/tax-receipt/lookup" element={<WorkspaceLayout><TaxReceiptLookupPage /></WorkspaceLayout>} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { Navigate, Route, BrowserRouter as Router, Routes, useParams } from 'rea
 import ErrorFallback from './components/ErrorFallback';
 import WorkspaceLayout from './components/WorkspaceLayout';
 import AdminDashboard from './pages/AdminDashboard';
+import AnalyticsDashboardPage from './pages/AnalyticsDashboardPage';
 import AssetDetailPage from './pages/AssetDetailPage';
 import AssetFormPage from './pages/AssetFormPage';
 import MaintenanceItemFormPage from './pages/MaintenanceItemFormPage';
@@ -203,6 +204,10 @@ function AppContent() {
           <Route path="/facilities/electrical/light-switches/:id/edit" element={<WorkspaceLayout><LightSwitchFormPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/network-drops/new" element={<WorkspaceLayout><NetworkDropFormPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/network-drops/:id/edit" element={<WorkspaceLayout><NetworkDropFormPage /></WorkspaceLayout>} />
+
+          {/* Analytics dashboard */}
+          <Route path="/analytics" element={<WorkspaceLayout><AnalyticsDashboardPage /></WorkspaceLayout>} />
+          <Route path="/analytics/shared" element={<AnalyticsDashboardPage shared />} />
 
           {/* Preventive Maintenance */}
           <Route path="/maintenance" element={<WorkspaceLayout><MaintenanceDashboardPage /></WorkspaceLayout>} />

--- a/frontend/src/__tests__/components/Breadcrumbs.test.tsx
+++ b/frontend/src/__tests__/components/Breadcrumbs.test.tsx
@@ -58,5 +58,30 @@ describe('Breadcrumbs Component', () => {
     const assetsBreadcrumb = screen.getByText(/assets/i);
     expect(assetsBreadcrumb).toHaveAttribute('aria-current', 'page');
   });
+
+  it('renders non-routable ancestor segments as non-clickable spans (AC-4)', () => {
+    // /maintenance/work-orders has no list-page route — only :id child
+    // routes. The "Work Orders" segment must therefore not be a Link.
+    renderWithRouter(['/maintenance/work-orders/abc123']);
+    expect(screen.queryByRole('link', { name: /work orders/i })).not.toBeInTheDocument();
+    // It still shows up as text:
+    expect(screen.getByText(/work orders/i)).toBeInTheDocument();
+    // And ancestors that ARE routable remain clickable:
+    expect(screen.getByRole('link', { name: /maintenance/i })).toBeInTheDocument();
+  });
+
+  it('uses canonical labels for major workspaces (AC-5)', () => {
+    renderWithRouter(['/facilities/tv-dashboard']);
+    // Canonical "TV Dashboard", not raw-slug "Tv-dashboard".
+    expect(screen.getByText('TV Dashboard')).toBeInTheDocument();
+  });
+
+  it('linkifies the new overview-page parent paths (AC-3)', () => {
+    // /purchasing was previously an orphan path that would 404 on click.
+    // It now has a route handler, so the breadcrumb segment is a link.
+    renderWithRouter(['/purchasing/orders']);
+    const purchasingLink = screen.getByRole('link', { name: /^purchasing$/i });
+    expect(purchasingLink).toHaveAttribute('href', '/purchasing');
+  });
 });
 

--- a/frontend/src/__tests__/components/landing/CapabilityCard.test.tsx
+++ b/frontend/src/__tests__/components/landing/CapabilityCard.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Smoke tests for the shared CapabilityCard primitive (AC-2).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import CapabilityCard from '../../../components/landing/CapabilityCard';
+
+const renderCard = (props: Partial<React.ComponentProps<typeof CapabilityCard>> = {}) =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <CapabilityCard
+          to="/inventory"
+          title="Inventory"
+          description="Items, suppliers, locations."
+          icon={<svg data-testid="card-icon" />}
+          {...props}
+        />
+      </MemoryRouter>
+    </MantineProvider>
+  );
+
+describe('CapabilityCard', () => {
+  it('renders title, description, and icon', () => {
+    renderCard();
+    expect(screen.getByRole('heading', { level: 3, name: /inventory/i })).toBeInTheDocument();
+    expect(screen.getByText(/items, suppliers/i)).toBeInTheDocument();
+    expect(screen.getByTestId('card-icon')).toBeInTheDocument();
+  });
+
+  it('renders the eyebrow when provided', () => {
+    renderCard({ eyebrow: 'Workspace' });
+    expect(screen.getByText(/workspace/i)).toBeInTheDocument();
+  });
+
+  it('renders the staff badge when provided', () => {
+    renderCard({ badge: 'Staff' });
+    expect(screen.getByText('Staff')).toBeInTheDocument();
+  });
+
+  it('uses the custom CTA label when provided', () => {
+    renderCard({ ctaLabel: 'Launch' });
+    expect(screen.getByText(/launch/i)).toBeInTheDocument();
+  });
+
+  it('whole card is a single link to the destination', () => {
+    renderCard({ to: '/inventory/scan' });
+    const link = screen.getByRole('link', { name: /inventory/i });
+    expect(link).toHaveAttribute('href', '/inventory/scan');
+  });
+
+  it('uses the override testId when provided', () => {
+    renderCard({ testId: 'custom-id' });
+    expect(screen.getByTestId('custom-id')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/landing/PageHero.test.tsx
+++ b/frontend/src/__tests__/components/landing/PageHero.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Smoke tests for the shared PageHero primitive (AC-2).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import PageHero from '../../../components/landing/PageHero';
+
+const renderHero = (props: Partial<React.ComponentProps<typeof PageHero>> = {}) =>
+  render(
+    <MantineProvider>
+      <PageHero title="Run the shop." {...props} />
+    </MantineProvider>
+  );
+
+describe('PageHero', () => {
+  it('renders the title as an h1', () => {
+    renderHero();
+    expect(screen.getByRole('heading', { level: 1, name: /run the shop/i })).toBeInTheDocument();
+  });
+
+  it('renders the eyebrow when provided', () => {
+    renderHero({ eyebrow: 'OpenMakerSuite' });
+    expect(screen.getByTestId('page-hero-eyebrow')).toHaveTextContent('OpenMakerSuite');
+  });
+
+  it('omits the eyebrow when not provided', () => {
+    renderHero();
+    expect(screen.queryByTestId('page-hero-eyebrow')).not.toBeInTheDocument();
+  });
+
+  it('renders the description when provided', () => {
+    renderHero({ description: 'One operations layer.' });
+    expect(screen.getByText(/one operations layer/i)).toBeInTheDocument();
+  });
+
+  it('renders the action slot when provided', () => {
+    renderHero({ action: <button>Share</button> });
+    expect(screen.getByTestId('page-hero-action')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /share/i })).toBeInTheDocument();
+  });
+
+  it('omits the action slot when not provided', () => {
+    renderHero();
+    expect(screen.queryByTestId('page-hero-action')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/navigation/entryPoints.test.tsx
+++ b/frontend/src/__tests__/navigation/entryPoints.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * Entry-point regression tests (AC-7).
+ *
+ * Asserts that every workspace called out in the spec has a registered
+ * route map entry with a clickable, human-readable label. This is the
+ * structural half of AC-7; the overview-render tests in
+ * routeNavigation.test.tsx cover the "actually loads" half.
+ *
+ * If a future change removes one of these entry points without
+ * deliberately replacing it, this test fails — preventing the
+ * dead-link regression the spec calls out.
+ */
+import { getRouteEntry, isClickable } from '../../navigation/routeMap';
+
+describe('AC-7 — top-level navigation entry points are present and clickable', () => {
+  // Spec calls out: inventory/scan workflows, purchasing, assets,
+  // facilities/operations dashboards, maintenance, reports, settings,
+  // plus analytics (just shipped) and SIGs (existing workspace).
+  const ENTRY_POINTS: Array<{ path: string; label: string }> = [
+    { path: 'inventory', label: 'Inventory' },
+    { path: 'inventory/scan', label: 'Scan Items' },
+    { path: 'purchasing', label: 'Purchasing' },
+    { path: 'assets', label: 'Assets' },
+    { path: 'facilities', label: 'Facilities' },
+    { path: 'maintenance', label: 'Maintenance' },
+    { path: 'sigs', label: 'SIGs' },
+    { path: 'reports', label: 'Reports' },
+    { path: 'analytics', label: 'Analytics Pulse' },
+    { path: 'settings', label: 'Settings' },
+  ];
+
+  it.each(ENTRY_POINTS)('$path is registered with the canonical label "$label"', ({ path, label }) => {
+    const entry = getRouteEntry(path);
+    expect(entry).toBeDefined();
+    expect(entry!.label).toBe(label);
+  });
+
+  it.each(ENTRY_POINTS)('$path is clickable (no dead link)', ({ path }) => {
+    expect(isClickable(path)).toBe(true);
+  });
+});

--- a/frontend/src/__tests__/navigation/routeMap.test.ts
+++ b/frontend/src/__tests__/navigation/routeMap.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for the route-map helpers powering Breadcrumbs.
+ *
+ * Companion: routeNavigation.test.tsx exercises the actual rendering of
+ * the previously-404 parent paths.
+ */
+import {
+  ROUTE_MAP_ENTRIES,
+  getRouteEntry,
+  isClickable,
+  labelFor,
+  titleCaseSegment,
+} from '../../navigation/routeMap';
+
+describe('routeMap helpers', () => {
+  describe('getRouteEntry', () => {
+    it('returns the entry for a registered path', () => {
+      const entry = getRouteEntry('inventory/assets');
+      expect(entry).toBeDefined();
+      expect(entry?.label).toBe('Assets');
+    });
+
+    it('returns undefined for an unregistered path', () => {
+      expect(getRouteEntry('not/a/real/path')).toBeUndefined();
+    });
+  });
+
+  describe('labelFor', () => {
+    it('uses canonical label when registered', () => {
+      expect(labelFor('purchasing', 'purchasing')).toBe('Purchasing');
+      expect(labelFor('facilities/tv-dashboard', 'tv-dashboard')).toBe('TV Dashboard');
+    });
+
+    it('falls back to title-cased segment when unregistered', () => {
+      expect(labelFor('not/in/map', 'foo-bar-baz')).toBe('Foo Bar Baz');
+    });
+  });
+
+  describe('isClickable', () => {
+    it('defaults to true for registered entries', () => {
+      expect(isClickable('inventory')).toBe(true);
+      expect(isClickable('purchasing')).toBe(true);
+    });
+
+    it('respects clickable: false on registered entries', () => {
+      // /maintenance/work-orders has no list page (only /maintenance/work-orders/:id),
+      // so the segment must render as a non-clickable label.
+      expect(isClickable('maintenance/work-orders')).toBe(false);
+      expect(isClickable('settings/tax-receipt')).toBe(false);
+    });
+
+    it('defaults to true for unregistered paths', () => {
+      // Unregistered paths fall through; if they're truly orphaned they will
+      // be caught by the routeNavigation regression test instead.
+      expect(isClickable('something/random')).toBe(true);
+    });
+  });
+
+  describe('titleCaseSegment', () => {
+    it('handles single words', () => {
+      expect(titleCaseSegment('inventory')).toBe('Inventory');
+    });
+
+    it('handles hyphenated slugs', () => {
+      expect(titleCaseSegment('tv-dashboard')).toBe('Tv Dashboard');
+    });
+
+    it('handles empty string', () => {
+      expect(titleCaseSegment('')).toBe('');
+    });
+  });
+
+  describe('AC-5 canonical labels per major workspace', () => {
+    // Smoke test that the map has at least one entry covering every
+    // top-level workspace called out in the spec. If this fails, a
+    // workspace was removed from the route map and breadcrumbs in that
+    // workspace will fall back to slug-formatted labels.
+    const required = [
+      'inventory',
+      'purchasing',
+      'assets',
+      'facilities',
+      'maintenance',
+      'sigs',
+      'reports',
+      'settings',
+      'analytics',
+    ];
+    it.each(required)('has a label for %s', (workspace) => {
+      const entry = getRouteEntry(workspace);
+      expect(entry).toBeDefined();
+      expect(entry!.label.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('ROUTE_MAP_ENTRIES', () => {
+    it('has no duplicate paths', () => {
+      const paths = ROUTE_MAP_ENTRIES.map((e) => e.path);
+      const unique = new Set(paths);
+      expect(unique.size).toBe(paths.length);
+    });
+  });
+});

--- a/frontend/src/__tests__/navigation/routeNavigation.test.tsx
+++ b/frontend/src/__tests__/navigation/routeNavigation.test.tsx
@@ -34,7 +34,7 @@ describe('Workspace overview pages (AC-3, AC-7)', () => {
       expect(screen.getByRole('heading', { level: 1, name: /purchasing/i })).toBeInTheDocument();
       const links = screen.getAllByRole('link');
       expect(links.length).toBeGreaterThanOrEqual(2);
-      expect(screen.getByRole('heading', { level: 4, name: /purchase orders/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /purchase orders/i })).toBeInTheDocument();
     });
   });
 
@@ -42,9 +42,9 @@ describe('Workspace overview pages (AC-3, AC-7)', () => {
     it('renders title + the major child entry points', () => {
       renderWithProviders(<FacilitiesOverviewPage />);
       expect(screen.getByRole('heading', { level: 1, name: /facilities/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /tv dashboard/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /logistics/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /^electrical$/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /tv dashboard/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /logistics/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /^electrical$/i })).toBeInTheDocument();
       const links = screen.getAllByRole('link');
       expect(links.length).toBeGreaterThanOrEqual(5);
     });
@@ -56,10 +56,10 @@ describe('Workspace overview pages (AC-3, AC-7)', () => {
       expect(screen.getByRole('heading', { level: 1, name: /reports/i })).toBeInTheDocument();
       // Use heading role (the card titles) so we don't collide with the
       // accessible-name text inside Link-wrapped cards.
-      expect(screen.getByRole('heading', { level: 4, name: /analytics pulse/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /inventory report/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /purchasing report/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /asset report/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /analytics pulse/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /inventory report/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /purchasing report/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /asset report/i })).toBeInTheDocument();
     });
   });
 
@@ -67,10 +67,10 @@ describe('Workspace overview pages (AC-3, AC-7)', () => {
     it('renders profile + site + webhooks + tax-receipt links', () => {
       renderWithProviders(<SettingsOverviewPage />);
       expect(screen.getByRole('heading', { level: 1, name: /settings/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /^profile$/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /site settings/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /^webhooks$/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { level: 4, name: /tax receipt lookup/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /^profile$/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /site settings/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /^webhooks$/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 3, name: /tax receipt lookup/i })).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/__tests__/navigation/routeNavigation.test.tsx
+++ b/frontend/src/__tests__/navigation/routeNavigation.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Navigation regression tests (AC-3, AC-7).
+ *
+ * The four parent paths /purchasing, /facilities, /reports, /settings
+ * previously had no route handler — clicking the matching breadcrumb
+ * ancestor on any deep route 404'd. PR1 ships overview pages for each.
+ * These tests assert each overview page renders meaningful content with
+ * actionable links, so regressions are caught before they ship.
+ *
+ * AC-7 dead-link prevention is split between this file (overview entry
+ * points) and entryPoints.test.tsx (homepage-card + sidebar coverage).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import FacilitiesOverviewPage from '../../pages/FacilitiesOverviewPage';
+import PurchasingOverviewPage from '../../pages/PurchasingOverviewPage';
+import ReportsOverviewPage from '../../pages/ReportsOverviewPage';
+import SettingsOverviewPage from '../../pages/SettingsOverviewPage';
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </MantineProvider>
+  );
+
+describe('Workspace overview pages (AC-3, AC-7)', () => {
+  describe('Purchasing', () => {
+    it('renders title + at least 2 actionable links', () => {
+      renderWithProviders(<PurchasingOverviewPage />);
+      expect(screen.getByRole('heading', { level: 1, name: /purchasing/i })).toBeInTheDocument();
+      const links = screen.getAllByRole('link');
+      expect(links.length).toBeGreaterThanOrEqual(2);
+      expect(screen.getByRole('heading', { level: 4, name: /purchase orders/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Facilities', () => {
+    it('renders title + the major child entry points', () => {
+      renderWithProviders(<FacilitiesOverviewPage />);
+      expect(screen.getByRole('heading', { level: 1, name: /facilities/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 4, name: /tv dashboard/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 4, name: /logistics/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 4, name: /^electrical$/i })).toBeInTheDocument();
+      const links = screen.getAllByRole('link');
+      expect(links.length).toBeGreaterThanOrEqual(5);
+    });
+  });
+
+  describe('Reports', () => {
+    it('renders all four report links including the analytics pulse', () => {
+      renderWithProviders(<ReportsOverviewPage />);
+      expect(screen.getByRole('heading', { level: 1, name: /reports/i })).toBeInTheDocument();
+      // Use heading role (the card titles) so we don't collide with the
+      // accessible-name text inside Link-wrapped cards.
+      expect(screen.getByRole('heading', { level: 4, name: /analytics pulse/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 4, name: /inventory report/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 4, name: /purchasing report/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 4, name: /asset report/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Settings', () => {
+    it('renders profile + site + webhooks + tax-receipt links', () => {
+      renderWithProviders(<SettingsOverviewPage />);
+      expect(screen.getByRole('heading', { level: 1, name: /settings/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 4, name: /^profile$/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 4, name: /site settings/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 4, name: /^webhooks$/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 4, name: /tax receipt lookup/i })).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Overview pages have actionable href targets (AC-7)', () => {
+  // Each overview page link should point to a path inside its workspace.
+  const cases: Array<[string, React.ComponentType, RegExp]> = [
+    ['Purchasing', PurchasingOverviewPage, /^\/purchasing\//],
+    ['Facilities', FacilitiesOverviewPage, /^\/facilities\//],
+    ['Settings', SettingsOverviewPage, /^\/settings\//],
+  ];
+
+  it.each(cases)('%s links stay inside the workspace', (_name, Component, prefix) => {
+    renderWithProviders(<Component />);
+    const links = screen.getAllByRole('link');
+    expect(links.length).toBeGreaterThan(0);
+    // At least one link must match the workspace prefix; cross-workspace
+    // links (e.g. Reports → /analytics) are intentional and skipped here.
+    const inside = links.filter((link) => prefix.test(link.getAttribute('href') || ''));
+    expect(inside.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/__tests__/pages/AnalyticsDashboardPage.test.tsx
+++ b/frontend/src/__tests__/pages/AnalyticsDashboardPage.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Smoke tests for AnalyticsDashboardPage. Covers:
+ * - happy path render with mocked pulse response
+ * - error path
+ * - shared mode forwards token from query param and hides Share button
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import AnalyticsDashboardPage from '../../pages/AnalyticsDashboardPage';
+import * as api from '../../services/api';
+
+jest.mock('../../services/api');
+
+// Recharts is heavy — render placeholders so the smoke test stays focused.
+jest.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
+  LineChart: () => <div data-testid="line-chart" />,
+  Line: () => null,
+  BarChart: () => <div data-testid="bar-chart" />,
+  Bar: () => null,
+  RadialBarChart: () => <div data-testid="radial-bar-chart" />,
+  RadialBar: () => null,
+  PolarAngleAxis: () => null,
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+}));
+
+const renderAt = (path: string) =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/analytics" element={<AnalyticsDashboardPage />} />
+          <Route path="/analytics/shared" element={<AnalyticsDashboardPage shared />} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>
+  );
+
+const mockPulse: api.AnalyticsPulseResponse = {
+  summary: {
+    period_start: '2026-04-01',
+    period_end: '2026-05-01',
+    internal_completed_count: 12,
+    internal_estimated_external_cost: '3000.00',
+    internal_estimated_internal_cost: '500.00',
+    internal_net_value: '2500.00',
+    external_closed_count: 2,
+    external_actual_cost: '950.00',
+    external_estimated_cost: '1200.00',
+    total_value_to_makerspace: '1550.00',
+  },
+  wo_volume_trend: [
+    { period: '2026-04-01', count: 12 },
+  ],
+  top_users: [
+    { user_id: 1, username: 'alice', display_name: 'Alice Wonder', completed_wo_count: 5 },
+  ],
+  utilization: [
+    { asset_id: 'a1', asset_name: 'CNC Mill', category: 'CNC', hours_used: 150, completed_wo_count: 3, status: 'active' },
+  ],
+  category_spend: [
+    { category_id: 1, category_name: 'CNC', internal_estimated: '300.00', external_estimated: '600.00', external_actual: '950.00', internal_wo_count: 2, external_wo_count: 1 },
+  ],
+  maintenance_forecast: [
+    { asset_id: 'a1', asset_name: 'CNC Mill', category: 'CNC', status: 'active', hours_used: 150, last_completed_wo_at: null, interval_hours: 100, interval_days: null, days_since_last_wo: null, due_reason: 'hours' },
+  ],
+  monthly_budget: '5000.00',
+};
+
+describe('AnalyticsDashboardPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all panels with mocked pulse data', async () => {
+    (api.pulseAPI.getPulse as jest.Mock).mockResolvedValue({ data: mockPulse });
+
+    renderAt('/analytics');
+
+    await waitFor(() => {
+      expect(screen.getByText('Makerspace pulse')).toBeInTheDocument();
+    });
+
+    // Summary stats
+    expect(screen.getByText('Net value created')).toBeInTheDocument();
+    // Panels rendered
+    expect(screen.getByTestId('budget-gauge')).toBeInTheDocument();
+    expect(screen.getByTestId('volume-trend-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('category-spend-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('top-users-table')).toBeInTheDocument();
+    expect(screen.getByTestId('maintenance-forecast-list')).toBeInTheDocument();
+    expect(screen.getByTestId('equipment-status-grid')).toBeInTheDocument();
+    // Top user surfaces
+    expect(screen.getByText('Alice Wonder')).toBeInTheDocument();
+    // Share button visible in default (non-shared) mode
+    expect(screen.getByRole('button', { name: /share with board/i })).toBeInTheDocument();
+  });
+
+  it('renders error state on API failure', async () => {
+    (api.pulseAPI.getPulse as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    renderAt('/analytics');
+
+    await waitFor(() => {
+      // Mantine Alert renders title + body. Pick whichever instance is present.
+      const matches = screen.getAllByText(/Could not load analytics/);
+      expect(matches.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('shared mode forwards token and hides share button', async () => {
+    (api.pulseAPI.getPulse as jest.Mock).mockResolvedValue({ data: mockPulse });
+
+    renderAt('/analytics/shared?token=signed.token.here');
+
+    await waitFor(() => {
+      expect(screen.getByText(/shared link/i)).toBeInTheDocument();
+    });
+
+    expect(api.pulseAPI.getPulse).toHaveBeenCalledWith({ token: 'signed.token.here' });
+    expect(screen.queryByRole('button', { name: /share with board/i })).not.toBeInTheDocument();
+  });
+
+  it('hides budget gauge when monthly_budget is null', async () => {
+    (api.pulseAPI.getPulse as jest.Mock).mockResolvedValue({
+      data: { ...mockPulse, monthly_budget: null },
+    });
+
+    renderAt('/analytics');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('budget-gauge-disabled')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('budget-gauge')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/HomePage.test.tsx
+++ b/frontend/src/__tests__/pages/HomePage.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * HomePage tests (AC-1).
+ *
+ * Asserts every spec-listed capability area is enumerated on the
+ * homepage with an actionable link, and that the Common workflows row
+ * is present. Catches regressions where a workspace silently disappears
+ * from the homepage capability grid.
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import HomePage from '../../pages/HomePage';
+
+// AuthSection talks to the API and renders auth UI. The homepage tests
+// don't need to exercise that surface; render a stub instead.
+jest.mock('../../components/AuthSection', () => () => <div data-testid="auth-section-stub" />);
+// Footer pulls in Mantine + assets we don't care about for these tests.
+jest.mock('../../components/Footer', () => () => <div data-testid="footer-stub" />);
+
+const renderHome = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    </MantineProvider>
+  );
+
+describe('HomePage (AC-1)', () => {
+  it('renders the hero and Common workflows row', () => {
+    renderHome();
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/run the shop/i);
+    expect(screen.getByTestId('home-quick-workflows')).toBeInTheDocument();
+  });
+
+  it('Common workflows row links to scan, dashboard, and maintenance', () => {
+    renderHome();
+    const row = screen.getByTestId('home-quick-workflows');
+    expect(within(row).getByRole('link', { name: /scan a qr code/i }))
+      .toHaveAttribute('href', '/inventory/scan');
+    expect(within(row).getByRole('link', { name: /operations dashboard/i }))
+      .toHaveAttribute('href', '/dashboard');
+    expect(within(row).getByRole('link', { name: /maintenance/i }))
+      .toHaveAttribute('href', '/maintenance');
+  });
+
+  describe('every spec-listed workspace has a CapabilityCard', () => {
+    // Path → expected card title (used to disambiguate when multiple
+    // sections mention the same word).
+    const expected: Array<[string, RegExp]> = [
+      ['/inventory', /^inventory$/i],
+      ['/purchasing', /^purchasing$/i],
+      ['/assets', /^assets$/i],
+      ['/facilities', /^facilities$/i],
+      ['/maintenance', /^maintenance$/i],
+      ['/sigs/dashboard', /^sigs$/i],
+      ['/reports', /^reports$/i],
+      ['/analytics', /analytics pulse/i],
+      ['/settings', /settings/i],
+    ];
+    it.each(expected)('links to %s with title matching %s', (href, _titleRe) => {
+      renderHome();
+      const grid = screen.getByTestId('home-workspaces');
+      const link = within(grid).getByRole('link', { name: _titleRe });
+      expect(link).toHaveAttribute('href', href);
+    });
+  });
+
+  it('badges Analytics Pulse as Staff', () => {
+    renderHome();
+    const grid = screen.getByTestId('home-workspaces');
+    const analyticsCard = within(grid).getByTestId('home-workspace-/analytics');
+    expect(within(analyticsCard).getByText(/staff/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Breadcrumbs.tsx
+++ b/frontend/src/components/Breadcrumbs.tsx
@@ -1,70 +1,45 @@
 /**
  * Breadcrumbs Component
- * Displays full navigation path from current route
+ *
+ * Renders the navigation path from current route. Labels and click-target
+ * routability come from `frontend/src/navigation/routeMap.ts` so a single
+ * place defines both. Segments that are not navigable (no route handler)
+ * render as plain text instead of links — see `clickable: false` entries
+ * in the route map.
  */
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import '../styles/Breadcrumbs.css';
 
+import { isClickable, labelFor } from '../navigation/routeMap';
+
 interface BreadcrumbSegment {
   path: string;
   label: string;
+  clickable: boolean;
 }
 
 const Breadcrumbs: React.FC = () => {
   const location = useLocation();
 
-  const getBreadcrumbs = (): BreadcrumbSegment[] => {
+  const breadcrumbs = React.useMemo<BreadcrumbSegment[]>(() => {
     const pathSegments = location.pathname.split('/').filter(Boolean);
-    const breadcrumbs: BreadcrumbSegment[] = [{ path: '/', label: 'Home' }];
-
-    // Route to label mapping
-    const routeLabels: Record<string, string> = {
-      inventory: 'Inventory',
-      'inventory/assets': 'Assets',
-      'inventory/admin': 'Admin Dashboard',
-      'inventory/code-entry': 'Code Entry',
-      'inventory/transparency': 'Transparency',
-      'inventory/scan': 'Scan Items',
-      maintenance: 'Maintenance',
-      'maintenance/location-problems': 'Location Problems',
-      'maintenance/work-orders': 'Work Orders',
-      'maintenance/third-party': 'Third-Party Work Orders',
-      'maintenance/dashboard': 'PM Dashboard',
-      purchasing: 'Purchasing',
-      'purchasing/orders': 'Purchase Orders',
-      assets: 'Assets',
-      facilities: 'Facilities',
-      'facilities/tv-dashboard': 'TV Dashboard',
-      'facilities/logistics': 'Logistics',
-      'facilities/checklist': 'Checklist',
-      sigs: 'SIGs',
-      'sigs/dashboard': 'SIG Dashboard',
-      settings: 'Settings',
-      'settings/tax-receipt': 'Tax Receipt',
-      'settings/tax-receipt/lookup': 'Tax Receipt Lookup',
-    };
+    const out: BreadcrumbSegment[] = [{ path: '/', label: 'Home', clickable: true }];
 
     let currentPath = '';
     pathSegments.forEach((segment, index) => {
       currentPath += `/${segment}`;
       const pathKey = pathSegments.slice(0, index + 1).join('/');
-      
-      // Use mapped label or format segment
-      const label = routeLabels[pathKey] || 
-                   segment.split('-').map(word => 
-                     word.charAt(0).toUpperCase() + word.slice(1)
-                   ).join(' ');
-      
-      breadcrumbs.push({ path: currentPath, label });
+      out.push({
+        path: currentPath,
+        label: labelFor(pathKey, segment),
+        clickable: isClickable(pathKey),
+      });
     });
 
-    return breadcrumbs;
-  };
+    return out;
+  }, [location.pathname]);
 
-  const breadcrumbs = getBreadcrumbs();
-
-  // Don't show breadcrumbs on home page
   if (location.pathname === '/') {
     return null;
   }
@@ -74,17 +49,21 @@ const Breadcrumbs: React.FC = () => {
       <ol className="breadcrumb-list">
         {breadcrumbs.map((crumb, index) => {
           const isLast = index === breadcrumbs.length - 1;
-          
+          const renderAsLink = !isLast && crumb.clickable;
+
           return (
             <li key={crumb.path} className="breadcrumb-item">
-              {isLast ? (
-                <span className="breadcrumb-current" aria-current="page">
-                  {crumb.label}
-                </span>
-              ) : (
+              {renderAsLink ? (
                 <Link to={crumb.path} className="breadcrumb-link">
                   {crumb.label}
                 </Link>
+              ) : (
+                <span
+                  className={isLast ? 'breadcrumb-current' : 'breadcrumb-static'}
+                  aria-current={isLast ? 'page' : undefined}
+                >
+                  {crumb.label}
+                </span>
               )}
               {!isLast && <span className="breadcrumb-separator">›</span>}
             </li>
@@ -96,4 +75,3 @@ const Breadcrumbs: React.FC = () => {
 };
 
 export default Breadcrumbs;
-

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -139,6 +139,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed = false, isMobileOpen = f
       label: 'Reports',
       icon: '📊',
       items: [
+        { path: '/analytics', label: 'Analytics Pulse', icon: '📈', requiresAuth: true, requiresStaff: true },
         { path: '/reports/inventory', label: 'Inventory Report', icon: '📦', requiresAuth: true },
         { path: '/reports/purchasing', label: 'Purchasing Report', icon: '🛒', requiresAuth: true },
         { path: '/reports/assets', label: 'Asset Report', icon: '🏢', requiresAuth: true },

--- a/frontend/src/components/analytics/BudgetGauge.tsx
+++ b/frontend/src/components/analytics/BudgetGauge.tsx
@@ -1,0 +1,52 @@
+import { Card, Group, Stack, Text, Title } from '@mantine/core';
+import React from 'react';
+import {
+  PolarAngleAxis,
+  RadialBar,
+  RadialBarChart,
+  ResponsiveContainer,
+} from 'recharts';
+
+interface BudgetGaugeProps {
+  budget: string | null;
+  externalActualCost: string;
+}
+
+const fmt = (n: number) =>
+  n.toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+
+export const BudgetGauge: React.FC<BudgetGaugeProps> = ({ budget, externalActualCost }) => {
+  if (!budget) {
+    return (
+      <Card withBorder p="md" radius="md" data-testid="budget-gauge-disabled">
+        <Title order={4}>Monthly budget</Title>
+        <Text size="sm" c="dimmed" mt="sm">
+          Set <code>MONTHLY_BUDGET_TOTAL</code> in backend settings to enable this gauge.
+        </Text>
+      </Card>
+    );
+  }
+
+  const budgetNum = Number(budget);
+  const spent = Number(externalActualCost);
+  const pct = budgetNum > 0 ? Math.min(100, Math.round((spent / budgetNum) * 100)) : 0;
+  const data = [{ name: 'spent', value: pct, fill: pct >= 90 ? 'var(--mantine-color-red-6)' : pct >= 70 ? 'var(--mantine-color-yellow-6)' : 'var(--mantine-color-green-6)' }];
+
+  return (
+    <Card withBorder p="md" radius="md" data-testid="budget-gauge">
+      <Title order={4}>Monthly budget</Title>
+      <Stack gap="xs" mt="sm">
+        <ResponsiveContainer width="100%" height={180}>
+          <RadialBarChart innerRadius="70%" outerRadius="100%" data={data} startAngle={180} endAngle={0}>
+            <PolarAngleAxis type="number" domain={[0, 100]} angleAxisId={0} tick={false} />
+            <RadialBar background dataKey="value" angleAxisId={0} />
+          </RadialBarChart>
+        </ResponsiveContainer>
+        <Group justify="space-between">
+          <Text size="sm" c="dimmed">Spent</Text>
+          <Text fw={600}>{fmt(spent)} / {fmt(budgetNum)} ({pct}%)</Text>
+        </Group>
+      </Stack>
+    </Card>
+  );
+};

--- a/frontend/src/components/analytics/CategorySpendChart.tsx
+++ b/frontend/src/components/analytics/CategorySpendChart.tsx
@@ -1,0 +1,50 @@
+import { Card, Text, Title } from '@mantine/core';
+import React from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { AnalyticsCategorySpendRow } from '../../services/api';
+
+interface CategorySpendChartProps {
+  data: AnalyticsCategorySpendRow[];
+}
+
+const fmtMoney = (n: number) =>
+  n.toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+
+export const CategorySpendChart: React.FC<CategorySpendChartProps> = ({ data }) => {
+  const chartData = data.map((row) => ({
+    category: row.category_name ?? 'Uncategorized',
+    'Internal estimated': Number(row.internal_estimated),
+    'External actual': Number(row.external_actual),
+  }));
+
+  return (
+    <Card withBorder p="md" radius="md" data-testid="category-spend-chart">
+      <Title order={4}>Spend by category</Title>
+      {chartData.length === 0 ? (
+        <Text size="sm" c="dimmed" mt="sm">No work orders attributed to a category in this window.</Text>
+      ) : (
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart data={chartData} margin={{ top: 16, right: 16, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="category" />
+            <YAxis tickFormatter={fmtMoney} />
+            <Tooltip formatter={(value: number) => fmtMoney(value)} />
+            <Legend />
+            <Bar dataKey="Internal estimated" fill="var(--mantine-color-blue-5)" />
+            <Bar dataKey="External actual" fill="var(--mantine-color-orange-6)" />
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </Card>
+  );
+};

--- a/frontend/src/components/analytics/EquipmentStatusGrid.tsx
+++ b/frontend/src/components/analytics/EquipmentStatusGrid.tsx
@@ -1,0 +1,54 @@
+import { Badge, Card, Table, Text, Title } from '@mantine/core';
+import React from 'react';
+
+import type { AnalyticsUtilizationRow } from '../../services/api';
+
+interface EquipmentStatusGridProps {
+  rows: AnalyticsUtilizationRow[];
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  active: 'green',
+  maintenance: 'yellow',
+  testing: 'blue',
+  implementing: 'cyan',
+  retired: 'gray',
+  lost: 'red',
+  donated_out: 'gray',
+};
+
+export const EquipmentStatusGrid: React.FC<EquipmentStatusGridProps> = ({ rows }) => (
+  <Card withBorder p="md" radius="md" data-testid="equipment-status-grid">
+    <Title order={4}>Equipment touched this period</Title>
+    {rows.length === 0 ? (
+      <Text size="sm" c="dimmed" mt="sm">No assets had completed work orders in this window.</Text>
+    ) : (
+      <Table mt="sm" striped highlightOnHover>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Asset</Table.Th>
+            <Table.Th>Category</Table.Th>
+            <Table.Th>Status</Table.Th>
+            <Table.Th ta="right">Hours used</Table.Th>
+            <Table.Th ta="right">Completed WOs</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {rows.map((r) => (
+            <Table.Tr key={r.asset_id}>
+              <Table.Td>{r.asset_name}</Table.Td>
+              <Table.Td>{r.category ?? '—'}</Table.Td>
+              <Table.Td>
+                <Badge color={STATUS_COLORS[r.status] ?? 'gray'} variant="light">
+                  {r.status}
+                </Badge>
+              </Table.Td>
+              <Table.Td ta="right">{r.hours_used}</Table.Td>
+              <Table.Td ta="right">{r.completed_wo_count}</Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    )}
+  </Card>
+);

--- a/frontend/src/components/analytics/MaintenanceForecastList.tsx
+++ b/frontend/src/components/analytics/MaintenanceForecastList.tsx
@@ -1,0 +1,60 @@
+import { Badge, Card, Table, Text, Title } from '@mantine/core';
+import React from 'react';
+
+import type { AnalyticsForecastEntry } from '../../services/api';
+
+interface MaintenanceForecastListProps {
+  entries: AnalyticsForecastEntry[];
+}
+
+const REASON_COLORS: Record<string, string> = {
+  both: 'red',
+  days: 'orange',
+  hours: 'yellow',
+};
+
+const REASON_LABELS: Record<string, string> = {
+  both: 'Hours + days',
+  days: 'Days',
+  hours: 'Hours',
+};
+
+export const MaintenanceForecastList: React.FC<MaintenanceForecastListProps> = ({ entries }) => (
+  <Card withBorder p="md" radius="md" data-testid="maintenance-forecast-list">
+    <Title order={4}>Maintenance forecast</Title>
+    {entries.length === 0 ? (
+      <Text size="sm" c="dimmed" mt="sm">No assets are due for service.</Text>
+    ) : (
+      <Table mt="sm" striped highlightOnHover>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Asset</Table.Th>
+            <Table.Th>Trigger</Table.Th>
+            <Table.Th ta="right">Hours used</Table.Th>
+            <Table.Th ta="right">Days since last WO</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {entries.map((e) => (
+            <Table.Tr key={e.asset_id}>
+              <Table.Td>{e.asset_name}</Table.Td>
+              <Table.Td>
+                <Badge color={REASON_COLORS[e.due_reason] ?? 'gray'} variant="light">
+                  {REASON_LABELS[e.due_reason] ?? e.due_reason}
+                </Badge>
+              </Table.Td>
+              <Table.Td ta="right">
+                {e.hours_used}
+                {e.interval_hours !== null && <Text component="span" size="xs" c="dimmed"> / {e.interval_hours}</Text>}
+              </Table.Td>
+              <Table.Td ta="right">
+                {e.days_since_last_wo ?? '—'}
+                {e.interval_days !== null && <Text component="span" size="xs" c="dimmed"> / {e.interval_days}</Text>}
+              </Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    )}
+  </Card>
+);

--- a/frontend/src/components/analytics/ShareLinkButton.tsx
+++ b/frontend/src/components/analytics/ShareLinkButton.tsx
@@ -1,0 +1,108 @@
+import { Button, CopyButton, Group, Modal, NumberInput, Stack, Text, TextInput, Tooltip } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { IconCheck, IconCopy, IconShare } from '@tabler/icons-react';
+import React, { useState } from 'react';
+
+import { pulseAPI } from '../../services/api';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
+
+interface ShareLinkButtonProps {
+  /** Origin URL to compose into the share link, e.g. window.location.origin. */
+  baseUrl: string;
+}
+
+export const ShareLinkButton: React.FC<ShareLinkButtonProps> = ({ baseUrl }) => {
+  const [opened, { open, close }] = useDisclosure(false);
+  const [ttlDays, setTtlDays] = useState<number | string>(30);
+  const [submitting, setSubmitting] = useState(false);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+
+  const reset = () => {
+    setTtlDays(30);
+    setShareUrl(null);
+  };
+
+  const onClose = () => {
+    close();
+    reset();
+  };
+
+  const onMint = async () => {
+    setSubmitting(true);
+    try {
+      const ttl = typeof ttlDays === 'number' ? ttlDays : parseInt(String(ttlDays), 10);
+      const resp = await pulseAPI.createShare(ttl);
+      const url = `${baseUrl}/analytics/shared?token=${encodeURIComponent(resp.data.token)}`;
+      setShareUrl(url);
+    } catch (err) {
+      notifications.show({
+        color: 'red',
+        title: 'Could not create share link',
+        message: extractErrorMessage(err) ?? 'Unknown error',
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Button leftSection={<IconShare size={16} />} variant="light" onClick={open}>
+        Share with board
+      </Button>
+      <Modal opened={opened} onClose={onClose} title="Share analytics dashboard" size="md">
+        <Stack>
+          <Text size="sm">
+            Generates a signed URL that anyone can use to view the dashboard read-only,
+            even without an OMS account. The URL expires after the chosen number of days.
+          </Text>
+          {shareUrl ? (
+            <Stack gap="xs">
+              <TextInput
+                label="Shareable URL"
+                value={shareUrl}
+                readOnly
+                onFocus={(e) => e.currentTarget.select()}
+                rightSection={
+                  <CopyButton value={shareUrl} timeout={2000}>
+                    {({ copied, copy }) => (
+                      <Tooltip label={copied ? 'Copied' : 'Copy'} withArrow>
+                        <Button size="xs" variant="subtle" onClick={copy} aria-label="Copy share URL">
+                          {copied ? <IconCheck size={16} /> : <IconCopy size={16} />}
+                        </Button>
+                      </Tooltip>
+                    )}
+                  </CopyButton>
+                }
+                rightSectionWidth={48}
+              />
+              <Text size="xs" c="dimmed">
+                Treat this URL as sensitive. Anyone with the link can view the dashboard until it expires.
+                To revoke a leaked link before expiry, rotate <code>ANALYTICS_SHARE_SALT</code> in backend settings.
+              </Text>
+            </Stack>
+          ) : (
+            <NumberInput
+              label="Expires after"
+              description="Days from now (1–365)"
+              value={ttlDays}
+              onChange={setTtlDays}
+              min={1}
+              max={365}
+              data-testid="share-ttl-input"
+            />
+          )}
+          <Group justify="flex-end" mt="sm">
+            <Button variant="subtle" onClick={onClose}>Close</Button>
+            {!shareUrl && (
+              <Button onClick={onMint} loading={submitting} data-testid="share-mint-button">
+                Generate URL
+              </Button>
+            )}
+          </Group>
+        </Stack>
+      </Modal>
+    </>
+  );
+};

--- a/frontend/src/components/analytics/ShareLinkButton.tsx
+++ b/frontend/src/components/analytics/ShareLinkButton.tsx
@@ -39,7 +39,7 @@ export const ShareLinkButton: React.FC<ShareLinkButtonProps> = ({ baseUrl }) => 
       notifications.show({
         color: 'red',
         title: 'Could not create share link',
-        message: extractErrorMessage(err) ?? 'Unknown error',
+        message: extractErrorMessage(err, 'Unknown error'),
       });
     } finally {
       setSubmitting(false);

--- a/frontend/src/components/analytics/TopUsersTable.tsx
+++ b/frontend/src/components/analytics/TopUsersTable.tsx
@@ -1,0 +1,34 @@
+import { Card, Table, Text, Title } from '@mantine/core';
+import React from 'react';
+
+import type { AnalyticsTopUser } from '../../services/api';
+
+interface TopUsersTableProps {
+  users: AnalyticsTopUser[];
+}
+
+export const TopUsersTable: React.FC<TopUsersTableProps> = ({ users }) => (
+  <Card withBorder p="md" radius="md" data-testid="top-users-table">
+    <Title order={4}>Top contributors</Title>
+    {users.length === 0 ? (
+      <Text size="sm" c="dimmed" mt="sm">No completed work orders in this window.</Text>
+    ) : (
+      <Table mt="sm" striped highlightOnHover>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Member</Table.Th>
+            <Table.Th ta="right">Completed WOs</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {users.map((u) => (
+            <Table.Tr key={u.user_id}>
+              <Table.Td>{u.display_name}</Table.Td>
+              <Table.Td ta="right">{u.completed_wo_count}</Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    )}
+  </Card>
+);

--- a/frontend/src/components/analytics/VolumeTrendChart.tsx
+++ b/frontend/src/components/analytics/VolumeTrendChart.tsx
@@ -1,0 +1,41 @@
+import { Card, Text, Title } from '@mantine/core';
+import React from 'react';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { AnalyticsTrendPoint } from '../../services/api';
+
+interface VolumeTrendChartProps {
+  data: AnalyticsTrendPoint[];
+}
+
+const formatPeriodLabel = (iso: string) => {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, { month: 'short', year: '2-digit' });
+};
+
+export const VolumeTrendChart: React.FC<VolumeTrendChartProps> = ({ data }) => (
+  <Card withBorder p="md" radius="md" data-testid="volume-trend-chart">
+    <Title order={4}>Work order volume — last 12 months</Title>
+    {data.length === 0 ? (
+      <Text size="sm" c="dimmed" mt="sm">No completed work orders in the trend window.</Text>
+    ) : (
+      <ResponsiveContainer width="100%" height={260}>
+        <LineChart data={data} margin={{ top: 16, right: 16, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="period" tickFormatter={formatPeriodLabel} />
+          <YAxis allowDecimals={false} />
+          <Tooltip labelFormatter={formatPeriodLabel} />
+          <Line type="monotone" dataKey="count" stroke="var(--mantine-color-blue-6)" strokeWidth={2} dot={{ r: 3 }} />
+        </LineChart>
+      </ResponsiveContainer>
+    )}
+  </Card>
+);

--- a/frontend/src/components/landing/CapabilityCard.tsx
+++ b/frontend/src/components/landing/CapabilityCard.tsx
@@ -1,0 +1,96 @@
+/**
+ * CapabilityCard — single grid item used on the homepage and every
+ * workspace overview page. Composes:
+ *   - Optional eyebrow (mono caps): a numbered or category label
+ *   - Icon "instrument chip" (Tabler icon on a dark square)
+ *   - Title (sans, semibold)
+ *   - Description (1-3 lines, muted)
+ *   - Optional badge (e.g. "Staff" for gated capabilities)
+ *   - "Open →" affordance that animates on hover
+ *
+ * The whole card is the link (single click target — no accessibility
+ * footgun where the title and the arrow are separate links).
+ *
+ * AC-2: every workspace overview page uses this component, so card
+ * styling stays consistent without per-page duplication.
+ */
+import { Badge, Box, Group, Stack, Text } from '@mantine/core';
+import { IconArrowNarrowRight } from '@tabler/icons-react';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import '../../styles/landing.css';
+
+export interface CapabilityCardProps {
+  /** Destination path. Use absolute paths (e.g. "/inventory/scan"). */
+  to: string;
+  /** Required: card title in body sans. */
+  title: string;
+  /** Required: 1-3 line description shown beneath the title. */
+  description: string;
+  /** Tabler icon component (rendered at 22px on a dark chip). */
+  icon: React.ReactNode;
+  /** Optional eyebrow (mono caps). Use for capability numbering or category. */
+  eyebrow?: string;
+  /** Optional pill badge (e.g. "Staff") shown above the title. */
+  badge?: string;
+  /** Override the call-to-action label; defaults to "Open". */
+  ctaLabel?: string;
+  /** Stable test selector. Defaults to `capability-card-${to}`. */
+  testId?: string;
+}
+
+const CapabilityCard: React.FC<CapabilityCardProps> = ({
+  to,
+  title,
+  description,
+  icon,
+  eyebrow,
+  badge,
+  ctaLabel = 'Open',
+  testId,
+}) => (
+  <Link
+    to={to}
+    className="landing-capability-card"
+    data-testid={testId ?? `capability-card-${to}`}
+    aria-label={title}
+    style={{ padding: '1.4rem' }}
+  >
+    <Stack gap="md" style={{ height: '100%' }}>
+      <Group justify="space-between" align="flex-start" wrap="nowrap">
+        <Box className="landing-icon-chip" aria-hidden>
+          {icon}
+        </Box>
+        {badge && (
+          <Badge color="blue" variant="light" size="sm" radius="sm">
+            {badge}
+          </Badge>
+        )}
+      </Group>
+
+      <Stack gap={6} style={{ flex: 1 }}>
+        {eyebrow && (
+          <Text component="span" className="landing-eyebrow">
+            {eyebrow}
+          </Text>
+        )}
+        <Text component="h3" fw={600} size="lg" style={{ margin: 0, lineHeight: 1.25 }}>
+          {title}
+        </Text>
+        <Text size="sm" c="dimmed" style={{ lineHeight: 1.5 }}>
+          {description}
+        </Text>
+      </Stack>
+
+      <Box>
+        <span className="landing-arrow">
+          {ctaLabel}
+          <IconArrowNarrowRight size={16} stroke={2.4} />
+        </span>
+      </Box>
+    </Stack>
+  </Link>
+);
+
+export default CapabilityCard;

--- a/frontend/src/components/landing/PageHero.tsx
+++ b/frontend/src/components/landing/PageHero.tsx
@@ -1,0 +1,68 @@
+/**
+ * PageHero — the top-of-page banner for the homepage and workspace
+ * overview pages. Renders an optional eyebrow (mono caps), a display
+ * title, an optional description, and an optional action slot
+ * (right-aligned on wide viewports, stacked under the description on
+ * narrow ones).
+ *
+ * Usage:
+ *   <PageHero
+ *     eyebrow="Reports"
+ *     title="Operational + executive reporting"
+ *     description="Pulse, inventory, purchasing, and asset reports."
+ *     action={<ShareLinkButton ... />}
+ *   />
+ *
+ * AC-2: this is the canonical hero used by the homepage and every
+ * workspace landing page so typography + spacing stay consistent.
+ */
+import { Box, Group, Stack, Text } from '@mantine/core';
+import React from 'react';
+
+import '../../styles/landing.css';
+
+export interface PageHeroProps {
+  eyebrow?: string;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  action?: React.ReactNode;
+}
+
+const PageHero: React.FC<PageHeroProps> = ({ eyebrow, title, description, action }) => (
+  <Box component="header" data-testid="page-hero" mb="xl">
+    <Group justify="space-between" align="flex-end" wrap="wrap" gap="md">
+      <Stack gap="xs" style={{ flex: '1 1 360px' }}>
+        {eyebrow && (
+          <Text component="span" className="landing-eyebrow" data-testid="page-hero-eyebrow">
+            {eyebrow}
+          </Text>
+        )}
+        <Text
+          component="h1"
+          className="landing-display"
+          data-testid="page-hero-title"
+          style={{ fontSize: 'clamp(1.9rem, 3.4vw, 2.7rem)', margin: 0 }}
+        >
+          {title}
+        </Text>
+        {description && (
+          <Text
+            size="md"
+            c="dimmed"
+            data-testid="page-hero-description"
+            style={{ maxWidth: 64 * 8 }}
+          >
+            {description}
+          </Text>
+        )}
+      </Stack>
+      {action && (
+        <Box data-testid="page-hero-action" style={{ flexShrink: 0 }}>
+          {action}
+        </Box>
+      )}
+    </Group>
+  </Box>
+);
+
+export default PageHero;

--- a/frontend/src/components/landing/WorkspaceLanding.tsx
+++ b/frontend/src/components/landing/WorkspaceLanding.tsx
@@ -1,0 +1,67 @@
+/**
+ * WorkspaceLanding — page shell composed of <PageHero> + a card grid +
+ * an optional footer slot. Used by every workspace overview page so
+ * spacing, typography, and card rhythm stay identical (AC-2).
+ *
+ * Pass capability cards as `children`; this component handles the
+ * SimpleGrid layout and the warm-paper landing surface. If a workspace
+ * needs more bespoke content beneath the grid (e.g. a list of recent
+ * activity), put it in `footer`.
+ *
+ * Usage:
+ *   <WorkspaceLanding
+ *     hero={{ eyebrow: "Reports", title: "...", description: "..." }}
+ *   >
+ *     <CapabilityCard ... />
+ *     <CapabilityCard ... />
+ *   </WorkspaceLanding>
+ */
+import { Box, Container, SimpleGrid, Stack } from '@mantine/core';
+import React from 'react';
+
+import '../../styles/landing.css';
+import PageHero, { PageHeroProps } from './PageHero';
+
+export interface WorkspaceLandingProps {
+  /** Hero props passed straight to <PageHero>. */
+  hero: PageHeroProps;
+  /**
+   * Capability cards to lay out in a responsive grid. The grid is 1/2/3
+   * columns at base/sm/lg breakpoints — matches the existing dashboard
+   * stat-card pattern so workspaces feel rhythmically consistent.
+   */
+  children?: React.ReactNode;
+  /**
+   * Optional content rendered below the capability grid (e.g. recent
+   * activity, "what changed last month" callouts).
+   */
+  footer?: React.ReactNode;
+  /** Override the column count if the workspace has fewer cards. */
+  cols?: { base?: number; sm?: number; lg?: number };
+  /** Stable test selector. */
+  testId?: string;
+}
+
+const WorkspaceLanding: React.FC<WorkspaceLandingProps> = ({
+  hero,
+  children,
+  footer,
+  cols = { base: 1, sm: 2, lg: 3 },
+  testId = 'workspace-landing',
+}) => (
+  <Box className="landing-surface" data-testid={testId}>
+    <Container size="xl" py="xl">
+      <Stack gap="xl">
+        <PageHero {...hero} />
+        {children && (
+          <SimpleGrid cols={cols} spacing="md" verticalSpacing="md">
+            {children}
+          </SimpleGrid>
+        )}
+        {footer && <Box>{footer}</Box>}
+      </Stack>
+    </Container>
+  </Box>
+);
+
+export default WorkspaceLanding;

--- a/frontend/src/navigation/routeMap.ts
+++ b/frontend/src/navigation/routeMap.ts
@@ -1,0 +1,123 @@
+/**
+ * Single source of truth for breadcrumb labels and click-target routability.
+ *
+ * Each entry maps a URL path (without leading slash) to:
+ *   - label: the human-readable name shown in breadcrumbs and (later) the
+ *     homepage capability cards.
+ *   - clickable: whether breadcrumb segments matching this path are
+ *     rendered as a <Link>. Set false when the path has no route handler
+ *     and clicking would dead-end. The current page is always rendered as
+ *     a non-clickable <span> regardless of this flag (see Breadcrumbs).
+ *
+ * Adding a new top-level workspace? Add an entry here AND register a
+ * route in App.tsx. The entryPoints test in
+ * __tests__/navigation/entryPoints.test.tsx asserts that every clickable
+ * route map entry mounts a non-error page.
+ */
+
+export interface RouteEntry {
+  /** Path without leading slash, e.g. "inventory/assets". */
+  path: string;
+  /** Human-readable label shown in breadcrumbs. */
+  label: string;
+  /**
+   * Whether this path is a clickable navigation target. Set false for
+   * structural URL segments that have no route handler (e.g. parents
+   * intentionally left as namespacing-only). Default is true.
+   */
+  clickable?: boolean;
+}
+
+const ENTRIES: RouteEntry[] = [
+  // Top-level workspaces — every entry below resolves to a real page.
+  { path: 'inventory', label: 'Inventory' },
+  { path: 'inventory/assets', label: 'Assets' },
+  { path: 'inventory/admin', label: 'Admin Dashboard' },
+  { path: 'inventory/code-entry', label: 'Code Entry' },
+  { path: 'inventory/transparency', label: 'Transparency' },
+  { path: 'inventory/scan', label: 'Scan Items' },
+  { path: 'inventory/items', label: 'Items' },
+  { path: 'inventory/suppliers', label: 'Suppliers' },
+  { path: 'inventory/categories', label: 'Categories' },
+  { path: 'inventory/locations', label: 'Locations' },
+
+  { path: 'dashboard', label: 'Dashboard' },
+
+  { path: 'purchasing', label: 'Purchasing' },
+  { path: 'purchasing/orders', label: 'Purchase Orders' },
+
+  { path: 'assets', label: 'Assets' },
+
+  { path: 'facilities', label: 'Facilities' },
+  { path: 'facilities/tv-dashboard', label: 'TV Dashboard' },
+  { path: 'facilities/logistics', label: 'Logistics' },
+  { path: 'facilities/checklist', label: 'Checklist' },
+  { path: 'facilities/screens', label: 'Screens' },
+  { path: 'facilities/maker-boxes', label: 'Maker Boxes' },
+  { path: 'facilities/electrical', label: 'Electrical' },
+  { path: 'facilities/forgekey-devices', label: 'ForgeKey Devices' },
+
+  { path: 'maintenance', label: 'Maintenance' },
+  { path: 'maintenance/dashboard', label: 'PM Dashboard' },
+  { path: 'maintenance/work-orders', label: 'Work Orders', clickable: false },
+  { path: 'maintenance/location-problems', label: 'Location Problems' },
+  { path: 'maintenance/third-party', label: 'Third-Party Work Orders', clickable: false },
+
+  { path: 'sigs', label: 'SIGs' },
+  { path: 'sigs/dashboard', label: 'SIG Dashboard' },
+
+  { path: 'reports', label: 'Reports' },
+  { path: 'reports/inventory', label: 'Inventory Report' },
+  { path: 'reports/purchasing', label: 'Purchasing Report' },
+  { path: 'reports/assets', label: 'Asset Report' },
+
+  { path: 'analytics', label: 'Analytics Pulse' },
+
+  { path: 'settings', label: 'Settings' },
+  { path: 'settings/profile', label: 'Profile' },
+  { path: 'settings/site', label: 'Site' },
+  { path: 'settings/webhooks', label: 'Webhooks' },
+  { path: 'settings/tax-receipt', label: 'Tax Receipt', clickable: false },
+  { path: 'settings/tax-receipt/lookup', label: 'Tax Receipt Lookup' },
+];
+
+const BY_PATH: Map<string, RouteEntry> = new Map(ENTRIES.map((e) => [e.path, e]));
+
+/** Returns the route entry for an exact path key, or undefined. */
+export function getRouteEntry(pathKey: string): RouteEntry | undefined {
+  return BY_PATH.get(pathKey);
+}
+
+/**
+ * Title-cases a slug-style segment as a fallback when the path is not in
+ * the map. Drops the trailing/leading slash. ``"work-orders" → "Work Orders"``.
+ */
+export function titleCaseSegment(segment: string): string {
+  return segment
+    .split('-')
+    .map((word) => (word ? word[0].toUpperCase() + word.slice(1) : ''))
+    .join(' ');
+}
+
+/**
+ * Returns the label for a path segment, preferring the route map. Used by
+ * breadcrumbs to avoid raw slug formatting where a canonical label exists.
+ */
+export function labelFor(pathKey: string, fallbackSegment: string): string {
+  const entry = BY_PATH.get(pathKey);
+  return entry ? entry.label : titleCaseSegment(fallbackSegment);
+}
+
+/**
+ * Returns true when a breadcrumb segment for this path should be a
+ * clickable <Link>. False when the path is a structural-only segment
+ * (no route handler) and clicking would dead-end.
+ */
+export function isClickable(pathKey: string): boolean {
+  const entry = BY_PATH.get(pathKey);
+  if (!entry) return true;
+  return entry.clickable !== false;
+}
+
+/** All registered entries — exposed for tests + the homepage in PR2. */
+export const ROUTE_MAP_ENTRIES: ReadonlyArray<RouteEntry> = ENTRIES;

--- a/frontend/src/pages/AnalyticsDashboardPage.tsx
+++ b/frontend/src/pages/AnalyticsDashboardPage.tsx
@@ -73,7 +73,7 @@ export const AnalyticsDashboardPage: React.FC<AnalyticsDashboardPageProps> = ({ 
       })
       .catch((err) => {
         if (!cancelled) {
-          setError(extractErrorMessage(err) ?? 'Could not load analytics.');
+          setError(extractErrorMessage(err, 'Could not load analytics.'));
           setLoading(false);
         }
       });

--- a/frontend/src/pages/AnalyticsDashboardPage.tsx
+++ b/frontend/src/pages/AnalyticsDashboardPage.tsx
@@ -1,0 +1,168 @@
+import {
+  Alert,
+  Card,
+  Container,
+  Grid,
+  Group,
+  Loader,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import { BudgetGauge } from '../components/analytics/BudgetGauge';
+import { CategorySpendChart } from '../components/analytics/CategorySpendChart';
+import { EquipmentStatusGrid } from '../components/analytics/EquipmentStatusGrid';
+import { MaintenanceForecastList } from '../components/analytics/MaintenanceForecastList';
+import { ShareLinkButton } from '../components/analytics/ShareLinkButton';
+import { TopUsersTable } from '../components/analytics/TopUsersTable';
+import { VolumeTrendChart } from '../components/analytics/VolumeTrendChart';
+import { pulseAPI, AnalyticsPulseResponse } from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+interface AnalyticsDashboardPageProps {
+  /**
+   * When true, the page renders the board-shareable view: no share button,
+   * a notice that this is a read-only snapshot, and the token from the URL
+   * is forwarded on the API call. Wired by the parent Route.
+   */
+  shared?: boolean;
+}
+
+const fmtMoney = (raw: string) => {
+  const n = Number(raw);
+  if (!isFinite(n)) return raw;
+  return n.toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 2 });
+};
+
+const SummaryStat: React.FC<{ label: string; value: string; hint?: string; emphasis?: boolean }> = ({
+  label,
+  value,
+  hint,
+  emphasis,
+}) => (
+  <Card withBorder p="md" radius="md">
+    <Text size="sm" c="dimmed" fw={500}>{label}</Text>
+    <Text size="1.6rem" fw={700} c={emphasis ? 'green.7' : undefined}>{value}</Text>
+    {hint && <Text size="xs" c="dimmed" mt={2}>{hint}</Text>}
+  </Card>
+);
+
+export const AnalyticsDashboardPage: React.FC<AnalyticsDashboardPageProps> = ({ shared = false }) => {
+  const [searchParams] = useSearchParams();
+  const [data, setData] = useState<AnalyticsPulseResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const token = shared ? searchParams.get('token') ?? undefined : undefined;
+    setLoading(true);
+    setError(null);
+    pulseAPI
+      .getPulse({ token })
+      .then((resp) => {
+        if (!cancelled) {
+          setData(resp.data);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(extractErrorMessage(err) ?? 'Could not load analytics.');
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [shared, searchParams]);
+
+  if (loading) {
+    return (
+      <Container size="xl" py="xl">
+        <Group justify="center"><Loader /></Group>
+      </Container>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <Container size="xl" py="xl">
+        <Alert color="red" icon={<IconAlertTriangle size={16} />} title="Could not load analytics">
+          {error ?? 'Unknown error'}
+        </Alert>
+      </Container>
+    );
+  }
+
+  const { summary } = data;
+
+  return (
+    <Container size="xl" py="lg">
+      <Group justify="space-between" mb="lg">
+        <Stack gap={2}>
+          <Title order={1}>Makerspace pulse</Title>
+          <Text size="sm" c="dimmed">
+            {summary.period_start} → {summary.period_end}
+            {shared && ' · shared link (read-only)'}
+          </Text>
+        </Stack>
+        {!shared && <ShareLinkButton baseUrl={window.location.origin} />}
+      </Group>
+
+      <Stack gap="lg">
+        <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="md">
+          <SummaryStat
+            label="Net value created"
+            value={fmtMoney(summary.internal_net_value)}
+            hint="External estimate − internal cost"
+            emphasis
+          />
+          <SummaryStat
+            label="External spend (closed)"
+            value={fmtMoney(summary.external_actual_cost)}
+            hint={`${summary.external_closed_count} third-party WO${summary.external_closed_count === 1 ? '' : 's'}`}
+          />
+          <SummaryStat
+            label="Internal WOs completed"
+            value={String(summary.internal_completed_count)}
+          />
+          <SummaryStat
+            label="Total to makerspace"
+            value={fmtMoney(summary.total_value_to_makerspace)}
+            hint="Net internal − external spent"
+          />
+        </SimpleGrid>
+
+        <Grid>
+          <Grid.Col span={{ base: 12, lg: 4 }}>
+            <BudgetGauge budget={data.monthly_budget} externalActualCost={summary.external_actual_cost} />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, lg: 8 }}>
+            <VolumeTrendChart data={data.wo_volume_trend} />
+          </Grid.Col>
+        </Grid>
+
+        <CategorySpendChart data={data.category_spend} />
+
+        <Grid>
+          <Grid.Col span={{ base: 12, lg: 6 }}>
+            <TopUsersTable users={data.top_users} />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, lg: 6 }}>
+            <MaintenanceForecastList entries={data.maintenance_forecast} />
+          </Grid.Col>
+        </Grid>
+
+        <EquipmentStatusGrid rows={data.utilization} />
+      </Stack>
+    </Container>
+  );
+};
+
+export default AnalyticsDashboardPage;

--- a/frontend/src/pages/AnalyticsDashboardPage.tsx
+++ b/frontend/src/pages/AnalyticsDashboardPage.tsx
@@ -8,7 +8,6 @@ import {
   SimpleGrid,
   Stack,
   Text,
-  Title,
 } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
@@ -21,6 +20,7 @@ import { MaintenanceForecastList } from '../components/analytics/MaintenanceFore
 import { ShareLinkButton } from '../components/analytics/ShareLinkButton';
 import { TopUsersTable } from '../components/analytics/TopUsersTable';
 import { VolumeTrendChart } from '../components/analytics/VolumeTrendChart';
+import PageHero from '../components/landing/PageHero';
 import { pulseAPI, AnalyticsPulseResponse } from '../services/api';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
 
@@ -104,16 +104,12 @@ export const AnalyticsDashboardPage: React.FC<AnalyticsDashboardPageProps> = ({ 
 
   return (
     <Container size="xl" py="lg">
-      <Group justify="space-between" mb="lg">
-        <Stack gap={2}>
-          <Title order={1}>Makerspace pulse</Title>
-          <Text size="sm" c="dimmed">
-            {summary.period_start} → {summary.period_end}
-            {shared && ' · shared link (read-only)'}
-          </Text>
-        </Stack>
-        {!shared && <ShareLinkButton baseUrl={window.location.origin} />}
-      </Group>
+      <PageHero
+        eyebrow="Analytics pulse"
+        title="Makerspace pulse"
+        description={`${summary.period_start} → ${summary.period_end}${shared ? ' · shared link (read-only)' : ''}`}
+        action={!shared ? <ShareLinkButton baseUrl={window.location.origin} /> : undefined}
+      />
 
       <Stack gap="lg">
         <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="md">

--- a/frontend/src/pages/FacilitiesOverviewPage.tsx
+++ b/frontend/src/pages/FacilitiesOverviewPage.tsx
@@ -1,0 +1,104 @@
+/**
+ * Landing page for the Facilities workspace. Same shape as the other
+ * overview pages added in this PR: a card grid with one entry per major
+ * child route. Lives at `/facilities/` so breadcrumb clicks have a real
+ * destination (was previously a 404).
+ */
+import { Card, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import {
+  IconBolt,
+  IconBox,
+  IconChecklist,
+  IconDeviceTv,
+  IconKey,
+  IconScreenshot,
+  IconTruck,
+} from '@tabler/icons-react';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+interface OverviewItem {
+  to: string;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+}
+
+const ITEMS: OverviewItem[] = [
+  {
+    to: '/facilities/tv-dashboard',
+    title: 'TV dashboard',
+    description: 'Full-screen status board for shop displays.',
+    icon: <IconDeviceTv size={28} />,
+  },
+  {
+    to: '/facilities/logistics',
+    title: 'Logistics dashboard',
+    description: 'Logistics view of open work, reorders, and location problems.',
+    icon: <IconTruck size={28} />,
+  },
+  {
+    to: '/facilities/screens',
+    title: 'Screens',
+    description: 'Configure kiosk and display screens.',
+    icon: <IconScreenshot size={28} />,
+  },
+  {
+    to: '/facilities/maker-boxes',
+    title: 'Maker boxes',
+    description: 'Inventory and check-out activity for member maker boxes.',
+    icon: <IconBox size={28} />,
+  },
+  {
+    to: '/facilities/electrical',
+    title: 'Electrical',
+    description: 'Breakers, outlets, light switches, and network drops.',
+    icon: <IconBolt size={28} />,
+  },
+  {
+    to: '/facilities/forgekey-devices',
+    title: 'ForgeKey devices',
+    description: 'Door, locker, and equipment-control devices on the ForgeKey bus.',
+    icon: <IconKey size={28} />,
+  },
+  {
+    to: '/facilities/checklist',
+    title: 'Checklists',
+    description: 'Recurring opening, closing, and safety walk-through checklists.',
+    icon: <IconChecklist size={28} />,
+  },
+];
+
+const FacilitiesOverviewPage: React.FC = () => (
+  <Container size="xl" py="lg">
+    <Stack gap="xl">
+      <Stack gap={4}>
+        <Title order={1}>Facilities</Title>
+        <Text c="dimmed">Operations dashboards, kiosks, and the physical-plant systems that keep the shop running.</Text>
+      </Stack>
+
+      <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
+        {ITEMS.map((item) => (
+          <Card
+            key={item.to}
+            withBorder
+            radius="md"
+            p="lg"
+            component={Link}
+            to={item.to}
+            data-testid={`facilities-overview-card-${item.to}`}
+            style={{ textDecoration: 'none', color: 'inherit' }}
+          >
+            <Stack gap="sm">
+              <Text c="blue.7">{item.icon}</Text>
+              <Title order={4}>{item.title}</Title>
+              <Text size="sm" c="dimmed">{item.description}</Text>
+            </Stack>
+          </Card>
+        ))}
+      </SimpleGrid>
+    </Stack>
+  </Container>
+);
+
+export default FacilitiesOverviewPage;

--- a/frontend/src/pages/FacilitiesOverviewPage.tsx
+++ b/frontend/src/pages/FacilitiesOverviewPage.tsx
@@ -1,10 +1,8 @@
 /**
- * Landing page for the Facilities workspace. Same shape as the other
- * overview pages added in this PR: a card grid with one entry per major
- * child route. Lives at `/facilities/` so breadcrumb clicks have a real
- * destination (was previously a 404).
+ * Landing page for the Facilities workspace, mounted at `/facilities/`.
+ * Refactored in nav-cohesion PR2 to use the shared <WorkspaceLanding>
+ * + <CapabilityCard> primitives.
  */
-import { Card, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import {
   IconBolt,
   IconBox,
@@ -15,90 +13,77 @@ import {
   IconTruck,
 } from '@tabler/icons-react';
 import React from 'react';
-import { Link } from 'react-router-dom';
 
-interface OverviewItem {
-  to: string;
-  title: string;
-  description: string;
-  icon: React.ReactNode;
-}
-
-const ITEMS: OverviewItem[] = [
-  {
-    to: '/facilities/tv-dashboard',
-    title: 'TV dashboard',
-    description: 'Full-screen status board for shop displays.',
-    icon: <IconDeviceTv size={28} />,
-  },
-  {
-    to: '/facilities/logistics',
-    title: 'Logistics dashboard',
-    description: 'Logistics view of open work, reorders, and location problems.',
-    icon: <IconTruck size={28} />,
-  },
-  {
-    to: '/facilities/screens',
-    title: 'Screens',
-    description: 'Configure kiosk and display screens.',
-    icon: <IconScreenshot size={28} />,
-  },
-  {
-    to: '/facilities/maker-boxes',
-    title: 'Maker boxes',
-    description: 'Inventory and check-out activity for member maker boxes.',
-    icon: <IconBox size={28} />,
-  },
-  {
-    to: '/facilities/electrical',
-    title: 'Electrical',
-    description: 'Breakers, outlets, light switches, and network drops.',
-    icon: <IconBolt size={28} />,
-  },
-  {
-    to: '/facilities/forgekey-devices',
-    title: 'ForgeKey devices',
-    description: 'Door, locker, and equipment-control devices on the ForgeKey bus.',
-    icon: <IconKey size={28} />,
-  },
-  {
-    to: '/facilities/checklist',
-    title: 'Checklists',
-    description: 'Recurring opening, closing, and safety walk-through checklists.',
-    icon: <IconChecklist size={28} />,
-  },
-];
+import CapabilityCard from '../components/landing/CapabilityCard';
+import WorkspaceLanding from '../components/landing/WorkspaceLanding';
 
 const FacilitiesOverviewPage: React.FC = () => (
-  <Container size="xl" py="lg">
-    <Stack gap="xl">
-      <Stack gap={4}>
-        <Title order={1}>Facilities</Title>
-        <Text c="dimmed">Operations dashboards, kiosks, and the physical-plant systems that keep the shop running.</Text>
-      </Stack>
-
-      <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
-        {ITEMS.map((item) => (
-          <Card
-            key={item.to}
-            withBorder
-            radius="md"
-            p="lg"
-            component={Link}
-            to={item.to}
-            data-testid={`facilities-overview-card-${item.to}`}
-            style={{ textDecoration: 'none', color: 'inherit' }}
-          >
-            <Stack gap="sm">
-              <Text c="blue.7">{item.icon}</Text>
-              <Title order={4}>{item.title}</Title>
-              <Text size="sm" c="dimmed">{item.description}</Text>
-            </Stack>
-          </Card>
-        ))}
-      </SimpleGrid>
-    </Stack>
-  </Container>
+  <WorkspaceLanding
+    testId="facilities-overview"
+    hero={{
+      eyebrow: 'Facilities',
+      title: 'Facilities',
+      description:
+        'Operations dashboards, kiosks, and the physical-plant systems that keep the shop running.',
+    }}
+  >
+    <CapabilityCard
+      to="/facilities/tv-dashboard"
+      title="TV dashboard"
+      description="Full-screen status board for shop displays."
+      icon={<IconDeviceTv size={22} stroke={1.8} />}
+      eyebrow="Display"
+      testId="facilities-overview-card-/facilities/tv-dashboard"
+    />
+    <CapabilityCard
+      to="/facilities/logistics"
+      title="Logistics dashboard"
+      description="Logistics view of open work, reorders, and location problems."
+      icon={<IconTruck size={22} stroke={1.8} />}
+      eyebrow="Display"
+      testId="facilities-overview-card-/facilities/logistics"
+    />
+    <CapabilityCard
+      to="/facilities/screens"
+      title="Screens"
+      description="Configure kiosk and display screens."
+      icon={<IconScreenshot size={22} stroke={1.8} />}
+      eyebrow="Setup"
+      testId="facilities-overview-card-/facilities/screens"
+    />
+    <CapabilityCard
+      to="/facilities/maker-boxes"
+      title="Maker boxes"
+      description="Inventory and check-out activity for member maker boxes."
+      icon={<IconBox size={22} stroke={1.8} />}
+      eyebrow="Members"
+      testId="facilities-overview-card-/facilities/maker-boxes"
+    />
+    <CapabilityCard
+      to="/facilities/electrical"
+      title="Electrical"
+      description="Breakers, outlets, light switches, and network drops."
+      icon={<IconBolt size={22} stroke={1.8} />}
+      eyebrow="Plant"
+      testId="facilities-overview-card-/facilities/electrical"
+    />
+    <CapabilityCard
+      to="/facilities/forgekey-devices"
+      title="ForgeKey devices"
+      description="Door, locker, and equipment-control devices on the ForgeKey bus."
+      icon={<IconKey size={22} stroke={1.8} />}
+      eyebrow="Access"
+      testId="facilities-overview-card-/facilities/forgekey-devices"
+    />
+    <CapabilityCard
+      to="/facilities/checklist"
+      title="Checklists"
+      description="Recurring opening, closing, and safety walk-through checklists."
+      icon={<IconChecklist size={22} stroke={1.8} />}
+      eyebrow="Routine"
+      testId="facilities-overview-card-/facilities/checklist"
+    />
+  </WorkspaceLanding>
 );
 
 export default FacilitiesOverviewPage;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,17 +1,149 @@
 /**
- * Home Page
- * Landing page with links to scan items, admin dashboard, and authentication
+ * Home Page (`/`).
+ *
+ * Capability-showcase landing for OpenMakerSuite (AC-1). Lists every
+ * top-level workspace as a CapabilityCard with a 1-line value prop and
+ * a deep link, plus a "Common workflows" quick-action row at the top
+ * for the highest-traffic flows (scan, dashboard, work orders).
+ *
+ * Uses the same PageHero + CapabilityCard primitives the workspace
+ * overview pages use, so visuals stay continuous across the app (AC-2).
  */
+import { Box, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import {
+  IconAdjustments,
+  IconBoxSeam,
+  IconBuildingFactory2,
+  IconChartBar,
+  IconChartLine,
+  IconClipboardList,
+  IconLayoutDashboard,
+  IconQrcode,
+  IconReceipt,
+  IconShoppingCart,
+  IconStack2,
+  IconUsersGroup,
+  IconTool,
+} from '@tabler/icons-react';
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+
 import AuthSection from '../components/AuthSection';
 import Footer from '../components/Footer';
-import '../styles/HomePage.css';
+import CapabilityCard from '../components/landing/CapabilityCard';
+import PageHero from '../components/landing/PageHero';
+import '../styles/landing.css';
+
+interface Capability {
+  to: string;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  eyebrow: string;
+  badge?: string;
+}
+
+/**
+ * Most-used workflows surfaced above the workspace grid. Kept short so
+ * a member arriving at /, with a phone in hand, can act in one tap.
+ */
+const QUICK_WORKFLOWS: Capability[] = [
+  {
+    to: '/inventory/scan',
+    title: 'Scan a QR code',
+    description: 'Look up a shelf, asset, or fixture from a printed label.',
+    icon: <IconQrcode size={22} stroke={1.8} />,
+    eyebrow: '01 / Quick',
+  },
+  {
+    to: '/dashboard',
+    title: 'Operations dashboard',
+    description: 'Live status across reorders, deliveries, and asset problems.',
+    icon: <IconLayoutDashboard size={22} stroke={1.8} />,
+    eyebrow: '02 / Quick',
+  },
+  {
+    to: '/maintenance',
+    title: 'Maintenance + work orders',
+    description: 'Open the PM dashboard, queue up scheduled work, log completions.',
+    icon: <IconClipboardList size={22} stroke={1.8} />,
+    eyebrow: '03 / Quick',
+  },
+];
+
+/**
+ * Every top-level workspace. Order matches the sidebar so navigation
+ * patterns are reinforced rather than competing.
+ */
+const WORKSPACES: Capability[] = [
+  {
+    to: '/inventory',
+    title: 'Inventory',
+    description: 'Items, suppliers, locations, and the QR-coded scan workflows the shop runs on.',
+    icon: <IconBoxSeam size={22} stroke={1.8} />,
+    eyebrow: 'Inventory',
+  },
+  {
+    to: '/purchasing',
+    title: 'Purchasing',
+    description: 'Purchase orders, suggested reorders, and the public transparency ledger.',
+    icon: <IconShoppingCart size={22} stroke={1.8} />,
+    eyebrow: 'Purchasing',
+  },
+  {
+    to: '/assets',
+    title: 'Assets',
+    description: 'Equipment register: lifecycle, ownership, maintenance plans, and parts.',
+    icon: <IconStack2 size={22} stroke={1.8} />,
+    eyebrow: 'Assets',
+  },
+  {
+    to: '/facilities',
+    title: 'Facilities',
+    description: 'Operations dashboards, kiosks, electrical, ForgeKey devices, and checklists.',
+    icon: <IconBuildingFactory2 size={22} stroke={1.8} />,
+    eyebrow: 'Facilities',
+  },
+  {
+    to: '/maintenance',
+    title: 'Maintenance',
+    description: 'Preventive maintenance, work orders, and third-party vendor coordination.',
+    icon: <IconTool size={22} stroke={1.8} />,
+    eyebrow: 'Maintenance',
+  },
+  {
+    to: '/sigs/dashboard',
+    title: 'SIGs',
+    description: 'Special Interest Group operations: members, assets, and SIG-owned inventory.',
+    icon: <IconUsersGroup size={22} stroke={1.8} />,
+    eyebrow: 'Community',
+  },
+  {
+    to: '/reports',
+    title: 'Reports',
+    description: 'Operational reports across inventory, purchasing, and assets.',
+    icon: <IconChartBar size={22} stroke={1.8} />,
+    eyebrow: 'Reports',
+  },
+  {
+    to: '/analytics',
+    title: 'Analytics pulse',
+    description: 'Executive dashboard: ROI, utilization, category spend, and the maintenance forecast.',
+    icon: <IconChartLine size={22} stroke={1.8} />,
+    eyebrow: 'Reports',
+    badge: 'Staff',
+  },
+  {
+    to: '/settings',
+    title: 'Settings + integrations',
+    description: 'Profile, organization configuration, webhooks, and tax-receipt tooling.',
+    icon: <IconAdjustments size={22} stroke={1.8} />,
+    eyebrow: 'Admin',
+  },
+];
 
 const HomePage: React.FC = () => {
-  const navigate = useNavigate();
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [username, setUsername] = useState('');
+  const [, setIsLoggedIn] = useState(false);
+  const [, setUsername] = useState('');
 
   const handleAuthChange = (loggedIn: boolean, user?: string) => {
     setIsLoggedIn(loggedIn);
@@ -19,106 +151,70 @@ const HomePage: React.FC = () => {
   };
 
   return (
-    <div className="home-page">
-      <div className="hero">
-        <h1> Dallas Makerspace Inventory Management</h1>
-        <p className="tagline">Scan. Track. Reorder. Simple.</p>
-      </div>
+    <Box className="landing-surface" data-testid="home-page">
+      <Container size="xl" py="xl">
+        <Stack gap="xl">
+          <PageHero
+            eyebrow="OpenMakerSuite"
+            title="Run the shop."
+            description="One operations layer for the makerspace — inventory, equipment, maintenance, purchasing, and the analytics that show your members what they get back from the room."
+          />
 
-      <AuthSection onAuthChange={handleAuthChange} />
+          <Box>
+            <AuthSection onAuthChange={handleAuthChange} />
+          </Box>
 
-      <div className="card-grid">
-        <div className="feature-card">
-          <div className="icon">📱</div>
-          <h2>Scan QR Code</h2>
-          <p>
-            Scan the QR code on any item shelf label to view details and submit
-            reorder requests.
-          </p>
-          <p className="instruction">
-            Use your phone camera to scan the QR codes on inventory labels.
-          </p>
-        </div>
+          <Stack gap="md" data-testid="home-quick-workflows">
+            <Stack gap={2}>
+              <Text component="span" className="landing-eyebrow">Common workflows</Text>
+              <Title order={2} className="landing-display" style={{ fontSize: '1.4rem', margin: 0 }}>
+                Start here
+              </Title>
+            </Stack>
+            <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
+              {QUICK_WORKFLOWS.map((c) => (
+                <CapabilityCard
+                  key={c.to}
+                  to={c.to}
+                  title={c.title}
+                  description={c.description}
+                  icon={c.icon}
+                  eyebrow={c.eyebrow}
+                  testId={`home-quick-${c.to}`}
+                  ctaLabel="Go"
+                />
+              ))}
+            </SimpleGrid>
+          </Stack>
 
-        <div className="feature-card" onClick={() => navigate('/inventory/admin')}>
-          <div className="icon">⚙️</div>
-          <h2>{isLoggedIn ? 'Admin Dashboard' : 'Admin Dashboard'}</h2>
-          <p>
-            {isLoggedIn
-              ? 'Manage reorder queue, approve requests, and process bulk orders by supplier.'
-              : 'View pending reorder requests and manage inventory workflow (login for enhanced features).'
-            }
-          </p>
-          <button className="card-button">
-            {isLoggedIn ? `Go to Dashboard (${username})` : 'Go to Dashboard'}
-          </button>
-        </div>
+          <hr className="landing-rule" />
 
-        <div className="feature-card">
-          <div className="icon">📊</div>
-          <h2>Features</h2>
-          <ul className="feature-list">
-            <li>Automatic QR code generation</li>
-            <li>3x5" printable index cards</li>
-            <li>Lead time tracking</li>
-            <li>Multi-supplier support</li>
-            <li>Stock level monitoring</li>
-          </ul>
-        </div>
-
-        <div className="feature-card" onClick={() => navigate('/facilities/tv-dashboard')}>
-          <div className="icon">📺</div>
-          <h2>TV Dashboard</h2>
-          <p>
-            Large-screen display optimized for Chromecast and TV viewing.
-            Shows items that have been reordered and are in progress with delivery tracking.
-          </p>
-          <button className="card-button">
-            Open TV Dashboard
-          </button>
-        </div>
-
-        <div className="feature-card" onClick={() => navigate('/facilities/logistics')}>
-          <div className="icon">🚛</div>
-          <h2>Logistics Display</h2>
-          <p>
-            FireTV-friendly board for the logistics bay. Highlights refill requests, open purchase orders,
-            and progress toward delivery.
-          </p>
-          <button className="card-button">
-            Launch Logistics Dashboard
-          </button>
-        </div>
-      </div>
-
-      <div className="info-section">
-        <h2>How It Works</h2>
-        <div className="steps">
-          <div className="step">
-            <div className="step-number">1</div>
-            <h3>Create Item</h3>
-            <p>Add inventory items via Django admin with photos, descriptions, and reorder quantities.</p>
-          </div>
-          <div className="step">
-            <div className="step-number">2</div>
-            <h3>Generate Labels</h3>
-            <p>Print 3x5" index cards with QR codes to laminate and hang from shelves.</p>
-          </div>
-          <div className="step">
-            <div className="step-number">3</div>
-            <h3>Scan & Request</h3>
-            <p>Users scan QR codes when items run low and submit reorder requests.</p>
-          </div>
-          <div className="step">
-            <div className="step-number">4</div>
-            <h3>Admin Review</h3>
-            <p>Admins review requests, generate supplier cart links, and track deliveries.</p>
-          </div>
-        </div>
-      </div>
-
+          <Stack gap="md" data-testid="home-workspaces">
+            <Stack gap={2}>
+              <Text component="span" className="landing-eyebrow">Workspaces</Text>
+              <Title order={2} className="landing-display" style={{ fontSize: '1.4rem', margin: 0 }}>
+                Everything OpenMakerSuite covers
+              </Title>
+            </Stack>
+            <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
+              {WORKSPACES.map((w) => (
+                <CapabilityCard
+                  key={w.to}
+                  to={w.to}
+                  title={w.title}
+                  description={w.description}
+                  icon={w.icon}
+                  eyebrow={w.eyebrow}
+                  badge={w.badge}
+                  testId={`home-workspace-${w.to}`}
+                />
+              ))}
+            </SimpleGrid>
+          </Stack>
+        </Stack>
+      </Container>
       <Footer />
-    </div>
+    </Box>
   );
 };
 

--- a/frontend/src/pages/PurchasingOverviewPage.tsx
+++ b/frontend/src/pages/PurchasingOverviewPage.tsx
@@ -1,0 +1,74 @@
+/**
+ * Landing page for the Purchasing workspace. Listed under
+ * `/purchasing/` so breadcrumb clicks on the "Purchasing" segment have
+ * a real destination (was previously a 404).
+ *
+ * Layout uses Mantine primitives directly; PR2 will refactor onto the
+ * shared <CapabilityCard> / <PageHero> / <WorkspaceLanding> components.
+ */
+import { Card, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import { IconClipboardList, IconPlus, IconReceipt } from '@tabler/icons-react';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+interface OverviewItem {
+  to: string;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+}
+
+const ITEMS: OverviewItem[] = [
+  {
+    to: '/purchasing/orders',
+    title: 'Purchase orders',
+    description: 'Open the queue of pending and recent purchase orders.',
+    icon: <IconClipboardList size={28} />,
+  },
+  {
+    to: '/purchasing/orders/new',
+    title: 'New purchase order',
+    description: 'Start a new purchase order from suggested reorders or a blank template.',
+    icon: <IconPlus size={28} />,
+  },
+  {
+    to: '/inventory/transparency',
+    title: 'Transparency ledger',
+    description: 'Public-facing view of recent reorder activity for membership transparency.',
+    icon: <IconReceipt size={28} />,
+  },
+];
+
+const PurchasingOverviewPage: React.FC = () => (
+  <Container size="xl" py="lg">
+    <Stack gap="xl">
+      <Stack gap={4}>
+        <Title order={1}>Purchasing</Title>
+        <Text c="dimmed">Manage purchase orders, reorder requests, and vendor transparency.</Text>
+      </Stack>
+
+      <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
+        {ITEMS.map((item) => (
+          <Card
+            key={item.to}
+            withBorder
+            radius="md"
+            p="lg"
+            component={Link}
+            to={item.to}
+            data-testid={`purchasing-overview-card-${item.to}`}
+            style={{ textDecoration: 'none', color: 'inherit' }}
+          >
+            <Stack gap="sm">
+              <Text c="blue.7">{item.icon}</Text>
+              <Title order={4}>{item.title}</Title>
+              <Text size="sm" c="dimmed">{item.description}</Text>
+            </Stack>
+          </Card>
+        ))}
+      </SimpleGrid>
+    </Stack>
+  </Container>
+);
+
+export default PurchasingOverviewPage;

--- a/frontend/src/pages/PurchasingOverviewPage.tsx
+++ b/frontend/src/pages/PurchasingOverviewPage.tsx
@@ -1,74 +1,49 @@
 /**
- * Landing page for the Purchasing workspace. Listed under
- * `/purchasing/` so breadcrumb clicks on the "Purchasing" segment have
- * a real destination (was previously a 404).
- *
- * Layout uses Mantine primitives directly; PR2 will refactor onto the
- * shared <CapabilityCard> / <PageHero> / <WorkspaceLanding> components.
+ * Landing page for the Purchasing workspace, mounted at `/purchasing/`.
+ * Refactored in nav-cohesion PR2 to use the shared <WorkspaceLanding>
+ * + <CapabilityCard> primitives so it matches the homepage rhythm.
  */
-import { Card, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import { IconClipboardList, IconPlus, IconReceipt } from '@tabler/icons-react';
 import React from 'react';
-import { Link } from 'react-router-dom';
 
-interface OverviewItem {
-  to: string;
-  title: string;
-  description: string;
-  icon: React.ReactNode;
-}
-
-const ITEMS: OverviewItem[] = [
-  {
-    to: '/purchasing/orders',
-    title: 'Purchase orders',
-    description: 'Open the queue of pending and recent purchase orders.',
-    icon: <IconClipboardList size={28} />,
-  },
-  {
-    to: '/purchasing/orders/new',
-    title: 'New purchase order',
-    description: 'Start a new purchase order from suggested reorders or a blank template.',
-    icon: <IconPlus size={28} />,
-  },
-  {
-    to: '/inventory/transparency',
-    title: 'Transparency ledger',
-    description: 'Public-facing view of recent reorder activity for membership transparency.',
-    icon: <IconReceipt size={28} />,
-  },
-];
+import CapabilityCard from '../components/landing/CapabilityCard';
+import WorkspaceLanding from '../components/landing/WorkspaceLanding';
 
 const PurchasingOverviewPage: React.FC = () => (
-  <Container size="xl" py="lg">
-    <Stack gap="xl">
-      <Stack gap={4}>
-        <Title order={1}>Purchasing</Title>
-        <Text c="dimmed">Manage purchase orders, reorder requests, and vendor transparency.</Text>
-      </Stack>
-
-      <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
-        {ITEMS.map((item) => (
-          <Card
-            key={item.to}
-            withBorder
-            radius="md"
-            p="lg"
-            component={Link}
-            to={item.to}
-            data-testid={`purchasing-overview-card-${item.to}`}
-            style={{ textDecoration: 'none', color: 'inherit' }}
-          >
-            <Stack gap="sm">
-              <Text c="blue.7">{item.icon}</Text>
-              <Title order={4}>{item.title}</Title>
-              <Text size="sm" c="dimmed">{item.description}</Text>
-            </Stack>
-          </Card>
-        ))}
-      </SimpleGrid>
-    </Stack>
-  </Container>
+  <WorkspaceLanding
+    testId="purchasing-overview"
+    hero={{
+      eyebrow: 'Purchasing',
+      title: 'Purchasing',
+      description:
+        'Manage purchase orders, reorder requests, and the public transparency ledger.',
+    }}
+  >
+    <CapabilityCard
+      to="/purchasing/orders"
+      title="Purchase orders"
+      description="Open the queue of pending and recent purchase orders."
+      icon={<IconClipboardList size={22} stroke={1.8} />}
+      eyebrow="Workflow"
+      testId="purchasing-overview-card-/purchasing/orders"
+    />
+    <CapabilityCard
+      to="/purchasing/orders/new"
+      title="New purchase order"
+      description="Start a new purchase order from suggested reorders or a blank template."
+      icon={<IconPlus size={22} stroke={1.8} />}
+      eyebrow="Action"
+      testId="purchasing-overview-card-/purchasing/orders/new"
+    />
+    <CapabilityCard
+      to="/inventory/transparency"
+      title="Transparency ledger"
+      description="Public-facing view of recent reorder activity for membership transparency."
+      icon={<IconReceipt size={22} stroke={1.8} />}
+      eyebrow="Public"
+      testId="purchasing-overview-card-/inventory/transparency"
+    />
+  </WorkspaceLanding>
 );
 
 export default PurchasingOverviewPage;

--- a/frontend/src/pages/ReportsOverviewPage.tsx
+++ b/frontend/src/pages/ReportsOverviewPage.tsx
@@ -1,9 +1,8 @@
 /**
- * Landing page for the Reports workspace. Same shape as the other
- * overview pages added in this PR. Includes the new Analytics Pulse
- * dashboard so it is reachable through breadcrumb + sidebar navigation.
+ * Landing page for the Reports workspace, mounted at `/reports/`.
+ * Refactored in nav-cohesion PR2 to use the shared <WorkspaceLanding>
+ * + <CapabilityCard> primitives.
  */
-import { Card, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import {
   IconChartBar,
   IconReportAnalytics,
@@ -11,73 +10,54 @@ import {
   IconStack,
 } from '@tabler/icons-react';
 import React from 'react';
-import { Link } from 'react-router-dom';
 
-interface OverviewItem {
-  to: string;
-  title: string;
-  description: string;
-  icon: React.ReactNode;
-}
-
-const ITEMS: OverviewItem[] = [
-  {
-    to: '/analytics',
-    title: 'Analytics pulse',
-    description:
-      'Executive dashboard: ROI, utilization, category spend, and the maintenance forecast. Source for the monthly board email.',
-    icon: <IconChartBar size={28} />,
-  },
-  {
-    to: '/reports/inventory',
-    title: 'Inventory report',
-    description: 'Stock levels, low-stock alerts, and item-level activity.',
-    icon: <IconStack size={28} />,
-  },
-  {
-    to: '/reports/purchasing',
-    title: 'Purchasing report',
-    description: 'Spend by supplier, vendor performance, and reorder cycle metrics.',
-    icon: <IconShoppingCart size={28} />,
-  },
-  {
-    to: '/reports/assets',
-    title: 'Asset report',
-    description: 'Asset roster, lifecycle status, and maintenance history.',
-    icon: <IconReportAnalytics size={28} />,
-  },
-];
+import CapabilityCard from '../components/landing/CapabilityCard';
+import WorkspaceLanding from '../components/landing/WorkspaceLanding';
 
 const ReportsOverviewPage: React.FC = () => (
-  <Container size="xl" py="lg">
-    <Stack gap="xl">
-      <Stack gap={4}>
-        <Title order={1}>Reports</Title>
-        <Text c="dimmed">Operational and executive reports across inventory, purchasing, assets, and the analytics pulse.</Text>
-      </Stack>
-
-      <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
-        {ITEMS.map((item) => (
-          <Card
-            key={item.to}
-            withBorder
-            radius="md"
-            p="lg"
-            component={Link}
-            to={item.to}
-            data-testid={`reports-overview-card-${item.to}`}
-            style={{ textDecoration: 'none', color: 'inherit' }}
-          >
-            <Stack gap="sm">
-              <Text c="blue.7">{item.icon}</Text>
-              <Title order={4}>{item.title}</Title>
-              <Text size="sm" c="dimmed">{item.description}</Text>
-            </Stack>
-          </Card>
-        ))}
-      </SimpleGrid>
-    </Stack>
-  </Container>
+  <WorkspaceLanding
+    testId="reports-overview"
+    hero={{
+      eyebrow: 'Reports',
+      title: 'Reports',
+      description:
+        'Operational and executive reports across inventory, purchasing, assets, and the analytics pulse.',
+    }}
+  >
+    <CapabilityCard
+      to="/analytics"
+      title="Analytics pulse"
+      description="Executive dashboard: ROI, utilization, category spend, and the maintenance forecast. Source for the monthly board email."
+      icon={<IconChartBar size={22} stroke={1.8} />}
+      eyebrow="Executive"
+      badge="Staff"
+      testId="reports-overview-card-/analytics"
+    />
+    <CapabilityCard
+      to="/reports/inventory"
+      title="Inventory report"
+      description="Stock levels, low-stock alerts, and item-level activity."
+      icon={<IconStack size={22} stroke={1.8} />}
+      eyebrow="Operational"
+      testId="reports-overview-card-/reports/inventory"
+    />
+    <CapabilityCard
+      to="/reports/purchasing"
+      title="Purchasing report"
+      description="Spend by supplier, vendor performance, and reorder cycle metrics."
+      icon={<IconShoppingCart size={22} stroke={1.8} />}
+      eyebrow="Operational"
+      testId="reports-overview-card-/reports/purchasing"
+    />
+    <CapabilityCard
+      to="/reports/assets"
+      title="Asset report"
+      description="Asset roster, lifecycle status, and maintenance history."
+      icon={<IconReportAnalytics size={22} stroke={1.8} />}
+      eyebrow="Operational"
+      testId="reports-overview-card-/reports/assets"
+    />
+  </WorkspaceLanding>
 );
 
 export default ReportsOverviewPage;

--- a/frontend/src/pages/ReportsOverviewPage.tsx
+++ b/frontend/src/pages/ReportsOverviewPage.tsx
@@ -1,0 +1,83 @@
+/**
+ * Landing page for the Reports workspace. Same shape as the other
+ * overview pages added in this PR. Includes the new Analytics Pulse
+ * dashboard so it is reachable through breadcrumb + sidebar navigation.
+ */
+import { Card, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import {
+  IconChartBar,
+  IconReportAnalytics,
+  IconShoppingCart,
+  IconStack,
+} from '@tabler/icons-react';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+interface OverviewItem {
+  to: string;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+}
+
+const ITEMS: OverviewItem[] = [
+  {
+    to: '/analytics',
+    title: 'Analytics pulse',
+    description:
+      'Executive dashboard: ROI, utilization, category spend, and the maintenance forecast. Source for the monthly board email.',
+    icon: <IconChartBar size={28} />,
+  },
+  {
+    to: '/reports/inventory',
+    title: 'Inventory report',
+    description: 'Stock levels, low-stock alerts, and item-level activity.',
+    icon: <IconStack size={28} />,
+  },
+  {
+    to: '/reports/purchasing',
+    title: 'Purchasing report',
+    description: 'Spend by supplier, vendor performance, and reorder cycle metrics.',
+    icon: <IconShoppingCart size={28} />,
+  },
+  {
+    to: '/reports/assets',
+    title: 'Asset report',
+    description: 'Asset roster, lifecycle status, and maintenance history.',
+    icon: <IconReportAnalytics size={28} />,
+  },
+];
+
+const ReportsOverviewPage: React.FC = () => (
+  <Container size="xl" py="lg">
+    <Stack gap="xl">
+      <Stack gap={4}>
+        <Title order={1}>Reports</Title>
+        <Text c="dimmed">Operational and executive reports across inventory, purchasing, assets, and the analytics pulse.</Text>
+      </Stack>
+
+      <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
+        {ITEMS.map((item) => (
+          <Card
+            key={item.to}
+            withBorder
+            radius="md"
+            p="lg"
+            component={Link}
+            to={item.to}
+            data-testid={`reports-overview-card-${item.to}`}
+            style={{ textDecoration: 'none', color: 'inherit' }}
+          >
+            <Stack gap="sm">
+              <Text c="blue.7">{item.icon}</Text>
+              <Title order={4}>{item.title}</Title>
+              <Text size="sm" c="dimmed">{item.description}</Text>
+            </Stack>
+          </Card>
+        ))}
+      </SimpleGrid>
+    </Stack>
+  </Container>
+);
+
+export default ReportsOverviewPage;

--- a/frontend/src/pages/SettingsOverviewPage.tsx
+++ b/frontend/src/pages/SettingsOverviewPage.tsx
@@ -1,0 +1,76 @@
+/**
+ * Landing page for the Settings workspace. Same shape as the other
+ * overview pages added in this PR.
+ */
+import { Card, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import { IconAdjustments, IconReceipt, IconUser, IconWebhook } from '@tabler/icons-react';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+interface OverviewItem {
+  to: string;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+}
+
+const ITEMS: OverviewItem[] = [
+  {
+    to: '/settings/profile',
+    title: 'Profile',
+    description: 'Manage your account, contact info, and notification preferences.',
+    icon: <IconUser size={28} />,
+  },
+  {
+    to: '/settings/site',
+    title: 'Site settings',
+    description: 'Organization-wide configuration for OpenMakerSuite.',
+    icon: <IconAdjustments size={28} />,
+  },
+  {
+    to: '/settings/webhooks',
+    title: 'Webhooks',
+    description: 'Outbound webhook endpoints and delivery history.',
+    icon: <IconWebhook size={28} />,
+  },
+  {
+    to: '/settings/tax-receipt/lookup',
+    title: 'Tax receipt lookup',
+    description: 'Look up an issued donor tax receipt by donation reference.',
+    icon: <IconReceipt size={28} />,
+  },
+];
+
+const SettingsOverviewPage: React.FC = () => (
+  <Container size="xl" py="lg">
+    <Stack gap="xl">
+      <Stack gap={4}>
+        <Title order={1}>Settings</Title>
+        <Text c="dimmed">Account, organization, and integration configuration.</Text>
+      </Stack>
+
+      <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
+        {ITEMS.map((item) => (
+          <Card
+            key={item.to}
+            withBorder
+            radius="md"
+            p="lg"
+            component={Link}
+            to={item.to}
+            data-testid={`settings-overview-card-${item.to}`}
+            style={{ textDecoration: 'none', color: 'inherit' }}
+          >
+            <Stack gap="sm">
+              <Text c="blue.7">{item.icon}</Text>
+              <Title order={4}>{item.title}</Title>
+              <Text size="sm" c="dimmed">{item.description}</Text>
+            </Stack>
+          </Card>
+        ))}
+      </SimpleGrid>
+    </Stack>
+  </Container>
+);
+
+export default SettingsOverviewPage;

--- a/frontend/src/pages/SettingsOverviewPage.tsx
+++ b/frontend/src/pages/SettingsOverviewPage.tsx
@@ -1,76 +1,56 @@
 /**
- * Landing page for the Settings workspace. Same shape as the other
- * overview pages added in this PR.
+ * Landing page for the Settings workspace, mounted at `/settings/`.
+ * Refactored in nav-cohesion PR2 to use the shared <WorkspaceLanding>
+ * + <CapabilityCard> primitives.
  */
-import { Card, Container, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import { IconAdjustments, IconReceipt, IconUser, IconWebhook } from '@tabler/icons-react';
 import React from 'react';
-import { Link } from 'react-router-dom';
 
-interface OverviewItem {
-  to: string;
-  title: string;
-  description: string;
-  icon: React.ReactNode;
-}
-
-const ITEMS: OverviewItem[] = [
-  {
-    to: '/settings/profile',
-    title: 'Profile',
-    description: 'Manage your account, contact info, and notification preferences.',
-    icon: <IconUser size={28} />,
-  },
-  {
-    to: '/settings/site',
-    title: 'Site settings',
-    description: 'Organization-wide configuration for OpenMakerSuite.',
-    icon: <IconAdjustments size={28} />,
-  },
-  {
-    to: '/settings/webhooks',
-    title: 'Webhooks',
-    description: 'Outbound webhook endpoints and delivery history.',
-    icon: <IconWebhook size={28} />,
-  },
-  {
-    to: '/settings/tax-receipt/lookup',
-    title: 'Tax receipt lookup',
-    description: 'Look up an issued donor tax receipt by donation reference.',
-    icon: <IconReceipt size={28} />,
-  },
-];
+import CapabilityCard from '../components/landing/CapabilityCard';
+import WorkspaceLanding from '../components/landing/WorkspaceLanding';
 
 const SettingsOverviewPage: React.FC = () => (
-  <Container size="xl" py="lg">
-    <Stack gap="xl">
-      <Stack gap={4}>
-        <Title order={1}>Settings</Title>
-        <Text c="dimmed">Account, organization, and integration configuration.</Text>
-      </Stack>
-
-      <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
-        {ITEMS.map((item) => (
-          <Card
-            key={item.to}
-            withBorder
-            radius="md"
-            p="lg"
-            component={Link}
-            to={item.to}
-            data-testid={`settings-overview-card-${item.to}`}
-            style={{ textDecoration: 'none', color: 'inherit' }}
-          >
-            <Stack gap="sm">
-              <Text c="blue.7">{item.icon}</Text>
-              <Title order={4}>{item.title}</Title>
-              <Text size="sm" c="dimmed">{item.description}</Text>
-            </Stack>
-          </Card>
-        ))}
-      </SimpleGrid>
-    </Stack>
-  </Container>
+  <WorkspaceLanding
+    testId="settings-overview"
+    hero={{
+      eyebrow: 'Settings',
+      title: 'Settings',
+      description: 'Account, organization, and integration configuration.',
+    }}
+  >
+    <CapabilityCard
+      to="/settings/profile"
+      title="Profile"
+      description="Manage your account, contact info, and notification preferences."
+      icon={<IconUser size={22} stroke={1.8} />}
+      eyebrow="Account"
+      testId="settings-overview-card-/settings/profile"
+    />
+    <CapabilityCard
+      to="/settings/site"
+      title="Site settings"
+      description="Organization-wide configuration for OpenMakerSuite."
+      icon={<IconAdjustments size={22} stroke={1.8} />}
+      eyebrow="Org"
+      testId="settings-overview-card-/settings/site"
+    />
+    <CapabilityCard
+      to="/settings/webhooks"
+      title="Webhooks"
+      description="Outbound webhook endpoints and delivery history."
+      icon={<IconWebhook size={22} stroke={1.8} />}
+      eyebrow="Integrations"
+      testId="settings-overview-card-/settings/webhooks"
+    />
+    <CapabilityCard
+      to="/settings/tax-receipt/lookup"
+      title="Tax receipt lookup"
+      description="Look up an issued donor tax receipt by donation reference."
+      icon={<IconReceipt size={22} stroke={1.8} />}
+      eyebrow="Tools"
+      testId="settings-overview-card-/settings/tax-receipt/lookup"
+    />
+  </WorkspaceLanding>
 );
 
 export default SettingsOverviewPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2140,4 +2140,86 @@ export const thirdPartyMaintenanceAPI = {
   }) => api.post<ThirdPartyQuoteDto>('/maintenance-orders/quotes/', payload),
 };
 
+// Analytics API
+export interface AnalyticsValueSummary {
+  period_start: string;
+  period_end: string;
+  internal_completed_count: number;
+  internal_estimated_external_cost: string;
+  internal_estimated_internal_cost: string;
+  internal_net_value: string;
+  external_closed_count: number;
+  external_actual_cost: string;
+  external_estimated_cost: string;
+  total_value_to_makerspace: string;
+}
+
+export interface AnalyticsTrendPoint {
+  period: string;
+  count: number;
+}
+
+export interface AnalyticsTopUser {
+  user_id: number;
+  username: string;
+  display_name: string;
+  completed_wo_count: number;
+}
+
+export interface AnalyticsUtilizationRow {
+  asset_id: string;
+  asset_name: string;
+  category: string | null;
+  hours_used: number;
+  completed_wo_count: number;
+  status: string;
+}
+
+export interface AnalyticsCategorySpendRow {
+  category_id: number | null;
+  category_name: string | null;
+  internal_estimated: string;
+  external_estimated: string;
+  external_actual: string;
+  internal_wo_count: number;
+  external_wo_count: number;
+}
+
+export interface AnalyticsForecastEntry {
+  asset_id: string;
+  asset_name: string;
+  category: string | null;
+  status: string;
+  hours_used: number;
+  last_completed_wo_at: string | null;
+  interval_hours: number | null;
+  interval_days: number | null;
+  days_since_last_wo: number | null;
+  due_reason: 'hours' | 'days' | 'both';
+}
+
+export interface AnalyticsPulseResponse {
+  summary: AnalyticsValueSummary;
+  wo_volume_trend: AnalyticsTrendPoint[];
+  top_users: AnalyticsTopUser[];
+  utilization: AnalyticsUtilizationRow[];
+  category_spend: AnalyticsCategorySpendRow[];
+  maintenance_forecast: AnalyticsForecastEntry[];
+  monthly_budget: string | null;
+}
+
+export interface AnalyticsShareResponse {
+  token: string;
+  ttl_days: number;
+  expires_in_days: number;
+}
+
+export const pulseAPI = {
+  getPulse: (params?: { start?: string; end?: string; bucket?: 'month' | 'quarter'; token?: string }) =>
+    api.get<AnalyticsPulseResponse>('/analytics/pulse/', { params }),
+
+  createShare: (ttlDays?: number) =>
+    api.post<AnalyticsShareResponse>('/analytics/share/', ttlDays ? { ttl_days: ttlDays } : {}),
+};
+
 export default api;

--- a/frontend/src/styles/Breadcrumbs.css
+++ b/frontend/src/styles/Breadcrumbs.css
@@ -42,6 +42,13 @@
   padding: 2px 4px;
 }
 
+/* Non-clickable ancestor segments (structural-only paths with no route). */
+.breadcrumb-static {
+  color: #777;
+  padding: 2px 4px;
+  cursor: default;
+}
+
 .breadcrumb-separator {
   margin: 0 8px;
   color: #999;

--- a/frontend/src/styles/landing.css
+++ b/frontend/src/styles/landing.css
@@ -1,0 +1,130 @@
+/**
+ * Design tokens for the homepage + workspace overview pages.
+ *
+ * Aesthetic direction: refined editorial × industrial control panel.
+ * - Display: DM Serif Display gives section titles weight without
+ *   shouting; pairs with the system sans body to keep workspace pages
+ *   continuous with everything else in the app.
+ * - Mono accents (IBM Plex Mono) for eyebrow labels — channels the
+ *   "instrument label" feel without dressing every page in monospace.
+ *
+ * Tokens are scoped to .landing-surface so workspace pages that opt out
+ * (e.g. data-grid pages) don't pick them up by accident.
+ */
+
+:root {
+  --landing-display-font: 'DM Serif Display', 'Iowan Old Style', 'Cambria',
+    'Georgia', serif;
+  --landing-mono-font: 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo,
+    Consolas, monospace;
+
+  --landing-surface-bg: #faf8f4;
+  --landing-card-bg: #ffffff;
+  --landing-card-border: rgba(15, 23, 42, 0.08);
+  --landing-card-border-hover: rgba(25, 113, 194, 0.45);
+  --landing-card-shadow-hover: 0 18px 40px -28px rgba(15, 23, 42, 0.4);
+
+  --landing-eyebrow: #6b7280;
+  --landing-text: #111827;
+  --landing-muted: #4b5563;
+  --landing-rule: rgba(15, 23, 42, 0.08);
+
+  --landing-accent: #1971c2;
+  --landing-accent-soft: #e7f1fb;
+  --landing-chip-bg: #1a1a1a;
+  --landing-chip-fg: #f5f1e8;
+
+  --landing-radius: 14px;
+}
+
+/*
+ * Apply the warm-paper background only when a page opts in by wrapping
+ * its content in `.landing-surface`. Workspace pages already on white
+ * Mantine cards stay unchanged.
+ */
+.landing-surface {
+  background: var(--landing-surface-bg);
+  min-height: 100%;
+}
+
+/* Display headings inside landing surfaces. */
+.landing-display {
+  font-family: var(--landing-display-font);
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  line-height: 1.05;
+  color: var(--landing-text);
+}
+
+.landing-eyebrow {
+  font-family: var(--landing-mono-font);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--landing-eyebrow);
+}
+
+/* Capability card hover — subtle lift, no parallax tricks. */
+.landing-capability-card {
+  background: var(--landing-card-bg);
+  border: 1px solid var(--landing-card-border);
+  border-radius: var(--landing-radius);
+  transition: border-color 160ms ease, transform 160ms ease,
+    box-shadow 160ms ease;
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.landing-capability-card:hover {
+  border-color: var(--landing-card-border-hover);
+  transform: translateY(-2px);
+  box-shadow: var(--landing-card-shadow-hover);
+}
+
+.landing-capability-card:focus-visible {
+  outline: 2px solid var(--landing-accent);
+  outline-offset: 3px;
+}
+
+.landing-icon-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: var(--landing-chip-bg);
+  color: var(--landing-chip-fg);
+}
+
+.landing-arrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--landing-accent);
+  font-weight: 500;
+  font-size: 0.9rem;
+  transition: gap 160ms ease;
+}
+
+.landing-capability-card:hover .landing-arrow {
+  gap: 10px;
+}
+
+.landing-rule {
+  border: 0;
+  border-top: 1px solid var(--landing-rule);
+  margin: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .landing-capability-card,
+  .landing-arrow {
+    transition: none;
+  }
+  .landing-capability-card:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## What this is

A **rollup PR** that lands the four already-reviewed-and-merged PRs that didn't actually reach `main` due to a stacked-PR base-branch issue. Re-applies their squash commits in order onto a fresh branch off `main`.

## Why it's needed

The previous PRs were merged with stacked bases (each PR's base pointed at the predecessor's branch, not `main`). When you clicked "Squash and merge" on each:

| PR | Was merged into | Reached main? |
|---|---|---|
| #387 analytics PR1 | `main` | ✅ |
| #388 analytics PR2 (dashboard + share) | `oms-mayor/analytics-pulse-phase-1` | ❌ |
| #389 analytics PR3 (monthly email + Beat) | `oms-mayor/analytics-pulse-phase-2` | ❌ |
| #391 nav PR1 (route map + overview pages) | `oms-mayor/analytics-pulse-phase-3` | ❌ |
| #392 nav PR2 (homepage + landing primitives) | `oms-mayor/nav-cohesion-phase-1` | ❌ |

So `main` currently has the analytics data layer but not:
- The analytics dashboard, share-token endpoint, or React pulse page
- The monthly Beat email task / management command
- The new route map / breadcrumb fix / 4 workspace overview pages
- The redesigned homepage / shared landing primitives

## What this PR contains

The same 4 squash commits that merged into the stacked branches, cherry-picked onto a fresh branch off `main`:

```
4fd6aa4 feat(nav): capability-showcase homepage + shared landing primitives (PR2 of 2)
1279272 feat(nav): fix breadcrumb dead-ends + workspace overview pages (PR1 of 2)
cd9b9ac feat(analytics): monthly pulse email + Celery Beat schedule (PR3 of 3)
2336345 feat(analytics): dashboard UI + signed-URL share for board (PR2 of 3)
```

No new code is added — these are byte-for-byte the same commits that already received review on PRs #388, #389, #391, #392.

## Verification

- [x] `pytest backend/analytics/ backend/inventory/tests/test_asset_log_hours.py backend/config/tests/test_permission_matrix.py` → **100 passed**
- [x] `npm test --testPathPattern='(HomePage|PageHero|CapabilityCard|navigation|Breadcrumbs|AnalyticsDashboard)'` → **85 passed**
- [x] No merge conflicts during cherry-pick (the analytics PR1 commit on this branch's parent is already represented by `078c1bf` on `main`, so git skipped it as expected)
- [ ] Manual smoke after merge: visit `/`, `/analytics`, `/purchasing`, `/facilities`, `/reports`, `/settings`; confirm new homepage and overview pages render

## Recommended merge action

**Squash and merge.** The 4 commits collapse to a single rollup commit on `main`, with this PR description as the body. Avoids re-listing every PR's individual commit history.

After merge, the stacked base branches (`oms-mayor/analytics-pulse-phase-1` through `nav-cohesion-phase-1`) can be safely deleted — their content is now on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)