### PR TITLE
feat(ui): landing-surface rollout — form pages (batch 3)

### DIFF
--- a/frontend/src/__tests__/pages/AssetFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/AssetFormPage.test.tsx
@@ -114,7 +114,7 @@ describe('AssetFormPage', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Create Asset' })).toBeInTheDocument();
+      expect(screen.getByTestId('page-hero-title')).toBeInTheDocument();
     });
 
     expect(screen.getByLabelText(/Name/i)).toBeInTheDocument();
@@ -318,7 +318,7 @@ describe('AssetFormPage', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Edit Asset')).toBeInTheDocument();
+      expect(screen.getByTestId('page-hero-title')).toHaveTextContent(/edit asset/i);
     });
 
     await waitFor(() => {
@@ -342,7 +342,7 @@ describe('AssetFormPage', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.getByText(/Loading asset/)).toBeInTheDocument();
   });
 
   it('handles API responses with missing results property gracefully', async () => {
@@ -390,7 +390,7 @@ describe('AssetFormPage', () => {
 
     // Should render the form (not crash) - arrays should be empty, not undefined
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Create Asset' })).toBeInTheDocument();
+      expect(screen.getByTestId('page-hero-title')).toBeInTheDocument();
     });
 
     // Form fields should be accessible (arrays should be empty, not undefined)
@@ -424,7 +424,7 @@ describe('AssetFormPage', () => {
 
     // Should still render the form (not crash)
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Create Asset' })).toBeInTheDocument();
+      expect(screen.getByTestId('page-hero-title')).toBeInTheDocument();
     });
 
     // Form fields should be accessible (arrays should be empty, not undefined)
@@ -538,7 +538,7 @@ describe('AssetFormPage', () => {
 
     // Should render the edit form (not crash) - arrays should be empty, not undefined
     await waitFor(() => {
-      expect(screen.getByText('Edit Asset')).toBeInTheDocument();
+      expect(screen.getByTestId('page-hero-title')).toHaveTextContent(/edit asset/i);
     });
 
     // Asset data should still be loaded

--- a/frontend/src/__tests__/pages/InventoryItemFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemFormPage.test.tsx
@@ -160,7 +160,7 @@ describe('InventoryItemFormPage', () => {
     renderCreatePage();
 
     await waitFor(() => {
-      expect(screen.getByText('Create Inventory Item')).toBeInTheDocument();
+      expect(screen.getByTestId('page-hero-title')).toHaveTextContent(/new item/i);
     });
 
     // Use getAllByLabelText and get the first one if multiple
@@ -173,7 +173,7 @@ describe('InventoryItemFormPage', () => {
     renderEditPage();
 
     await waitFor(() => {
-      expect(screen.getByText('Edit Inventory Item')).toBeInTheDocument();
+      expect(screen.getByTestId('page-hero-title')).toHaveTextContent(/edit item/i);
     });
 
     expect(screen.getByDisplayValue('Test Item')).toBeInTheDocument();
@@ -293,7 +293,7 @@ describe('InventoryItemFormPage', () => {
     renderCreatePage();
 
     await waitFor(() => {
-      expect(screen.getByText('Create Inventory Item')).toBeInTheDocument();
+      expect(screen.getByTestId('page-hero-title')).toHaveTextContent(/new item/i);
     });
 
     // Open create-category modal flow if "Create New Category" button is exposed.

--- a/frontend/src/__tests__/pages/SupplierFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/SupplierFormPage.test.tsx
@@ -32,7 +32,7 @@ describe('SupplierFormPage - Create Mode', () => {
       </MantineProvider>
     );
 
-    expect(screen.getByText('Create New Supplier')).toBeInTheDocument();
+    expect(screen.getByTestId('page-hero-title')).toHaveTextContent(/new supplier/i);
     // Check for name input by placeholder
     expect(screen.getByPlaceholderText('Supplier name')).toBeInTheDocument();
   });

--- a/frontend/src/pages/AssetFormPage.tsx
+++ b/frontend/src/pages/AssetFormPage.tsx
@@ -3,7 +3,7 @@
  * Create/Edit form for assets with all fields
  */
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Alert, Button, Group, Modal, Paper, Stack, Switch, Text, TextInput, Title } from '@mantine/core';
+import { Alert, Button, Group, Modal, Paper, Stack, Switch, Text, TextInput } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -15,6 +15,7 @@ import { FormLayout } from '../components/forms/FormLayout';
 import { FormNumberInput } from '../components/forms/FormNumberInput';
 import { FormSelect } from '../components/forms/FormSelect';
 import { FormTextarea } from '../components/forms/FormTextarea';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { assetsAPI, inventoryAPI, sigAPI } from '../services/api';
 import { Asset, Category, InventoryItem, Location, SIG } from '../types';
 import { AssetFormData, assetFormSchema } from '../utils/formSchemas';
@@ -237,9 +238,14 @@ const AssetFormPage: React.FC = () => {
 
   if (loading) {
     return (
-      <Paper p="md">
-        <Text>Loading...</Text>
-      </Paper>
+      <WorkspacePage
+        testId="asset-form-page"
+        hero={{ eyebrow: 'Assets', title: 'Asset', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading asset…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
@@ -274,14 +280,21 @@ const AssetFormPage: React.FC = () => {
   const sigOptions = sigs.map((sig) => ({ value: String(sig.id), label: sig.name }));
 
   return (
-    <Stack gap="md">
-      <Group justify="space-between">
-        <Title order={2}>{isEditMode ? 'Edit Asset' : 'Create Asset'}</Title>
-        <Button variant="subtle" onClick={() => navigate(-1)}>
-          Cancel
-        </Button>
-      </Group>
-
+    <WorkspacePage
+      testId="asset-form-page"
+      hero={{
+        eyebrow: 'Assets',
+        title: isEditMode ? 'Edit asset' : 'New asset',
+        description: isEditMode
+          ? 'Update lifecycle, ownership, maintenance plan, and parts.'
+          : 'Register a new piece of equipment in the asset roster.',
+        action: (
+          <Button variant="default" onClick={() => navigate(-1)}>
+            Cancel
+          </Button>
+        ),
+      }}
+    >
       {error && (
         <Alert icon={<IconAlertCircle size={16} />} title="Error" color="red">
           {error}
@@ -647,7 +660,7 @@ const AssetFormPage: React.FC = () => {
           </Group>
         </Stack>
       </Modal>
-    </Stack>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/CategoryFormPage.tsx
+++ b/frontend/src/pages/CategoryFormPage.tsx
@@ -2,9 +2,11 @@
  * Category Form Page
  * Create/Edit form for categories
  */
+import { Paper, Text } from '@mantine/core';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import ColorPicker from '../components/ColorPicker';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { inventoryAPI } from '../services/api';
 import '../styles/CategoryFormPage.css';
 import { Category } from '../types';
@@ -140,23 +142,32 @@ const CategoryFormPage: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="category-form-page">
-        <div className="loading">Loading category...</div>
-      </div>
+      <WorkspacePage
+        testId="category-form-page"
+        hero={{ eyebrow: 'Inventory · Category', title: 'Category', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading category…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   return (
-    <div className="category-form-page">
-      <header className="page-header">
-        <h1>{isEditMode ? 'Edit Category' : 'Create Category'}</h1>
-      </header>
-
-      {error && (
-        <div className="error-message">
-          {error}
-        </div>
-      )}
+    <WorkspacePage
+      testId="category-form-page"
+      hero={{
+        eyebrow: 'Inventory · Category',
+        title: isEditMode ? 'Edit category' : 'New category',
+        description: 'Categories group SKUs for reporting and reorder approvals.',
+      }}
+    >
+      <div className="category-form-page">
+        {error && (
+          <div className="error-message">
+            {error}
+          </div>
+        )}
 
       <form onSubmit={handleSubmit} className="category-form">
         <div className="form-group">
@@ -226,7 +237,8 @@ const CategoryFormPage: React.FC = () => {
           </button>
         </div>
       </form>
-    </div>
+      </div>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/InventoryItemFormPage.tsx
+++ b/frontend/src/pages/InventoryItemFormPage.tsx
@@ -17,6 +17,7 @@ import { FormLayout } from '../components/forms/FormLayout';
 import { FormNumberInput } from '../components/forms/FormNumberInput';
 import { FormSelect } from '../components/forms/FormSelect';
 import { FormTextarea } from '../components/forms/FormTextarea';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { inventoryAPI } from '../services/api';
 import { Category, InventoryItem, ItemSupplier, Location, Supplier } from '../types';
 import { promptInput, showError } from '../utils/dialogs';
@@ -241,9 +242,14 @@ const InventoryItemFormPage: React.FC = () => {
 
   if (loading) {
     return (
-      <Paper p="md">
-        <Text>Loading...</Text>
-      </Paper>
+      <WorkspacePage
+        testId="inventory-item-form-page"
+        hero={{ eyebrow: 'Inventory · Item', title: 'Item', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading item…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
@@ -258,14 +264,21 @@ const InventoryItemFormPage: React.FC = () => {
   ];
 
   return (
-    <Stack gap="md">
-      <Group justify="space-between">
-        <Title order={2}>{isEditMode ? 'Edit Inventory Item' : 'Create Inventory Item'}</Title>
-        <Button variant="subtle" onClick={() => navigate(-1)}>
-          Cancel
-        </Button>
-      </Group>
-
+    <WorkspacePage
+      testId="inventory-item-form-page"
+      hero={{
+        eyebrow: 'Inventory · Item',
+        title: isEditMode ? 'Edit item' : 'New item',
+        description: isEditMode
+          ? 'Update stock thresholds, suppliers, hazard data, and pricing.'
+          : 'Register a new inventory SKU with reorder thresholds and a primary supplier.',
+        action: (
+          <Button variant="default" onClick={() => navigate(-1)}>
+            Cancel
+          </Button>
+        ),
+      }}
+    >
       {error && (
         <Alert icon={<IconAlertCircle size={16} />} title="Error" color="red">
           {error}
@@ -577,7 +590,7 @@ const InventoryItemFormPage: React.FC = () => {
           </Group>
         </Stack>
       </Modal>
-    </Stack>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/LocationFormPage.tsx
+++ b/frontend/src/pages/LocationFormPage.tsx
@@ -2,8 +2,10 @@
  * Location Form Page
  * Create/Edit form for locations
  */
+import { Paper, Text } from '@mantine/core';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { inventoryAPI } from '../services/api';
 import '../styles/LocationFormPage.css';
 import { Location } from '../types';
@@ -135,23 +137,32 @@ const LocationFormPage: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="location-form-page">
-        <div className="loading">Loading location...</div>
-      </div>
+      <WorkspacePage
+        testId="location-form-page"
+        hero={{ eyebrow: 'Inventory · Location', title: 'Location', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading location…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   return (
-    <div className="location-form-page">
-      <header className="page-header">
-        <h1>{isEditMode ? 'Edit Location' : 'Create Location'}</h1>
-      </header>
-
-      {error && (
-        <div className="error-message">
-          {error}
-        </div>
-      )}
+    <WorkspacePage
+      testId="location-form-page"
+      hero={{
+        eyebrow: 'Inventory · Location',
+        title: isEditMode ? 'Edit location' : 'New location',
+        description: 'Locations describe where in the shop something lives — used by every QR scan path.',
+      }}
+    >
+      <div className="location-form-page">
+        {error && (
+          <div className="error-message">
+            {error}
+          </div>
+        )}
 
       <form onSubmit={handleSubmit} className="location-form">
         <div className="form-group">
@@ -225,7 +236,8 @@ const LocationFormPage: React.FC = () => {
           </button>
         </div>
       </form>
-    </div>
+      </div>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/SupplierFormPage.tsx
+++ b/frontend/src/pages/SupplierFormPage.tsx
@@ -8,10 +8,8 @@ import {
     Button,
     Group,
     Paper,
-    Stack,
     Switch,
     Text,
-    Title,
 } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
@@ -21,6 +19,7 @@ import { FormInput } from '../components/forms/FormInput';
 import { FormLayout } from '../components/forms/FormLayout';
 import { FormSelect } from '../components/forms/FormSelect';
 import { FormTextarea } from '../components/forms/FormTextarea';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { inventoryAPI } from '../services/api';
 import { SupplierFormData, supplierSchema } from '../utils/formSchemas';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
@@ -107,16 +106,28 @@ const SupplierFormPage: React.FC = () => {
 
   if (loading) {
     return (
-      <Stack gap="md">
-        <Text>Loading supplier...</Text>
-      </Stack>
+      <WorkspacePage
+        testId="supplier-form-page"
+        hero={{ eyebrow: 'Inventory · Supplier', title: 'Supplier', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading supplier…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   return (
-    <Stack gap="md">
-      <Title order={2}>{isEditMode ? 'Edit Supplier' : 'Create New Supplier'}</Title>
-
+    <WorkspacePage
+      testId="supplier-form-page"
+      hero={{
+        eyebrow: 'Inventory · Supplier',
+        title: isEditMode ? 'Edit supplier' : 'New supplier',
+        description: isEditMode
+          ? 'Update contact info, tax-free paperwork status, and notes.'
+          : 'Add a new supplier so items can be sourced from it.',
+      }}
+    >
       {error && (
         <Alert icon={<IconAlertCircle size={16} />} title="Error" color="red">
           {error}
@@ -212,7 +223,7 @@ const SupplierFormPage: React.FC = () => {
           </Group>
         </Paper>
       </form>
-    </Stack>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/WebhookFormPage.tsx
+++ b/frontend/src/pages/WebhookFormPage.tsx
@@ -21,6 +21,7 @@ import { FormInput } from '../components/forms/FormInput';
 import { FormLayout } from '../components/forms/FormLayout';
 import { FormSelect } from '../components/forms/FormSelect';
 import { FormTextarea } from '../components/forms/FormTextarea';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { webhooksAPI } from '../services/api';
 import '../styles/WebhookFormPage.css';
 import { WebhookFormData, webhookSchema } from '../utils/formSchemas';
@@ -150,17 +151,29 @@ const WebhookFormPage: React.FC = () => {
 
   if (loading) {
     return (
-      <Stack gap="md">
-        <Text>Loading webhook...</Text>
-      </Stack>
+      <WorkspacePage
+        testId="webhook-form-page"
+        hero={{ eyebrow: 'Settings · Webhook', title: 'Webhook', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading webhook…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   return (
-    <div className="webhook-form-page">
-      <Stack gap="md">
-        <Title order={2}>{isEditMode ? 'Edit Webhook' : 'Create New Webhook'}</Title>
-
+    <WorkspacePage
+      testId="webhook-form-page"
+      hero={{
+        eyebrow: 'Settings · Webhook',
+        title: isEditMode ? 'Edit webhook' : 'New webhook',
+        description: isEditMode
+          ? 'Update target URL, secret, and event subscriptions.'
+          : 'Subscribe an external system to OMS events with a signed payload.',
+      }}
+    >
+      <div className="webhook-form-page">
         {error && (
           <Alert icon={<IconAlertCircle size={16} />} title="Error" color="red">
             {error}
@@ -275,8 +288,8 @@ const WebhookFormPage: React.FC = () => {
             </Group>
           </Paper>
         </form>
-      </Stack>
-    </div>
+      </div>
+    </WorkspacePage>
   );
 };
 


### PR DESCRIPTION
## Summary

Continues the homepage look-and-feel migration onto the create/edit form
pages so the warm-paper hero pattern extends into the surfaces staff
use to add or modify inventory, assets, suppliers, locations,
categories, and webhooks. Same ``<WorkspacePage>`` shell as #398 / #399.

## Pages migrated

- ``SupplierFormPage`` (``/inventory/suppliers/new`` + ``/:id/edit``)
- ``AssetFormPage`` (``/inventory/assets/new`` + ``/:id/edit``)
- ``InventoryItemFormPage`` (``/inventory/items/new`` + ``/:id/edit``)
- ``WebhookFormPage`` (``/settings/webhooks/new`` + ``/:id/edit``)
- ``CategoryFormPage`` (``/inventory/categories/new`` + ``/:id/edit``)
- ``LocationFormPage`` (``/inventory/locations/new`` + ``/:id/edit``)

## Tests

- 23 / 23 in the affected suites pass
- Pinned to ``getByTestId('page-hero-title')`` where they previously
  pinned the (now-changed) literal heading text
- Submit button labels untouched, so submit-flow assertions stay valid

## Test plan

- [x] ``CI=true npm test`` on affected suites — green
- [x] ``npm run build`` clean
- [x] ``pre-commit run`` — green
- [ ] CI green