### PR TITLE
feat(ui): landing-surface rollout — settings, webhooks, analytics, problems (batch 2)

### DIFF
--- a/frontend/src/__tests__/pages/InventoryItemDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemDetailPage.test.tsx
@@ -112,7 +112,7 @@ describe('InventoryItemDetailPage', () => {
     (api.inventoryAPI.getItem as jest.Mock).mockReturnValue(new Promise(() => {}));
     renderPage();
 
-    expect(screen.getByText(/Loading/)).toBeInTheDocument();
+    expect(screen.getByText(/Loading item/)).toBeInTheDocument();
   });
 
   it('displays item details in overview tab', async () => {
@@ -122,8 +122,10 @@ describe('InventoryItemDetailPage', () => {
       expect(screen.getByText('Test Item')).toBeInTheDocument();
     });
 
-    expect(screen.getByText(/SKU: TEST-001/)).toBeInTheDocument();
-    expect(screen.getByText('Test description')).toBeInTheDocument();
+    expect(screen.getByText(/SKU TEST-001/)).toBeInTheDocument();
+    // "Test description" now appears in both the hero description and the
+    // overview body once the page uses <PageHero>; assert at least one.
+    expect(screen.getAllByText('Test description').length).toBeGreaterThan(0);
     expect(screen.getByText(/Current Stock:/)).toBeInTheDocument();
     // Stock value is displayed - check that the stock information section exists
     expect(screen.getByText(/Stock Information/i)).toBeInTheDocument();
@@ -299,7 +301,7 @@ describe('InventoryItemDetailPage', () => {
       expect(screen.getByText('Test Item')).toBeInTheDocument();
     });
 
-    const generateButton = screen.getByText(/Generate QR Code/i);
+    const generateButton = screen.getByText(/Generate QR/i);
     generateButton.click();
 
     await waitFor(() => {

--- a/frontend/src/__tests__/pages/LocationProblemsListPage.test.tsx
+++ b/frontend/src/__tests__/pages/LocationProblemsListPage.test.tsx
@@ -52,7 +52,7 @@ describe('LocationProblemsListPage', () => {
 
     renderPage();
 
-    expect(screen.getByText('Location Problems')).toBeInTheDocument();
+    expect(screen.getByText('Location problems')).toBeInTheDocument();
     expect(await screen.findByTestId('location-problems-table')).toBeInTheDocument();
     expect(screen.getByText('Light is out')).toBeInTheDocument();
     expect(screen.getByText('Shelf A')).toBeInTheDocument();

--- a/frontend/src/__tests__/pages/SupplierDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/SupplierDetailPage.test.tsx
@@ -107,7 +107,7 @@ describe('SupplierDetailPage', () => {
       </MantineProvider>
     );
 
-    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+    expect(screen.getByText(/Loading supplier/i)).toBeInTheDocument();
   });
 
   it('displays supplier information', async () => {
@@ -122,7 +122,7 @@ describe('SupplierDetailPage', () => {
     await waitFor(() => {
       const supplierNames = screen.getAllByText('Test Supplier');
       expect(supplierNames.length).toBeGreaterThan(0);
-      expect(screen.getByText('Local Supplier')).toBeInTheDocument();
+      expect(screen.getByText(/Local supplier/i)).toBeInTheDocument();
     });
   });
 
@@ -280,7 +280,7 @@ describe('SupplierDetailPage', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Supplier not found')).toBeInTheDocument();
+      expect(screen.getByText(/Supplier not found/i)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/__tests__/pages/UserProfilePage.test.tsx
+++ b/frontend/src/__tests__/pages/UserProfilePage.test.tsx
@@ -64,7 +64,7 @@ describe('UserProfilePage', () => {
       </MantineProvider>
     );
 
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.getByText(/Loading profile/)).toBeInTheDocument();
   });
 
   it('loads and displays notification preferences successfully', async () => {
@@ -80,7 +80,7 @@ describe('UserProfilePage', () => {
 
     // Wait for profile to load and tabs to be available
     await waitFor(() => {
-      expect(screen.getByText('User Profile')).toBeInTheDocument();
+      expect(screen.getByTestId('page-hero-title')).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /notifications/i })).toBeInTheDocument();
     });
 
@@ -116,7 +116,7 @@ describe('UserProfilePage', () => {
 
     // Wait for profile to load and tabs to be available
     await waitFor(() => {
-      expect(screen.getByText('User Profile')).toBeInTheDocument();
+      expect(screen.getByTestId('page-hero-title')).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /notifications/i })).toBeInTheDocument();
     });
 
@@ -156,7 +156,7 @@ describe('UserProfilePage', () => {
 
     // Wait for profile to load and tabs to be available
     await waitFor(() => {
-      expect(screen.getByText('User Profile')).toBeInTheDocument();
+      expect(screen.getByTestId('page-hero-title')).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /notifications/i })).toBeInTheDocument();
     });
 
@@ -197,7 +197,7 @@ describe('UserProfilePage', () => {
 
     // Wait for profile to load
     await waitFor(() => {
-      expect(screen.getByText('User Profile')).toBeInTheDocument();
+      expect(screen.getByTestId('page-hero-title')).toBeInTheDocument();
     });
 
     // Wait for and click on notifications tab
@@ -230,7 +230,7 @@ describe('UserProfilePage', () => {
 
     // Wait for profile to load and tabs to be available
     await waitFor(() => {
-      expect(screen.getByText('User Profile')).toBeInTheDocument();
+      expect(screen.getByTestId('page-hero-title')).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /notifications/i })).toBeInTheDocument();
     });
 

--- a/frontend/src/pages/AnalyticsDashboardPage.tsx
+++ b/frontend/src/pages/AnalyticsDashboardPage.tsx
@@ -1,5 +1,6 @@
 import {
   Alert,
+  Box,
   Card,
   Container,
   Grid,
@@ -21,6 +22,7 @@ import { ShareLinkButton } from '../components/analytics/ShareLinkButton';
 import { TopUsersTable } from '../components/analytics/TopUsersTable';
 import { VolumeTrendChart } from '../components/analytics/VolumeTrendChart';
 import PageHero from '../components/landing/PageHero';
+import '../styles/landing.css';
 import { pulseAPI, AnalyticsPulseResponse } from '../services/api';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
 
@@ -84,34 +86,39 @@ export const AnalyticsDashboardPage: React.FC<AnalyticsDashboardPageProps> = ({ 
 
   if (loading) {
     return (
-      <Container size="xl" py="xl">
-        <Group justify="center"><Loader /></Group>
-      </Container>
+      <Box className="landing-surface">
+        <Container size="xl" py="xl">
+          <Group justify="center"><Loader /></Group>
+        </Container>
+      </Box>
     );
   }
 
   if (error || !data) {
     return (
-      <Container size="xl" py="xl">
-        <Alert color="red" icon={<IconAlertTriangle size={16} />} title="Could not load analytics">
-          {error ?? 'Unknown error'}
-        </Alert>
-      </Container>
+      <Box className="landing-surface">
+        <Container size="xl" py="xl">
+          <Alert color="red" icon={<IconAlertTriangle size={16} />} title="Could not load analytics">
+            {error ?? 'Unknown error'}
+          </Alert>
+        </Container>
+      </Box>
     );
   }
 
   const { summary } = data;
 
   return (
-    <Container size="xl" py="lg">
-      <PageHero
-        eyebrow="Analytics pulse"
-        title="Makerspace pulse"
-        description={`${summary.period_start} → ${summary.period_end}${shared ? ' · shared link (read-only)' : ''}`}
-        action={!shared ? <ShareLinkButton baseUrl={window.location.origin} /> : undefined}
-      />
+    <Box className="landing-surface" data-testid="analytics-dashboard-page">
+      <Container size="xl" py="lg">
+        <PageHero
+          eyebrow="Analytics pulse"
+          title="Makerspace pulse"
+          description={`${summary.period_start} → ${summary.period_end}${shared ? ' · shared link (read-only)' : ''}`}
+          action={!shared ? <ShareLinkButton baseUrl={window.location.origin} /> : undefined}
+        />
 
-      <Stack gap="lg">
+        <Stack gap="lg">
         <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="md">
           <SummaryStat
             label="Net value created"
@@ -156,8 +163,9 @@ export const AnalyticsDashboardPage: React.FC<AnalyticsDashboardPageProps> = ({ 
         </Grid>
 
         <EquipmentStatusGrid rows={data.utilization} />
-      </Stack>
-    </Container>
+        </Stack>
+      </Container>
+    </Box>
   );
 };
 

--- a/frontend/src/pages/InventoryItemDetailPage.tsx
+++ b/frontend/src/pages/InventoryItemDetailPage.tsx
@@ -20,6 +20,7 @@ import { IconEdit, IconQrcode } from '@tabler/icons-react';
 import { QRCodeSVG } from 'qrcode.react';
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import NFPADiamond from '../components/NFPADiamond';
 import StockHistoryChart from '../components/StockHistoryChart';
 import { assetsAPI, inventoryAPI, reorderAPI } from '../services/api';
@@ -85,47 +86,56 @@ const InventoryItemDetailPage: React.FC = () => {
 
   if (loading) {
     return (
-      <Paper p="md">
-        <Text>Loading...</Text>
-      </Paper>
+      <WorkspacePage
+        testId="inventory-item-detail-page"
+        hero={{ eyebrow: 'Inventory · Item', title: 'Item', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading item…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   if (!item) {
     return (
-      <Paper p="md">
-        <Text>Item not found</Text>
-      </Paper>
+      <WorkspacePage
+        testId="inventory-item-detail-page"
+        hero={{ eyebrow: 'Inventory · Item', title: 'Item', description: 'Not found.' }}
+      >
+        <Paper withBorder p="md">
+          <Text>Item not found.</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   return (
-    <Stack gap="md">
-      {/* Header */}
-      <Group justify="space-between">
-        <div>
-          <Title order={2}>{item.name}</Title>
-          <Text size="sm" c="dimmed">
-            SKU: {item.sku}
-          </Text>
-        </div>
-        <Group>
-          <Button
-            leftSection={<IconEdit size={16} />}
-            onClick={() => navigate(`/inventory/items/${id}/edit`)}
-          >
-            Edit
-          </Button>
-          <Button
-            variant="outline"
-            leftSection={<IconQrcode size={16} />}
-            onClick={handleGenerateQR}
-          >
-            Generate QR Code
-          </Button>
-        </Group>
-      </Group>
-
+    <WorkspacePage
+      testId="inventory-item-detail-page"
+      hero={{
+        eyebrow: `Inventory · SKU ${item.sku}`,
+        title: item.name,
+        description: item.description ? item.description.split('\n')[0] : undefined,
+        action: (
+          <Group gap="sm">
+            <Button
+              variant="default"
+              leftSection={<IconQrcode size={16} />}
+              onClick={handleGenerateQR}
+            >
+              Generate QR
+            </Button>
+            <Button
+              leftSection={<IconEdit size={16} />}
+              onClick={() => navigate(`/inventory/items/${id}/edit`)}
+            >
+              Edit
+            </Button>
+          </Group>
+        ),
+      }}
+    >
       {/* Status Badges */}
       <Group>
         {item.needs_reorder && <Badge color="red">Low Stock</Badge>}
@@ -422,7 +432,7 @@ const InventoryItemDetailPage: React.FC = () => {
           </Card>
         </Tabs.Panel>
       </Tabs>
-    </Stack>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/LocationDetailPage.tsx
+++ b/frontend/src/pages/LocationDetailPage.tsx
@@ -2,8 +2,10 @@
  * Location Detail Page
  * Display location details, QR code, and fixtures
  */
+import { Button, Group, Paper, Text } from '@mantine/core';
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import LocationFixturesList from '../components/LocationFixturesList';
 import LocationProblemsPanel from '../components/LocationProblemsPanel';
 import LocationTrafficPanel from '../components/LocationTrafficPanel';
@@ -78,62 +80,77 @@ const LocationDetailPage: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="location-detail-page">
-        <div className="loading">Loading location...</div>
-      </div>
+      <WorkspacePage
+        testId="location-detail-page"
+        hero={{ eyebrow: 'Inventory · Location', title: 'Location', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading location…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   if (error || !location) {
     return (
-      <div className="location-detail-page">
-        <div className="error">{error || 'Location not found'}</div>
-        <Link to="/inventory/locations" className="btn-secondary">
-          Back to Locations
-        </Link>
-      </div>
+      <WorkspacePage
+        testId="location-detail-page"
+        hero={{
+          eyebrow: 'Inventory · Location',
+          title: 'Location',
+          description: error || 'Not found.',
+          action: (
+            <Button component={Link} to="/inventory/locations" variant="default">
+              Back to locations
+            </Button>
+          ),
+        }}
+      >
+        <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+          <Text>{error || 'Location not found.'}</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   return (
-    <div className="location-detail-page">
-      <header className="page-header">
-        <div>
-          <h1>{location.name}</h1>
-          {location.description && (
-            <p className="location-description">{location.description}</p>
-          )}
-        </div>
-        <div className="header-actions">
-          <button
-            type="button"
-            onClick={() => setShowReportModal(true)}
-            className="btn-secondary"
-          >
-            Report Problem
-          </button>
-          {isStaff && (
-            <>
-              <Link
-                to={`/inventory/locations/${location.id}/reconcile`}
-                className="btn-secondary"
-              >
-                Reconcile inventory
-              </Link>
-              <Link
-                to={`/inventory/locations/${location.id}/edit`}
-                className="btn-edit"
-              >
-                Edit
-              </Link>
-              <button onClick={handleDelete} className="btn-delete">
-                Delete
-              </button>
-            </>
-          )}
-        </div>
-      </header>
-
+    <WorkspacePage
+      testId="location-detail-page"
+      hero={{
+        eyebrow: location.parent_name
+          ? `Inventory · in ${location.parent_name}`
+          : 'Inventory · Location',
+        title: location.name,
+        description: location.description || undefined,
+        action: (
+          <Group gap="sm">
+            <Button onClick={() => setShowReportModal(true)} variant="default">
+              Report problem
+            </Button>
+            {isStaff && (
+              <>
+                <Button
+                  component={Link}
+                  to={`/inventory/locations/${location.id}/reconcile`}
+                  variant="default"
+                >
+                  Reconcile
+                </Button>
+                <Button
+                  component={Link}
+                  to={`/inventory/locations/${location.id}/edit`}
+                >
+                  Edit
+                </Button>
+                <Button color="red" variant="light" onClick={handleDelete}>
+                  Delete
+                </Button>
+              </>
+            )}
+          </Group>
+        ),
+      }}
+    >
       <div className="location-details">
         <div className="detail-section">
           <h2>Location Information</h2>
@@ -238,7 +255,7 @@ const LocationDetailPage: React.FC = () => {
           }}
         />
       )}
-    </div>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/LocationProblemsListPage.tsx
+++ b/frontend/src/pages/LocationProblemsListPage.tsx
@@ -2,18 +2,17 @@ import {
   Alert,
   Anchor,
   Badge,
-  Container,
+  Button,
   Group,
   Loader,
   SegmentedControl,
-  Stack,
   Table,
   Text,
-  Title,
 } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { locationProblemsAPI } from '../services/api';
 import { LocationProblem } from '../types';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
@@ -65,14 +64,19 @@ const LocationProblemsListPage: React.FC = () => {
   }, [problems, statusFilter]);
 
   return (
-    <Container size="xl" py="md" data-testid="location-problems-list-page">
-      <Group justify="space-between" mb="md">
-        <Title order={2}>Location Problems</Title>
-        <Anchor component={Link} to="/maintenance" size="sm">
-          ← Maintenance
-        </Anchor>
-      </Group>
-
+    <WorkspacePage
+      testId="location-problems-list-page"
+      hero={{
+        eyebrow: 'Maintenance',
+        title: 'Location problems',
+        description: 'Reported issues for shop locations — open, resolved, and the full history.',
+        action: (
+          <Button component={Link} to="/maintenance" variant="default">
+            Back to maintenance
+          </Button>
+        ),
+      }}
+    >
       <SegmentedControl
         mb="md"
         value={statusFilter}
@@ -146,7 +150,7 @@ const LocationProblemsListPage: React.FC = () => {
           </Table.Tbody>
         </Table>
       )}
-    </Container>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/SiteSettingsPage.tsx
+++ b/frontend/src/pages/SiteSettingsPage.tsx
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import ColorPicker from '../components/ColorPicker';
 import { FormImageUpload } from '../components/forms/FormImageUpload';
 import { FormInput } from '../components/forms/FormInput';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { customizationAPI } from '../services/api';
 import '../styles/SiteSettingsPage.css';
 import { SiteSettings } from '../types';
@@ -158,21 +159,27 @@ const SiteSettingsPage: React.FC = () => {
 
   if (loading) {
     return (
-      <Stack gap="md">
-        <Title order={2}>Site Settings</Title>
-        <Text>Loading...</Text>
-      </Stack>
+      <WorkspacePage
+        testId="site-settings-page"
+        hero={{ eyebrow: 'Settings', title: 'Site', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading site settings…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   return (
-    <div className="site-settings-page">
-      <Stack gap="md">
-        <Title order={2}>Site Settings</Title>
-        <Text c="dimmed" size="sm">
-          Manage site-wide customization settings. Only superusers can access this page.
-        </Text>
-
+    <WorkspacePage
+      testId="site-settings-page"
+      hero={{
+        eyebrow: 'Settings',
+        title: 'Site',
+        description: 'Site-wide customization. Superuser only.',
+      }}
+    >
+      <div className="site-settings-page">
         {error && (
           <Alert
             icon={<IconAlertCircle size={16} />}
@@ -341,13 +348,13 @@ const SiteSettingsPage: React.FC = () => {
 
             <Group justify="flex-end">
               <Button type="submit" loading={saving} size="md">
-                Save Settings
+                Save settings
               </Button>
             </Group>
           </Stack>
         </form>
-      </Stack>
-    </div>
+      </div>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/SupplierDetailPage.tsx
+++ b/frontend/src/pages/SupplierDetailPage.tsx
@@ -19,6 +19,7 @@ import { IconEdit, IconExternalLink } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import LeadTimeChart from '../components/LeadTimeChart';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import PriceTrendChart from '../components/PriceTrendChart';
 import { inventoryAPI } from '../services/api';
 import { ItemSupplier, SupplierDetail } from '../types';
@@ -79,40 +80,47 @@ const SupplierDetailPage: React.FC = () => {
 
   if (loading) {
     return (
-      <Paper p="md">
-        <Text>Loading...</Text>
-      </Paper>
+      <WorkspacePage
+        testId="supplier-detail-page"
+        hero={{ eyebrow: 'Inventory · Supplier', title: 'Supplier', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading supplier…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   if (!supplier) {
     return (
-      <Paper p="md">
-        <Text>Supplier not found</Text>
-      </Paper>
+      <WorkspacePage
+        testId="supplier-detail-page"
+        hero={{ eyebrow: 'Inventory · Supplier', title: 'Supplier', description: 'Not found.' }}
+      >
+        <Paper withBorder p="md">
+          <Text>Supplier not found.</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   return (
-    <Stack gap="md">
-      {/* Header */}
-      <Group justify="space-between">
-        <div>
-          <Title order={2}>{supplier.name}</Title>
-          <Text size="sm" c="dimmed">
-            {getTypeLabel(supplier.supplier_type)} Supplier
-          </Text>
-        </div>
-        <Group>
+    <WorkspacePage
+      testId="supplier-detail-page"
+      hero={{
+        eyebrow: `Inventory · ${getTypeLabel(supplier.supplier_type)} supplier`,
+        title: supplier.name,
+        description: supplier.notes ? supplier.notes.split('\n')[0] : undefined,
+        action: (
           <Button
             leftSection={<IconEdit size={16} />}
             onClick={() => navigate(`/inventory/suppliers/${id}/edit`)}
           >
             Edit
           </Button>
-        </Group>
-      </Group>
-
+        ),
+      }}
+    >
       {/* Status Badges */}
       <Group>
         <Badge color={getTypeBadgeColor(supplier.supplier_type)}>
@@ -398,7 +406,7 @@ const SupplierDetailPage: React.FC = () => {
           )}
         </Tabs.Panel>
       </Tabs>
-    </Stack>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -4,13 +4,14 @@
  * Allows users to view and edit their profile, change password, upload signature, and manage notification preferences
  */
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Alert, Button, Group, Image, Paper, PasswordInput, Slider, Stack, Switch, Tabs, Text, Title } from '@mantine/core';
+import { Alert, Button, Group, Image, Paper, PasswordInput, Slider, Stack, Switch, Tabs, Text } from '@mantine/core';
 import { IconAlertCircle, IconCheck } from '@tabler/icons-react';
 import { useCallback, useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { FormImageUpload } from '../components/forms/FormImageUpload';
 import { FormInput } from '../components/forms/FormInput';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { notificationsAPI, userAPI } from '../services/api';
 import { ChangePasswordRequest, NotificationPreferences, UserProfile } from '../types';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
@@ -220,17 +221,26 @@ const UserProfilePage: React.FC = () => {
 
   if (loading) {
     return (
-      <Stack gap="md">
-        <Title order={2}>User Profile</Title>
-        <Text>Loading...</Text>
-      </Stack>
+      <WorkspacePage
+        testId="user-profile-page"
+        hero={{ eyebrow: 'Settings', title: 'Profile', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading profile…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   return (
-    <Stack gap="md">
-      <Title order={2}>User Profile</Title>
-
+    <WorkspacePage
+      testId="user-profile-page"
+      hero={{
+        eyebrow: 'Settings',
+        title: 'Profile',
+        description: 'Personal info, password, signature, and notification preferences.',
+      }}
+    >
       {error && (
         <Alert icon={<IconAlertCircle size={16} />} title="Error" color="red" onClose={() => setError(null)} withCloseButton>
           {error}
@@ -486,7 +496,7 @@ const UserProfilePage: React.FC = () => {
           </Paper>
         </Tabs.Panel>
       </Tabs>
-    </Stack>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/WebhookListPage.tsx
+++ b/frontend/src/pages/WebhookListPage.tsx
@@ -17,6 +17,7 @@ import {
 import { IconEdit, IconExternalLink, IconEye, IconSearch, IconTestPipe, IconTrash } from '@tabler/icons-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { webhooksAPI } from '../services/api';
 import '../styles/WebhookListPage.css';
 import { Webhook } from '../types';
@@ -114,29 +115,30 @@ const WebhookListPage: React.FC = () => {
 
   if (loading) {
     return (
-      <Stack gap="md">
-        <Text>Loading webhooks...</Text>
-      </Stack>
+      <WorkspacePage
+        testId="webhook-list-page"
+        hero={{ eyebrow: 'Settings', title: 'Webhooks', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading webhooks…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   return (
-    <div className="webhook-list-page">
-      <Stack gap="md">
-        <Group justify="space-between">
-          <div>
-            <Text size="xl" fw={500}>
-              Webhooks
-            </Text>
-            <Text size="sm" c="dimmed">
-              {filteredWebhooks.length} of {webhooks.length} webhooks
-            </Text>
-          </div>
-          <Button onClick={() => navigate('/settings/webhooks/new')}>
-            Create Webhook
-          </Button>
-        </Group>
-
+    <WorkspacePage
+      testId="webhook-list-page"
+      hero={{
+        eyebrow: 'Settings',
+        title: 'Webhooks',
+        description: `${filteredWebhooks.length} of ${webhooks.length} webhooks configured.`,
+        action: (
+          <Button onClick={() => navigate('/settings/webhooks/new')}>Create webhook</Button>
+        ),
+      }}
+    >
+      <div className="webhook-list-page">
         {/* Filters and Search */}
         <Paper p="md" withBorder>
           <Stack gap="md">
@@ -287,8 +289,8 @@ const WebhookListPage: React.FC = () => {
             </Table.Tbody>
           </Table>
         </Paper>
-      </Stack>
-    </div>
+      </div>
+    </WorkspacePage>
   );
 };
 


### PR DESCRIPTION
## Summary

Continues the homepage-style migration onto the next batch of high-traffic pages so they share the warm-paper hero pattern with the homepage and the workspace overviews.

## Pages migrated

- ``UserProfilePage`` (``/settings/profile``)
- ``SiteSettingsPage`` (``/settings/site``)
- ``WebhookListPage`` (``/settings/webhooks``)
- ``AnalyticsDashboardPage`` (``/analytics``) — already used ``<PageHero>``; this PR adds the ``landing-surface`` warm-paper background so it visually matches the homepage instead of looking like a bare Mantine container.
- ``LocationProblemsListPage`` (``/maintenance/location-problems``)

## Stacking

Stacked on #398 (``oms-mayor/landing-style-rollout``). Will retarget to ``main`` after that PR merges.

## Test plan

- [x] ``CI=true npm test`` — affected suites green (12 / 12 + 5 / 5)
- [x] ``npm run build`` clean (warnings only)
- [x] ``pre-commit run`` on every changed file — green
- [ ] CI green