### PR TITLE
fix(forgekey): align MQTT with the firmware contract end-to-end

### DIFF
--- a/backend/config/tests/test_task_idempotency.py
+++ b/backend/config/tests/test_task_idempotency.py
@@ -166,8 +166,9 @@ class TestMQTTCommandIsLevelTriggered:
         second_topic, second_body = client.publish.call_args_list[1][0][:2]
         assert first_topic == second_topic
         # Command name is identical; only the timestamp differs (stamped per call).
-        assert '"command": "disable"' in first_body
-        assert '"command": "disable"' in second_body
+        # Firmware contract: verb is keyed under "cmd", not "command".
+        assert '"cmd": "disable"' in first_body
+        assert '"cmd": "disable"' in second_body
 
 
 @pytest.mark.django_db

--- a/backend/forgekey/management/commands/mqtt_consumer.py
+++ b/backend/forgekey/management/commands/mqtt_consumer.py
@@ -189,19 +189,57 @@ def handle_status_message(topic: str, payload: bytes) -> bool:
         logger.info("Dropping status message: unknown MAC %s on topic %s", mac, topic)
         return False
 
-    # Firmware ack channel: a status payload may include
-    # ``cmd_ack: {"command_id": ..., "status": ..., "error": ...}`` to mark a
-    # specific :class:`DeviceCommand` row as acked. Lives in status (not a
-    # separate topic) so the firmware needs no new MQTT subscription.
-    ack = body.get("cmd_ack") if isinstance(body, dict) else None
-    if isinstance(ack, dict):
-        from forgekey.services.device_commands import apply_command_ack
+    # Firmware ack channel: a status payload may include ``cmd_ack`` to
+    # mark a :class:`DeviceCommand` row as acked. Two shapes are accepted
+    # so we work with both the current firmware (flat) and any future
+    # firmware that grows the richer object form:
+    #
+    #   * Object form (preferred):
+    #       ``cmd_ack: {"command_id": "<uuid>", "status": "ok|error", ...}``
+    #     Acks a specific row by id — robust under burst commands.
+    #
+    #   * Flat form (current firmware):
+    #       ``cmd_ack: "<verb>"`` with sibling ``command_id`` / ``status``
+    #     fields, OR just the verb. Falls back to the most-recent
+    #     ``ACK_PENDING`` row of that verb for this device — best-effort
+    #     when the firmware doesn't echo the id.
+    #
+    # Lives in status (not a separate topic) so the firmware needs no
+    # new MQTT subscription.
+    if isinstance(body, dict) and "cmd_ack" in body:
+        from forgekey.services.device_commands import apply_command_ack, apply_command_ack_by_verb
 
-        apply_command_ack(
-            command_id=str(ack.get("command_id") or ""),
-            status=str(ack.get("status") or ""),
-            ack_payload=ack,
-        )
+        ack = body.get("cmd_ack")
+        sibling_command_id = body.get("command_id")
+        sibling_status = body.get("status") or body.get("ack_status") or "ok"
+
+        if isinstance(ack, dict):
+            apply_command_ack(
+                command_id=str(ack.get("command_id") or sibling_command_id or ""),
+                status=str(ack.get("status") or sibling_status or ""),
+                ack_payload=ack,
+            )
+        elif isinstance(ack, str):
+            verb = ack.strip()
+            if sibling_command_id:
+                apply_command_ack(
+                    command_id=str(sibling_command_id),
+                    status=str(sibling_status),
+                    ack_payload={
+                        "cmd_ack": verb,
+                        **{k: v for k, v in body.items() if k != "cmd_ack"},
+                    },
+                )
+            elif verb:
+                apply_command_ack_by_verb(
+                    device=ESP32Device.objects.filter(mac_address=mac).first(),
+                    verb=verb,
+                    status=str(sibling_status),
+                    ack_payload={
+                        "cmd_ack": verb,
+                        **{k: v for k, v in body.items() if k != "cmd_ack"},
+                    },
+                )
     return True
 
 

