### PR TITLE
feat(electrical): power-topology visualization frontend (oms-b25 [6/7])

### DIFF
--- a/backend/electrical_circuits/safety_views.py
+++ b/backend/electrical_circuits/safety_views.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+from django.db import models
 from django.shortcuts import get_object_or_404
 
 from rest_framework.permissions import BasePermission, IsAuthenticated
@@ -232,5 +233,41 @@ class AssetPowerChainView(APIView):
             {
                 "asset": _serialize_asset(asset),
                 "chain": chain_payload,
+            }
+        )
+
+
+class PowerPanelListView(APIView):
+    """``GET /api/electrical/panels/`` — directory of every panel.
+
+    Backs the frontend visualization ([6/7]). Annotates each panel with
+    its location, breaker count, and the ``needs_review`` flag set on
+    migration-created placeholders so admins can prioritize cleanup.
+    """
+
+    permission_classes = [IsAuthenticated, IsStaffUser]
+
+    def get(self, request):
+        panels = (
+            PowerPanel.objects.select_related("location")
+            .annotate(breaker_count=models.Count("breakers"))
+            .order_by("location__name", "name")
+        )
+        return Response(
+            {
+                "results": [
+                    {
+                        "id": panel.pk,
+                        "name": panel.name,
+                        "location_id": panel.location_id,
+                        "location_name": panel.location.name,
+                        "phase_configuration": panel.phase_configuration,
+                        "voltage": panel.voltage,
+                        "main_breaker_amperage": panel.main_breaker_amperage,
+                        "breaker_count": panel.breaker_count,
+                        "needs_review": panel.needs_review,
+                    }
+                    for panel in panels
+                ]
             }
         )

--- a/backend/electrical_circuits/tests/test_safety_api.py
+++ b/backend/electrical_circuits/tests/test_safety_api.py
@@ -143,6 +143,33 @@ def test_asset_power_chain_requires_staff(non_staff_client, topology):
     assert non_staff_client.get(url).status_code == 403
 
 
+def test_panel_list_requires_staff(non_staff_client, topology):
+    url = reverse("electrical-panel-list")
+    assert non_staff_client.get(url).status_code == 403
+
+
+# ---------------------------------------------------------------------
+# Panel list — backs the frontend panel directory ([6/7])
+# ---------------------------------------------------------------------
+
+
+def test_panel_list_returns_breaker_count_and_review_flag(staff_client, topology, db):
+    # A second panel with no breakers + needs_review flag exercises the
+    # annotation and the placeholder pathway from the migration.
+    placeholder = PowerPanel.objects.create(
+        location=topology["loc"], name="Placeholder", needs_review=True
+    )
+
+    resp = staff_client.get(reverse("electrical-panel-list"))
+    assert resp.status_code == 200
+    by_name = {p["name"]: p for p in resp.json()["results"]}
+    assert by_name["Sewing A"]["breaker_count"] == 1
+    assert by_name["Sewing A"]["needs_review"] is False
+    assert by_name["Placeholder"]["breaker_count"] == 0
+    assert by_name["Placeholder"]["needs_review"] is True
+    assert by_name["Placeholder"]["id"] == placeholder.pk
+
+
 # ---------------------------------------------------------------------
 # AC-1 — trip impact
 # ---------------------------------------------------------------------

