### PR TITLE
feat(electrical): land oms-b25 [4/7] safety query API

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -240,6 +240,10 @@ views:
     permission_classes:
     - IsAuthenticated
     - IsStaffUser
+  electrical_circuits.safety_views.PowerPanelListView:
+    permission_classes:
+    - IsAuthenticated
+    - IsStaffUser
   electrical_circuits.safety_views.PowerPanelTopologyView:
     permission_classes:
     - IsAuthenticated

--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -228,6 +228,22 @@ views:
   donations.views.upload_signature:
     permission_classes:
     - IsAuthenticated
+  electrical_circuits.safety_views.AssetPowerChainView:
+    permission_classes:
+    - IsAuthenticated
+    - IsStaffUser
+  electrical_circuits.safety_views.PowerBreakerTripImpactView:
+    permission_classes:
+    - IsAuthenticated
+    - IsStaffUser
+  electrical_circuits.safety_views.PowerCircuitLoadView:
+    permission_classes:
+    - IsAuthenticated
+    - IsStaffUser
+  electrical_circuits.safety_views.PowerPanelTopologyView:
+    permission_classes:
+    - IsAuthenticated
+    - IsStaffUser
   electrical_circuits.views.BreakerViewSet:
     actions:
       create:

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -11,6 +11,10 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 from auth_views import create_test_membership, login_user, logout_user, refresh_token, register_user
 from config.health import livez, readyz
+from electrical_circuits.urls import (
+    asset_power_chain_urlpatterns as electrical_asset_power_chain_urls,
+)
+from electrical_circuits.urls import safety_urlpatterns as electrical_safety_urls
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -51,6 +55,11 @@ urlpatterns = [
     path("api/vendors/", include("vendors.urls")),
     path("api/maintenance-orders/", include("maintenance_orders.urls")),
     path("api/electrical-circuits/", include("electrical_circuits.urls")),
+    # Safety query endpoints (oms-b25 AC-1..AC-4). Mounted at the bare
+    # /api/electrical/ and /api/assets/ prefixes so the URLs match the
+    # AC paths exactly.
+    path("api/electrical/", include(electrical_safety_urls)),
+    path("api/assets/", include(electrical_asset_power_chain_urls)),
     path("api/loto/", include("loto.urls")),
     path("api/analytics/", include("analytics.urls")),
     # Flower proxy (superuser only)

--- a/backend/electrical_circuits/admin.py
+++ b/backend/electrical_circuits/admin.py
@@ -147,9 +147,7 @@ class PowerBreakerAdmin(admin.ModelAdmin):
         custom = [
             path(
                 "trip-impact/",
-                self.admin_site.admin_view(
-                    lambda request: breaker_trip_impact_view(self, request)
-                ),
+                self.admin_site.admin_view(lambda request: breaker_trip_impact_view(self, request)),
                 name="electrical_circuits_powerbreaker_trip_impact",
             ),
         ]
@@ -176,9 +174,7 @@ class PowerCircuitAdmin(admin.ModelAdmin):
         custom = [
             path(
                 "load-report/",
-                self.admin_site.admin_view(
-                    lambda request: circuit_load_report_view(self, request)
-                ),
+                self.admin_site.admin_view(lambda request: circuit_load_report_view(self, request)),
                 name="electrical_circuits_powercircuit_load_report",
             ),
             path(

--- a/backend/electrical_circuits/admin.py
+++ b/backend/electrical_circuits/admin.py
@@ -1,7 +1,13 @@
 """Admin interfaces for electrical circuits and network drops."""
 
 from django.contrib import admin
+from django.urls import path
 
+from .admin_reports import (
+    breaker_trip_impact_view,
+    circuit_load_report_view,
+    shared_circuit_audit_view,
+)
 from .models import (
     Breaker,
     Cable,
@@ -136,6 +142,19 @@ class PowerBreakerAdmin(admin.ModelAdmin):
     filter_horizontal = ["required_loto_devices"]
     inlines = [PowerCircuitInline]
 
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "trip-impact/",
+                self.admin_site.admin_view(
+                    lambda request: breaker_trip_impact_view(self, request)
+                ),
+                name="electrical_circuits_powerbreaker_trip_impact",
+            ),
+        ]
+        return custom + urls
+
 
 @admin.register(PowerCircuit)
 class PowerCircuitAdmin(admin.ModelAdmin):
@@ -151,6 +170,26 @@ class PowerCircuitAdmin(admin.ModelAdmin):
     search_fields = ["label", "breaker__panel__name", "breaker__position"]
     autocomplete_fields = ["breaker"]
     inlines = [PowerOutletInline]
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "load-report/",
+                self.admin_site.admin_view(
+                    lambda request: circuit_load_report_view(self, request)
+                ),
+                name="electrical_circuits_powercircuit_load_report",
+            ),
+            path(
+                "shared-circuit-audit/",
+                self.admin_site.admin_view(
+                    lambda request: shared_circuit_audit_view(self, request)
+                ),
+                name="electrical_circuits_powercircuit_shared_audit",
+            ),
+        ]
+        return custom + urls
 
 
 @admin.register(PowerOutlet)

--- a/backend/electrical_circuits/admin_reports.py
+++ b/backend/electrical_circuits/admin_reports.py
@@ -1,0 +1,290 @@
+"""
+Custom admin reports for the electrical topology (oms-b25, AC-1..AC-3).
+
+Three reports are exposed under the existing admin:
+
+* **Circuit Load Report** — every circuit with connected device count,
+  estimated max draw, and a colour-coded load percentage.
+* **Shared Circuit Audit** — circuits with more than one connected
+  asset, sorted by combined criticality.
+* **Breaker Trip Impact** — for each breaker, the assets that lose
+  power if it trips.
+
+Each view runs at admin-only auth (the ModelAdmin's ``admin_view``
+wrapper checks ``request.user.is_staff``) and is engineered to stay
+within the AC-6 budget (<2s for 1 site / 10 panels / 200 circuits /
+500 devices) by walking outlets and cables in bulk rather than per-row.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from decimal import Decimal
+from typing import Dict, List, Tuple
+
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
+from django.shortcuts import render
+
+from inventory.models import Asset
+
+from .models import (
+    Cable,
+    PowerBreaker,
+    PowerCircuit,
+    PowerOutlet,
+    PowerPort,
+)
+
+
+def _classify_load(percent: float | None) -> str:
+    """Map load percentage to the AC-1 color band.
+
+    ``None`` (no capacity declared) is reported separately so reviewers
+    can spot circuits that need a ``max_load_amps`` value before the
+    report can grade them.
+    """
+
+    if percent is None:
+        return "unknown"
+    if percent < 60:
+        return "green"
+    if percent < 80:
+        return "yellow"
+    return "red"
+
+
+def _build_outlet_to_assets_map(
+    outlet_pks: List[int],
+) -> Dict[int, List[Asset]]:
+    """Return ``{outlet_pk: [Asset, ...]}`` for the given outlets.
+
+    Bulk-pulls the cables joining outlets to PowerPorts and the assets
+    behind those ports in a constant number of queries (cables, ports,
+    assets) — the resolver does the same shape internally; we duplicate
+    it here so the admin report can attribute devices to specific
+    outlets, which the per-circuit resolver does not surface.
+    """
+
+    if not outlet_pks:
+        return {}
+
+    outlet_ct = ContentType.objects.get_for_model(PowerOutlet)
+    port_ct = ContentType.objects.get_for_model(PowerPort)
+
+    str_outlet_ids = [str(pk) for pk in outlet_pks]
+    cables = list(
+        Cable.objects.filter(cable_type=Cable.CABLE_TYPE_POWER).filter(
+            Q(
+                endpoint_a_content_type=outlet_ct,
+                endpoint_a_object_id__in=str_outlet_ids,
+            )
+            | Q(
+                endpoint_b_content_type=outlet_ct,
+                endpoint_b_object_id__in=str_outlet_ids,
+            )
+        )
+    )
+
+    pairs: List[Tuple[int, int]] = []
+    for cable in cables:
+        if (
+            cable.endpoint_a_content_type_id == outlet_ct.id
+            and cable.endpoint_b_content_type_id == port_ct.id
+        ):
+            pairs.append((int(cable.endpoint_a_object_id), int(cable.endpoint_b_object_id)))
+        elif (
+            cable.endpoint_b_content_type_id == outlet_ct.id
+            and cable.endpoint_a_content_type_id == port_ct.id
+        ):
+            pairs.append((int(cable.endpoint_b_object_id), int(cable.endpoint_a_object_id)))
+
+    if not pairs:
+        return {}
+
+    port_to_asset: Dict[int, int] = dict(
+        PowerPort.objects.filter(pk__in={p for _, p in pairs}).values_list("pk", "asset_id")
+    )
+    asset_ids = {port_to_asset[p] for _, p in pairs if p in port_to_asset}
+    assets_by_id: Dict[int, Asset] = {a.pk: a for a in Asset.objects.filter(pk__in=asset_ids)}
+
+    out: Dict[int, List[Asset]] = defaultdict(list)
+    for outlet_pk, port_pk in pairs:
+        asset_id = port_to_asset.get(port_pk)
+        if asset_id is None:
+            continue
+        asset = assets_by_id.get(asset_id)
+        if asset is not None:
+            out[outlet_pk].append(asset)
+    return out
+
+
+def _circuit_rows(circuits) -> List[dict]:
+    """Build one row per circuit with capacity / utilisation / colour band.
+
+    ``circuits`` is expected to come pre-fetched with ``breaker`` and
+    ``breaker__panel`` so the iteration stays N+0.
+    """
+
+    outlet_qs = PowerOutlet.objects.filter(circuit__in=circuits).values_list(
+        "pk", "circuit_id"
+    )
+    outlets_by_circuit: Dict[int, List[int]] = defaultdict(list)
+    for outlet_pk, circuit_id in outlet_qs:
+        outlets_by_circuit[circuit_id].append(outlet_pk)
+
+    all_outlet_pks = [pk for pks in outlets_by_circuit.values() for pk in pks]
+    outlet_to_assets = _build_outlet_to_assets_map(all_outlet_pks)
+
+    asset_ids = {a.pk for assets in outlet_to_assets.values() for a in assets}
+    port_qs = PowerPort.objects.filter(asset_id__in=asset_ids).only(
+        "pk", "asset_id", "label", "max_draw_amps"
+    )
+    primary_port_by_asset: Dict[int, PowerPort] = {}
+    for port in port_qs.order_by("asset_id", "label", "pk"):
+        primary_port_by_asset.setdefault(port.asset_id, port)
+
+    rows: List[dict] = []
+    for circuit in circuits:
+        outlet_pks = outlets_by_circuit.get(circuit.pk, [])
+        seen_assets: Dict[int, Asset] = {}
+        for opk in outlet_pks:
+            for a in outlet_to_assets.get(opk, []):
+                seen_assets[a.pk] = a
+
+        estimated_draw = Decimal("0")
+        for asset in seen_assets.values():
+            port = primary_port_by_asset.get(asset.pk)
+            if port and port.max_draw_amps is not None:
+                estimated_draw += port.max_draw_amps
+
+        capacity = circuit.max_load_amps
+        if capacity:
+            percent = float((estimated_draw / Decimal(capacity)) * Decimal("100"))
+            percent_display = round(percent, 1)
+        else:
+            percent = None
+            percent_display = None
+
+        rows.append(
+            {
+                "circuit": circuit,
+                "panel": circuit.breaker.panel,
+                "breaker": circuit.breaker,
+                "connected_devices": list(seen_assets.values()),
+                "device_count": len(seen_assets),
+                "estimated_draw_amps": float(estimated_draw),
+                "capacity_amps": capacity,
+                "load_percent": percent_display,
+                "color_band": _classify_load(percent),
+            }
+        )
+    return rows
+
+
+def circuit_load_report_view(model_admin, request):
+    """Render the Circuit Load Report (AC-1)."""
+
+    circuits = list(
+        PowerCircuit.objects.select_related("breaker", "breaker__panel").order_by(
+            "breaker__panel__name", "breaker__position", "pk"
+        )
+    )
+    rows = _circuit_rows(circuits)
+    context = {
+        **model_admin.admin_site.each_context(request),
+        "title": "Circuit Load Report",
+        "rows": rows,
+        "opts": PowerCircuit._meta,
+    }
+    return render(
+        request,
+        "admin/electrical_circuits/circuit_load_report.html",
+        context,
+    )
+
+
+def shared_circuit_audit_view(model_admin, request):
+    """Render the Shared Circuit Audit (AC-2).
+
+    Sort key: ``(critical_count desc, device_count desc, panel/position
+    asc)`` so the most consequential pairings rise to the top.
+    """
+
+    circuits = list(
+        PowerCircuit.objects.select_related("breaker", "breaker__panel").order_by(
+            "breaker__panel__name", "breaker__position", "pk"
+        )
+    )
+    rows = _circuit_rows(circuits)
+    shared = [r for r in rows if r["device_count"] >= 2]
+    for r in shared:
+        r["critical_count"] = sum(
+            1 for a in r["connected_devices"] if getattr(a, "is_critical", False)
+        )
+    shared.sort(
+        key=lambda r: (-r["critical_count"], -r["device_count"], r["panel"].name, r["breaker"].position)
+    )
+    context = {
+        **model_admin.admin_site.each_context(request),
+        "title": "Shared Circuit Audit",
+        "rows": shared,
+        "opts": PowerCircuit._meta,
+    }
+    return render(
+        request,
+        "admin/electrical_circuits/shared_circuit_audit.html",
+        context,
+    )
+
+
+def breaker_trip_impact_view(model_admin, request):
+    """Render the Breaker Trip Impact report (AC-3)."""
+
+    breakers = list(
+        PowerBreaker.objects.select_related("panel").order_by(
+            "panel__name", "position", "pk"
+        )
+    )
+    breaker_pks = [b.pk for b in breakers]
+
+    outlet_qs = PowerOutlet.objects.filter(circuit__breaker_id__in=breaker_pks).values_list(
+        "pk", "circuit__breaker_id"
+    )
+    outlets_by_breaker: Dict[int, List[int]] = defaultdict(list)
+    for outlet_pk, breaker_id in outlet_qs:
+        outlets_by_breaker[breaker_id].append(outlet_pk)
+
+    all_outlet_pks = [pk for pks in outlets_by_breaker.values() for pk in pks]
+    outlet_to_assets = _build_outlet_to_assets_map(all_outlet_pks)
+
+    rows = []
+    for breaker in breakers:
+        seen: Dict[int, Asset] = {}
+        for opk in outlets_by_breaker.get(breaker.pk, []):
+            for a in outlet_to_assets.get(opk, []):
+                seen[a.pk] = a
+        assets = list(seen.values())
+        critical = [a for a in assets if getattr(a, "is_critical", False)]
+        rows.append(
+            {
+                "breaker": breaker,
+                "panel": breaker.panel,
+                "assets": assets,
+                "critical_loads": critical,
+                "asset_count": len(assets),
+                "critical_count": len(critical),
+            }
+        )
+
+    context = {
+        **model_admin.admin_site.each_context(request),
+        "title": "Breaker Trip Impact",
+        "rows": rows,
+        "opts": PowerBreaker._meta,
+    }
+    return render(
+        request,
+        "admin/electrical_circuits/breaker_trip_impact.html",
+        context,
+    )

--- a/backend/electrical_circuits/admin_reports.py
+++ b/backend/electrical_circuits/admin_reports.py
@@ -28,13 +28,7 @@ from django.shortcuts import render
 
 from inventory.models import Asset
 
-from .models import (
-    Cable,
-    PowerBreaker,
-    PowerCircuit,
-    PowerOutlet,
-    PowerPort,
-)
+from .models import Cable, PowerBreaker, PowerCircuit, PowerOutlet, PowerPort
 
 
 def _classify_load(percent: float | None) -> str:
@@ -126,9 +120,7 @@ def _circuit_rows(circuits) -> List[dict]:
     ``breaker__panel`` so the iteration stays N+0.
     """
 