--- a/backend/forgekey/services/device_commands.py
+++ b/backend/forgekey/services/device_commands.py
@@ -31,6 +31,9 @@ class DeviceCommandError(RuntimeError):
     """Raised when the broker rejects a publish."""
 
 
+PUBACK_WAIT_SECONDS = 2.0
+
+
 def publish_command(
     device: ESP32Device,
     command_payload: Dict[str, Any],
@@ -41,9 +44,17 @@ def publish_command(
 ) -> str:
     """Publish a JSON command payload to a device's MQTT command topic.
 
-    Returns the topic the message was published on. Raises
-    :class:`DeviceCommandError` on broker rejection so callers can map it to
-    an HTTP 502 / retryable failure.
+    Waits up to ``PUBACK_WAIT_SECONDS`` for the broker PUBACK before
+    returning so callers get "broker has the message" rather than just
+    "queued in the local paho buffer". Returns the topic the message
+    was published on. Raises :class:`DeviceCommandError` on broker
+    rejection or PUBACK timeout so callers can map it to a retryable
+    failure.
+
+    Note: a successful return still does not guarantee the device
+    received the command — that's confirmed asynchronously via
+    ``cmd_ack`` on the device's status topic and tracked on the
+    :class:`DeviceCommand` row.
     """
 
     topic = get_mqtt_command_topic(device.mac_address)
@@ -63,6 +74,26 @@ def publish_command(
             payload,
         )
         raise DeviceCommandError(f"MQTT publish failed (rc={rc})")
+
+    # Block briefly for the broker PUBACK. paho's wait_for_publish blocks
+    # the calling thread until the broker confirms (QoS 1) or the timeout
+    # fires; a False return signals the broker dropped or never confirmed.
+    wait_for_publish = getattr(result, "wait_for_publish", None)
+    if callable(wait_for_publish):
+        try:
+            acknowledged = wait_for_publish(timeout=PUBACK_WAIT_SECONDS)
+        except (RuntimeError, ValueError):
+            # Older paho releases raise instead of returning False — treat
+            # as "broker never PUBACK'd" rather than letting it bubble up.
+            acknowledged = False
+        # paho < 2.0 returns None (no signal); only fail on explicit False.
+        if acknowledged is False:
+            logger.error(
+                "Command publish broker PUBACK timeout: device=%s topic=%s",
+                device.mac_address,
+                topic,
+            )
+            raise DeviceCommandError(f"MQTT broker did not PUBACK within {PUBACK_WAIT_SECONDS}s")
 
     actor_id = None
     actor_username = None
@@ -138,6 +169,17 @@ def dispatch_command(
     return topic, record
 
 
+def _resolve_ack_status(status: str) -> str:
+    normalized = (status or "").lower()
+    if normalized in ("ok", "success", "acked", "complete", "completed", "done"):
+        return DeviceCommand.ACK_OK
+    if normalized in ("error", "failed", "failure", "rejected", "unknown_command"):
+        return DeviceCommand.ACK_ERROR
+    # Treat anything else as an error so the UI surfaces the firmware
+    # message rather than silently leaving the command pending.
+    return DeviceCommand.ACK_ERROR
+
+
 def apply_command_ack(
     *,
     command_id: str,
@@ -152,22 +194,57 @@ def apply_command_ack(
     """
     if not command_id:
         return False
-    normalized = (status or "").lower()
-    if normalized in ("ok", "success", "acked", "complete", "completed", "done"):
-        ack_status = DeviceCommand.ACK_OK
-    elif normalized in ("error", "failed", "failure", "rejected", "unknown_command"):
-        ack_status = DeviceCommand.ACK_ERROR
-    else:
-        # Treat anything else as an error so the UI surfaces the firmware
-        # message rather than silently leaving the command pending.
-        ack_status = DeviceCommand.ACK_ERROR
-
     rows = DeviceCommand.objects.filter(id=command_id, ack_status=DeviceCommand.ACK_PENDING).update(
-        ack_status=ack_status,
+        ack_status=_resolve_ack_status(status),
         ack_at=timezone.now(),
         ack_payload=ack_payload or None,
     )
     return rows > 0
 
 
-__all__ = ["DeviceCommandError", "publish_command", "dispatch_command", "apply_command_ack"]
+def apply_command_ack_by_verb(
+    *,
+    device: Optional[ESP32Device],
+    verb: str,
+    status: str,
+    ack_payload: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Best-effort ack when the firmware doesn't echo a ``command_id``.
+
+    Matches the most-recent pending :class:`DeviceCommand` row for the
+    given device whose ``command`` matches ``verb``. Used for the flat
+    ``cmd_ack: "<verb>"`` snapshot form the current firmware emits.
+    Returns ``True`` if a row was updated.
+
+    Caveat: under a burst of two identical commands this collapses both
+    into the older row. The object-form ack (``cmd_ack: {command_id, ...}``)
+    is preferred and should be adopted by future firmware.
+    """
+    if device is None or not verb:
+        return False
+    pending = (
+        DeviceCommand.objects.filter(
+            device=device,
+            command=verb,
+            ack_status=DeviceCommand.ACK_PENDING,
+        )
+        .order_by("-sent_at")
+        .first()
+    )
+    if pending is None:
+        return False
+    DeviceCommand.objects.filter(pk=pending.pk).update(
+        ack_status=_resolve_ack_status(status),
+        ack_at=timezone.now(),
+        ack_payload=ack_payload or None,
+    )
+    return True
+
+
+__all__ = [
+    "DeviceCommandError",
+    "publish_command",
+    "dispatch_command",
+    "apply_command_ack",
+    "apply_command_ack_by_verb",
+]

--- a/backend/forgekey/tasks.py
+++ b/backend/forgekey/tasks.py
@@ -65,7 +65,25 @@ def get_mqtt_client() -> mqtt.Client:
     global _mqtt_client, _mqtt_connect_failed_at
 
     if _mqtt_client is not None:
-        return _mqtt_client
+        # Trust paho's `is_connected()` over our singleton cache: a backend
+        # that lost its broker session and never reconnected was returning
+        # the stale client and silently swallowing publishes. Drop and
+        # re-create when the link is dead so the next caller gets a live
+        # client (the cooldown still protects against thrashing — a
+        # failing reconnect updates _mqtt_connect_failed_at below).
+        is_connected_fn = getattr(_mqtt_client, "is_connected", None)
+        if is_connected_fn is None or is_connected_fn():
+            return _mqtt_client
+        logger.warning("MQTT client cached but not connected; recreating")
+        try:
+            _mqtt_client.loop_stop()
+        except Exception as cleanup_exc:
+            logger.warning("MQTT cleanup: loop_stop() on stale client: %s", cleanup_exc)
+        try:
+            _mqtt_client.disconnect()
+        except Exception as cleanup_exc:
+            logger.warning("MQTT cleanup: disconnect() on stale client: %s", cleanup_exc)
+        _mqtt_client = None
 
     cooldown = getattr(settings, "MQTT_CONNECT_RETRY_COOLDOWN_SECONDS", 30)
     if _mqtt_connect_failed_at:
@@ -167,8 +185,12 @@ def send_mqtt_command(
         client = get_mqtt_client()
         topic = get_mqtt_command_topic(mac_address)
 
+        # Firmware contract: the command verb is keyed under ``cmd``, not
+        # ``command``. The older ``"command"`` key was silently dropped by
+        # firmware so /enable, /disable, and /status were no-ops on the
+        # device side even after the topic was correct.
         message = {
-            "command": command,
+            "cmd": command,
             "timestamp": timezone.now().isoformat(),
         }
 

--- a/backend/forgekey/tests/test_device_commands.py
+++ b/backend/forgekey/tests/test_device_commands.py
@@ -253,3 +253,80 @@ class TestPublishCommandStillReturnsTopic:
         topic = publish_command(device, {"cmd": "restart"}, client=client)
         assert isinstance(topic, str)
         assert topic.endswith("/command")
+
+
+class TestPublishCommandWaitsForBrokerAck:
+    """publish_command must wait for the broker PUBACK so callers don't get a
+    success return for a publish the broker actually dropped."""
+
+    def test_pubacked_publish_returns_topic(self):
+        from forgekey.services.device_commands import publish_command
+
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:00:60")
+        result = MagicMock(rc=0)
+        result.wait_for_publish.return_value = True
+        client = MagicMock()
+        client.publish.return_value = result
+
+        topic = publish_command(device, {"cmd": "restart"}, client=client)
+        assert topic.endswith("/command")
+        result.wait_for_publish.assert_called_once()
+
+    def test_puback_timeout_raises_device_command_error(self):
+        from forgekey.services.device_commands import DeviceCommandError, publish_command
+
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:00:61")
+        result = MagicMock(rc=0)
+        result.wait_for_publish.return_value = False
+        client = MagicMock()
+        client.publish.return_value = result
+
+        with pytest.raises(DeviceCommandError, match="PUBACK"):
+            publish_command(device, {"cmd": "restart"}, client=client)
+
+
+class TestStatusHandlerAcceptsFlatCmdAck:
+    """Current firmware emits ``cmd_ack: "<verb>"`` (a flat string) rather
+    than the richer object form. The consumer must accept both."""
+
+    def test_flat_cmd_ack_with_sibling_command_id(self):
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:00:70")
+        rec = DeviceCommand.objects.create(device=device, command="status", payload={})
+        topic = f"forgekey/{device.mac_address.replace(':', '').lower()}/status"
+        body = json.dumps(
+            {
+                "online": True,
+                "cmd_ack": "status",
+                "command_id": str(rec.id),
+                "status": "ok",
+            }
+        ).encode("utf-8")
+
+        assert handle_status_message(topic, body) is True
+        rec.refresh_from_db()
+        assert rec.ack_status == DeviceCommand.ACK_OK
+
+    def test_flat_cmd_ack_falls_back_to_most_recent_pending_of_verb(self):
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:00:71")
+        # Older pending row of the same verb — should be skipped in favour
+        # of the newer one.
+        DeviceCommand.objects.create(
+            device=device,
+            command="status",
+            payload={},
+            sent_at=timezone.now() - timedelta(seconds=30),
+        )
+        newer = DeviceCommand.objects.create(device=device, command="status", payload={})
+        topic = f"forgekey/{device.mac_address.replace(':', '').lower()}/status"
+        body = json.dumps({"online": True, "cmd_ack": "status"}).encode("utf-8")
+
+        assert handle_status_message(topic, body) is True
+        newer.refresh_from_db()
+        assert newer.ack_status == DeviceCommand.ACK_OK
+
+    def test_flat_cmd_ack_for_unknown_device_is_silent(self):
+        topic = "forgekey/aabbcc000099/status"
+        body = json.dumps({"online": True, "cmd_ack": "status"}).encode("utf-8")
+        # Unknown MAC: handle_status_message returns False (nothing to do)
+        # rather than raising.
+        assert handle_status_message(topic, body) is False

--- a/backend/forgekey/tests/test_firmware_signing.py
+++ b/backend/forgekey/tests/test_firmware_signing.py
@@ -340,10 +340,11 @@ class TestRotateProvisioningTokenCommand:
             )
 
         topics = [call.args[0] for call in client.publish.call_args_list]
+        # Firmware contract MAC encoding: lowercase hex, no separators.
         assert sorted(topics) == sorted(
             [
-                f"forgekey/{a.mac_address.replace(':', '-')}/config",
-                f"forgekey/{b.mac_address.replace(':', '-')}/config",
+                f"forgekey/{a.mac_address.replace(':', '').lower()}/config",
+                f"forgekey/{b.mac_address.replace(':', '').lower()}/config",
             ]
         )
 

--- a/backend/forgekey/tests/test_mqtt_consumer.py
+++ b/backend/forgekey/tests/test_mqtt_consumer.py
@@ -197,9 +197,11 @@ class TestPublishCommandService:
                 client=client,
             )
 
-        # Command topic uses the colon→hyphen form per get_mqtt_command_topic
+        # Command topic uses the firmware contract MAC encoding
+        # (lowercase hex, no separators) — see get_mqtt_command_topic.
         assert topic.endswith("/command")
-        assert device.mac_address.replace(":", "-") in topic
+        contract_mac = device.mac_address.replace(":", "").lower()
+        assert contract_mac in topic
         # Payload has the command and a server-applied timestamp
         published_topic, body, *_rest = client.publish.call_args[0]
         body_obj = json.loads(body)

--- a/backend/forgekey/tests/test_tasks.py
+++ b/backend/forgekey/tests/test_tasks.py
@@ -39,6 +39,24 @@ class TestMQTTTasks:
         assert result["command"] == "enable"
         mock_client.publish.assert_called_once()
 
+    @patch("forgekey.tasks.get_mqtt_client")
+    def test_send_mqtt_command_uses_firmware_payload_contract(self, mock_get_client):
+        """Published payload must key the verb under ``cmd`` — firmware
+        ignores the older ``command`` key."""
+        import json
+
+        mock_client = MagicMock()
+        mock_client.publish.return_value.rc = 0
+        mock_get_client.return_value = mock_client
+
+        send_mqtt_command("AA:BB:CC:DD:EE:FF", "enable")
+
+        topic, body, *_ = mock_client.publish.call_args[0]
+        assert topic.endswith("/aabbccddeeff/command")
+        body_obj = json.loads(body)
+        assert body_obj["cmd"] == "enable"
+        assert "command" not in body_obj
+
     @patch("forgekey.tasks.send_mqtt_command")
     def test_enable_device(self, mock_send_command):
         """Test enabling a device."""
@@ -280,6 +298,41 @@ class TestMQTTTasks:
 
         with pytest.raises(Exception, match="Connection refused"):
             get_mqtt_client()
+
+    @patch("paho.mqtt.client.Client")
+    @patch("forgekey.tasks.settings")
+    def test_get_mqtt_client_drops_disconnected_singleton(self, mock_settings, mock_client_class):
+        """Stale-singleton bug: a backend that lost its broker session was
+        getting handed back the dead client and silently dropping publishes.
+        After the link is dead, the next call must recreate."""
+        from forgekey.tasks import _reset_mqtt_client_state_for_tests, get_mqtt_client
+
+        _reset_mqtt_client_state_for_tests()
+        mock_settings.MQTT_CLIENT_ID = "test-client"
+        mock_settings.MQTT_BROKER_HOST = "localhost"
+        mock_settings.MQTT_BROKER_PORT = 1883
+        mock_settings.MQTT_KEEPALIVE = 60
+        mock_settings.MQTT_BROKER_USERNAME = ""  # nosec B105
+        mock_settings.MQTT_BROKER_PASSWORD = ""  # nosec B105
+        mock_settings.MQTT_CONNECT_RETRY_COOLDOWN_SECONDS = 0
+
+        first_client = MagicMock()
+        second_client = MagicMock()
+        mock_client_class.side_effect = [first_client, second_client]
+
+        # First call connects + caches.
+        first_client.is_connected.return_value = True
+        client = get_mqtt_client()
+        assert client is first_client
+
+        # Simulate a dropped broker connection on the cached client.
+        first_client.is_connected.return_value = False
+        second_client.is_connected.return_value = True
+
+        client = get_mqtt_client()
+        assert client is second_client, "expected a fresh client when cached one is disconnected"
+        first_client.loop_stop.assert_called_once()
+        first_client.disconnect.assert_called_once()
 
 
 @pytest.mark.django_db

--- a/backend/forgekey/tests/test_utils.py
+++ b/backend/forgekey/tests/test_utils.py
@@ -54,16 +54,28 @@ class TestMQTTTopics:
     """Tests for MQTT topic generation."""
 
     def test_command_topic(self):
+        # Lowercase, no separators — matches the firmware subscription
+        # contract (firmware listens on forgekey/<mac>/command). The old
+        # UPPER-WITH-HYPHENS encoding silently broke command delivery
+        # because the device was never subscribed to that topic.
         topic = get_mqtt_command_topic("AA:BB:CC:DD:EE:FF")
-        assert topic == f"{settings.MQTT_TOPIC_PREFIX}/AA-BB-CC-DD-EE-FF/command"
+        assert topic == f"{settings.MQTT_TOPIC_PREFIX}/aabbccddeeff/command"
 
     def test_status_topic(self):
         topic = get_mqtt_status_topic("AA:BB:CC:DD:EE:FF")
-        assert topic == f"{settings.MQTT_TOPIC_PREFIX}/AA-BB-CC-DD-EE-FF/status"
+        assert topic == f"{settings.MQTT_TOPIC_PREFIX}/aabbccddeeff/status"
 
     def test_data_topic(self):
         topic = get_mqtt_data_topic("AA:BB:CC:DD:EE:FF")
-        assert topic == f"{settings.MQTT_TOPIC_PREFIX}/AA-BB-CC-DD-EE-FF/data"
+        assert topic == f"{settings.MQTT_TOPIC_PREFIX}/aabbccddeeff/data"
+
+    def test_command_topic_normalizes_arbitrary_input_format(self):
+        """Any reasonable input shape resolves to the contract topic."""
+        expected = f"{settings.MQTT_TOPIC_PREFIX}/aabbccddeeff/command"
+        assert get_mqtt_command_topic("aa:bb:cc:dd:ee:ff") == expected
+        assert get_mqtt_command_topic("AA-BB-CC-DD-EE-FF") == expected
+        assert get_mqtt_command_topic("aabbccddeeff") == expected
+        assert get_mqtt_command_topic("AABBCCDDEEFF") == expected
 
 
 @pytest.mark.unit

--- a/backend/forgekey/utils.py
+++ b/backend/forgekey/utils.py
@@ -207,15 +207,20 @@ def get_mqtt_topic(mac_address: str, topic_type: str) -> str:
     """
     Generate MQTT topic for a device.
 
+    Uses the firmware provisioning contract MAC encoding (lowercase hex,
+    no separators) — the same form the firmware subscribes / publishes
+    on and the same form the JWT ACL grants. The previous
+    ``UPPER-WITH-HYPHENS`` encoding silently broke command delivery
+    because the device was never subscribed to that topic.
+
     Args:
-        mac_address: MAC address of the device
+        mac_address: MAC address of the device (any input format)
         topic_type: Type of topic (e.g., 'command', 'status', 'data')
 
     Returns:
-        MQTT topic string
+        MQTT topic string, e.g. ``forgekey/aabbccddeeff/command``.
     """
-    normalized_mac = normalize_mac_address(mac_address).replace(":", "-")
-    return f"{settings.MQTT_TOPIC_PREFIX}/{normalized_mac}/{topic_type}"
+    return f"{settings.MQTT_TOPIC_PREFIX}/{_firmware_contract_mac(mac_address)}/{topic_type}"
 
 
 def get_mqtt_command_topic(mac_address: str) -> str:


### PR DESCRIPTION
## Summary

Five interlocking bugs were keeping commands from ever reaching a
ForgeKey device — and even when delivery worked, OMS reported the
command as un-acked. They all trace back to the firmware contract
already encoded in ``_firmware_contract_mac`` (lowercase hex, no
separators); the publish + ack paths just hadn't been brought into line.

### 1. Topic mismatch (the biggest one)

``get_mqtt_topic()`` was emitting ``forgekey/AA-BB-CC-DD-EE-FF/<verb>``,
but firmware subscribes on ``forgekey/aabbccddeeff/<verb>``. **The
device never saw the publish.** Fixed by routing ``get_mqtt_topic``
through ``_firmware_contract_mac``.

### 2. Stale Celery payload key

``send_mqtt_command`` (used by ``/enable``, ``/disable``, and the older
``/status`` endpoints) was emitting ``{\"command\": ...}``. Firmware
ignores anything that isn't keyed under ``cmd``. Switched to
``{\"cmd\": ...}``.

### 3. Ack tracking expected the wrong shape

Current firmware emits ``cmd_ack: \"<verb>\"`` as a flat snapshot field;
``mqtt_consumer`` only matched the richer ``cmd_ack: {command_id, status}``
object form. Now accepts both:
- Object form acks the row by id (preferred, no ambiguity)
- Flat form acks by sibling ``command_id`` if present, otherwise falls
  back to the most-recent-pending row of that verb for the device

New ``apply_command_ack_by_verb`` helper carries the fallback path.

### 4. ``publish() rc==0`` was treated as device-received

It only means \"queued in the local paho buffer.\" Added a
``wait_for_publish`` block (2s) so callers get the broker PUBACK before
returning, and raise ``DeviceCommandError`` if the broker never
confirms. Docstring spells out that even a PUBACK doesn't guarantee
device delivery — that still rides on the ``cmd_ack`` channel.

### 5. MQTT singleton never revalidated

``get_mqtt_client()`` handed back the cached client even after the
broker session dropped, silently losing every subsequent publish.
Now checks ``is_connected()`` and re-creates if false (with the
existing cooldown still gating reconnect storms).

## Tests

- ``test_command_topic_normalizes_arbitrary_input_format`` — locks
  in the firmware contract for arbitrary input MAC shapes
- ``test_send_mqtt_command_uses_firmware_payload_contract`` — pins
  the ``cmd`` key
- ``TestPublishCommandWaitsForBrokerAck`` — PUBACK happy path +
  timeout-raises path
- ``TestStatusHandlerAcceptsFlatCmdAck`` — flat form with sibling
  id, flat form fallback to most-recent-pending, and silent drop
  for unknown MAC
- ``test_get_mqtt_client_drops_disconnected_singleton`` — stale
  cached client gets cleaned up + replaced

Plus an existing ``test_firmware_signing`` fixture updated for the
new topic encoding.

All 316 forgekey tests pass; permission-matrix test still green.

## Notes for review

- I left the doc string in ``publish_command`` honest: this PR
  closes the broker-side gap (PUBACK), but device-side delivery
  is still confirmed asynchronously via ``cmd_ack``. The UI's
  \"timeout\" badge after the existing 5 minute window already
  surfaces the device-not-acked case correctly once the topic is
  right.
- Footguns the user mentioned (literal MQTT credentials in
  production, ALLOWED_HOSTS / JWKS) are deployment config issues
  flagged by ``checks.py``, not code bugs — left untouched in this
  PR.

## Test plan

- [x] ``pytest forgekey/`` — 316 / 316 pass
- [x] ``pytest config/tests/test_permission_matrix.py`` — green
  (no new endpoints to register)
- [x] ``pre-commit run`` on every changed file — green
- [ ] CI green
- [ ] Manual smoke on a real device once merged: open the
  ForgeKey live control panel, hit \"ping\", confirm a status
  payload comes back AND the command ack flips from pending to
  acked in the recent-commands view