--- a/backend/electrical_circuits/urls.py
+++ b/backend/electrical_circuits/urls.py
@@ -8,6 +8,7 @@ from .safety_views import (
     AssetPowerChainView,
     PowerBreakerTripImpactView,
     PowerCircuitLoadView,
+    PowerPanelListView,
     PowerPanelTopologyView,
 )
 from .views import (
@@ -43,6 +44,11 @@ urlpatterns = [
 # Safety query endpoints (oms-b25 [4/7]). Mounted by config.urls under
 # /api/electrical/ so the URLs match the AC-1..AC-4 paths exactly.
 safety_urlpatterns = [
+    path(
+        "panels/",
+        PowerPanelListView.as_view(),
+        name="electrical-panel-list",
+    ),
     path(
         "breakers/<int:pk>/trip-impact/",
         PowerBreakerTripImpactView.as_view(),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,8 +21,14 @@ import ChecklistCompletionPage from './pages/ChecklistCompletionPage';
 import CodeEntryPage from './pages/CodeEntryPage';
 import DashboardPage from './pages/DashboardPage';
 import DonationItemScanPage from './pages/DonationItemScanPage';
+import AssetPowerChainPage from './pages/AssetPowerChainPage';
+import BreakerTripImpactPage from './pages/BreakerTripImpactPage';
+import CircuitLoadPage from './pages/CircuitLoadPage';
 import ElectricalCircuitsPage from './pages/ElectricalCircuitsPage';
+import ElectricalOverviewPage from './pages/ElectricalOverviewPage';
 import FacilitiesOverviewPage from './pages/FacilitiesOverviewPage';
+import PowerPanelDetailPage from './pages/PowerPanelDetailPage';
+import PowerPanelDirectoryPage from './pages/PowerPanelDirectoryPage';
 import FixtureScanPage from './pages/FixtureScanPage';
 import ForgeKeyDeviceDetailPage from './pages/ForgeKeyDeviceDetailPage';
 import ForgeKeyDevicesPage from './pages/ForgeKeyDevicesPage';
@@ -199,8 +205,18 @@ function AppContent() {
           <Route path="/facilities/maker-boxes/scan" element={<WorkspaceLayout><MakerBoxScanPage /></WorkspaceLayout>} />
           <Route path="/facilities/maker-boxes" element={<WorkspaceLayout><MakerBoxAdminPage /></WorkspaceLayout>} />
 
-          {/* Electrical circuits & network drops (oms-a5f) */}
-          <Route path="/facilities/electrical" element={<WorkspaceLayout><ElectricalCircuitsPage /></WorkspaceLayout>} />
+          {/* Electrical workspace — overview + power-topology visualization (oms-b25 [6/7]) */}
+          <Route path="/facilities/electrical" element={<WorkspaceLayout><ElectricalOverviewPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/panels" element={<WorkspaceLayout><PowerPanelDirectoryPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/panels/:id" element={<WorkspaceLayout><PowerPanelDetailPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/breakers/:id/trip-impact" element={<WorkspaceLayout><BreakerTripImpactPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/circuits/:id/load" element={<WorkspaceLayout><CircuitLoadPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/power-chain" element={<WorkspaceLayout><AssetPowerChainPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/power-chain/:assetId" element={<WorkspaceLayout><AssetPowerChainPage /></WorkspaceLayout>} />
+
+          {/* Legacy fixture inventory (oms-a5f). Kept under /electrical/fixtures so
+              existing bookmarks redirect cleanly via the routes below. */}
+          <Route path="/facilities/electrical/fixtures" element={<WorkspaceLayout><ElectricalCircuitsPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/breakers/new" element={<WorkspaceLayout><BreakerFormPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/breakers/:id/edit" element={<WorkspaceLayout><BreakerFormPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/breakers/:id/trace" element={<WorkspaceLayout><BreakerTracePage /></WorkspaceLayout>} />

--- a/frontend/src/__tests__/components/Breadcrumbs.test.tsx
+++ b/frontend/src/__tests__/components/Breadcrumbs.test.tsx
@@ -83,5 +83,23 @@ describe('Breadcrumbs Component', () => {
     const purchasingLink = screen.getByRole('link', { name: /^purchasing$/i });
     expect(purchasingLink).toHaveAttribute('href', '/purchasing');
   });
+
+  it('hides bare UUID segments between a parent listing and an action', () => {
+    // /facilities/electrical/breakers/<uuid>/edit used to render the raw
+    // UUID as its own breadcrumb chip. Hide it so the trail reads
+    // "Electrical → Breakers → Edit".
+    renderWithRouter([
+      '/facilities/electrical/breakers/550e8400-e29b-41d4-a716-446655440000/edit',
+    ]);
+    expect(screen.queryByText(/550e8400/)).not.toBeInTheDocument();
+    expect(screen.getByText(/breakers/i)).toBeInTheDocument();
+    expect(screen.getByText(/edit/i)).toBeInTheDocument();
+  });
+
+  it('hides numeric ID segments too', () => {
+    renderWithRouter(['/facilities/electrical/panels/42']);
+    expect(screen.queryByText('42')).not.toBeInTheDocument();
+    expect(screen.getByText(/panels/i)).toBeInTheDocument();
+  });
 });
 

--- a/frontend/src/__tests__/pages/BreakerTripImpactPage.test.tsx
+++ b/frontend/src/__tests__/pages/BreakerTripImpactPage.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Tests for BreakerTripImpactPage (oms-b25 [6/7]).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import BreakerTripImpactPage from '../../pages/BreakerTripImpactPage';
+import * as api from '../../services/api';
+
+jest.mock('../../services/api');
+
+const renderAt = (path: string) =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route
+            path="/facilities/electrical/breakers/:id/trip-impact"
+            element={<BreakerTripImpactPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('BreakerTripImpactPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('separates critical loads from the full asset list', async () => {
+    (api.electricalSafetyAPI.getBreakerTripImpact as jest.Mock).mockResolvedValue({
+      data: {
+        breaker: {
+          id: 5,
+          panel_id: 1,
+          panel_name: 'Sewing A',
+          position: '12',
+          amperage: 20,
+          phase: 'A',
+          pole_count: 1,
+          status: 'on',
+          label: 'Bench row 1',
+        },
+        assets: [
+          { id: 'a1', name: 'Server', asset_tag: 'TAG-1', is_critical: true },
+          { id: 'a2', name: 'Lamp', asset_tag: 'TAG-2', is_critical: false },
+        ],
+        critical_loads: [
+          { id: 'a1', name: 'Server', asset_tag: 'TAG-1', is_critical: true },
+        ],
+      },
+    });
+
+    renderAt('/facilities/electrical/breakers/5/trip-impact');
+
+    expect(await screen.findByText(/Bench row 1/)).toBeInTheDocument();
+    expect(screen.getByText(/1 critical asset on this breaker/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 total assets fed by this breaker/i)).toBeInTheDocument();
+    expect(screen.getByTestId('critical-asset-a1')).toHaveTextContent('Server');
+    expect(screen.getByTestId('asset-a2')).toHaveTextContent('Lamp');
+  });
+
+  it('renders an error state when the API rejects', async () => {
+    (api.electricalSafetyAPI.getBreakerTripImpact as jest.Mock).mockRejectedValue({
+      response: { data: { detail: 'Not found' } },
+    });
+    renderAt('/facilities/electrical/breakers/999/trip-impact');
+    expect(await screen.findByText('Not found')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/ElectricalOverviewPage.test.tsx
+++ b/frontend/src/__tests__/pages/ElectricalOverviewPage.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * Tests for ElectricalOverviewPage (oms-b25 [6/7]).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import ElectricalOverviewPage from '../../pages/ElectricalOverviewPage';
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <ElectricalOverviewPage />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('ElectricalOverviewPage', () => {
+  it('renders the workspace hero with the canonical title', () => {
+    renderPage();
+    expect(screen.getByTestId('page-hero-title')).toHaveTextContent(/electrical/i);
+  });
+
+  it('links the panel directory card to the new visualization', () => {
+    renderPage();
+    const panelCard = screen.getByTestId('electrical-overview-card-panels');
+    expect(panelCard).toHaveAttribute('href', '/facilities/electrical/panels');
+  });
+
+  it('keeps the legacy fixture inventory accessible from the overview', () => {
+    renderPage();
+    const fixturesCard = screen.getByTestId('electrical-overview-card-fixtures');
+    expect(fixturesCard).toHaveAttribute('href', '/facilities/electrical/fixtures');
+  });
+
+  it('exposes the asset power-chain lookup', () => {
+    renderPage();
+    const lookupCard = screen.getByTestId('electrical-overview-card-power-chain');
+    expect(lookupCard).toHaveAttribute('href', '/facilities/electrical/power-chain');
+  });
+});

--- a/frontend/src/__tests__/pages/PowerPanelDirectoryPage.test.tsx
+++ b/frontend/src/__tests__/pages/PowerPanelDirectoryPage.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Tests for PowerPanelDirectoryPage (oms-b25 [6/7]).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import PowerPanelDirectoryPage from '../../pages/PowerPanelDirectoryPage';
+import * as api from '../../services/api';
+
+jest.mock('../../services/api');
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <PowerPanelDirectoryPage />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('PowerPanelDirectoryPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lists every panel with its breaker count', async () => {
+    (api.electricalSafetyAPI.listPanels as jest.Mock).mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 1,
+            name: 'Sewing A',
+            location_id: 10,
+            location_name: 'Sewing Room',
+            phase_configuration: 'split',
+            voltage: 240,
+            main_breaker_amperage: 100,
+            breaker_count: 12,
+            needs_review: false,
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Sewing A')).toBeInTheDocument();
+    expect(screen.getByText(/12 breakers/)).toBeInTheDocument();
+    expect(screen.getByText('Sewing Room')).toBeInTheDocument();
+    const card = screen.getByTestId('panel-card-1');
+    expect(card).toHaveAttribute('href', '/facilities/electrical/panels/1');
+  });
+
+  it('flags placeholders that need admin review', async () => {
+    (api.electricalSafetyAPI.listPanels as jest.Mock).mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 9,
+            name: 'Placeholder',
+            location_id: 5,
+            location_name: 'Workshop',
+            phase_configuration: 'single',
+            voltage: 120,
+            main_breaker_amperage: null,
+            breaker_count: 0,
+            needs_review: true,
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Placeholder')).toBeInTheDocument());
+    expect(screen.getByText(/1 panel flagged for review/i)).toBeInTheDocument();
+  });
+
+  it('renders an empty state when there are no panels', async () => {
+    (api.electricalSafetyAPI.listPanels as jest.Mock).mockResolvedValue({
+      data: { results: [] },
+    });
+    renderPage();
+    expect(await screen.findByText(/no power panels yet/i)).toBeInTheDocument();
+  });
+
+  it('shows an error message if the API rejects', async () => {
+    (api.electricalSafetyAPI.listPanels as jest.Mock).mockRejectedValue({
+      response: { data: { detail: 'Boom' } },
+    });
+    renderPage();
+    expect(await screen.findByText('Boom')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/PowerPanelDirectoryPage.test.tsx
+++ b/frontend/src/__tests__/pages/PowerPanelDirectoryPage.test.tsx
@@ -2,7 +2,7 @@
  * Tests for PowerPanelDirectoryPage (oms-b25 [6/7]).
  */
 import { MantineProvider } from '@mantine/core';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import PowerPanelDirectoryPage from '../../pages/PowerPanelDirectoryPage';
@@ -73,7 +73,7 @@ describe('PowerPanelDirectoryPage', () => {
 
     renderPage();
 
-    await waitFor(() => expect(screen.getByText('Placeholder')).toBeInTheDocument());
+    expect(await screen.findByText('Placeholder')).toBeInTheDocument();
     expect(screen.getByText(/1 panel flagged for review/i)).toBeInTheDocument();
   });
 

--- a/frontend/src/components/Breadcrumbs.tsx
+++ b/frontend/src/components/Breadcrumbs.tsx
@@ -11,13 +11,18 @@ import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import '../styles/Breadcrumbs.css';
 
-import { isClickable, labelFor } from '../navigation/routeMap';
+import { getRouteEntry, isClickable, labelFor } from '../navigation/routeMap';
 
 interface BreadcrumbSegment {
   path: string;
   label: string;
   clickable: boolean;
 }
+
+// Bare resource identifiers (UUIDs or all-digit ids). Rendering one between
+// the parent listing and an action label like "Edit" is noise — the user
+// already navigated through the parent to get here.
+const ID_LIKE = /^(\d+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
 
 const Breadcrumbs: React.FC = () => {
   const location = useLocation();
@@ -30,6 +35,11 @@ const Breadcrumbs: React.FC = () => {
     pathSegments.forEach((segment, index) => {
       currentPath += `/${segment}`;
       const pathKey = pathSegments.slice(0, index + 1).join('/');
+      // Hide ID-like segments unless the route map explicitly registers
+      // them (e.g. a code that's worth surfacing to the user).
+      if (ID_LIKE.test(segment) && !getRouteEntry(pathKey)) {
+        return;
+      }
       out.push({
         path: currentPath,
         label: labelFor(pathKey, segment),

--- a/frontend/src/navigation/routeMap.ts
+++ b/frontend/src/navigation/routeMap.ts
@@ -55,6 +55,20 @@ const ENTRIES: RouteEntry[] = [
   { path: 'facilities/screens', label: 'Screens' },
   { path: 'facilities/maker-boxes', label: 'Maker Boxes' },
   { path: 'facilities/electrical', label: 'Electrical' },
+  // Power-topology visualization ([6/7]). Resource leaves are not their
+  // own listing pages — they're surfaced via the panel detail view — so
+  // their breadcrumb segments are non-clickable.
+  { path: 'facilities/electrical/panels', label: 'Panels' },
+  { path: 'facilities/electrical/breakers', label: 'Breakers', clickable: false },
+  { path: 'facilities/electrical/circuits', label: 'Circuits', clickable: false },
+  { path: 'facilities/electrical/power-chain', label: 'Power Chain' },
+  // Legacy fixture inventory (oms-a5f). Kept under the same /electrical
+  // root so existing bookmarks don't break; sub-resources point back to
+  // the tabbed listing rather than dead-ending.
+  { path: 'facilities/electrical/fixtures', label: 'Fixtures' },
+  { path: 'facilities/electrical/outlets', label: 'Outlets', clickable: false },
+  { path: 'facilities/electrical/light-switches', label: 'Light Switches', clickable: false },
+  { path: 'facilities/electrical/network-drops', label: 'Network Drops', clickable: false },
   { path: 'facilities/forgekey-devices', label: 'ForgeKey Devices' },
 
   { path: 'maintenance', label: 'Maintenance' },

--- a/frontend/src/pages/AssetPowerChainPage.tsx
+++ b/frontend/src/pages/AssetPowerChainPage.tsx
@@ -1,0 +1,278 @@
+/**
+ * Asset power chain at `/facilities/electrical/power-chain` and
+ * `/facilities/electrical/power-chain/:assetId`.
+ *
+ * "What feeds this?" — given an asset, walks back through cables,
+ * outlets, circuits, and breakers to the panel. Lets a maintainer pick
+ * an asset by tag from the asset list, or jump straight to one via the
+ * URL (useful when linked from an asset detail page).
+ */
+import {
+  Anchor,
+  Badge,
+  Box,
+  Container,
+  Group,
+  Paper,
+  Select,
+  Stack,
+  Text,
+  Timeline,
+} from '@mantine/core';
+import {
+  IconAlertCircle,
+  IconBolt,
+  IconCircuitGround,
+  IconCpu,
+  IconLayoutGrid,
+  IconPlugConnected,
+  IconRouteAltLeft,
+  IconSitemap,
+} from '@tabler/icons-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import PageHero from '../components/landing/PageHero';
+import { AssetPowerChain, assetsAPI, electricalSafetyAPI } from '../services/api';
+import { Asset } from '../types';
+import '../styles/landing.css';
+
+const HOP_ICON: Record<AssetPowerChain['chain'][number]['kind'], React.ReactNode> = {
+  panel: <IconLayoutGrid size={14} />,
+  breaker: <IconBolt size={14} />,
+  circuit: <IconCircuitGround size={14} />,
+  outlet: <IconPlugConnected size={14} />,
+  cable: <IconRouteAltLeft size={14} />,
+  port: <IconCpu size={14} />,
+};
+
+const HOP_TITLE: Record<AssetPowerChain['chain'][number]['kind'], string> = {
+  panel: 'Panel',
+  breaker: 'Breaker',
+  circuit: 'Circuit',
+  outlet: 'Outlet',
+  cable: 'Cable',
+  port: 'Port',
+};
+
+const AssetPowerChainPage: React.FC = () => {
+  const { assetId } = useParams<{ assetId?: string }>();
+  const navigate = useNavigate();
+
+  const [assets, setAssets] = useState<Asset[]>([]);
+  const [chain, setChain] = useState<AssetPowerChain | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Asset picker: lazy-load the assets list once.
+  useEffect(() => {
+    let cancelled = false;
+    assetsAPI
+      .listAssets({ page_size: 500, is_active: true })
+      .then((response) => {
+        if (cancelled) return;
+        setAssets(response.data.results ?? []);
+      })
+      .catch(() => {
+        // Picker is a convenience — degrade silently if assets fail to
+        // load. The URL-driven flow still works.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!assetId) {
+      setChain(null);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    electricalSafetyAPI
+      .getAssetPowerChain(assetId)
+      .then((response) => {
+        if (cancelled) return;
+        setChain(response.data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err?.response?.data?.detail || 'Failed to load power chain.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [assetId]);
+
+  const assetOptions = useMemo(
+    () =>
+      assets.map((asset) => ({
+        value: String(asset.id),
+        label: asset.asset_tag ? `${asset.asset_tag} — ${asset.name}` : asset.name,
+      })),
+    [assets],
+  );
+
+  return (
+    <Box className="landing-surface" data-testid="asset-power-chain">
+      <Container size="lg" py="xl">
+        <Stack gap="xl">
+          <PageHero
+            eyebrow="Electrical · Lookup"
+            title="Asset power chain"
+            description='Pick an asset to walk back through cables, outlets, circuits, and breakers to its panel.'
+          />
+
+          <Paper withBorder p="md" radius="md">
+            <Select
+              label="Asset"
+              placeholder="Type to filter by tag or name"
+              data={assetOptions}
+              value={assetId ?? null}
+              onChange={(value) => {
+                if (value) {
+                  navigate(`/facilities/electrical/power-chain/${value}`);
+                } else {
+                  navigate('/facilities/electrical/power-chain');
+                }
+              }}
+              searchable
+              clearable
+              nothingFoundMessage="No matching assets"
+              data-testid="asset-power-chain-picker"
+            />
+          </Paper>
+
+          {error && (
+            <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+              <Group gap="xs">
+                <IconAlertCircle size={16} />
+                <Text>{error}</Text>
+              </Group>
+            </Paper>
+          )}
+
+          {loading && (
+            <Paper withBorder p="xl" radius="md">
+              <Text c="dimmed" ta="center">
+                Loading…
+              </Text>
+            </Paper>
+          )}
+
+          {!assetId && !loading && (
+            <Paper withBorder p="xl" radius="md">
+              <Stack gap="xs" align="center">
+                <IconRouteAltLeft size={28} stroke={1.6} />
+                <Text fw={500}>Pick an asset to start.</Text>
+                <Text size="sm" c="dimmed" ta="center" maw={420}>
+                  The chain shows every hop from the asset's power port back to the panel that
+                  feeds it. Useful when planning a shutdown.
+                </Text>
+              </Stack>
+            </Paper>
+          )}
+
+          {chain && !loading && (
+            <Stack gap="md">
+              <Paper withBorder p="md" radius="md" data-testid="asset-summary">
+                <Group justify="space-between" wrap="wrap">
+                  <Stack gap={2}>
+                    <Text component="span" className="landing-eyebrow">
+                      Asset
+                    </Text>
+                    <Text fw={600} size="lg">
+                      {chain.asset.name}
+                    </Text>
+                    <Text size="sm" c="dimmed">
+                      {chain.asset.asset_tag}
+                    </Text>
+                  </Stack>
+                  {chain.asset.is_critical && (
+                    <Badge color="red" variant="filled" radius="sm">
+                      critical
+                    </Badge>
+                  )}
+                </Group>
+              </Paper>
+
+              {chain.chain.length === 0 ? (
+                <Paper withBorder p="xl" radius="md" bg="yellow.0">
+                  <Stack gap="xs" align="center">
+                    <IconAlertCircle size={24} />
+                    <Text fw={500}>This asset is not wired into a power topology.</Text>
+                    <Text size="sm" c="dimmed" ta="center" maw={420}>
+                      Add a PowerPort and a Cable from the port to an outlet via Django admin to
+                      see the chain.
+                    </Text>
+                  </Stack>
+                </Paper>
+              ) : (
+                <Paper withBorder p="md" radius="md" data-testid="asset-chain-timeline">
+                  <Timeline
+                    active={chain.chain.length}
+                    bulletSize={26}
+                    lineWidth={2}
+                    color="blue"
+                  >
+                    {chain.chain.map((hop, index) => (
+                      <Timeline.Item
+                        key={`${hop.kind}-${hop.id}-${index}`}
+                        bullet={HOP_ICON[hop.kind]}
+                        title={
+                          <Group gap="xs">
+                            <Text fw={600}>{HOP_TITLE[hop.kind]}</Text>
+                            <Badge size="xs" variant="light" color="gray">
+                              {hop.type}
+                            </Badge>
+                          </Group>
+                        }
+                      >
+                        {hop.kind === 'panel' ? (
+                          <Anchor
+                            component="a"
+                            href={`/facilities/electrical/panels/${hop.id}`}
+                            size="sm"
+                          >
+                            {String(hop.label)}
+                          </Anchor>
+                        ) : hop.kind === 'breaker' ? (
+                          <Anchor
+                            component="a"
+                            href={`/facilities/electrical/breakers/${hop.id}/trip-impact`}
+                            size="sm"
+                          >
+                            {String(hop.label)}
+                          </Anchor>
+                        ) : hop.kind === 'circuit' ? (
+                          <Anchor
+                            component="a"
+                            href={`/facilities/electrical/circuits/${hop.id}/load`}
+                            size="sm"
+                          >
+                            {String(hop.label)}
+                          </Anchor>
+                        ) : (
+                          <Text size="sm" c="dimmed">
+                            {String(hop.label)}
+                          </Text>
+                        )}
+                      </Timeline.Item>
+                    ))}
+                  </Timeline>
+                </Paper>
+              )}
+            </Stack>
+          )}
+        </Stack>
+      </Container>
+    </Box>
+  );
+};
+
+export default AssetPowerChainPage;

--- a/frontend/src/pages/BreakerTripImpactPage.tsx
+++ b/frontend/src/pages/BreakerTripImpactPage.tsx
@@ -1,0 +1,197 @@
+/**
+ * Breaker trip-impact view at
+ * `/facilities/electrical/breakers/:id/trip-impact`.
+ *
+ * Answers "what loses power if I trip this breaker?" by surfacing the
+ * `/api/electrical/breakers/<id>/trip-impact/` endpoint. Critical loads
+ * are listed first so a maintainer never accidentally drops fire alarms,
+ * APs, or freezers.
+ */
+import { Badge, Box, Container, List, Paper, Stack, Text, ThemeIcon } from '@mantine/core';
+import { IconAlertCircle, IconBolt, IconShieldHalfFilled } from '@tabler/icons-react';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import PageHero from '../components/landing/PageHero';
+import { BreakerTripImpact, electricalSafetyAPI } from '../services/api';
+import '../styles/landing.css';
+
+const BreakerTripImpactPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [impact, setImpact] = useState<BreakerTripImpact | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setLoading(true);
+    electricalSafetyAPI
+      .getBreakerTripImpact(id)
+      .then((response) => {
+        if (cancelled) return;
+        setImpact(response.data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err?.response?.data?.detail || 'Failed to load trip impact.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  return (
+    <Box className="landing-surface" data-testid="breaker-trip-impact">
+      <Container size="lg" py="xl">
+        <Stack gap="xl">
+          <PageHero
+            eyebrow={impact ? `Electrical · ${impact.breaker.panel_name}` : 'Electrical'}
+            title={impact ? `Trip impact · breaker ${impact.breaker.position}` : 'Trip impact'}
+            description="What loses power if this breaker is opened. Verify before maintenance."
+          />
+
+          {error && (
+            <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+              <Text>{error}</Text>
+            </Paper>
+          )}
+
+          {loading && !impact && (
+            <Paper withBorder p="xl" radius="md">
+              <Text c="dimmed" ta="center">
+                Loading…
+              </Text>
+            </Paper>
+          )}
+
+          {impact && (
+            <>
+              <Paper withBorder p="md" radius="md">
+                <Stack gap="xs">
+                  <Text component="span" className="landing-eyebrow">
+                    Breaker
+                  </Text>
+                  <Text fw={600} size="lg">
+                    {impact.breaker.label || `Breaker ${impact.breaker.position}`}
+                  </Text>
+                  <Text size="sm" c="dimmed">
+                    {impact.breaker.amperage}A · {impact.breaker.pole_count}-pole · phase{' '}
+                    {impact.breaker.phase}
+                  </Text>
+                </Stack>
+              </Paper>
+
+              <Paper
+                withBorder
+                p="md"
+                radius="md"
+                data-testid="trip-impact-critical-loads"
+                bg={impact.critical_loads.length > 0 ? 'red.0' : undefined}
+              >
+                <Stack gap="sm">
+                  <Stack gap={2}>
+                    <Text component="span" className="landing-eyebrow">
+                      Critical loads
+                    </Text>
+                    <Text fw={600} size="md">
+                      {impact.critical_loads.length} critical asset
+                      {impact.critical_loads.length === 1 ? '' : 's'} on this breaker
+                    </Text>
+                  </Stack>
+                  {impact.critical_loads.length === 0 ? (
+                    <Text size="sm" c="dimmed">
+                      No assets on this breaker are flagged as critical.
+                    </Text>
+                  ) : (
+                    <List
+                      spacing="xs"
+                      icon={
+                        <ThemeIcon color="red" radius="xl" size={20}>
+                          <IconAlertCircle size={12} />
+                        </ThemeIcon>
+                      }
+                    >
+                      {impact.critical_loads.map((asset) => (
+                        <List.Item key={asset.id} data-testid={`critical-asset-${asset.id}`}>
+                          <Text fw={500} component="span">
+                            {asset.name}
+                          </Text>{' '}
+                          <Text component="span" size="sm" c="dimmed">
+                            ({asset.asset_tag})
+                          </Text>
+                        </List.Item>
+                      ))}
+                    </List>
+                  )}
+                </Stack>
+              </Paper>
+
+              <Paper withBorder p="md" radius="md" data-testid="trip-impact-all-assets">
+                <Stack gap="sm">
+                  <Stack gap={2}>
+                    <Text component="span" className="landing-eyebrow">
+                      All assets
+                    </Text>
+                    <Text fw={600} size="md">
+                      {impact.assets.length} total asset
+                      {impact.assets.length === 1 ? '' : 's'} fed by this breaker
+                    </Text>
+                  </Stack>
+                  {impact.assets.length === 0 ? (
+                    <Text size="sm" c="dimmed">
+                      No assets are wired into this breaker yet.
+                    </Text>
+                  ) : (
+                    <List
+                      spacing={4}
+                      icon={
+                        <ThemeIcon color="gray" variant="light" radius="xl" size={20}>
+                          <IconBolt size={12} />
+                        </ThemeIcon>
+                      }
+                    >
+                      {impact.assets.map((asset) => (
+                        <List.Item key={asset.id} data-testid={`asset-${asset.id}`}>
+                          <Text component="span">{asset.name}</Text>{' '}
+                          <Text component="span" size="sm" c="dimmed">
+                            ({asset.asset_tag})
+                          </Text>
+                          {asset.is_critical && (
+                            <Badge ml="xs" color="red" size="xs" variant="filled">
+                              critical
+                            </Badge>
+                          )}
+                        </List.Item>
+                      ))}
+                    </List>
+                  )}
+                </Stack>
+              </Paper>
+
+              <Paper withBorder p="md" radius="md" bg="gray.0">
+                <Stack gap="xs">
+                  <Text component="span" className="landing-eyebrow">
+                    Reminder
+                  </Text>
+                  <Text size="sm" c="dimmed">
+                    <ThemeIcon color="gray" variant="light" size={16} mr={6}>
+                      <IconShieldHalfFilled size={10} />
+                    </ThemeIcon>
+                    LOTO requirements for these assets are surfaced under
+                    Maintenance · Lockout/Tagout. Cross-check before opening the panel.
+                  </Text>
+                </Stack>
+              </Paper>
+            </>
+          )}
+        </Stack>
+      </Container>
+    </Box>
+  );
+};
+
+export default BreakerTripImpactPage;

--- a/frontend/src/pages/CircuitLoadPage.tsx
+++ b/frontend/src/pages/CircuitLoadPage.tsx
@@ -1,0 +1,193 @@
+/**
+ * Circuit load report at `/facilities/electrical/circuits/:id/load`.
+ *
+ * Surfaces `/api/electrical/circuits/<id>/load/` so an operator can see
+ * the connected devices on a circuit, the estimated nameplate draw, and
+ * how that compares to the breaker's NEC-derated capacity (default 80%
+ * of the breaker amperage).
+ */
+import {
+  Badge,
+  Box,
+  Container,
+  Group,
+  List,
+  Paper,
+  Progress,
+  Stack,
+  Text,
+  ThemeIcon,
+} from '@mantine/core';
+import { IconBolt, IconPlugConnected } from '@tabler/icons-react';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import PageHero from '../components/landing/PageHero';
+import { CircuitLoad, electricalSafetyAPI } from '../services/api';
+import '../styles/landing.css';
+
+const utilizationColor = (percent: number | null): string => {
+  if (percent == null) return 'gray';
+  if (percent >= 100) return 'red';
+  if (percent >= 80) return 'orange';
+  if (percent >= 60) return 'yellow';
+  return 'green';
+};
+
+const CircuitLoadPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [load, setLoad] = useState<CircuitLoad | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setLoading(true);
+    electricalSafetyAPI
+      .getCircuitLoad(id)
+      .then((response) => {
+        if (cancelled) return;
+        setLoad(response.data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err?.response?.data?.detail || 'Failed to load circuit data.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  return (
+    <Box className="landing-surface" data-testid="circuit-load">
+      <Container size="lg" py="xl">
+        <Stack gap="xl">
+          <PageHero
+            eyebrow="Electrical · Circuit"
+            title={load ? load.circuit.label || `Circuit ${load.circuit.id}` : 'Circuit load'}
+            description="Connected devices, estimated nameplate draw, and capacity utilization vs the NEC 80% derate."
+          />
+
+          {error && (
+            <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+              <Text>{error}</Text>
+            </Paper>
+          )}
+
+          {loading && !load && (
+            <Paper withBorder p="xl" radius="md">
+              <Text c="dimmed" ta="center">
+                Loading…
+              </Text>
+            </Paper>
+          )}
+
+          {load && (
+            <>
+              <Paper withBorder p="md" radius="md">
+                <Stack gap="xs">
+                  <Group justify="space-between" align="flex-end" wrap="wrap">
+                    <Stack gap={2}>
+                      <Text component="span" className="landing-eyebrow">
+                        Capacity utilization
+                      </Text>
+                      <Text fw={600} size="xl">
+                        {load.capacity_utilization_percent != null
+                          ? `${load.capacity_utilization_percent.toFixed(1)}%`
+                          : 'No capacity configured'}
+                      </Text>
+                      <Text size="sm" c="dimmed">
+                        {load.estimated_max_draw_amps.toFixed(1)}A estimated draw
+                        {load.capacity_amps != null
+                          ? ` of ${load.capacity_amps}A circuit capacity`
+                          : ''}
+                      </Text>
+                    </Stack>
+                    <Badge
+                      color={utilizationColor(load.capacity_utilization_percent)}
+                      variant="light"
+                      size="lg"
+                      radius="sm"
+                    >
+                      {load.connected_device_count} connected
+                    </Badge>
+                  </Group>
+                  {load.capacity_utilization_percent != null && (
+                    <Progress
+                      value={Math.min(load.capacity_utilization_percent, 100)}
+                      color={utilizationColor(load.capacity_utilization_percent)}
+                      size="lg"
+                      radius="md"
+                      striped={load.capacity_utilization_percent >= 80}
+                      animated={load.capacity_utilization_percent >= 100}
+                    />
+                  )}
+                </Stack>
+              </Paper>
+
+              <Paper withBorder p="md" radius="md">
+                <Stack gap="sm">
+                  <Stack gap={2}>
+                    <Text component="span" className="landing-eyebrow">
+                      Connected devices
+                    </Text>
+                    <Text fw={500}>
+                      {load.connected_device_count} asset
+                      {load.connected_device_count === 1 ? '' : 's'} on this circuit
+                    </Text>
+                  </Stack>
+                  {load.connected_devices.length === 0 ? (
+                    <Text size="sm" c="dimmed">
+                      No assets are wired into this circuit yet.
+                    </Text>
+                  ) : (
+                    <List
+                      spacing={4}
+                      icon={
+                        <ThemeIcon color="gray" variant="light" radius="xl" size={20}>
+                          <IconPlugConnected size={12} />
+                        </ThemeIcon>
+                      }
+                    >
+                      {load.connected_devices.map((asset) => (
+                        <List.Item key={asset.id} data-testid={`circuit-asset-${asset.id}`}>
+                          <Text component="span">{asset.name}</Text>{' '}
+                          <Text component="span" size="sm" c="dimmed">
+                            ({asset.asset_tag})
+                          </Text>
+                          {asset.is_critical && (
+                            <Badge ml="xs" color="red" size="xs" variant="filled">
+                              critical
+                            </Badge>
+                          )}
+                        </List.Item>
+                      ))}
+                    </List>
+                  )}
+                </Stack>
+              </Paper>
+
+              <Paper withBorder p="md" radius="md" bg="gray.0">
+                <Group gap="xs" align="center">
+                  <ThemeIcon color="gray" variant="light" size={20}>
+                    <IconBolt size={12} />
+                  </ThemeIcon>
+                  <Text size="sm" c="dimmed">
+                    Capacity defaults to 80% of breaker amperage per NEC continuous-load rule.
+                    Override via Django admin if a different derate applies.
+                  </Text>
+                </Group>
+              </Paper>
+            </>
+          )}
+        </Stack>
+      </Container>
+    </Box>
+  );
+};
+
+export default CircuitLoadPage;

--- a/frontend/src/pages/ElectricalOverviewPage.tsx
+++ b/frontend/src/pages/ElectricalOverviewPage.tsx
@@ -1,0 +1,74 @@
+/**
+ * Electrical workspace overview, mounted at `/facilities/electrical`.
+ *
+ * Replaces the legacy tabbed `ElectricalCircuitsPage` as the landing
+ * surface so the entry point matches the homepage design language. The
+ * old fixture inventory is still reachable via the "Fixture inventory"
+ * card so existing bookmarks keep working.
+ */
+import {
+  IconBolt,
+  IconClipboardList,
+  IconLayoutGrid,
+  IconRouteAltLeft,
+  IconSitemap,
+} from '@tabler/icons-react';
+import React from 'react';
+
+import CapabilityCard from '../components/landing/CapabilityCard';
+import WorkspaceLanding from '../components/landing/WorkspaceLanding';
+
+const ElectricalOverviewPage: React.FC = () => (
+  <WorkspaceLanding
+    testId="electrical-overview"
+    hero={{
+      eyebrow: 'Facilities',
+      title: 'Electrical',
+      description:
+        'Power-distribution topology, trip-impact lookups, and the fixture inventory the shop runs on.',
+    }}
+  >
+    <CapabilityCard
+      to="/facilities/electrical/panels"
+      title="Power panel directory"
+      description="Every panel in the building, with breaker counts and migration-review flags."
+      icon={<IconSitemap size={22} stroke={1.8} />}
+      eyebrow="Topology"
+      testId="electrical-overview-card-panels"
+    />
+    <CapabilityCard
+      to="/facilities/electrical/power-chain"
+      title="Asset power chain"
+      description='"What feeds this?" — trace any asset back to its panel through cables, ports, and breakers.'
+      icon={<IconRouteAltLeft size={22} stroke={1.8} />}
+      eyebrow="Lookup"
+      testId="electrical-overview-card-power-chain"
+    />
+    <CapabilityCard
+      to="/facilities/electrical/fixtures"
+      title="Fixture inventory"
+      description="Legacy breakers, outlets, light switches, and network drops with create/edit forms and PDF reports."
+      icon={<IconLayoutGrid size={22} stroke={1.8} />}
+      eyebrow="Inventory"
+      testId="electrical-overview-card-fixtures"
+    />
+    <CapabilityCard
+      to="/api/electrical-circuits/reports/panel-directory.pdf"
+      title="Panel directory PDF"
+      description="Printable directory of every breaker and the outlets / switches it feeds. Tape it to the panel."
+      icon={<IconClipboardList size={22} stroke={1.8} />}
+      eyebrow="Report"
+      testId="electrical-overview-card-panel-directory-pdf"
+    />
+    <CapabilityCard
+      to="/api/electrical-circuits/reports/network-drop-list.pdf"
+      title="Network-drop report PDF"
+      description="Patch-panel + port assignments grouped by location. Useful for switch audits."
+      icon={<IconBolt size={22} stroke={1.8} />}
+      eyebrow="Report"
+      testId="electrical-overview-card-network-drop-pdf"
+    />
+  </WorkspaceLanding>
+);
+
+export default ElectricalOverviewPage;

--- a/frontend/src/pages/PowerPanelDetailPage.tsx
+++ b/frontend/src/pages/PowerPanelDetailPage.tsx
@@ -1,0 +1,207 @@
+/**
+ * Single power panel topology view at
+ * `/facilities/electrical/panels/:id`.
+ *
+ * Renders the breaker → circuit → outlet tree returned by
+ * `/api/electrical/panels/<id>/topology/` so a maintainer can scan a
+ * panel without picking through Django admin. Each breaker links to its
+ * trip-impact view ("what loses power if I trip this?") and each
+ * circuit links to its load report.
+ */
+import {
+  Badge,
+  Box,
+  Container,
+  Group,
+  Paper,
+  Stack,
+  Table,
+  Text,
+} from '@mantine/core';
+import { IconBolt, IconRouteAltLeft } from '@tabler/icons-react';
+import React, { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import PageHero from '../components/landing/PageHero';
+import { electricalSafetyAPI, PowerPanelTopology } from '../services/api';
+import '../styles/landing.css';
+
+const PowerPanelDetailPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [topology, setTopology] = useState<PowerPanelTopology | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setLoading(true);
+    electricalSafetyAPI
+      .getPanelTopology(id)
+      .then((response) => {
+        if (cancelled) return;
+        setTopology(response.data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err?.response?.data?.detail || 'Failed to load panel topology.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  return (
+    <Box className="landing-surface" data-testid="power-panel-detail">
+      <Container size="xl" py="xl">
+        <Stack gap="xl">
+          <PageHero
+            eyebrow={topology ? `Electrical · ${topology.location_name}` : 'Electrical'}
+            title={topology ? topology.name : 'Power panel'}
+            description={
+              topology
+                ? `${topology.voltage}V · ${topology.phase_configuration} phase${
+                    topology.main_breaker_amperage
+                      ? ` · ${topology.main_breaker_amperage}A main`
+                      : ''
+                  }`
+                : 'Loading panel topology…'
+            }
+          />
+
+          {error && (
+            <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+              <Text>{error}</Text>
+            </Paper>
+          )}
+
+          {loading && !topology && (
+            <Paper withBorder p="xl" radius="md">
+              <Text c="dimmed" ta="center">
+                Loading…
+              </Text>
+            </Paper>
+          )}
+
+          {topology && topology.breakers.length === 0 && (
+            <Paper withBorder p="xl" radius="md">
+              <Stack gap="xs" align="center">
+                <IconBolt size={28} stroke={1.6} />
+                <Text fw={500}>No breakers configured for this panel</Text>
+                <Text size="sm" c="dimmed">
+                  Add breakers via Django admin to populate this view.
+                </Text>
+              </Stack>
+            </Paper>
+          )}
+
+          {topology &&
+            topology.breakers.map((breaker) => (
+              <Paper
+                key={breaker.id}
+                withBorder
+                p="md"
+                radius="md"
+                data-testid={`breaker-row-${breaker.id}`}
+              >
+                <Stack gap="sm">
+                  <Group justify="space-between" align="flex-start" wrap="wrap">
+                    <Stack gap={2}>
+                      <Text component="span" className="landing-eyebrow">
+                        Breaker · position {breaker.position}
+                      </Text>
+                      <Text fw={600} size="lg">
+                        {breaker.label || `Breaker ${breaker.position}`}
+                      </Text>
+                      <Text size="sm" c="dimmed">
+                        {breaker.amperage}A · {breaker.pole_count}-pole · phase {breaker.phase}
+                      </Text>
+                    </Stack>
+                    <Group gap="xs">
+                      <Badge
+                        color={breaker.status === 'on' ? 'green' : 'gray'}
+                        variant="light"
+                        size="sm"
+                        radius="sm"
+                      >
+                        {breaker.status}
+                      </Badge>
+                      <Link
+                        to={`/facilities/electrical/breakers/${breaker.id}/trip-impact`}
+                        className="landing-arrow"
+                        data-testid={`breaker-trip-impact-${breaker.id}`}
+                        style={{ textDecoration: 'none' }}
+                      >
+                        <IconRouteAltLeft size={16} stroke={2.4} />
+                        Trip impact
+                      </Link>
+                    </Group>
+                  </Group>
+
+                  {breaker.circuits.length === 0 ? (
+                    <Text size="sm" c="dimmed">
+                      No circuits wired to this breaker yet.
+                    </Text>
+                  ) : (
+                    <Table withTableBorder withColumnBorders striped>
+                      <Table.Thead>
+                        <Table.Tr>
+                          <Table.Th>Circuit</Table.Th>
+                          <Table.Th>Conductor</Table.Th>
+                          <Table.Th>Capacity</Table.Th>
+                          <Table.Th>Outlets</Table.Th>
+                          <Table.Th>Load report</Table.Th>
+                        </Table.Tr>
+                      </Table.Thead>
+                      <Table.Tbody>
+                        {breaker.circuits.map((circuit) => (
+                          <Table.Tr key={circuit.id}>
+                            <Table.Td>
+                              <Text fw={500}>{circuit.label || `Circuit ${circuit.id}`}</Text>
+                            </Table.Td>
+                            <Table.Td>{circuit.conductor_size || '—'}</Table.Td>
+                            <Table.Td>
+                              {circuit.max_load_amps != null ? `${circuit.max_load_amps}A` : '—'}
+                            </Table.Td>
+                            <Table.Td>
+                              {circuit.outlets.length === 0 ? (
+                                <Text size="sm" c="dimmed">
+                                  no outlets
+                                </Text>
+                              ) : (
+                                <Stack gap={2}>
+                                  {circuit.outlets.map((outlet) => (
+                                    <Text key={outlet.id} size="sm">
+                                      {outlet.label || `Outlet ${outlet.id}`}
+                                      {outlet.location_name ? ` — ${outlet.location_name}` : ''}
+                                    </Text>
+                                  ))}
+                                </Stack>
+                              )}
+                            </Table.Td>
+                            <Table.Td>
+                              <Link
+                                to={`/facilities/electrical/circuits/${circuit.id}/load`}
+                                data-testid={`circuit-load-${circuit.id}`}
+                              >
+                                Load
+                              </Link>
+                            </Table.Td>
+                          </Table.Tr>
+                        ))}
+                      </Table.Tbody>
+                    </Table>
+                  )}
+                </Stack>
+              </Paper>
+            ))}
+        </Stack>
+      </Container>
+    </Box>
+  );
+};
+
+export default PowerPanelDetailPage;

--- a/frontend/src/pages/PowerPanelDirectoryPage.tsx
+++ b/frontend/src/pages/PowerPanelDirectoryPage.tsx
@@ -1,0 +1,165 @@
+/**
+ * Power panel directory at `/facilities/electrical/panels`.
+ *
+ * Lists every PowerPanel with a breaker count, voltage, and a flag for
+ * panels that the data migration created as placeholders and that an
+ * admin still needs to triage.
+ */
+import {
+  Badge,
+  Box,
+  Container,
+  Group,
+  Paper,
+  SimpleGrid,
+  Stack,
+  Text,
+} from '@mantine/core';
+import { IconAlertTriangle, IconBolt, IconSitemap } from '@tabler/icons-react';
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import PageHero from '../components/landing/PageHero';
+import { electricalSafetyAPI, PowerPanelSummary } from '../services/api';
+import '../styles/landing.css';
+
+const phaseLabel = (phase: PowerPanelSummary['phase_configuration']) => {
+  switch (phase) {
+    case 'single':
+      return 'Single phase';
+    case 'split':
+      return 'Split phase 120/240V';
+    case 'three':
+      return 'Three phase';
+    default:
+      return phase;
+  }
+};
+
+const PowerPanelDirectoryPage: React.FC = () => {
+  const [panels, setPanels] = useState<PowerPanelSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    electricalSafetyAPI
+      .listPanels()
+      .then((response) => {
+        if (cancelled) return;
+        setPanels(response.data.results);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err?.response?.data?.detail || 'Failed to load panels.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const reviewCount = panels.filter((p) => p.needs_review).length;
+
+  return (
+    <Box className="landing-surface" data-testid="power-panel-directory">
+      <Container size="xl" py="xl">
+        <Stack gap="xl">
+          <PageHero
+            eyebrow="Electrical · Topology"
+            title="Power panel directory"
+            description="Every load center in the building. Open one to see its breakers, circuits, and the assets they feed."
+          />
+
+          {error && (
+            <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+              <Text>{error}</Text>
+            </Paper>
+          )}
+
+          {!error && reviewCount > 0 && (
+            <Paper withBorder p="md" radius="md" bg="yellow.0" c="yellow.9">
+              <Group gap="sm" align="center">
+                <IconAlertTriangle size={18} />
+                <Text fw={500}>
+                  {reviewCount} panel{reviewCount === 1 ? '' : 's'} flagged for review (migration
+                  placeholder).
+                </Text>
+              </Group>
+            </Paper>
+          )}
+
+          {loading ? (
+            <Paper withBorder p="xl" radius="md">
+              <Text c="dimmed" ta="center">
+                Loading panels…
+              </Text>
+            </Paper>
+          ) : panels.length === 0 ? (
+            <Paper withBorder p="xl" radius="md">
+              <Stack gap="xs" align="center">
+                <IconSitemap size={28} stroke={1.6} />
+                <Text fw={500}>No power panels yet</Text>
+                <Text size="sm" c="dimmed" ta="center" maw={400}>
+                  Add a PowerPanel from Django admin to see it here. The legacy breaker/outlet
+                  inventory lives under the "Fixture inventory" card on the Electrical overview.
+                </Text>
+              </Stack>
+            </Paper>
+          ) : (
+            <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="md">
+              {panels.map((panel) => (
+                <Link
+                  key={panel.id}
+                  to={`/facilities/electrical/panels/${panel.id}`}
+                  className="landing-capability-card"
+                  data-testid={`panel-card-${panel.id}`}
+                  aria-label={panel.name}
+                  style={{ padding: '1.4rem' }}
+                >
+                  <Stack gap="md" h="100%">
+                    <Group justify="space-between" align="flex-start" wrap="nowrap">
+                      <Box className="landing-icon-chip" aria-hidden>
+                        <IconBolt size={22} stroke={1.8} />
+                      </Box>
+                      {panel.needs_review && (
+                        <Badge color="yellow" variant="light" size="sm" radius="sm">
+                          Review
+                        </Badge>
+                      )}
+                    </Group>
+                    <Stack gap={4} style={{ flex: 1 }}>
+                      <Text component="span" className="landing-eyebrow">
+                        {panel.location_name}
+                      </Text>
+                      <Text component="h3" fw={600} size="lg" style={{ margin: 0, lineHeight: 1.25 }}>
+                        {panel.name}
+                      </Text>
+                      <Text size="sm" c="dimmed" style={{ lineHeight: 1.5 }}>
+                        {phaseLabel(panel.phase_configuration)} · {panel.voltage}V
+                        {panel.main_breaker_amperage
+                          ? ` · ${panel.main_breaker_amperage}A main`
+                          : ''}
+                      </Text>
+                    </Stack>
+                    <Group justify="space-between" align="center">
+                      <Text size="sm" c="dimmed">
+                        {panel.breaker_count} breaker
+                        {panel.breaker_count === 1 ? '' : 's'}
+                      </Text>
+                      <span className="landing-arrow">Open →</span>
+                    </Group>
+                  </Stack>
+                </Link>
+              ))}
+            </SimpleGrid>
+          )}
+        </Stack>
+      </Container>
+    </Box>
+  );
+};
+
+export default PowerPanelDirectoryPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1930,6 +1930,115 @@ export const OUTLET_TYPE_OPTIONS = [
   { value: 'other', label: 'Other' },
 ];
 
+// ---------------------------------------------------------------------
+// Power topology safety API (oms-b25 [4/7]). Read-only views over the
+// PowerPanel → PowerBreaker → PowerCircuit → PowerOutlet ↔ PowerPort
+// hierarchy. Used by the [6/7] visualization pages.
+// ---------------------------------------------------------------------
+
+export type PowerPanelPhase = 'single' | 'split' | 'three';
+
+export interface PowerPanelSummary {
+  id: number;
+  name: string;
+  location_id: number;
+  location_name: string;
+  phase_configuration: PowerPanelPhase;
+  voltage: number;
+  main_breaker_amperage: number | null;
+  breaker_count: number;
+  needs_review: boolean;
+}
+
+export interface PowerOutletNode {
+  id: number;
+  label: string;
+  outlet_type: string;
+  status: string;
+  location_id: number | null;
+  location_name: string | null;
+}
+
+export interface PowerCircuitNode {
+  id: number;
+  label: string;
+  breaker_id: number;
+  max_load_amps: number | null;
+  conductor_size: string;
+  outlets: PowerOutletNode[];
+}
+
+export interface PowerBreakerNode {
+  id: number;
+  panel_id: number;
+  panel_name: string;
+  position: string;
+  amperage: number;
+  phase: string;
+  pole_count: number;
+  status: string;
+  label: string;
+  circuits: PowerCircuitNode[];
+}
+
+export interface PowerPanelTopology {
+  id: number;
+  name: string;
+  location_id: number;
+  location_name: string;
+  phase_configuration: PowerPanelPhase;
+  voltage: number;
+  main_breaker_amperage: number | null;
+  breakers: PowerBreakerNode[];
+}
+
+export interface PowerSafetyAsset {
+  id: string;
+  name: string;
+  asset_tag: string;
+  is_critical: boolean;
+}
+
+export interface BreakerTripImpact {
+  breaker: Omit<PowerBreakerNode, 'circuits'>;
+  assets: PowerSafetyAsset[];
+  critical_loads: PowerSafetyAsset[];
+}
+
+export interface CircuitLoad {
+  circuit: Omit<PowerCircuitNode, 'outlets'>;
+  connected_device_count: number;
+  connected_devices: PowerSafetyAsset[];
+  estimated_max_draw_amps: number;
+  capacity_amps: number | null;
+  capacity_utilization_percent: number | null;
+}
+
+export interface PowerChainHop {
+  kind: 'panel' | 'breaker' | 'circuit' | 'outlet' | 'cable' | 'port';
+  id: number;
+  type: string;
+  label: string | number;
+}
+
+export interface AssetPowerChain {
+  asset: PowerSafetyAsset;
+  chain: PowerChainHop[];
+}
+
+export const electricalSafetyAPI = {
+  listPanels: () =>
+    api.get<{ results: PowerPanelSummary[] }>('/electrical/panels/'),
+  getPanelTopology: (panelId: number | string) =>
+    api.get<PowerPanelTopology>(`/electrical/panels/${panelId}/topology/`),
+  getBreakerTripImpact: (breakerId: number | string) =>
+    api.get<BreakerTripImpact>(`/electrical/breakers/${breakerId}/trip-impact/`),
+  getCircuitLoad: (circuitId: number | string) =>
+    api.get<CircuitLoad>(`/electrical/circuits/${circuitId}/load/`),
+  getAssetPowerChain: (assetId: string) =>
+    api.get<AssetPowerChain>(`/assets/${assetId}/power-chain/`),
+};
+
 // LOTO (lockout / tagout) — oms-78j
 export type LOTODeviceType =
   | 'padlock'


### PR DESCRIPTION
## Summary

Builds the React/TS visualization layer on top of the safety query API
in #395. Replaces the legacy tabbed ``ElectricalCircuitsPage`` as the
``/facilities/electrical`` landing — that page moves under
``/facilities/electrical/fixtures`` so existing CRUD URLs keep working
— and the root path becomes a homepage-styled overview that fans into:

- **Panel directory** (\`/panels\`) — every PowerPanel with breaker
  count, voltage/phase, and a yellow \"Review\" badge for the
  migration placeholders.
- **Panel detail** (\`/panels/:id\`) — breaker-by-breaker layout with
  circuit tables and deep links into trip-impact + circuit-load.
- **Trip impact** (\`/breakers/:id/trip-impact\`) — critical loads
  called out separately so a maintainer can't miss them before
  opening a panel.
- **Circuit load** (\`/circuits/:id/load\`) — capacity-utilization
  progress bar coloured against the NEC 80% derate.
- **Asset power chain** (\`/power-chain[/:assetId]\`) — asset picker +
  Mantine Timeline of every hop. URL is shareable so an asset detail
  page can deep-link.

## Breadcrumb fix

User-reported \"Circuit breakers is broken\" — addressed in two
places:

- ``Breadcrumbs.tsx`` now hides bare UUID / numeric segments so
  ``/facilities/electrical/breakers/<uuid>/edit`` reads
  \"Electrical → Breakers → Edit\" instead of dragging the raw
  identifier into the trail.
- ``routeMap.ts`` adds entries for every new visualization path and
  marks the legacy resource leaves (breakers, outlets,
  light-switches, network-drops, circuits) as ``clickable: false``
  so they no longer dead-end on click.

## Backend

One small endpoint added:
``GET /api/electrical/panels/`` — directory list with breaker count
and ``needs_review`` annotation. Staff-gated like the rest of the
safety API.

## Notes for review

- Stacked on #395 (PR A). Will retarget to ``main`` after that one
  merges.
- The new ElectricalOverviewPage links the two PDF report URLs
  directly — they're staff-gated by the existing endpoints, so
  the frontend doesn't need to know about auth.

## Test plan

- [x] ``pytest electrical_circuits/tests/test_safety_api.py`` —
  15 passed (10 carried over + 2 new for the panel-list view + 3
  reformatted)
- [x] ``CI=true npm test -- --testPathPattern=...`` — all 57 tests
  in the touched areas pass; new pages: 10 tests, all green
- [x] ``npm run build`` — clean (warnings only)
- [x] ``pre-commit run`` on every changed file — green
- [ ] CI green
- [ ] Manual smoke: navigate \`/facilities/electrical\` →
  \`/panels\` → pick one → click \"Trip impact\"