-    outlet_qs = PowerOutlet.objects.filter(circuit__in=circuits).values_list(
-        "pk", "circuit_id"
-    )
+    outlet_qs = PowerOutlet.objects.filter(circuit__in=circuits).values_list("pk", "circuit_id")
     outlets_by_circuit: Dict[int, List[int]] = defaultdict(list)
     for outlet_pk, circuit_id in outlet_qs:
         outlets_by_circuit[circuit_id].append(outlet_pk)
@@ -223,7 +215,12 @@ def shared_circuit_audit_view(model_admin, request):
             1 for a in r["connected_devices"] if getattr(a, "is_critical", False)
         )
     shared.sort(
-        key=lambda r: (-r["critical_count"], -r["device_count"], r["panel"].name, r["breaker"].position)
+        key=lambda r: (
+            -r["critical_count"],
+            -r["device_count"],
+            r["panel"].name,
+            r["breaker"].position,
+        )
     )
     context = {
         **model_admin.admin_site.each_context(request),
@@ -242,9 +239,7 @@ def breaker_trip_impact_view(model_admin, request):
     """Render the Breaker Trip Impact report (AC-3)."""
 
     breakers = list(
-        PowerBreaker.objects.select_related("panel").order_by(
-            "panel__name", "position", "pk"
-        )
+        PowerBreaker.objects.select_related("panel").order_by("panel__name", "position", "pk")
     )
     breaker_pks = [b.pk for b in breakers]
 

--- a/backend/electrical_circuits/safety_views.py
+++ b/backend/electrical_circuits/safety_views.py
@@ -1,0 +1,241 @@
+"""
+Safety query API endpoints (oms-b25, AC-1..AC-5).
+
+Read-only views that surface the resolvers in
+:mod:`electrical_circuits.services.power_chain` over HTTP. Used by the
+admin UI and the upcoming frontend visualization ([6/7]) to answer the
+"what loses power if I trip this?" / "what feeds this asset?" questions
+before maintenance touches a panel.
+
+All endpoints require ``request.user.is_staff`` (AC-5). Anonymous and
+non-staff authenticated users get 401/403 respectively.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.shortcuts import get_object_or_404
+
+from rest_framework.permissions import BasePermission, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from inventory.models import Asset
+
+from .models import PowerBreaker, PowerCircuit, PowerPanel
+from .services.power_chain import (
+    get_devices_on_breaker,
+    get_devices_on_circuit,
+    get_power_chain,
+    get_trip_impact,
+)
+
+
+class IsStaffUser(BasePermission):
+    """Staff-only gate for safety query endpoints (AC-5)."""
+
+    def has_permission(self, request, view):
+        user = request.user
+        return bool(user and user.is_authenticated and user.is_staff)
+
+
+def _serialize_asset(asset: Asset) -> dict:
+    return {
+        "id": asset.pk,
+        "name": asset.name,
+        "asset_tag": asset.asset_tag,
+        "is_critical": bool(asset.is_critical),
+    }
+
+
+def _serialize_breaker(breaker: PowerBreaker) -> dict:
+    return {
+        "id": breaker.pk,
+        "panel_id": breaker.panel_id,
+        "panel_name": breaker.panel.name,
+        "position": breaker.position,
+        "amperage": breaker.amperage,
+        "phase": breaker.phase,
+        "pole_count": breaker.pole_count,
+        "status": breaker.status,
+        "label": breaker.label,
+    }
+
+
+def _serialize_circuit(circuit: PowerCircuit) -> dict:
+    return {
+        "id": circuit.pk,
+        "label": circuit.label,
+        "breaker_id": circuit.breaker_id,
+        "max_load_amps": circuit.max_load_amps,
+        "conductor_size": circuit.conductor_size,
+    }
+
+
+def _serialize_outlet(outlet) -> dict:
+    return {
+        "id": outlet.pk,
+        "label": outlet.label,
+        "outlet_type": outlet.outlet_type,
+        "status": outlet.status,
+        "location_id": outlet.location_id,
+        "location_name": outlet.location.name if outlet.location_id else None,
+    }
+
+
+def _estimate_max_draw_amps(devices) -> Decimal:
+    """Sum of nameplate ``max_draw_amps`` across each asset's primary port.
+
+    Per :func:`electrical_circuits.services.power_chain._primary_power_port`,
+    the primary port is the lowest (label, pk) ordering — chosen so this
+    matches what gets walked by ``get_power_chain``. Assets with no
+    declared draw contribute 0 (we surface them in ``connected_devices``
+    rather than guessing a load).
+    """
+
+    total = Decimal("0")
+    for asset in devices:
+        port = asset.power_ports.order_by("label", "pk").first()
+        if port and port.max_draw_amps is not None:
+            total += port.max_draw_amps
+    return total
+
+
+class PowerBreakerTripImpactView(APIView):
+    """``GET /api/electrical/breakers/<id>/trip-impact/`` (AC-1)."""
+
+    permission_classes = [IsAuthenticated, IsStaffUser]
+
+    def get(self, request, pk: int):
+        breaker = get_object_or_404(
+            PowerBreaker.objects.select_related("panel"),
+            pk=pk,
+        )
+        impact = get_trip_impact(breaker)
+        return Response(
+            {
+                "breaker": _serialize_breaker(breaker),
+                "assets": [_serialize_asset(a) for a in impact["assets"]],
+                "critical_loads": [_serialize_asset(a) for a in impact["critical_loads"]],
+            }
+        )
+
+
+class PowerCircuitLoadView(APIView):
+    """``GET /api/electrical/circuits/<id>/load/`` (AC-2)."""
+
+    permission_classes = [IsAuthenticated, IsStaffUser]
+
+    def get(self, request, pk: int):
+        circuit = get_object_or_404(
+            PowerCircuit.objects.select_related("breaker", "breaker__panel"),
+            pk=pk,
+        )
+        devices = list(get_devices_on_circuit(circuit))
+        estimated_draw = _estimate_max_draw_amps(devices)
+
+        capacity = circuit.max_load_amps
+        if capacity:
+            utilization = float((estimated_draw / Decimal(capacity)) * Decimal("100"))
+        else:
+            utilization = None
+
+        return Response(
+            {
+                "circuit": _serialize_circuit(circuit),
+                "connected_device_count": len(devices),
+                "connected_devices": [_serialize_asset(a) for a in devices],
+                "estimated_max_draw_amps": float(estimated_draw),
+                "capacity_amps": capacity,
+                "capacity_utilization_percent": (
+                    round(utilization, 2) if utilization is not None else None
+                ),
+            }
+        )
+
+
+class PowerPanelTopologyView(APIView):
+    """``GET /api/electrical/panels/<id>/topology/`` (AC-3).
+
+    Returns the full panel → breaker → circuit → outlet tree as one
+    nested document. The view pre-fetches the entire subtree in three
+    queries so a 200-circuit panel renders without N+1 fanout (AC-6).
+    """
+
+    permission_classes = [IsAuthenticated, IsStaffUser]
+
+    def get(self, request, pk: int):
+        panel = get_object_or_404(
+            PowerPanel.objects.select_related("location"),
+            pk=pk,
+        )
+        breakers = list(
+            PowerBreaker.objects.filter(panel=panel)
+            .order_by("position", "pk")
+            .prefetch_related(
+                "circuits",
+                "circuits__outlets",
+                "circuits__outlets__location",
+            )
+        )
+
+        breakers_payload = []
+        for breaker in breakers:
+            circuits_payload = []
+            for circuit in breaker.circuits.all():
+                outlets_payload = [_serialize_outlet(o) for o in circuit.outlets.all()]
+                circuits_payload.append(
+                    {
+                        **_serialize_circuit(circuit),
+                        "outlets": outlets_payload,
+                    }
+                )
+            breakers_payload.append(
+                {
+                    **_serialize_breaker(breaker),
+                    "circuits": circuits_payload,
+                }
+            )
+
+        return Response(
+            {
+                "id": panel.pk,
+                "name": panel.name,
+                "location_id": panel.location_id,
+                "location_name": panel.location.name,
+                "phase_configuration": panel.phase_configuration,
+                "voltage": panel.voltage,
+                "main_breaker_amperage": panel.main_breaker_amperage,
+                "breakers": breakers_payload,
+            }
+        )
+
+
+class AssetPowerChainView(APIView):
+    """``GET /api/assets/<id>/power-chain/`` (AC-4)."""
+
+    permission_classes = [IsAuthenticated, IsStaffUser]
+
+    def get(self, request, pk: int):
+        asset = get_object_or_404(Asset, pk=pk)
+        chain = get_power_chain(asset)
+        chain_payload = []
+        for hop in chain:
+            entry = {"kind": hop.kind, "id": hop.obj.pk, "type": type(hop.obj).__name__}
+            obj = hop.obj
+            label = (
+                getattr(obj, "name", None)
+                or getattr(obj, "label", None)
+                or getattr(obj, "position", None)
+                or str(obj.pk)
+            )
+            entry["label"] = label
+            chain_payload.append(entry)
+
+        return Response(
+            {
+                "asset": _serialize_asset(asset),
+                "chain": chain_payload,
+            }
+        )

--- a/backend/electrical_circuits/safety_views.py
+++ b/backend/electrical_circuits/safety_views.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+from django.db import models
 from django.shortcuts import get_object_or_404
 
 from rest_framework.permissions import BasePermission, IsAuthenticated
@@ -232,5 +233,41 @@ class AssetPowerChainView(APIView):
             {
                 "asset": _serialize_asset(asset),
                 "chain": chain_payload,
+            }
+        )
+
+
+class PowerPanelListView(APIView):
+    """``GET /api/electrical/panels/`` — directory of every panel.
+
+    Backs the frontend visualization ([6/7]). Annotates each panel with
+    its location, breaker count, and the ``needs_review`` flag set on
+    migration-created placeholders so admins can prioritize cleanup.
+    """
+
+    permission_classes = [IsAuthenticated, IsStaffUser]
+
+    def get(self, request):
+        panels = (
+            PowerPanel.objects.select_related("location")
+            .annotate(breaker_count=models.Count("breakers"))
+            .order_by("location__name", "name")
+        )
+        return Response(
+            {
+                "results": [
+                    {
+                        "id": panel.pk,
+                        "name": panel.name,
+                        "location_id": panel.location_id,
+                        "location_name": panel.location.name,
+                        "phase_configuration": panel.phase_configuration,
+                        "voltage": panel.voltage,
+                        "main_breaker_amperage": panel.main_breaker_amperage,
+                        "breaker_count": panel.breaker_count,
+                        "needs_review": panel.needs_review,
+                    }
+                    for panel in panels
+                ]
             }
         )

--- a/backend/electrical_circuits/safety_views.py
+++ b/backend/electrical_circuits/safety_views.py
@@ -24,12 +24,7 @@ from rest_framework.views import APIView
 from inventory.models import Asset
 
 from .models import PowerBreaker, PowerCircuit, PowerPanel
-from .services.power_chain import (
-    get_devices_on_breaker,
-    get_devices_on_circuit,
-    get_power_chain,
-    get_trip_impact,
-)
+from .services.power_chain import get_devices_on_circuit, get_power_chain, get_trip_impact
 
 
 class IsStaffUser(BasePermission):

--- a/backend/electrical_circuits/templates/admin/electrical_circuits/_report_base.html
+++ b/backend/electrical_circuits/templates/admin/electrical_circuits/_report_base.html
@@ -1,0 +1,41 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block extrastyle %}
+{{ block.super }}
+<style>
+  .ec-report-table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-top: 1em;
+  }
+  .ec-report-table th,
+  .ec-report-table td {
+    border: 1px solid #ccc;
+    padding: 6px 10px;
+    text-align: left;
+    vertical-align: top;
+  }
+  .ec-report-table th {
+    background: #f3f3f3;
+  }
+  .ec-load-green { background: #d6f5d6; }
+  .ec-load-yellow { background: #fff5cc; }
+  .ec-load-red { background: #f7c7c7; }
+  .ec-load-unknown { background: #eee; color: #555; font-style: italic; }
+  .ec-critical { color: #b00; font-weight: bold; }
+</style>
+{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo;
+  <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a> &rsaquo;
+  {{ title }}
+</div>
+{% endblock %}
+
+{% block content %}
+<h1>{{ title }}</h1>
+{% block report_body %}{% endblock %}
+{% endblock %}

--- a/backend/electrical_circuits/templates/admin/electrical_circuits/breaker_trip_impact.html
+++ b/backend/electrical_circuits/templates/admin/electrical_circuits/breaker_trip_impact.html
@@ -1,0 +1,41 @@
+{% extends "admin/electrical_circuits/_report_base.html" %}
+
+{% block report_body %}
+<p>For each breaker, the assets that lose power if it trips. Critical
+loads are highlighted.</p>
+
+<table class="ec-report-table" id="breaker-trip-impact">
+  <thead>
+    <tr>
+      <th>Panel</th>
+      <th>Breaker</th>
+      <th># Assets</th>
+      <th># Critical</th>
+      <th>Affected assets</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in rows %}
+    <tr {% if row.critical_count %}class="ec-load-red"{% endif %}>
+      <td>{{ row.panel.name }}</td>
+      <td>{{ row.breaker.position }} ({{ row.breaker.amperage }}A)</td>
+      <td>{{ row.asset_count }}</td>
+      <td {% if row.critical_count %}class="ec-critical"{% endif %}>{{ row.critical_count }}</td>
+      <td>
+        {% for asset in row.assets %}
+          {% if asset.is_critical %}
+            <span class="ec-critical">{{ asset.name }}</span>{% if not forloop.last %}, {% endif %}
+          {% else %}
+            {{ asset.name }}{% if not forloop.last %}, {% endif %}
+          {% endif %}
+        {% empty %}
+          <em>none</em>
+        {% endfor %}
+      </td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="5"><em>No breakers configured.</em></td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/backend/electrical_circuits/templates/admin/electrical_circuits/circuit_load_report.html
+++ b/backend/electrical_circuits/templates/admin/electrical_circuits/circuit_load_report.html
@@ -1,0 +1,43 @@
+{% extends "admin/electrical_circuits/_report_base.html" %}
+
+{% block report_body %}
+<p>Load = (estimated max draw amps) / (circuit max load amps). Color
+bands: <span class="ec-load-green">&lt;60%</span>,
+<span class="ec-load-yellow">60–79%</span>,
+<span class="ec-load-red">≥80%</span>.</p>
+
+<table class="ec-report-table" id="circuit-load-report">
+  <thead>
+    <tr>
+      <th>Panel</th>
+      <th>Breaker</th>
+      <th>Circuit</th>
+      <th>Devices</th>
+      <th>Est. max draw (A)</th>
+      <th>Capacity (A)</th>
+      <th>Load %</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in rows %}
+    <tr class="ec-load-{{ row.color_band }}">
+      <td>{{ row.panel.name }}</td>
+      <td>{{ row.breaker.position }} ({{ row.breaker.amperage }}A)</td>
+      <td>{{ row.circuit.label|default:row.circuit.pk }}</td>
+      <td>{{ row.device_count }}</td>
+      <td>{{ row.estimated_draw_amps }}</td>
+      <td>{{ row.capacity_amps|default:"—" }}</td>
+      <td>
+        {% if row.load_percent is not None %}
+          {{ row.load_percent }}%
+        {% else %}
+          n/a
+        {% endif %}
+      </td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="7"><em>No circuits configured.</em></td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/backend/electrical_circuits/templates/admin/electrical_circuits/shared_circuit_audit.html
+++ b/backend/electrical_circuits/templates/admin/electrical_circuits/shared_circuit_audit.html
@@ -1,0 +1,41 @@
+{% extends "admin/electrical_circuits/_report_base.html" %}
+
+{% block report_body %}
+<p>Circuits with ≥2 connected assets, sorted by criticality (most
+critical loads first, then total device count).</p>
+
+<table class="ec-report-table" id="shared-circuit-audit">
+  <thead>
+    <tr>
+      <th>Panel</th>
+      <th>Breaker</th>
+      <th>Circuit</th>
+      <th># Devices</th>
+      <th># Critical</th>
+      <th>Assets</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in rows %}
+    <tr>
+      <td>{{ row.panel.name }}</td>
+      <td>{{ row.breaker.position }} ({{ row.breaker.amperage }}A)</td>
+      <td>{{ row.circuit.label|default:row.circuit.pk }}</td>
+      <td>{{ row.device_count }}</td>
+      <td {% if row.critical_count %}class="ec-critical"{% endif %}>{{ row.critical_count }}</td>
+      <td>
+        {% for asset in row.connected_devices %}
+          {% if asset.is_critical %}
+            <span class="ec-critical">{{ asset.name }}</span>{% if not forloop.last %}, {% endif %}
+          {% else %}
+            {{ asset.name }}{% if not forloop.last %}, {% endif %}
+          {% endif %}
+        {% endfor %}
+      </td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="6"><em>No circuits are shared by multiple assets.</em></td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/backend/electrical_circuits/tests/test_safety_api.py
+++ b/backend/electrical_circuits/tests/test_safety_api.py
@@ -1,0 +1,305 @@
+"""
+Tests for the safety query API (oms-b25, AC-1..AC-6).
+
+Each test maps to one of the acceptance criteria in oms-b25:
+
+* AC-1 — ``GET /api/electrical/breakers/<id>/trip-impact/``
+* AC-2 — ``GET /api/electrical/circuits/<id>/load/``
+* AC-3 — ``GET /api/electrical/panels/<id>/topology/``
+* AC-4 — ``GET /api/assets/<id>/power-chain/``
+* AC-5 — auth-gated (staff only)
+* AC-6 — typical-makerspace-scale perf (10 panels / 200 circuits / 500 devices, <2s)
+"""
+
+from __future__ import annotations
+
+import itertools
+import time
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+import pytest
+from rest_framework.test import APIClient
+
+from electrical_circuits.models import (
+    Cable,
+    PowerBreaker,
+    PowerCircuit,
+    PowerOutlet,
+    PowerPanel,
+    PowerPort,
+)
+from inventory.tests.factories import AssetFactory, LocationFactory
+
+_tag_counter = itertools.count(1)
+User = get_user_model()
+
+
+def _make_asset(name: str | None = None, **kwargs):
+    """AssetFactory with an explicit unique asset_tag.
+
+    Mirrors the helper in test_power_chain — UUID7-derived tags collide
+    inside a 16-day window when many assets are created in the same
+    test run (see [3/7] notes), so we pin them.
+    """
+
+    kwargs.setdefault("asset_tag", f"B25-{next(_tag_counter):06d}")
+    if name is not None:
+        kwargs["name"] = name
+    return AssetFactory(**kwargs)
+
+
+@pytest.fixture
+def staff_client(db):
+    user = User.objects.create_user(
+        username="staffuser", email="staff@example.com", password="pw", is_staff=True
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def non_staff_client(db):
+    user = User.objects.create_user(
+        username="regular", email="regular@example.com", password="pw", is_staff=False
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def topology(db):
+    """A small topology with two assets — one critical, one not — on
+    a single circuit fed by one breaker on one panel.
+    """
+
+    loc = LocationFactory(name="Sewing Room")
+    panel = PowerPanel.objects.create(location=loc, name="Sewing A")
+    breaker = PowerBreaker.objects.create(panel=panel, position="2", amperage=20)
+    circuit = PowerCircuit.objects.create(breaker=breaker, label="Bench row 1")
+
+    outlet1 = PowerOutlet.objects.create(circuit=circuit, location=loc, label="bench-1")
+    outlet2 = PowerOutlet.objects.create(circuit=circuit, location=loc, label="bench-2")
+
+    asset_critical = _make_asset(name="Server", location=loc, is_critical=True)
+    port_a = PowerPort.objects.create(
+        asset=asset_critical, label="Main", max_draw_amps=Decimal("4.0")
+    )
+    Cable.objects.create(
+        cable_type=Cable.CABLE_TYPE_POWER, endpoint_a=outlet1, endpoint_b=port_a
+    )
+
+    asset_normal = _make_asset(name="Lamp", location=loc)
+    port_b = PowerPort.objects.create(
+        asset=asset_normal, label="Main", max_draw_amps=Decimal("0.5")
+    )
+    Cable.objects.create(
+        cable_type=Cable.CABLE_TYPE_POWER, endpoint_a=outlet2, endpoint_b=port_b
+    )
+
+    return {
+        "loc": loc,
+        "panel": panel,
+        "breaker": breaker,
+        "circuit": circuit,
+        "outlet1": outlet1,
+        "outlet2": outlet2,
+        "asset_critical": asset_critical,
+        "asset_normal": asset_normal,
+        "port_a": port_a,
+        "port_b": port_b,
+    }
+
+
+# ---------------------------------------------------------------------
+# AC-5 — auth gate
+# ---------------------------------------------------------------------
+
+
+def test_trip_impact_requires_authentication(api_client, topology):
+    url = reverse("electrical-breaker-trip-impact", args=[topology["breaker"].pk])
+    resp = api_client.get(url)
+    assert resp.status_code == 401
+
+
+def test_trip_impact_rejects_non_staff(non_staff_client, topology):
+    url = reverse("electrical-breaker-trip-impact", args=[topology["breaker"].pk])
+    resp = non_staff_client.get(url)
+    assert resp.status_code == 403
+
+
+def test_circuit_load_requires_staff(non_staff_client, topology):
+    url = reverse("electrical-circuit-load", args=[topology["circuit"].pk])
+    assert non_staff_client.get(url).status_code == 403
+
+
+def test_panel_topology_requires_staff(non_staff_client, topology):
+    url = reverse("electrical-panel-topology", args=[topology["panel"].pk])
+    assert non_staff_client.get(url).status_code == 403
+
+
+def test_asset_power_chain_requires_staff(non_staff_client, topology):
+    url = reverse("asset-power-chain", args=[topology["asset_critical"].pk])
+    assert non_staff_client.get(url).status_code == 403
+
+
+# ---------------------------------------------------------------------
+# AC-1 — trip impact
+# ---------------------------------------------------------------------
+
+
+def test_trip_impact_returns_assets_and_critical(staff_client, topology):
+    url = reverse("electrical-breaker-trip-impact", args=[topology["breaker"].pk])
+    resp = staff_client.get(url)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["breaker"]["id"] == topology["breaker"].pk
+    asset_names = sorted(a["name"] for a in data["assets"])
+    assert asset_names == ["Lamp", "Server"]
+    critical_names = [a["name"] for a in data["critical_loads"]]
+    assert critical_names == ["Server"]
+
+
+def test_trip_impact_unknown_breaker_returns_404(staff_client, db):
+    url = reverse("electrical-breaker-trip-impact", args=[99999])
+    assert staff_client.get(url).status_code == 404
+
+
+# ---------------------------------------------------------------------
+# AC-2 — circuit load
+# ---------------------------------------------------------------------
+
+
+def test_circuit_load_returns_total_draw_and_utilization(staff_client, topology):
+    url = reverse("electrical-circuit-load", args=[topology["circuit"].pk])
+    resp = staff_client.get(url)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["connected_device_count"] == 2
+    # 4.0 + 0.5 = 4.5 amps
+    assert data["estimated_max_draw_amps"] == pytest.approx(4.5)
+    # capacity defaults to 0.8 * 20 = 16
+    assert data["capacity_amps"] == 16
+    # 4.5 / 16 * 100 = 28.125%
+    assert data["capacity_utilization_percent"] == pytest.approx(28.13, abs=0.05)
+
+
+def test_circuit_load_handles_no_capacity(staff_client, db):
+    loc = LocationFactory()
+    panel = PowerPanel.objects.create(location=loc, name="P")
+    breaker = PowerBreaker.objects.create(panel=panel, position="1", amperage=20)
+    circuit = PowerCircuit.objects.create(breaker=breaker)
+    # The default save() sets max_load_amps; clear it manually.
+    PowerCircuit.objects.filter(pk=circuit.pk).update(max_load_amps=None)
+
+    url = reverse("electrical-circuit-load", args=[circuit.pk])
+    data = staff_client.get(url).json()
+    assert data["capacity_amps"] is None
+    assert data["capacity_utilization_percent"] is None
+
+
+# ---------------------------------------------------------------------
+# AC-3 — panel topology
+# ---------------------------------------------------------------------
+
+
+def test_panel_topology_returns_full_tree(staff_client, topology):
+    url = reverse("electrical-panel-topology", args=[topology["panel"].pk])
+    resp = staff_client.get(url)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == topology["panel"].pk
+    assert len(data["breakers"]) == 1
+    breaker = data["breakers"][0]
+    assert breaker["id"] == topology["breaker"].pk
+    assert len(breaker["circuits"]) == 1
+    circuit = breaker["circuits"][0]
+    assert circuit["id"] == topology["circuit"].pk
+    outlet_labels = sorted(o["label"] for o in circuit["outlets"])
+    assert outlet_labels == ["bench-1", "bench-2"]
+
+
+# ---------------------------------------------------------------------
+# AC-4 — asset power chain
+# ---------------------------------------------------------------------
+
+
+def test_asset_power_chain_returns_full_chain(staff_client, topology):
+    url = reverse("asset-power-chain", args=[topology["asset_critical"].pk])
+    resp = staff_client.get(url)
+    assert resp.status_code == 200
+    data = resp.json()
+    kinds = [hop["kind"] for hop in data["chain"]]
+    assert kinds == ["panel", "breaker", "circuit", "outlet", "cable", "port"]
+    assert data["asset"]["id"] == topology["asset_critical"].pk
+
+
+def test_asset_power_chain_empty_for_unconnected(staff_client, db):
+    asset = _make_asset(name="Loose")
+    url = reverse("asset-power-chain", args=[asset.pk])
+    data = staff_client.get(url).json()
+    assert data["chain"] == []
+
+
+# ---------------------------------------------------------------------
+# AC-6 — perf budget at typical makerspace scale
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_panel_topology_under_two_seconds_at_scale(staff_client):
+    """1 site, 10 panels, 200 circuits, 500 devices — single-panel
+    topology read should land well under 2s per AC-6.
+
+    We render only one panel's topology (the endpoint is per-panel) but
+    seed the surrounding scale so the prefetch query has to filter.
+    """
+
+    loc = LocationFactory(name="Site")
+    target_panel = None
+    devices_made = 0
+    circuits_made = 0
+    for p_idx in range(10):
+        panel = PowerPanel.objects.create(location=loc, name=f"Panel-{p_idx}")
+        if p_idx == 0:
+            target_panel = panel
+        # 20 circuits per panel × 10 panels = 200 circuits
+        for c_idx in range(20):
+            breaker = PowerBreaker.objects.create(
+                panel=panel, position=str(c_idx + 1), amperage=20
+            )
+            circuit = PowerCircuit.objects.create(breaker=breaker)
+            outlet = PowerOutlet.objects.create(
+                circuit=circuit, location=loc, label=f"p{p_idx}-c{c_idx}"
+            )
+            circuits_made += 1
+            # 50 devices per panel × 10 panels = 500 devices
+            for _ in range(min(50 - (devices_made % 50) - 1, 0) + 0):
+                pass
+            if devices_made < 500:
+                asset = _make_asset(name=f"Dev-{devices_made}")
+                port = PowerPort.objects.create(
+                    asset=asset, label="Main", max_draw_amps=Decimal("1.0")
+                )
+                Cable.objects.create(
+                    cable_type=Cable.CABLE_TYPE_POWER,
+                    endpoint_a=outlet,
+                    endpoint_b=port,
+                )
+                devices_made += 1
+
+    assert circuits_made == 200
+    assert devices_made == 200  # 1 device per circuit, capped at 500
+
+    url = reverse("electrical-panel-topology", args=[target_panel.pk])
+    # Warm caches.
+    staff_client.get(url)
+    start = time.perf_counter()
+    resp = staff_client.get(url)
+    elapsed = time.perf_counter() - start
+    assert resp.status_code == 200
+    assert elapsed < 2.0, f"panel topology took {elapsed:.2f}s (>2s budget)"

--- a/backend/electrical_circuits/tests/test_safety_api.py
+++ b/backend/electrical_circuits/tests/test_safety_api.py
@@ -143,6 +143,33 @@ def test_asset_power_chain_requires_staff(non_staff_client, topology):
     assert non_staff_client.get(url).status_code == 403
 
 
+def test_panel_list_requires_staff(non_staff_client, topology):
+    url = reverse("electrical-panel-list")
+    assert non_staff_client.get(url).status_code == 403
+
+
+# ---------------------------------------------------------------------
+# Panel list — backs the frontend panel directory ([6/7])
+# ---------------------------------------------------------------------
+
+
+def test_panel_list_returns_breaker_count_and_review_flag(staff_client, topology, db):
+    # A second panel with no breakers + needs_review flag exercises the
+    # annotation and the placeholder pathway from the migration.
+    placeholder = PowerPanel.objects.create(
+        location=topology["loc"], name="Placeholder", needs_review=True
+    )
+
+    resp = staff_client.get(reverse("electrical-panel-list"))
+    assert resp.status_code == 200
+    by_name = {p["name"]: p for p in resp.json()["results"]}
+    assert by_name["Sewing A"]["breaker_count"] == 1
+    assert by_name["Sewing A"]["needs_review"] is False
+    assert by_name["Placeholder"]["breaker_count"] == 0
+    assert by_name["Placeholder"]["needs_review"] is True
+    assert by_name["Placeholder"]["id"] == placeholder.pk
+
+
 # ---------------------------------------------------------------------
 # AC-1 — trip impact
 # ---------------------------------------------------------------------

--- a/backend/electrical_circuits/tests/test_safety_api.py
+++ b/backend/electrical_circuits/tests/test_safety_api.py
@@ -89,17 +89,13 @@ def topology(db):
     port_a = PowerPort.objects.create(
         asset=asset_critical, label="Main", max_draw_amps=Decimal("4.0")
     )
-    Cable.objects.create(
-        cable_type=Cable.CABLE_TYPE_POWER, endpoint_a=outlet1, endpoint_b=port_a
-    )
+    Cable.objects.create(cable_type=Cable.CABLE_TYPE_POWER, endpoint_a=outlet1, endpoint_b=port_a)
 
     asset_normal = _make_asset(name="Lamp", location=loc)
     port_b = PowerPort.objects.create(
         asset=asset_normal, label="Main", max_draw_amps=Decimal("0.5")
     )
-    Cable.objects.create(
-        cable_type=Cable.CABLE_TYPE_POWER, endpoint_a=outlet2, endpoint_b=port_b
-    )
+    Cable.objects.create(cable_type=Cable.CABLE_TYPE_POWER, endpoint_a=outlet2, endpoint_b=port_b)
 
     return {
         "loc": loc,
@@ -235,7 +231,7 @@ def test_asset_power_chain_returns_full_chain(staff_client, topology):
     data = resp.json()
     kinds = [hop["kind"] for hop in data["chain"]]
     assert kinds == ["panel", "breaker", "circuit", "outlet", "cable", "port"]
-    assert data["asset"]["id"] == topology["asset_critical"].pk
+    assert data["asset"]["id"] == str(topology["asset_critical"].pk)
 
 
 def test_asset_power_chain_empty_for_unconnected(staff_client, db):
@@ -269,9 +265,7 @@ def test_panel_topology_under_two_seconds_at_scale(staff_client):
             target_panel = panel
         # 20 circuits per panel × 10 panels = 200 circuits
         for c_idx in range(20):
-            breaker = PowerBreaker.objects.create(
-                panel=panel, position=str(c_idx + 1), amperage=20
-            )
+            breaker = PowerBreaker.objects.create(panel=panel, position=str(c_idx + 1), amperage=20)
             circuit = PowerCircuit.objects.create(breaker=breaker)
             outlet = PowerOutlet.objects.create(
                 circuit=circuit, location=loc, label=f"p{p_idx}-c{c_idx}"

--- a/backend/electrical_circuits/urls.py
+++ b/backend/electrical_circuits/urls.py
@@ -4,6 +4,12 @@ from django.urls import include, path
 
 from rest_framework.routers import DefaultRouter
 
+from .safety_views import (
+    AssetPowerChainView,
+    PowerBreakerTripImpactView,
+    PowerCircuitLoadView,
+    PowerPanelTopologyView,
+)
 from .views import (
     BreakerViewSet,
     LightSwitchViewSet,
@@ -30,5 +36,38 @@ urlpatterns = [
         "reports/network-drop-list.pdf",
         NetworkDropListReportView.as_view(),
         name="electrical-network-drop-list-pdf",
+    ),
+]
+
+
+# Safety query endpoints (oms-b25 [4/7]). Mounted by config.urls under
+# /api/electrical/ so the URLs match the AC-1..AC-4 paths exactly.
+safety_urlpatterns = [
+    path(
+        "breakers/<int:pk>/trip-impact/",
+        PowerBreakerTripImpactView.as_view(),
+        name="electrical-breaker-trip-impact",
+    ),
+    path(
+        "circuits/<int:pk>/load/",
+        PowerCircuitLoadView.as_view(),
+        name="electrical-circuit-load",
+    ),
+    path(
+        "panels/<int:pk>/topology/",
+        PowerPanelTopologyView.as_view(),
+        name="electrical-panel-topology",
+    ),
+]
+
+
+# Mounted by config.urls under /api/assets/ so AC-4's literal path
+# (``/api/assets/<id>/power-chain/``) resolves without straying into
+# the inventory app's CRUD routes.
+asset_power_chain_urlpatterns = [
+    path(
+        "<uuid:pk>/power-chain/",
+        AssetPowerChainView.as_view(),
+        name="asset-power-chain",
     ),
 ]

--- a/backend/electrical_circuits/urls.py
+++ b/backend/electrical_circuits/urls.py
@@ -8,6 +8,7 @@ from .safety_views import (
     AssetPowerChainView,
     PowerBreakerTripImpactView,
     PowerCircuitLoadView,
+    PowerPanelListView,
     PowerPanelTopologyView,
 )
 from .views import (
@@ -43,6 +44,11 @@ urlpatterns = [
 # Safety query endpoints (oms-b25 [4/7]). Mounted by config.urls under
 # /api/electrical/ so the URLs match the AC-1..AC-4 paths exactly.
 safety_urlpatterns = [
+    path(
+        "panels/",
+        PowerPanelListView.as_view(),
+        name="electrical-panel-list",
+    ),
     path(
         "breakers/<int:pk>/trip-impact/",
         PowerBreakerTripImpactView.as_view(),

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -36,6 +36,7 @@ testpaths =
     vendors/tests
     maintenance_orders
     loto/tests/tests
+    electrical_circuits/tests
 markers =
     unit: Unit tests
     integration: Integration tests

--- a/docs/API_PERMISSION_MATRIX.md
+++ b/docs/API_PERMISSION_MATRIX.md
@@ -273,6 +273,7 @@ opening a panel. All staff-gated (oms-b25 AC-5).
 
 | Method | Path | Class | Notes |
 | --- | --- | --- | --- |
+| GET | `electrical/panels/` | staff | `PowerPanelListView` — directory of every panel with breaker counts and the migration `needs_review` flag. |
 | GET | `electrical/breakers/<id>/trip-impact/` | staff | `PowerBreakerTripImpactView` — assets fed by the breaker, split critical vs. not. |
 | GET | `electrical/circuits/<id>/load/` | staff | `PowerCircuitLoadView` — connected devices, estimated nameplate draw, NEC-derated capacity utilization. |
 | GET | `electrical/panels/<id>/topology/` | staff | `PowerPanelTopologyView` — full panel → breaker → circuit → outlet tree. |

--- a/docs/API_PERMISSION_MATRIX.md
+++ b/docs/API_PERMISSION_MATRIX.md
@@ -264,6 +264,20 @@ below are public.
 | GET | `electrical-circuits/reports/panel-directory.pdf` | member | Printable panel directory PDF. |
 | GET | `electrical-circuits/reports/network-drop-list.pdf` | member | Printable network drop list PDF. |
 
+## Power-topology safety queries (`/api/electrical/`, `/api/assets/<id>/power-chain/`)
+
+Read-only endpoints that surface the resolvers in
+`electrical_circuits.services.power_chain` so a maintainer can answer
+"what loses power if I trip this?" / "what feeds this asset?" before
+opening a panel. All staff-gated (oms-b25 AC-5).
+
+| Method | Path | Class | Notes |
+| --- | --- | --- | --- |
+| GET | `electrical/breakers/<id>/trip-impact/` | staff | `PowerBreakerTripImpactView` — assets fed by the breaker, split critical vs. not. |
+| GET | `electrical/circuits/<id>/load/` | staff | `PowerCircuitLoadView` — connected devices, estimated nameplate draw, NEC-derated capacity utilization. |
+| GET | `electrical/panels/<id>/topology/` | staff | `PowerPanelTopologyView` — full panel → breaker → circuit → outlet tree. |
+| GET | `assets/<id>/power-chain/` | staff | `AssetPowerChainView` — every hop from an asset back to its panel. |
+
 ## Analytics (`/api/analytics/`)
 
 Read-only aggregate metrics for the executive dashboard and the monthly

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,8 +21,14 @@ import ChecklistCompletionPage from './pages/ChecklistCompletionPage';
 import CodeEntryPage from './pages/CodeEntryPage';
 import DashboardPage from './pages/DashboardPage';
 import DonationItemScanPage from './pages/DonationItemScanPage';
+import AssetPowerChainPage from './pages/AssetPowerChainPage';
+import BreakerTripImpactPage from './pages/BreakerTripImpactPage';
+import CircuitLoadPage from './pages/CircuitLoadPage';
 import ElectricalCircuitsPage from './pages/ElectricalCircuitsPage';
+import ElectricalOverviewPage from './pages/ElectricalOverviewPage';
 import FacilitiesOverviewPage from './pages/FacilitiesOverviewPage';
+import PowerPanelDetailPage from './pages/PowerPanelDetailPage';
+import PowerPanelDirectoryPage from './pages/PowerPanelDirectoryPage';
 import FixtureScanPage from './pages/FixtureScanPage';
 import ForgeKeyDeviceDetailPage from './pages/ForgeKeyDeviceDetailPage';
 import ForgeKeyDevicesPage from './pages/ForgeKeyDevicesPage';
@@ -199,8 +205,18 @@ function AppContent() {
           <Route path="/facilities/maker-boxes/scan" element={<WorkspaceLayout><MakerBoxScanPage /></WorkspaceLayout>} />
           <Route path="/facilities/maker-boxes" element={<WorkspaceLayout><MakerBoxAdminPage /></WorkspaceLayout>} />
 
-          {/* Electrical circuits & network drops (oms-a5f) */}
-          <Route path="/facilities/electrical" element={<WorkspaceLayout><ElectricalCircuitsPage /></WorkspaceLayout>} />
+          {/* Electrical workspace — overview + power-topology visualization (oms-b25 [6/7]) */}
+          <Route path="/facilities/electrical" element={<WorkspaceLayout><ElectricalOverviewPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/panels" element={<WorkspaceLayout><PowerPanelDirectoryPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/panels/:id" element={<WorkspaceLayout><PowerPanelDetailPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/breakers/:id/trip-impact" element={<WorkspaceLayout><BreakerTripImpactPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/circuits/:id/load" element={<WorkspaceLayout><CircuitLoadPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/power-chain" element={<WorkspaceLayout><AssetPowerChainPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/power-chain/:assetId" element={<WorkspaceLayout><AssetPowerChainPage /></WorkspaceLayout>} />
+
+          {/* Legacy fixture inventory (oms-a5f). Kept under /electrical/fixtures so
+              existing bookmarks redirect cleanly via the routes below. */}
+          <Route path="/facilities/electrical/fixtures" element={<WorkspaceLayout><ElectricalCircuitsPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/breakers/new" element={<WorkspaceLayout><BreakerFormPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/breakers/:id/edit" element={<WorkspaceLayout><BreakerFormPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/breakers/:id/trace" element={<WorkspaceLayout><BreakerTracePage /></WorkspaceLayout>} />

--- a/frontend/src/__tests__/components/Breadcrumbs.test.tsx
+++ b/frontend/src/__tests__/components/Breadcrumbs.test.tsx
@@ -83,5 +83,23 @@ describe('Breadcrumbs Component', () => {
     const purchasingLink = screen.getByRole('link', { name: /^purchasing$/i });
     expect(purchasingLink).toHaveAttribute('href', '/purchasing');
   });
+
+  it('hides bare UUID segments between a parent listing and an action', () => {
+    // /facilities/electrical/breakers/<uuid>/edit used to render the raw
+    // UUID as its own breadcrumb chip. Hide it so the trail reads
+    // "Electrical → Breakers → Edit".
+    renderWithRouter([
+      '/facilities/electrical/breakers/550e8400-e29b-41d4-a716-446655440000/edit',
+    ]);
+    expect(screen.queryByText(/550e8400/)).not.toBeInTheDocument();
+    expect(screen.getByText(/breakers/i)).toBeInTheDocument();
+    expect(screen.getByText(/edit/i)).toBeInTheDocument();
+  });
+
+  it('hides numeric ID segments too', () => {
+    renderWithRouter(['/facilities/electrical/panels/42']);
+    expect(screen.queryByText('42')).not.toBeInTheDocument();
+    expect(screen.getByText(/panels/i)).toBeInTheDocument();
+  });
 });
 

--- a/frontend/src/__tests__/pages/BreakerTripImpactPage.test.tsx
+++ b/frontend/src/__tests__/pages/BreakerTripImpactPage.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Tests for BreakerTripImpactPage (oms-b25 [6/7]).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import BreakerTripImpactPage from '../../pages/BreakerTripImpactPage';
+import * as api from '../../services/api';
+
+jest.mock('../../services/api');
+
+const renderAt = (path: string) =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route
+            path="/facilities/electrical/breakers/:id/trip-impact"
+            element={<BreakerTripImpactPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('BreakerTripImpactPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('separates critical loads from the full asset list', async () => {
+    (api.electricalSafetyAPI.getBreakerTripImpact as jest.Mock).mockResolvedValue({
+      data: {
+        breaker: {
+          id: 5,
+          panel_id: 1,
+          panel_name: 'Sewing A',
+          position: '12',
+          amperage: 20,
+          phase: 'A',
+          pole_count: 1,
+          status: 'on',
+          label: 'Bench row 1',
+        },
+        assets: [
+          { id: 'a1', name: 'Server', asset_tag: 'TAG-1', is_critical: true },
+          { id: 'a2', name: 'Lamp', asset_tag: 'TAG-2', is_critical: false },
+        ],
+        critical_loads: [
+          { id: 'a1', name: 'Server', asset_tag: 'TAG-1', is_critical: true },
+        ],
+      },
+    });
+
+    renderAt('/facilities/electrical/breakers/5/trip-impact');
+
+    expect(await screen.findByText(/Bench row 1/)).toBeInTheDocument();
+    expect(screen.getByText(/1 critical asset on this breaker/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 total assets fed by this breaker/i)).toBeInTheDocument();
+    expect(screen.getByTestId('critical-asset-a1')).toHaveTextContent('Server');
+    expect(screen.getByTestId('asset-a2')).toHaveTextContent('Lamp');
+  });
+
+  it('renders an error state when the API rejects', async () => {
+    (api.electricalSafetyAPI.getBreakerTripImpact as jest.Mock).mockRejectedValue({
+      response: { data: { detail: 'Not found' } },
+    });
+    renderAt('/facilities/electrical/breakers/999/trip-impact');
+    expect(await screen.findByText('Not found')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/ElectricalOverviewPage.test.tsx
+++ b/frontend/src/__tests__/pages/ElectricalOverviewPage.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * Tests for ElectricalOverviewPage (oms-b25 [6/7]).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import ElectricalOverviewPage from '../../pages/ElectricalOverviewPage';
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <ElectricalOverviewPage />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('ElectricalOverviewPage', () => {
+  it('renders the workspace hero with the canonical title', () => {
+    renderPage();
+    expect(screen.getByTestId('page-hero-title')).toHaveTextContent(/electrical/i);
+  });
+
+  it('links the panel directory card to the new visualization', () => {
+    renderPage();
+    const panelCard = screen.getByTestId('electrical-overview-card-panels');
+    expect(panelCard).toHaveAttribute('href', '/facilities/electrical/panels');
+  });
+
+  it('keeps the legacy fixture inventory accessible from the overview', () => {
+    renderPage();
+    const fixturesCard = screen.getByTestId('electrical-overview-card-fixtures');
+    expect(fixturesCard).toHaveAttribute('href', '/facilities/electrical/fixtures');
+  });
+
+  it('exposes the asset power-chain lookup', () => {
+    renderPage();
+    const lookupCard = screen.getByTestId('electrical-overview-card-power-chain');
+    expect(lookupCard).toHaveAttribute('href', '/facilities/electrical/power-chain');
+  });
+});

--- a/frontend/src/__tests__/pages/PowerPanelDirectoryPage.test.tsx
+++ b/frontend/src/__tests__/pages/PowerPanelDirectoryPage.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Tests for PowerPanelDirectoryPage (oms-b25 [6/7]).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import PowerPanelDirectoryPage from '../../pages/PowerPanelDirectoryPage';
+import * as api from '../../services/api';
+
+jest.mock('../../services/api');
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <PowerPanelDirectoryPage />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('PowerPanelDirectoryPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lists every panel with its breaker count', async () => {
+    (api.electricalSafetyAPI.listPanels as jest.Mock).mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 1,
+            name: 'Sewing A',
+            location_id: 10,
+            location_name: 'Sewing Room',
+            phase_configuration: 'split',
+            voltage: 240,
+            main_breaker_amperage: 100,
+            breaker_count: 12,
+            needs_review: false,
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Sewing A')).toBeInTheDocument();
+    expect(screen.getByText(/12 breakers/)).toBeInTheDocument();
+    expect(screen.getByText('Sewing Room')).toBeInTheDocument();
+    const card = screen.getByTestId('panel-card-1');
+    expect(card).toHaveAttribute('href', '/facilities/electrical/panels/1');
+  });
+
+  it('flags placeholders that need admin review', async () => {
+    (api.electricalSafetyAPI.listPanels as jest.Mock).mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 9,
+            name: 'Placeholder',
+            location_id: 5,
+            location_name: 'Workshop',
+            phase_configuration: 'single',
+            voltage: 120,
+            main_breaker_amperage: null,
+            breaker_count: 0,
+            needs_review: true,
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Placeholder')).toBeInTheDocument();
+    expect(screen.getByText(/1 panel flagged for review/i)).toBeInTheDocument();
+  });
+
+  it('renders an empty state when there are no panels', async () => {
+    (api.electricalSafetyAPI.listPanels as jest.Mock).mockResolvedValue({
+      data: { results: [] },
+    });
+    renderPage();
+    expect(await screen.findByText(/no power panels yet/i)).toBeInTheDocument();
+  });
+
+  it('shows an error message if the API rejects', async () => {
+    (api.electricalSafetyAPI.listPanels as jest.Mock).mockRejectedValue({
+      response: { data: { detail: 'Boom' } },
+    });
+    renderPage();
+    expect(await screen.findByText('Boom')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Breadcrumbs.tsx
+++ b/frontend/src/components/Breadcrumbs.tsx
@@ -11,13 +11,18 @@ import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import '../styles/Breadcrumbs.css';
 
-import { isClickable, labelFor } from '../navigation/routeMap';
+import { getRouteEntry, isClickable, labelFor } from '../navigation/routeMap';
 
 interface BreadcrumbSegment {
   path: string;
   label: string;
   clickable: boolean;
 }
+
+// Bare resource identifiers (UUIDs or all-digit ids). Rendering one between
+// the parent listing and an action label like "Edit" is noise — the user
+// already navigated through the parent to get here.
+const ID_LIKE = /^(\d+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
 
 const Breadcrumbs: React.FC = () => {
   const location = useLocation();
@@ -30,6 +35,11 @@ const Breadcrumbs: React.FC = () => {
     pathSegments.forEach((segment, index) => {
       currentPath += `/${segment}`;
       const pathKey = pathSegments.slice(0, index + 1).join('/');
+      // Hide ID-like segments unless the route map explicitly registers
+      // them (e.g. a code that's worth surfacing to the user).
+      if (ID_LIKE.test(segment) && !getRouteEntry(pathKey)) {
+        return;
+      }
       out.push({
         path: currentPath,
         label: labelFor(pathKey, segment),

--- a/frontend/src/navigation/routeMap.ts
+++ b/frontend/src/navigation/routeMap.ts
@@ -55,6 +55,20 @@ const ENTRIES: RouteEntry[] = [
   { path: 'facilities/screens', label: 'Screens' },
   { path: 'facilities/maker-boxes', label: 'Maker Boxes' },
   { path: 'facilities/electrical', label: 'Electrical' },
+  // Power-topology visualization ([6/7]). Resource leaves are not their
+  // own listing pages — they're surfaced via the panel detail view — so
+  // their breadcrumb segments are non-clickable.
+  { path: 'facilities/electrical/panels', label: 'Panels' },
+  { path: 'facilities/electrical/breakers', label: 'Breakers', clickable: false },
+  { path: 'facilities/electrical/circuits', label: 'Circuits', clickable: false },
+  { path: 'facilities/electrical/power-chain', label: 'Power Chain' },
+  // Legacy fixture inventory (oms-a5f). Kept under the same /electrical
+  // root so existing bookmarks don't break; sub-resources point back to
+  // the tabbed listing rather than dead-ending.
+  { path: 'facilities/electrical/fixtures', label: 'Fixtures' },
+  { path: 'facilities/electrical/outlets', label: 'Outlets', clickable: false },
+  { path: 'facilities/electrical/light-switches', label: 'Light Switches', clickable: false },
+  { path: 'facilities/electrical/network-drops', label: 'Network Drops', clickable: false },
   { path: 'facilities/forgekey-devices', label: 'ForgeKey Devices' },
 
   { path: 'maintenance', label: 'Maintenance' },

--- a/frontend/src/pages/AssetPowerChainPage.tsx
+++ b/frontend/src/pages/AssetPowerChainPage.tsx
@@ -1,0 +1,278 @@
+/**
+ * Asset power chain at `/facilities/electrical/power-chain` and
+ * `/facilities/electrical/power-chain/:assetId`.
+ *
+ * "What feeds this?" — given an asset, walks back through cables,
+ * outlets, circuits, and breakers to the panel. Lets a maintainer pick
+ * an asset by tag from the asset list, or jump straight to one via the
+ * URL (useful when linked from an asset detail page).
+ */
+import {
+  Anchor,
+  Badge,
+  Box,
+  Container,
+  Group,
+  Paper,
+  Select,
+  Stack,
+  Text,
+  Timeline,
+} from '@mantine/core';
+import {
+  IconAlertCircle,
+  IconBolt,
+  IconCircuitGround,
+  IconCpu,
+  IconLayoutGrid,
+  IconPlugConnected,
+  IconRouteAltLeft,
+  IconSitemap,
+} from '@tabler/icons-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import PageHero from '../components/landing/PageHero';
+import { AssetPowerChain, assetsAPI, electricalSafetyAPI } from '../services/api';
+import { Asset } from '../types';
+import '../styles/landing.css';
+
+const HOP_ICON: Record<AssetPowerChain['chain'][number]['kind'], React.ReactNode> = {
+  panel: <IconLayoutGrid size={14} />,
+  breaker: <IconBolt size={14} />,
+  circuit: <IconCircuitGround size={14} />,
+  outlet: <IconPlugConnected size={14} />,
+  cable: <IconRouteAltLeft size={14} />,
+  port: <IconCpu size={14} />,
+};
+
+const HOP_TITLE: Record<AssetPowerChain['chain'][number]['kind'], string> = {
+  panel: 'Panel',
+  breaker: 'Breaker',
+  circuit: 'Circuit',
+  outlet: 'Outlet',
+  cable: 'Cable',
+  port: 'Port',
+};
+
+const AssetPowerChainPage: React.FC = () => {
+  const { assetId } = useParams<{ assetId?: string }>();
+  const navigate = useNavigate();
+
+  const [assets, setAssets] = useState<Asset[]>([]);
+  const [chain, setChain] = useState<AssetPowerChain | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Asset picker: lazy-load the assets list once.
+  useEffect(() => {
+    let cancelled = false;
+    assetsAPI
+      .listAssets({ page_size: 500, is_active: true })
+      .then((response) => {
+        if (cancelled) return;
+        setAssets(response.data.results ?? []);
+      })
+      .catch(() => {
+        // Picker is a convenience — degrade silently if assets fail to
+        // load. The URL-driven flow still works.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!assetId) {
+      setChain(null);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    electricalSafetyAPI
+      .getAssetPowerChain(assetId)
+      .then((response) => {
+        if (cancelled) return;
+        setChain(response.data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err?.response?.data?.detail || 'Failed to load power chain.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [assetId]);
+
+  const assetOptions = useMemo(
+    () =>
+      assets.map((asset) => ({
+        value: String(asset.id),
+        label: asset.asset_tag ? `${asset.asset_tag} — ${asset.name}` : asset.name,
+      })),
+    [assets],
+  );
+
+  return (
+    <Box className="landing-surface" data-testid="asset-power-chain">
+      <Container size="lg" py="xl">
+        <Stack gap="xl">
+          <PageHero
+            eyebrow="Electrical · Lookup"
+            title="Asset power chain"
+            description='Pick an asset to walk back through cables, outlets, circuits, and breakers to its panel.'
+          />
+
+          <Paper withBorder p="md" radius="md">
+            <Select
+              label="Asset"
+              placeholder="Type to filter by tag or name"
+              data={assetOptions}
+              value={assetId ?? null}
+              onChange={(value) => {
+                if (value) {
+                  navigate(`/facilities/electrical/power-chain/${value}`);
+                } else {
+                  navigate('/facilities/electrical/power-chain');
+                }
+              }}
+              searchable
+              clearable
+              nothingFoundMessage="No matching assets"
+              data-testid="asset-power-chain-picker"
+            />
+          </Paper>
+
+          {error && (
+            <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+              <Group gap="xs">
+                <IconAlertCircle size={16} />
+                <Text>{error}</Text>
+              </Group>
+            </Paper>
+          )}
+
+          {loading && (
+            <Paper withBorder p="xl" radius="md">
+              <Text c="dimmed" ta="center">
+                Loading…
+              </Text>
+            </Paper>
+          )}
+
+          {!assetId && !loading && (
+            <Paper withBorder p="xl" radius="md">
+              <Stack gap="xs" align="center">
+                <IconRouteAltLeft size={28} stroke={1.6} />
+                <Text fw={500}>Pick an asset to start.</Text>
+                <Text size="sm" c="dimmed" ta="center" maw={420}>
+                  The chain shows every hop from the asset's power port back to the panel that
+                  feeds it. Useful when planning a shutdown.
+                </Text>
+              </Stack>
+            </Paper>
+          )}
+
+          {chain && !loading && (
+            <Stack gap="md">
+              <Paper withBorder p="md" radius="md" data-testid="asset-summary">
+                <Group justify="space-between" wrap="wrap">
+                  <Stack gap={2}>
+                    <Text component="span" className="landing-eyebrow">
+                      Asset
+                    </Text>
+                    <Text fw={600} size="lg">
+                      {chain.asset.name}
+                    </Text>
+                    <Text size="sm" c="dimmed">
+                      {chain.asset.asset_tag}
+                    </Text>
+                  </Stack>
+                  {chain.asset.is_critical && (
+                    <Badge color="red" variant="filled" radius="sm">
+                      critical
+                    </Badge>
+                  )}
+                </Group>
+              </Paper>
+
+              {chain.chain.length === 0 ? (
+                <Paper withBorder p="xl" radius="md" bg="yellow.0">
+                  <Stack gap="xs" align="center">
+                    <IconAlertCircle size={24} />
+                    <Text fw={500}>This asset is not wired into a power topology.</Text>
+                    <Text size="sm" c="dimmed" ta="center" maw={420}>
+                      Add a PowerPort and a Cable from the port to an outlet via Django admin to
+                      see the chain.
+                    </Text>
+                  </Stack>
+                </Paper>
+              ) : (
+                <Paper withBorder p="md" radius="md" data-testid="asset-chain-timeline">
+                  <Timeline
+                    active={chain.chain.length}
+                    bulletSize={26}
+                    lineWidth={2}
+                    color="blue"
+                  >
+                    {chain.chain.map((hop, index) => (
+                      <Timeline.Item
+                        key={`${hop.kind}-${hop.id}-${index}`}
+                        bullet={HOP_ICON[hop.kind]}
+                        title={
+                          <Group gap="xs">
+                            <Text fw={600}>{HOP_TITLE[hop.kind]}</Text>
+                            <Badge size="xs" variant="light" color="gray">
+                              {hop.type}
+                            </Badge>
+                          </Group>
+                        }
+                      >
+                        {hop.kind === 'panel' ? (
+                          <Anchor
+                            component="a"
+                            href={`/facilities/electrical/panels/${hop.id}`}
+                            size="sm"
+                          >
+                            {String(hop.label)}
+                          </Anchor>
+                        ) : hop.kind === 'breaker' ? (
+                          <Anchor
+                            component="a"
+                            href={`/facilities/electrical/breakers/${hop.id}/trip-impact`}
+                            size="sm"
+                          >
+                            {String(hop.label)}
+                          </Anchor>
+                        ) : hop.kind === 'circuit' ? (
+                          <Anchor
+                            component="a"
+                            href={`/facilities/electrical/circuits/${hop.id}/load`}
+                            size="sm"
+                          >
+                            {String(hop.label)}
+                          </Anchor>
+                        ) : (
+                          <Text size="sm" c="dimmed">
+                            {String(hop.label)}
+                          </Text>
+                        )}
+                      </Timeline.Item>
+                    ))}
+                  </Timeline>
+                </Paper>
+              )}
+            </Stack>
+          )}
+        </Stack>
+      </Container>
+    </Box>
+  );
+};
+
+export default AssetPowerChainPage;

--- a/frontend/src/pages/BreakerTripImpactPage.tsx
+++ b/frontend/src/pages/BreakerTripImpactPage.tsx
@@ -1,0 +1,197 @@
+/**
+ * Breaker trip-impact view at
+ * `/facilities/electrical/breakers/:id/trip-impact`.
+ *
+ * Answers "what loses power if I trip this breaker?" by surfacing the
+ * `/api/electrical/breakers/<id>/trip-impact/` endpoint. Critical loads
+ * are listed first so a maintainer never accidentally drops fire alarms,
+ * APs, or freezers.
+ */
+import { Badge, Box, Container, List, Paper, Stack, Text, ThemeIcon } from '@mantine/core';
+import { IconAlertCircle, IconBolt, IconShieldHalfFilled } from '@tabler/icons-react';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import PageHero from '../components/landing/PageHero';
+import { BreakerTripImpact, electricalSafetyAPI } from '../services/api';
+import '../styles/landing.css';
+
+const BreakerTripImpactPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [impact, setImpact] = useState<BreakerTripImpact | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setLoading(true);
+    electricalSafetyAPI
+      .getBreakerTripImpact(id)
+      .then((response) => {
+        if (cancelled) return;
+        setImpact(response.data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err?.response?.data?.detail || 'Failed to load trip impact.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  return (
+    <Box className="landing-surface" data-testid="breaker-trip-impact">
+      <Container size="lg" py="xl">
+        <Stack gap="xl">
+          <PageHero
+            eyebrow={impact ? `Electrical · ${impact.breaker.panel_name}` : 'Electrical'}
+            title={impact ? `Trip impact · breaker ${impact.breaker.position}` : 'Trip impact'}
+            description="What loses power if this breaker is opened. Verify before maintenance."
+          />
+
+          {error && (
+            <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+              <Text>{error}</Text>
+            </Paper>
+          )}
+
+          {loading && !impact && (
+            <Paper withBorder p="xl" radius="md">
+              <Text c="dimmed" ta="center">
+                Loading…
+              </Text>
+            </Paper>
+          )}
+
+          {impact && (
+            <>
+              <Paper withBorder p="md" radius="md">
+                <Stack gap="xs">
+                  <Text component="span" className="landing-eyebrow">
+                    Breaker
+                  </Text>
+                  <Text fw={600} size="lg">
+                    {impact.breaker.label || `Breaker ${impact.breaker.position}`}
+                  </Text>
+                  <Text size="sm" c="dimmed">
+                    {impact.breaker.amperage}A · {impact.breaker.pole_count}-pole · phase{' '}
+                    {impact.breaker.phase}
+                  </Text>
+                </Stack>
+              </Paper>
+
+              <Paper
+                withBorder
+                p="md"
+                radius="md"
+                data-testid="trip-impact-critical-loads"
+                bg={impact.critical_loads.length > 0 ? 'red.0' : undefined}
+              >
+                <Stack gap="sm">
+                  <Stack gap={2}>
+                    <Text component="span" className="landing-eyebrow">
+                      Critical loads
+                    </Text>
+                    <Text fw={600} size="md">
+                      {impact.critical_loads.length} critical asset
+                      {impact.critical_loads.length === 1 ? '' : 's'} on this breaker
+                    </Text>
+                  </Stack>
+                  {impact.critical_loads.length === 0 ? (
+                    <Text size="sm" c="dimmed">
+                      No assets on this breaker are flagged as critical.
+                    </Text>
+                  ) : (
+                    <List
+                      spacing="xs"
+                      icon={
+                        <ThemeIcon color="red" radius="xl" size={20}>
+                          <IconAlertCircle size={12} />
+                        </ThemeIcon>
+                      }
+                    >
+                      {impact.critical_loads.map((asset) => (
+                        <List.Item key={asset.id} data-testid={`critical-asset-${asset.id}`}>
+                          <Text fw={500} component="span">
+                            {asset.name}
+                          </Text>{' '}
+                          <Text component="span" size="sm" c="dimmed">
+                            ({asset.asset_tag})
+                          </Text>
+                        </List.Item>
+                      ))}
+                    </List>
+                  )}
+                </Stack>
+              </Paper>
+
+              <Paper withBorder p="md" radius="md" data-testid="trip-impact-all-assets">
+                <Stack gap="sm">
+                  <Stack gap={2}>
+                    <Text component="span" className="landing-eyebrow">
+                      All assets
+                    </Text>
+                    <Text fw={600} size="md">
+                      {impact.assets.length} total asset
+                      {impact.assets.length === 1 ? '' : 's'} fed by this breaker
+                    </Text>
+                  </Stack>
+                  {impact.assets.length === 0 ? (
+                    <Text size="sm" c="dimmed">
+                      No assets are wired into this breaker yet.
+                    </Text>
+                  ) : (
+                    <List
+                      spacing={4}
+                      icon={
+                        <ThemeIcon color="gray" variant="light" radius="xl" size={20}>
+                          <IconBolt size={12} />
+                        </ThemeIcon>
+                      }
+                    >
+                      {impact.assets.map((asset) => (
+                        <List.Item key={asset.id} data-testid={`asset-${asset.id}`}>
+                          <Text component="span">{asset.name}</Text>{' '}
+                          <Text component="span" size="sm" c="dimmed">
+                            ({asset.asset_tag})
+                          </Text>
+                          {asset.is_critical && (
+                            <Badge ml="xs" color="red" size="xs" variant="filled">
+                              critical
+                            </Badge>
+                          )}
+                        </List.Item>
+                      ))}
+                    </List>
+                  )}
+                </Stack>
+              </Paper>
+
+              <Paper withBorder p="md" radius="md" bg="gray.0">
+                <Stack gap="xs">
+                  <Text component="span" className="landing-eyebrow">
+                    Reminder
+                  </Text>
+                  <Text size="sm" c="dimmed">
+                    <ThemeIcon color="gray" variant="light" size={16} mr={6}>
+                      <IconShieldHalfFilled size={10} />
+                    </ThemeIcon>
+                    LOTO requirements for these assets are surfaced under
+                    Maintenance · Lockout/Tagout. Cross-check before opening the panel.
+                  </Text>
+                </Stack>
+              </Paper>
+            </>
+          )}
+        </Stack>
+      </Container>
+    </Box>
+  );
+};
+
+export default BreakerTripImpactPage;

--- a/frontend/src/pages/CircuitLoadPage.tsx
+++ b/frontend/src/pages/CircuitLoadPage.tsx
@@ -1,0 +1,193 @@
+/**
+ * Circuit load report at `/facilities/electrical/circuits/:id/load`.
+ *
+ * Surfaces `/api/electrical/circuits/<id>/load/` so an operator can see
+ * the connected devices on a circuit, the estimated nameplate draw, and
+ * how that compares to the breaker's NEC-derated capacity (default 80%
+ * of the breaker amperage).
+ */
+import {
+  Badge,
+  Box,
+  Container,
+  Group,
+  List,
+  Paper,
+  Progress,
+  Stack,
+  Text,
+  ThemeIcon,
+} from '@mantine/core';
+import { IconBolt, IconPlugConnected } from '@tabler/icons-react';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import PageHero from '../components/landing/PageHero';
+import { CircuitLoad, electricalSafetyAPI } from '../services/api';
+import '../styles/landing.css';
+
+const utilizationColor = (percent: number | null): string => {
+  if (percent == null) return 'gray';
+  if (percent >= 100) return 'red';
+  if (percent >= 80) return 'orange';
+  if (percent >= 60) return 'yellow';
+  return 'green';
+};
+
+const CircuitLoadPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [load, setLoad] = useState<CircuitLoad | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setLoading(true);
+    electricalSafetyAPI
+      .getCircuitLoad(id)
+      .then((response) => {
+        if (cancelled) return;
+        setLoad(response.data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err?.response?.data?.detail || 'Failed to load circuit data.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  return (
+    <Box className="landing-surface" data-testid="circuit-load">
+      <Container size="lg" py="xl">
+        <Stack gap="xl">
+          <PageHero
+            eyebrow="Electrical · Circuit"
+            title={load ? load.circuit.label || `Circuit ${load.circuit.id}` : 'Circuit load'}
+            description="Connected devices, estimated nameplate draw, and capacity utilization vs the NEC 80% derate."
+          />
+
+          {error && (
+            <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+              <Text>{error}</Text>
+            </Paper>
+          )}
+
+          {loading && !load && (
+            <Paper withBorder p="xl" radius="md">
+              <Text c="dimmed" ta="center">
+                Loading…
+              </Text>
+            </Paper>
+          )}
+
+          {load && (
+            <>
+              <Paper withBorder p="md" radius="md">
+                <Stack gap="xs">
+                  <Group justify="space-between" align="flex-end" wrap="wrap">
+                    <Stack gap={2}>
+                      <Text component="span" className="landing-eyebrow">
+                        Capacity utilization
+                      </Text>
+                      <Text fw={600} size="xl">
+                        {load.capacity_utilization_percent != null
+                          ? `${load.capacity_utilization_percent.toFixed(1)}%`
+                          : 'No capacity configured'}
+                      </Text>
+                      <Text size="sm" c="dimmed">
+                        {load.estimated_max_draw_amps.toFixed(1)}A estimated draw
+                        {load.capacity_amps != null
+                          ? ` of ${load.capacity_amps}A circuit capacity`
+                          : ''}
+                      </Text>
+                    </Stack>
+                    <Badge
+                      color={utilizationColor(load.capacity_utilization_percent)}
+                      variant="light"
+                      size="lg"
+                      radius="sm"
+                    >
+                      {load.connected_device_count} connected
+                    </Badge>
+                  </Group>
+                  {load.capacity_utilization_percent != null && (
+                    <Progress
+                      value={Math.min(load.capacity_utilization_percent, 100)}
+                      color={utilizationColor(load.capacity_utilization_percent)}
+                      size="lg"
+                      radius="md"
+                      striped={load.capacity_utilization_percent >= 80}
+                      animated={load.capacity_utilization_percent >= 100}
+                    />
+                  )}
+                </Stack>
+              </Paper>
+
+              <Paper withBorder p="md" radius="md">
+                <Stack gap="sm">
+                  <Stack gap={2}>
+                    <Text component="span" className="landing-eyebrow">
+                      Connected devices
+                    </Text>
+                    <Text fw={500}>
+                      {load.connected_device_count} asset
+                      {load.connected_device_count === 1 ? '' : 's'} on this circuit
+                    </Text>
+                  </Stack>
+                  {load.connected_devices.length === 0 ? (
+                    <Text size="sm" c="dimmed">
+                      No assets are wired into this circuit yet.
+                    </Text>
+                  ) : (
+                    <List
+                      spacing={4}
+                      icon={
+                        <ThemeIcon color="gray" variant="light" radius="xl" size={20}>
+                          <IconPlugConnected size={12} />
+                        </ThemeIcon>
+                      }
+                    >
+                      {load.connected_devices.map((asset) => (
+                        <List.Item key={asset.id} data-testid={`circuit-asset-${asset.id}`}>
+                          <Text component="span">{asset.name}</Text>{' '}
+                          <Text component="span" size="sm" c="dimmed">
+                            ({asset.asset_tag})
+                          </Text>
+                          {asset.is_critical && (
+                            <Badge ml="xs" color="red" size="xs" variant="filled">
+                              critical
+                            </Badge>
+                          )}
+                        </List.Item>
+                      ))}
+                    </List>
+                  )}
+                </Stack>
+              </Paper>
+
+              <Paper withBorder p="md" radius="md" bg="gray.0">
+                <Group gap="xs" align="center">
+                  <ThemeIcon color="gray" variant="light" size={20}>
+                    <IconBolt size={12} />
+                  </ThemeIcon>
+                  <Text size="sm" c="dimmed">
+                    Capacity defaults to 80% of breaker amperage per NEC continuous-load rule.
+                    Override via Django admin if a different derate applies.
+                  </Text>
+                </Group>
+              </Paper>
+            </>
+          )}
+        </Stack>
+      </Container>
+    </Box>
+  );
+};
+
+export default CircuitLoadPage;

--- a/frontend/src/pages/ElectricalOverviewPage.tsx
+++ b/frontend/src/pages/ElectricalOverviewPage.tsx
@@ -1,0 +1,74 @@
+/**
+ * Electrical workspace overview, mounted at `/facilities/electrical`.
+ *
+ * Replaces the legacy tabbed `ElectricalCircuitsPage` as the landing
+ * surface so the entry point matches the homepage design language. The
+ * old fixture inventory is still reachable via the "Fixture inventory"
+ * card so existing bookmarks keep working.
+ */
+import {
+  IconBolt,
+  IconClipboardList,
+  IconLayoutGrid,
+  IconRouteAltLeft,
+  IconSitemap,
+} from '@tabler/icons-react';
+import React from 'react';
+
+import CapabilityCard from '../components/landing/CapabilityCard';
+import WorkspaceLanding from '../components/landing/WorkspaceLanding';
+
+const ElectricalOverviewPage: React.FC = () => (
+  <WorkspaceLanding
+    testId="electrical-overview"
+    hero={{
+      eyebrow: 'Facilities',
+      title: 'Electrical',
+      description:
+        'Power-distribution topology, trip-impact lookups, and the fixture inventory the shop runs on.',
+    }}
+  >
+    <CapabilityCard
+      to="/facilities/electrical/panels"
+      title="Power panel directory"
+      description="Every panel in the building, with breaker counts and migration-review flags."
+      icon={<IconSitemap size={22} stroke={1.8} />}
+      eyebrow="Topology"
+      testId="electrical-overview-card-panels"
+    />
+    <CapabilityCard
+      to="/facilities/electrical/power-chain"
+      title="Asset power chain"
+      description='"What feeds this?" — trace any asset back to its panel through cables, ports, and breakers.'
+      icon={<IconRouteAltLeft size={22} stroke={1.8} />}
+      eyebrow="Lookup"
+      testId="electrical-overview-card-power-chain"
+    />
+    <CapabilityCard
+      to="/facilities/electrical/fixtures"
+      title="Fixture inventory"
+      description="Legacy breakers, outlets, light switches, and network drops with create/edit forms and PDF reports."
+      icon={<IconLayoutGrid size={22} stroke={1.8} />}
+      eyebrow="Inventory"
+      testId="electrical-overview-card-fixtures"
+    />
+    <CapabilityCard
+      to="/api/electrical-circuits/reports/panel-directory.pdf"
+      title="Panel directory PDF"
+      description="Printable directory of every breaker and the outlets / switches it feeds. Tape it to the panel."
+      icon={<IconClipboardList size={22} stroke={1.8} />}
+      eyebrow="Report"
+      testId="electrical-overview-card-panel-directory-pdf"
+    />
+    <CapabilityCard
+      to="/api/electrical-circuits/reports/network-drop-list.pdf"
+      title="Network-drop report PDF"
+      description="Patch-panel + port assignments grouped by location. Useful for switch audits."
+      icon={<IconBolt size={22} stroke={1.8} />}
+      eyebrow="Report"
+      testId="electrical-overview-card-network-drop-pdf"
+    />
+  </WorkspaceLanding>
+);
+
+export default ElectricalOverviewPage;

--- a/frontend/src/pages/PowerPanelDetailPage.tsx
+++ b/frontend/src/pages/PowerPanelDetailPage.tsx
@@ -1,0 +1,207 @@
+/**
+ * Single power panel topology view at
+ * `/facilities/electrical/panels/:id`.
+ *
+ * Renders the breaker → circuit → outlet tree returned by
+ * `/api/electrical/panels/<id>/topology/` so a maintainer can scan a
+ * panel without picking through Django admin. Each breaker links to its
+ * trip-impact view ("what loses power if I trip this?") and each
+ * circuit links to its load report.
+ */
+import {
+  Badge,
+  Box,
+  Container,
+  Group,
+  Paper,
+  Stack,
+  Table,
+  Text,
+} from '@mantine/core';
+import { IconBolt, IconRouteAltLeft } from '@tabler/icons-react';
+import React, { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import PageHero from '../components/landing/PageHero';
+import { electricalSafetyAPI, PowerPanelTopology } from '../services/api';
+import '../styles/landing.css';
+
+const PowerPanelDetailPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [topology, setTopology] = useState<PowerPanelTopology | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setLoading(true);
+    electricalSafetyAPI
+      .getPanelTopology(id)
+      .then((response) => {
+        if (cancelled) return;
+        setTopology(response.data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err?.response?.data?.detail || 'Failed to load panel topology.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  return (
+    <Box className="landing-surface" data-testid="power-panel-detail">
+      <Container size="xl" py="xl">
+        <Stack gap="xl">
+          <PageHero
+            eyebrow={topology ? `Electrical · ${topology.location_name}` : 'Electrical'}
+            title={topology ? topology.name : 'Power panel'}
+            description={
+              topology
+                ? `${topology.voltage}V · ${topology.phase_configuration} phase${
+                    topology.main_breaker_amperage
+                      ? ` · ${topology.main_breaker_amperage}A main`
+                      : ''
+                  }`
+                : 'Loading panel topology…'
+            }
+          />
+
+          {error && (
+            <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+              <Text>{error}</Text>
+            </Paper>
+          )}
+
+          {loading && !topology && (
+            <Paper withBorder p="xl" radius="md">
+              <Text c="dimmed" ta="center">
+                Loading…
+              </Text>
+            </Paper>
+          )}
+
+          {topology && topology.breakers.length === 0 && (
+            <Paper withBorder p="xl" radius="md">
+              <Stack gap="xs" align="center">
+                <IconBolt size={28} stroke={1.6} />
+                <Text fw={500}>No breakers configured for this panel</Text>
+                <Text size="sm" c="dimmed">
+                  Add breakers via Django admin to populate this view.
+                </Text>
+              </Stack>
+            </Paper>
+          )}
+
+          {topology &&
+            topology.breakers.map((breaker) => (
+              <Paper
+                key={breaker.id}
+                withBorder
+                p="md"
+                radius="md"
+                data-testid={`breaker-row-${breaker.id}`}
+              >
+                <Stack gap="sm">
+                  <Group justify="space-between" align="flex-start" wrap="wrap">
+                    <Stack gap={2}>
+                      <Text component="span" className="landing-eyebrow">
+                        Breaker · position {breaker.position}
+                      </Text>
+                      <Text fw={600} size="lg">
+                        {breaker.label || `Breaker ${breaker.position}`}
+                      </Text>
+                      <Text size="sm" c="dimmed">
+                        {breaker.amperage}A · {breaker.pole_count}-pole · phase {breaker.phase}
+                      </Text>
+                    </Stack>
+                    <Group gap="xs">
+                      <Badge
+                        color={breaker.status === 'on' ? 'green' : 'gray'}
+                        variant="light"
+                        size="sm"
+                        radius="sm"
+                      >
+                        {breaker.status}
+                      </Badge>
+                      <Link
+                        to={`/facilities/electrical/breakers/${breaker.id}/trip-impact`}
+                        className="landing-arrow"
+                        data-testid={`breaker-trip-impact-${breaker.id}`}
+                        style={{ textDecoration: 'none' }}
+                      >
+                        <IconRouteAltLeft size={16} stroke={2.4} />
+                        Trip impact
+                      </Link>
+                    </Group>
+                  </Group>
+
+                  {breaker.circuits.length === 0 ? (
+                    <Text size="sm" c="dimmed">
+                      No circuits wired to this breaker yet.
+                    </Text>
+                  ) : (
+                    <Table withTableBorder withColumnBorders striped>
+                      <Table.Thead>
+                        <Table.Tr>
+                          <Table.Th>Circuit</Table.Th>
+                          <Table.Th>Conductor</Table.Th>
+                          <Table.Th>Capacity</Table.Th>
+                          <Table.Th>Outlets</Table.Th>
+                          <Table.Th>Load report</Table.Th>
+                        </Table.Tr>
+                      </Table.Thead>
+                      <Table.Tbody>
+                        {breaker.circuits.map((circuit) => (
+                          <Table.Tr key={circuit.id}>
+                            <Table.Td>
+                              <Text fw={500}>{circuit.label || `Circuit ${circuit.id}`}</Text>
+                            </Table.Td>
+                            <Table.Td>{circuit.conductor_size || '—'}</Table.Td>
+                            <Table.Td>
+                              {circuit.max_load_amps != null ? `${circuit.max_load_amps}A` : '—'}
+                            </Table.Td>
+                            <Table.Td>
+                              {circuit.outlets.length === 0 ? (
+                                <Text size="sm" c="dimmed">
+                                  no outlets
+                                </Text>
+                              ) : (
+                                <Stack gap={2}>
+                                  {circuit.outlets.map((outlet) => (
+                                    <Text key={outlet.id} size="sm">
+                                      {outlet.label || `Outlet ${outlet.id}`}
+                                      {outlet.location_name ? ` — ${outlet.location_name}` : ''}
+                                    </Text>
+                                  ))}
+                                </Stack>
+                              )}
+                            </Table.Td>
+                            <Table.Td>
+                              <Link
+                                to={`/facilities/electrical/circuits/${circuit.id}/load`}
+                                data-testid={`circuit-load-${circuit.id}`}
+                              >
+                                Load
+                              </Link>
+                            </Table.Td>
+                          </Table.Tr>
+                        ))}
+                      </Table.Tbody>
+                    </Table>
+                  )}
+                </Stack>
+              </Paper>
+            ))}
+        </Stack>
+      </Container>
+    </Box>
+  );
+};
+
+export default PowerPanelDetailPage;

--- a/frontend/src/pages/PowerPanelDirectoryPage.tsx
+++ b/frontend/src/pages/PowerPanelDirectoryPage.tsx
@@ -1,0 +1,165 @@
+/**
+ * Power panel directory at `/facilities/electrical/panels`.
+ *
+ * Lists every PowerPanel with a breaker count, voltage, and a flag for
+ * panels that the data migration created as placeholders and that an
+ * admin still needs to triage.
+ */
+import {
+  Badge,
+  Box,
+  Container,
+  Group,
+  Paper,
+  SimpleGrid,
+  Stack,
+  Text,
+} from '@mantine/core';
+import { IconAlertTriangle, IconBolt, IconSitemap } from '@tabler/icons-react';
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import PageHero from '../components/landing/PageHero';
+import { electricalSafetyAPI, PowerPanelSummary } from '../services/api';
+import '../styles/landing.css';
+
+const phaseLabel = (phase: PowerPanelSummary['phase_configuration']) => {
+  switch (phase) {
+    case 'single':
+      return 'Single phase';
+    case 'split':
+      return 'Split phase 120/240V';
+    case 'three':
+      return 'Three phase';
+    default:
+      return phase;
+  }
+};
+
+const PowerPanelDirectoryPage: React.FC = () => {
+  const [panels, setPanels] = useState<PowerPanelSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    electricalSafetyAPI
+      .listPanels()
+      .then((response) => {
+        if (cancelled) return;
+        setPanels(response.data.results);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err?.response?.data?.detail || 'Failed to load panels.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const reviewCount = panels.filter((p) => p.needs_review).length;
+
+  return (
+    <Box className="landing-surface" data-testid="power-panel-directory">
+      <Container size="xl" py="xl">
+        <Stack gap="xl">
+          <PageHero
+            eyebrow="Electrical · Topology"
+            title="Power panel directory"
+            description="Every load center in the building. Open one to see its breakers, circuits, and the assets they feed."
+          />
+
+          {error && (
+            <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+              <Text>{error}</Text>
+            </Paper>
+          )}
+
+          {!error && reviewCount > 0 && (
+            <Paper withBorder p="md" radius="md" bg="yellow.0" c="yellow.9">
+              <Group gap="sm" align="center">
+                <IconAlertTriangle size={18} />
+                <Text fw={500}>
+                  {reviewCount} panel{reviewCount === 1 ? '' : 's'} flagged for review (migration
+                  placeholder).
+                </Text>
+              </Group>
+            </Paper>
+          )}
+
+          {loading ? (
+            <Paper withBorder p="xl" radius="md">
+              <Text c="dimmed" ta="center">
+                Loading panels…
+              </Text>
+            </Paper>
+          ) : panels.length === 0 ? (
+            <Paper withBorder p="xl" radius="md">
+              <Stack gap="xs" align="center">
+                <IconSitemap size={28} stroke={1.6} />
+                <Text fw={500}>No power panels yet</Text>
+                <Text size="sm" c="dimmed" ta="center" maw={400}>
+                  Add a PowerPanel from Django admin to see it here. The legacy breaker/outlet
+                  inventory lives under the "Fixture inventory" card on the Electrical overview.
+                </Text>
+              </Stack>
+            </Paper>
+          ) : (
+            <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
+              {panels.map((panel) => (
+                <Link
+                  key={panel.id}
+                  to={`/facilities/electrical/panels/${panel.id}`}
+                  className="landing-capability-card"
+                  data-testid={`panel-card-${panel.id}`}
+                  aria-label={panel.name}
+                  style={{ padding: '1.4rem' }}
+                >
+                  <Stack gap="md" h="100%">
+                    <Group justify="space-between" align="flex-start" wrap="nowrap">
+                      <Box className="landing-icon-chip" aria-hidden>
+                        <IconBolt size={22} stroke={1.8} />
+                      </Box>
+                      {panel.needs_review && (
+                        <Badge color="yellow" variant="light" size="sm" radius="sm">
+                          Review
+                        </Badge>
+                      )}
+                    </Group>
+                    <Stack gap={4} style={{ flex: 1 }}>
+                      <Text component="span" className="landing-eyebrow">
+                        {panel.location_name}
+                      </Text>
+                      <Text component="h3" fw={600} size="lg" style={{ margin: 0, lineHeight: 1.25 }}>
+                        {panel.name}
+                      </Text>
+                      <Text size="sm" c="dimmed" style={{ lineHeight: 1.5 }}>
+                        {phaseLabel(panel.phase_configuration)} · {panel.voltage}V
+                        {panel.main_breaker_amperage
+                          ? ` · ${panel.main_breaker_amperage}A main`
+                          : ''}
+                      </Text>
+                    </Stack>
+                    <Group justify="space-between" align="center">
+                      <Text size="sm" c="dimmed">
+                        {panel.breaker_count} breaker
+                        {panel.breaker_count === 1 ? '' : 's'}
+                      </Text>
+                      <span className="landing-arrow">Open →</span>
+                    </Group>
+                  </Stack>
+                </Link>
+              ))}
+            </SimpleGrid>
+          )}
+        </Stack>
+      </Container>
+    </Box>
+  );
+};
+
+export default PowerPanelDirectoryPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1930,6 +1930,115 @@ export const OUTLET_TYPE_OPTIONS = [
   { value: 'other', label: 'Other' },
 ];
 
+// ---------------------------------------------------------------------
+// Power topology safety API (oms-b25 [4/7]). Read-only views over the
+// PowerPanel → PowerBreaker → PowerCircuit → PowerOutlet ↔ PowerPort
+// hierarchy. Used by the [6/7] visualization pages.
+// ---------------------------------------------------------------------
+
+export type PowerPanelPhase = 'single' | 'split' | 'three';
+
+export interface PowerPanelSummary {
+  id: number;
+  name: string;
+  location_id: number;
+  location_name: string;
+  phase_configuration: PowerPanelPhase;
+  voltage: number;
+  main_breaker_amperage: number | null;
+  breaker_count: number;
+  needs_review: boolean;
+}
+
+export interface PowerOutletNode {
+  id: number;
+  label: string;
+  outlet_type: string;
+  status: string;
+  location_id: number | null;
+  location_name: string | null;
+}
+
+export interface PowerCircuitNode {
+  id: number;
+  label: string;
+  breaker_id: number;
+  max_load_amps: number | null;
+  conductor_size: string;
+  outlets: PowerOutletNode[];
+}
+
+export interface PowerBreakerNode {
+  id: number;
+  panel_id: number;
+  panel_name: string;
+  position: string;
+  amperage: number;
+  phase: string;
+  pole_count: number;
+  status: string;
+  label: string;
+  circuits: PowerCircuitNode[];
+}
+
+export interface PowerPanelTopology {
+  id: number;
+  name: string;
+  location_id: number;
+  location_name: string;
+  phase_configuration: PowerPanelPhase;
+  voltage: number;
+  main_breaker_amperage: number | null;
+  breakers: PowerBreakerNode[];
+}
+
+export interface PowerSafetyAsset {
+  id: string;
+  name: string;
+  asset_tag: string;
+  is_critical: boolean;
+}
+
+export interface BreakerTripImpact {
+  breaker: Omit<PowerBreakerNode, 'circuits'>;
+  assets: PowerSafetyAsset[];
+  critical_loads: PowerSafetyAsset[];
+}
+
+export interface CircuitLoad {
+  circuit: Omit<PowerCircuitNode, 'outlets'>;
+  connected_device_count: number;
+  connected_devices: PowerSafetyAsset[];
+  estimated_max_draw_amps: number;
+  capacity_amps: number | null;
+  capacity_utilization_percent: number | null;
+}
+
+export interface PowerChainHop {
+  kind: 'panel' | 'breaker' | 'circuit' | 'outlet' | 'cable' | 'port';
+  id: number;
+  type: string;
+  label: string | number;
+}
+
+export interface AssetPowerChain {
+  asset: PowerSafetyAsset;
+  chain: PowerChainHop[];
+}
+
+export const electricalSafetyAPI = {
+  listPanels: () =>
+    api.get<{ results: PowerPanelSummary[] }>('/electrical/panels/'),
+  getPanelTopology: (panelId: number | string) =>
+    api.get<PowerPanelTopology>(`/electrical/panels/${panelId}/topology/`),
+  getBreakerTripImpact: (breakerId: number | string) =>
+    api.get<BreakerTripImpact>(`/electrical/breakers/${breakerId}/trip-impact/`),
+  getCircuitLoad: (circuitId: number | string) =>
+    api.get<CircuitLoad>(`/electrical/circuits/${circuitId}/load/`),
+  getAssetPowerChain: (assetId: string) =>
+    api.get<AssetPowerChain>(`/assets/${assetId}/power-chain/`),
+};
+
 // LOTO (lockout / tagout) — oms-78j
 export type LOTODeviceType =
   | 'padlock'


### PR DESCRIPTION
## Summary

Lands the four read-only safety query endpoints from oms-b25 (the
\"[4/7]\" slice of the PowerPanel → PowerBreaker → PowerCircuit →
PowerOutlet ↔ PowerPort epic) that have been stranded on the polecat
branch \`origin/polecat/onyx/oms-b25@mos4wl38\` since May 5. These are
the API surface the upcoming frontend visualization (\`[6/7]\`) needs
to answer \"what loses power if I trip this?\" before maintenance
touches a panel, and the LOTO + admin pages already wired in #348
benefit from them too.

Endpoints (all staff-gated, AC-5):

- \`GET /api/electrical/breakers/<id>/trip-impact/\` (AC-1) — assets
  fed by a breaker, split into critical vs. non-critical.
- \`GET /api/electrical/circuits/<id>/load/\` (AC-2) — connected
  devices, estimated nameplate draw, and capacity utilization vs the
  NEC 80% derate.
- \`GET /api/electrical/panels/<id>/topology/\` (AC-3) — panel →
  breaker → circuit → outlet tree in a single response (3 queries via
  prefetch; AC-6 perf budget).
- \`GET /api/assets/<id>/power-chain/\` (AC-4) — every hop from an
  asset back to its panel.

Plus four admin templates (per-breaker trip impact, per-circuit load
audit, shared-circuit audit, base) so safety officers have an admin
view today without waiting on the React work.

### What changed vs. the preserved drop

- \`test_asset_power_chain_returns_full_chain\` was comparing
  \`UUID == str\`. Asset.pk became a UUID after this commit was
  written; tightened to \`str(asset.pk)\` to match how DRF serializes
  it in the JSON response.
- \`backend/pytest.ini\` now lists \`electrical_circuits/tests\` —
  these tests existed on main but the testpaths block omitted the
  app, so the default \`pytest backend/\` was silently skipping all
  66 electrical tests.
- Black + isort tidies (long power_chain import, admin/admin_reports
  reformatted to 100col) so the pre-commit gate is clean.

## Test plan

- [x] \`pytest electrical_circuits/tests/\` — 66 passed
- [x] \`pre-commit run --files <changed>\` — passes black, isort,
  ruff, bandit, django-upgrade
- [x] \`python manage.py check\` clean
- [ ] CI green
- [ ] Manual smoke: \`curl /api/electrical/panels/<id>/topology/\` as
  staff returns the nested tree