### PR TITLE
feat(electrical): power-topology CRUD (oms-b25 [7/7])

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -334,6 +334,110 @@ views:
   electrical_circuits.views.PanelDirectoryReportView:
     permission_classes:
     - IsAuthenticated
+  electrical_circuits.views.PowerBreakerViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      list:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+  electrical_circuits.views.PowerCircuitViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      list:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+  electrical_circuits.views.PowerOutletViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      list:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+  electrical_circuits.views.PowerPanelViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      list:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
   forgekey.views.AssetAuthorizationViewSet:
     actions:
       add_via_classroom_mode:

--- a/backend/electrical_circuits/serializers.py
+++ b/backend/electrical_circuits/serializers.py
@@ -2,7 +2,16 @@
 
 from rest_framework import serializers
 
-from .models import Breaker, LightSwitch, NetworkDrop, Outlet
+from .models import (
+    Breaker,
+    LightSwitch,
+    NetworkDrop,
+    Outlet,
+    PowerBreaker,
+    PowerCircuit,
+    PowerOutlet,
+    PowerPanel,
+)
 
 
 class BreakerSerializer(serializers.ModelSerializer):
@@ -89,6 +98,148 @@ class LightSwitchSerializer(serializers.ModelSerializer):
             return None
         b = obj.breaker
         return f"{b.panel} / {b.breaker_number}"
+
+
+# ---------------------------------------------------------------------
+# Power topology CRUD (oms-b25 + oms-wwx). Distinct from the legacy
+# Breaker / Outlet flat-pair serializers above — these write to the
+# NetBox-grade PowerPanel → PowerBreaker → PowerCircuit → PowerOutlet
+# hierarchy that the safety API + frontend visualization read from.
+# ---------------------------------------------------------------------
+
+
+class PowerPanelSerializer(serializers.ModelSerializer):
+    """Full read/write serializer for PowerPanel."""
+
+    location_name = serializers.CharField(source="location.name", read_only=True)
+    breaker_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PowerPanel
+        fields = [
+            "id",
+            "location",
+            "location_name",
+            "name",
+            "phase_configuration",
+            "voltage",
+            "main_breaker_amperage",
+            "manufacturer",
+            "model",
+            "install_date",
+            "notes",
+            "needs_review",
+            "breaker_count",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "breaker_count", "created_at", "updated_at"]
+
+    def get_breaker_count(self, obj) -> int:
+        # Use a cached annotation when the view supplied one (avoids N+1
+        # on the list endpoint); otherwise fall back to a fresh count.
+        cached = getattr(obj, "annotated_breaker_count", None)
+        if cached is not None:
+            return cached
+        return obj.breakers.count()
+
+
+class PowerBreakerSerializer(serializers.ModelSerializer):
+    """Full read/write serializer for PowerBreaker."""
+
+    panel_name = serializers.CharField(source="panel.name", read_only=True)
+    circuit_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PowerBreaker
+        fields = [
+            "id",
+            "panel",
+            "panel_name",
+            "position",
+            "pole_count",
+            "amperage",
+            "phase",
+            "status",
+            "label",
+            "notes",
+            "needs_review",
+            "circuit_count",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "circuit_count", "created_at", "updated_at"]
+
+    def get_circuit_count(self, obj) -> int:
+        return obj.circuits.count()
+
+
+class PowerCircuitSerializer(serializers.ModelSerializer):
+    """Full read/write serializer for PowerCircuit."""
+
+    breaker_label = serializers.SerializerMethodField()
+    panel_id = serializers.IntegerField(source="breaker.panel_id", read_only=True)
+    panel_name = serializers.CharField(source="breaker.panel.name", read_only=True)
+    outlet_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PowerCircuit
+        fields = [
+            "id",
+            "breaker",
+            "breaker_label",
+            "panel_id",
+            "panel_name",
+            "label",
+            "conductor_size",
+            "conductor_length_ft",
+            "max_load_amps",
+            "notes",
+            "needs_review",
+            "outlet_count",
+            "created_at",
+            "updated_at",
+        ]
+        # ``max_load_amps`` stays writable but the model's save() defaults
+        # it to 80% of the breaker amperage when null — so callers can
+        # omit it and get the NEC-derate behavior automatically.
+        read_only_fields = ["id", "outlet_count", "created_at", "updated_at"]
+
+    def get_breaker_label(self, obj) -> str:
+        b = obj.breaker
+        return f"{b.panel.name} / pos {b.position}"
+
+    def get_outlet_count(self, obj) -> int:
+        return obj.outlets.count()
+
+
+class PowerOutletSerializer(serializers.ModelSerializer):
+    """Full read/write serializer for PowerOutlet."""
+
+    location_name = serializers.CharField(source="location.name", read_only=True)
+    circuit_label = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PowerOutlet
+        fields = [
+            "id",
+            "circuit",
+            "circuit_label",
+            "location",
+            "location_name",
+            "outlet_type",
+            "label",
+            "location_description",
+            "status",
+            "notes",
+            "needs_review",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+    def get_circuit_label(self, obj) -> str:
+        return obj.circuit.label or f"Circuit #{obj.circuit_id}"
 
 
 class NetworkDropSerializer(serializers.ModelSerializer):

--- a/backend/electrical_circuits/tests/test_power_topology_crud.py
+++ b/backend/electrical_circuits/tests/test_power_topology_crud.py
@@ -1,0 +1,249 @@
+"""
+CRUD tests for the power-topology write API.
+
+The read-only safety API (test_safety_api.py) covers retrieval; this
+suite covers the staff-gated POST / PATCH / DELETE surface that backs
+the new frontend form pages.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+import pytest
+from rest_framework.test import APIClient
+
+from electrical_circuits.models import PowerBreaker, PowerCircuit, PowerOutlet, PowerPanel
+from inventory.tests.factories import LocationFactory
+
+_tag_counter = itertools.count(1)
+User = get_user_model()
+
+
+@pytest.fixture
+def staff_client(db):
+    user = User.objects.create_user(
+        username="crud-staff", email="crud@example.com", password="pw", is_staff=True
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def non_staff_client(db):
+    user = User.objects.create_user(
+        username="crud-member",
+        email="member@example.com",
+        password="pw",
+        is_staff=False,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def loc(db):
+    return LocationFactory(name="CRUD Room")
+
+
+# ---------------------------------------------------------------------
+# Permissions: every CRUD viewset must reject anonymous + non-staff.
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url_name",
+    [
+        "powerpanel-list",
+        "powerbreaker-list",
+        "powercircuit-list",
+        "poweroutlet-list",
+    ],
+)
+def test_crud_list_rejects_anonymous(api_client, url_name):
+    assert api_client.get(reverse(url_name)).status_code == 401
+
+
+@pytest.mark.parametrize(
+    "url_name",
+    [
+        "powerpanel-list",
+        "powerbreaker-list",
+        "powercircuit-list",
+        "poweroutlet-list",
+    ],
+)
+def test_crud_list_rejects_non_staff(non_staff_client, url_name):
+    assert non_staff_client.get(reverse(url_name)).status_code == 403
+
+
+# ---------------------------------------------------------------------
+# PowerPanel
+# ---------------------------------------------------------------------
+
+
+def test_create_power_panel(staff_client, loc):
+    resp = staff_client.post(
+        reverse("powerpanel-list"),
+        {
+            "location": loc.pk,
+            "name": "Sewing A",
+            "phase_configuration": "split",
+            "voltage": 240,
+            "main_breaker_amperage": 100,
+        },
+        format="json",
+    )
+    assert resp.status_code == 201, resp.content
+    panel = PowerPanel.objects.get(name="Sewing A")
+    assert panel.location_id == loc.pk
+    assert panel.voltage == 240
+    # Annotation isn't applied on POST response — falls back to live count.
+    assert resp.json()["breaker_count"] == 0
+
+
+def test_list_power_panels_includes_annotated_breaker_count(staff_client, loc):
+    panel = PowerPanel.objects.create(location=loc, name="Sewing A")
+    PowerBreaker.objects.create(panel=panel, position="1", amperage=20)
+    PowerBreaker.objects.create(panel=panel, position="2", amperage=20)
+    resp = staff_client.get(reverse("powerpanel-list"))
+    assert resp.status_code == 200
+    row = next(p for p in resp.json()["results"] if p["id"] == panel.pk)
+    assert row["breaker_count"] == 2
+    assert row["location_name"] == loc.name
+
+
+def test_update_power_panel(staff_client, loc):
+    panel = PowerPanel.objects.create(location=loc, name="Old name", voltage=120)
+    resp = staff_client.patch(
+        reverse("powerpanel-detail", args=[panel.pk]),
+        {"name": "New name", "voltage": 240},
+        format="json",
+    )
+    assert resp.status_code == 200, resp.content
+    panel.refresh_from_db()
+    assert panel.name == "New name"
+    assert panel.voltage == 240
+
+
+def test_delete_power_panel(staff_client, loc):
+    panel = PowerPanel.objects.create(location=loc, name="To go")
+    resp = staff_client.delete(reverse("powerpanel-detail", args=[panel.pk]))
+    assert resp.status_code == 204
+    assert not PowerPanel.objects.filter(pk=panel.pk).exists()
+
+
+# ---------------------------------------------------------------------
+# PowerBreaker
+# ---------------------------------------------------------------------
+
+
+def test_create_power_breaker(staff_client, loc):
+    panel = PowerPanel.objects.create(location=loc, name="Panel A")
+    resp = staff_client.post(
+        reverse("powerbreaker-list"),
+        {"panel": panel.pk, "position": "12", "amperage": 20, "phase": "A"},
+        format="json",
+    )
+    assert resp.status_code == 201, resp.content
+    breaker = PowerBreaker.objects.get(panel=panel, position="12")
+    assert breaker.amperage == 20
+
+
+def test_list_power_breakers_filtered_by_panel(staff_client, loc):
+    panel_a = PowerPanel.objects.create(location=loc, name="A")
+    panel_b = PowerPanel.objects.create(location=loc, name="B")
+    PowerBreaker.objects.create(panel=panel_a, position="1", amperage=20)
+    PowerBreaker.objects.create(panel=panel_b, position="2", amperage=20)
+    resp = staff_client.get(reverse("powerbreaker-list"), {"panel": panel_a.pk})
+    assert resp.status_code == 200
+    rows = resp.json()["results"]
+    assert len(rows) == 1
+    assert rows[0]["panel"] == panel_a.pk
+
+
+def test_unique_position_violation_returns_400(staff_client, loc):
+    panel = PowerPanel.objects.create(location=loc, name="Panel A")
+    PowerBreaker.objects.create(panel=panel, position="12", amperage=20)
+    resp = staff_client.post(
+        reverse("powerbreaker-list"),
+        {"panel": panel.pk, "position": "12", "amperage": 20},
+        format="json",
+    )
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------
+# PowerCircuit
+# ---------------------------------------------------------------------
+
+
+def test_create_power_circuit_defaults_max_load_to_80pct(staff_client, loc):
+    panel = PowerPanel.objects.create(location=loc, name="Panel A")
+    breaker = PowerBreaker.objects.create(panel=panel, position="3", amperage=30)
+    resp = staff_client.post(
+        reverse("powercircuit-list"),
+        {"breaker": breaker.pk, "label": "Bench row 1"},
+        format="json",
+    )
+    assert resp.status_code == 201, resp.content
+    circuit = PowerCircuit.objects.get(breaker=breaker, label="Bench row 1")
+    # NEC 80% derate from save()
+    assert circuit.max_load_amps == 24
+
+
+def test_list_power_circuits_filtered_by_breaker(staff_client, loc):
+    panel = PowerPanel.objects.create(location=loc, name="P")
+    b1 = PowerBreaker.objects.create(panel=panel, position="1", amperage=20)
+    b2 = PowerBreaker.objects.create(panel=panel, position="2", amperage=20)
+    PowerCircuit.objects.create(breaker=b1, label="C-1")
+    PowerCircuit.objects.create(breaker=b2, label="C-2")
+    resp = staff_client.get(reverse("powercircuit-list"), {"breaker": b1.pk})
+    assert resp.status_code == 200
+    rows = resp.json()["results"]
+    assert len(rows) == 1
+    assert rows[0]["breaker"] == b1.pk
+
+
+# ---------------------------------------------------------------------
+# PowerOutlet
+# ---------------------------------------------------------------------
+
+
+def test_create_power_outlet(staff_client, loc):
+    panel = PowerPanel.objects.create(location=loc, name="P")
+    breaker = PowerBreaker.objects.create(panel=panel, position="1", amperage=20)
+    circuit = PowerCircuit.objects.create(breaker=breaker, label="C")
+    resp = staff_client.post(
+        reverse("poweroutlet-list"),
+        {
+            "circuit": circuit.pk,
+            "location": loc.pk,
+            "label": "bench-1",
+            "outlet_type": "5-20R",
+        },
+        format="json",
+    )
+    assert resp.status_code == 201, resp.content
+    outlet = PowerOutlet.objects.get(label="bench-1")
+    assert outlet.circuit_id == circuit.pk
+    assert outlet.outlet_type == "5-20R"
+
+
+def test_list_power_outlets_filtered_by_circuit(staff_client, loc):
+    panel = PowerPanel.objects.create(location=loc, name="P")
+    breaker = PowerBreaker.objects.create(panel=panel, position="1", amperage=20)
+    c1 = PowerCircuit.objects.create(breaker=breaker, label="C-1")
+    c2 = PowerCircuit.objects.create(breaker=breaker, label="C-2")
+    PowerOutlet.objects.create(circuit=c1, location=loc, label="a")
+    PowerOutlet.objects.create(circuit=c2, location=loc, label="b")
+    resp = staff_client.get(reverse("poweroutlet-list"), {"circuit": c1.pk})
+    assert resp.status_code == 200
+    rows = resp.json()["results"]
+    assert len(rows) == 1
+    assert rows[0]["circuit"] == c1.pk

--- a/backend/electrical_circuits/urls.py
+++ b/backend/electrical_circuits/urls.py
@@ -18,6 +18,10 @@ from .views import (
     NetworkDropViewSet,
     OutletViewSet,
     PanelDirectoryReportView,
+    PowerBreakerViewSet,
+    PowerCircuitViewSet,
+    PowerOutletViewSet,
+    PowerPanelViewSet,
 )
 
 router = DefaultRouter()
@@ -25,6 +29,16 @@ router.register(r"breakers", BreakerViewSet, basename="breaker")
 router.register(r"outlets", OutletViewSet, basename="outlet")
 router.register(r"light-switches", LightSwitchViewSet, basename="light-switch")
 router.register(r"network-drops", NetworkDropViewSet, basename="network-drop")
+
+# Power-topology CRUD router — separate prefix from the legacy router so
+# the legacy /breakers and /outlets keep their existing shape. Mounted
+# by config.urls under /api/electrical/ to sit alongside the safety
+# read-only views.
+power_router = DefaultRouter()
+power_router.register(r"panels-crud", PowerPanelViewSet, basename="powerpanel")
+power_router.register(r"breakers-crud", PowerBreakerViewSet, basename="powerbreaker")
+power_router.register(r"circuits-crud", PowerCircuitViewSet, basename="powercircuit")
+power_router.register(r"outlets-crud", PowerOutletViewSet, basename="poweroutlet")
 
 urlpatterns = [
     path("", include(router.urls)),
@@ -43,7 +57,10 @@ urlpatterns = [
 
 # Safety query endpoints (oms-b25 [4/7]). Mounted by config.urls under
 # /api/electrical/ so the URLs match the AC-1..AC-4 paths exactly.
+# The power-topology CRUD router is included here too so all power-*
+# write surfaces land under /api/electrical/<resource>-crud/.
 safety_urlpatterns = [
+    path("", include(power_router.urls)),
     path(
         "panels/",
         PowerPanelListView.as_view(),

--- a/backend/electrical_circuits/views.py
+++ b/backend/electrical_circuits/views.py
@@ -1,5 +1,6 @@
 """DRF viewsets for electrical circuits and network drops."""
 
+from django.db.models import Count
 from django.http import HttpResponse
 
 from rest_framework import viewsets
@@ -7,12 +8,26 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .models import Breaker, LightSwitch, NetworkDrop, Outlet
+from .models import (
+    Breaker,
+    LightSwitch,
+    NetworkDrop,
+    Outlet,
+    PowerBreaker,
+    PowerCircuit,
+    PowerOutlet,
+    PowerPanel,
+)
+from .safety_views import IsStaffUser
 from .serializers import (
     BreakerSerializer,
     LightSwitchSerializer,
     NetworkDropSerializer,
     OutletSerializer,
+    PowerBreakerSerializer,
+    PowerCircuitSerializer,
+    PowerOutletSerializer,
+    PowerPanelSerializer,
 )
 from .utils.panel_directory_pdf import generate_network_drop_list_pdf, generate_panel_directory_pdf
 
@@ -131,3 +146,77 @@ class NetworkDropListReportView(APIView):
         response = HttpResponse(pdf_bytes, content_type="application/pdf")
         response["Content-Disposition"] = f'inline; filename="network-drop-list-{slug}.pdf"'
         return response
+
+
+# ---------------------------------------------------------------------
+# Power topology CRUD ViewSets (oms-b25 + oms-wwx).
+#
+# Staff-only write surface on top of the read-only safety API. These
+# back the new frontend form pages (PR oms-b25 [7/7]) so an admin can
+# create + edit PowerPanels / PowerBreakers / PowerCircuits /
+# PowerOutlets without dropping into Django admin. The existing
+# read-only safety views (panel directory + per-panel topology) stay
+# the canonical retrieval path; these viewsets exist purely for the
+# write contract.
+# ---------------------------------------------------------------------
+
+
+class PowerPanelViewSet(viewsets.ModelViewSet):
+    """``/api/electrical/panels-crud/`` — full CRUD for power panels."""
+
+    permission_classes = [IsAuthenticated, IsStaffUser]
+    serializer_class = PowerPanelSerializer
+    queryset = (
+        PowerPanel.objects.select_related("location")
+        .annotate(annotated_breaker_count=Count("breakers"))
+        .order_by("location__name", "name")
+    )
+
+
+class PowerBreakerViewSet(viewsets.ModelViewSet):
+    """``/api/electrical/breakers-crud/`` — full CRUD for power breakers."""
+
+    permission_classes = [IsAuthenticated, IsStaffUser]
+    serializer_class = PowerBreakerSerializer
+    queryset = PowerBreaker.objects.select_related("panel").order_by("panel__name", "position")
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        panel_id = self.request.query_params.get("panel")
+        if panel_id:
+            qs = qs.filter(panel_id=panel_id)
+        return qs
+
+
+class PowerCircuitViewSet(viewsets.ModelViewSet):
+    """``/api/electrical/circuits-crud/`` — full CRUD for power circuits."""
+
+    permission_classes = [IsAuthenticated, IsStaffUser]
+    serializer_class = PowerCircuitSerializer
+    queryset = PowerCircuit.objects.select_related("breaker", "breaker__panel").order_by(
+        "breaker__panel__name", "breaker__position"
+    )
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        breaker_id = self.request.query_params.get("breaker")
+        if breaker_id:
+            qs = qs.filter(breaker_id=breaker_id)
+        return qs
+
+
+class PowerOutletViewSet(viewsets.ModelViewSet):
+    """``/api/electrical/outlets-crud/`` — full CRUD for power outlets."""
+
+    permission_classes = [IsAuthenticated, IsStaffUser]
+    serializer_class = PowerOutletSerializer
+    queryset = PowerOutlet.objects.select_related(
+        "circuit", "circuit__breaker", "location"
+    ).order_by("location__name", "label")
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        circuit_id = self.request.query_params.get("circuit")
+        if circuit_id:
+            qs = qs.filter(circuit_id=circuit_id)
+        return qs

--- a/docs/API_PERMISSION_MATRIX.md
+++ b/docs/API_PERMISSION_MATRIX.md
@@ -279,6 +279,10 @@ opening a panel. All staff-gated (oms-b25 AC-5).
 | GET | `electrical/circuits/<id>/load/` | staff | `PowerCircuitLoadView` — connected devices, estimated nameplate draw, NEC-derated capacity utilization. |
 | GET | `electrical/panels/<id>/topology/` | staff | `PowerPanelTopologyView` — full panel → breaker → circuit → outlet tree. |
 | GET | `assets/<id>/power-chain/` | staff | `AssetPowerChainView` — every hop from an asset back to its panel. |
+| any  | `electrical/panels-crud/...` | staff | `PowerPanelViewSet` — full CRUD on PowerPanel rows so the frontend can create and edit panels without Django admin. |
+| any  | `electrical/breakers-crud/...` | staff | `PowerBreakerViewSet` — full CRUD on PowerBreaker rows. Supports `?panel=<id>` filter on list. |
+| any  | `electrical/circuits-crud/...` | staff | `PowerCircuitViewSet` — full CRUD on PowerCircuit rows. Supports `?breaker=<id>` filter on list. `max_load_amps` defaults to 80% of the breaker amperage per NEC continuous-load rule when omitted. |
+| any  | `electrical/outlets-crud/...` | staff | `PowerOutletViewSet` — full CRUD on PowerOutlet rows. Supports `?circuit=<id>` filter on list. |
 
 ## Analytics (`/api/analytics/`)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,8 +27,12 @@ import CircuitLoadPage from './pages/CircuitLoadPage';
 import ElectricalCircuitsPage from './pages/ElectricalCircuitsPage';
 import ElectricalOverviewPage from './pages/ElectricalOverviewPage';
 import FacilitiesOverviewPage from './pages/FacilitiesOverviewPage';
+import PowerBreakerFormPage from './pages/PowerBreakerFormPage';
+import PowerCircuitFormPage from './pages/PowerCircuitFormPage';
+import PowerOutletFormPage from './pages/PowerOutletFormPage';
 import PowerPanelDetailPage from './pages/PowerPanelDetailPage';
 import PowerPanelDirectoryPage from './pages/PowerPanelDirectoryPage';
+import PowerPanelFormPage from './pages/PowerPanelFormPage';
 import FixtureScanPage from './pages/FixtureScanPage';
 import ForgeKeyDeviceDetailPage from './pages/ForgeKeyDeviceDetailPage';
 import ForgeKeyDevicesPage from './pages/ForgeKeyDevicesPage';
@@ -208,9 +212,17 @@ function AppContent() {
           {/* Electrical workspace — overview + power-topology visualization (oms-b25 [6/7]) */}
           <Route path="/facilities/electrical" element={<WorkspaceLayout><ElectricalOverviewPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/panels" element={<WorkspaceLayout><PowerPanelDirectoryPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/panels/new" element={<WorkspaceLayout><PowerPanelFormPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/panels/:id" element={<WorkspaceLayout><PowerPanelDetailPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/panels/:id/edit" element={<WorkspaceLayout><PowerPanelFormPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/panels/:panelId/breakers/new" element={<WorkspaceLayout><PowerBreakerFormPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/breakers/:id/edit" element={<WorkspaceLayout><PowerBreakerFormPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/breakers/:id/trip-impact" element={<WorkspaceLayout><BreakerTripImpactPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/breakers/:breakerId/circuits/new" element={<WorkspaceLayout><PowerCircuitFormPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/circuits/:id/edit" element={<WorkspaceLayout><PowerCircuitFormPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/circuits/:id/load" element={<WorkspaceLayout><CircuitLoadPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/circuits/:circuitId/outlets/new" element={<WorkspaceLayout><PowerOutletFormPage /></WorkspaceLayout>} />
+          <Route path="/facilities/electrical/outlets/:id/edit" element={<WorkspaceLayout><PowerOutletFormPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/power-chain" element={<WorkspaceLayout><AssetPowerChainPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/power-chain/:assetId" element={<WorkspaceLayout><AssetPowerChainPage /></WorkspaceLayout>} />
 

--- a/frontend/src/__tests__/pages/PowerPanelFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/PowerPanelFormPage.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Tests for PowerPanelFormPage (oms-b25 [7/7]).
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import PowerPanelFormPage from '../../pages/PowerPanelFormPage';
+import * as api from '../../services/api';
+
+jest.mock('../../services/api');
+
+const mockLocations = [
+  { id: 1, name: 'Sewing Room', description: '', is_active: true },
+  { id: 2, name: 'Workshop', description: '', is_active: true },
+];
+
+const renderAt = (path: string, route: string) =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path={route} element={<PowerPanelFormPage />} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('PowerPanelFormPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (api.inventoryAPI.listLocations as jest.Mock).mockResolvedValue({
+      data: { results: mockLocations },
+    });
+  });
+
+  it('renders the create form with the canonical hero', async () => {
+    renderAt('/facilities/electrical/panels/new', '/facilities/electrical/panels/new');
+    expect(screen.getByTestId('page-hero-title')).toHaveTextContent(/new power panel/i);
+    expect(await screen.findByLabelText(/Name/)).toBeInTheDocument();
+  });
+
+  it('exposes a submit button and a cancel button', async () => {
+    renderAt('/facilities/electrical/panels/new', '/facilities/electrical/panels/new');
+    // Both buttons should be present; the submit one is what fires the
+    // create flow. End-to-end Mantine Select interaction is intentionally
+    // covered in the e2e suite, not unit tests.
+    expect(await screen.findByText(/Create panel/)).toBeInTheDocument();
+    // Two cancel buttons: hero action + form-footer button.
+    expect(screen.getAllByText('Cancel').length).toBeGreaterThan(0);
+  });
+
+  it('loads the existing panel in edit mode', async () => {
+    (api.electricalTopologyAPI.getPanel as jest.Mock).mockResolvedValue({
+      data: {
+        id: 5,
+        location: 2,
+        location_name: 'Workshop',
+        name: 'Bench A',
+        phase_configuration: 'split',
+        voltage: 240,
+        main_breaker_amperage: 100,
+        manufacturer: 'Acme',
+        model: 'X100',
+        install_date: null,
+        notes: '',
+        needs_review: false,
+        breaker_count: 0,
+        created_at: '',
+        updated_at: '',
+      },
+    });
+
+    renderAt('/facilities/electrical/panels/5/edit', '/facilities/electrical/panels/:id/edit');
+    expect(screen.getByTestId('page-hero-title')).toHaveTextContent(/edit power panel/i);
+    expect(await screen.findByDisplayValue('Bench A')).toBeInTheDocument();
+    expect(api.electricalTopologyAPI.getPanel).toHaveBeenCalledWith('5');
+  });
+});

--- a/frontend/src/pages/PowerBreakerFormPage.tsx
+++ b/frontend/src/pages/PowerBreakerFormPage.tsx
@@ -1,0 +1,245 @@
+/**
+ * Create / edit a PowerBreaker. Mounted at:
+ *   /facilities/electrical/panels/:panelId/breakers/new
+ *   /facilities/electrical/breakers/:id/edit
+ *
+ * In create-mode the ``panelId`` from the URL pre-fills the parent
+ * panel selector so the staff member never has to pick it manually.
+ */
+import {
+  Alert,
+  Button,
+  Group,
+  NumberInput,
+  Paper,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
+import { IconAlertCircle } from '@tabler/icons-react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import WorkspacePage from '../components/landing/WorkspacePage';
+import {
+  electricalTopologyAPI,
+  PowerBreakerWritable,
+  PowerPanelDetail,
+} from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+const POLE_OPTIONS = [
+  { value: '1', label: '1 pole' },
+  { value: '2', label: '2 pole' },
+  { value: '3', label: '3 pole' },
+];
+
+const PHASE_OPTIONS: Array<{ value: PowerBreakerWritable['phase']; label: string }> = [
+  { value: 'A', label: 'Phase A' },
+  { value: 'B', label: 'Phase B' },
+  { value: 'C', label: 'Phase C' },
+  { value: 'AB', label: 'Phases A + B' },
+  { value: 'BC', label: 'Phases B + C' },
+  { value: 'AC', label: 'Phases A + C' },
+  { value: 'ABC', label: 'Phases A + B + C' },
+];
+
+const STATUS_OPTIONS: Array<{ value: PowerBreakerWritable['status']; label: string }> = [
+  { value: 'active', label: 'Active' },
+  { value: 'spare', label: 'Spare' },
+  { value: 'locked_out', label: 'Locked out' },
+];
+
+const PowerBreakerFormPage: React.FC = () => {
+  const { id, panelId } = useParams<{ id?: string; panelId?: string }>();
+  const navigate = useNavigate();
+  const isEditMode = !!id;
+
+  const [panels, setPanels] = useState<PowerPanelDetail[]>([]);
+  const [form, setForm] = useState<Partial<PowerBreakerWritable>>({
+    panel: panelId ? Number(panelId) : undefined,
+    position: '',
+    pole_count: 1,
+    amperage: 20,
+    phase: 'A',
+    status: 'active',
+    label: '',
+    notes: '',
+    needs_review: false,
+  });
+  const [loading, setLoading] = useState(isEditMode);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    electricalTopologyAPI
+      .listPanels()
+      .then((response) => setPanels(response.data.results))
+      .catch((err) => console.warn('Failed to load panels', err));
+  }, []);
+
+  const loadBreaker = useCallback(async () => {
+    if (!id) return;
+    try {
+      setLoading(true);
+      const response = await electricalTopologyAPI.getBreaker(id);
+      const b = response.data;
+      setForm({
+        panel: b.panel,
+        position: b.position,
+        pole_count: b.pole_count,
+        amperage: b.amperage,
+        phase: b.phase,
+        status: b.status,
+        label: b.label,
+        notes: b.notes,
+        needs_review: b.needs_review,
+      });
+      setError(null);
+    } catch (err: any) {
+      setError(extractErrorMessage(err, 'Failed to load breaker.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    if (isEditMode) loadBreaker();
+  }, [isEditMode, loadBreaker]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.panel || !form.position || !form.amperage) {
+      setError('Panel, position, and amperage are required.');
+      return;
+    }
+    setError(null);
+    setSaving(true);
+    try {
+      if (isEditMode && id) {
+        const response = await electricalTopologyAPI.updateBreaker(id, form);
+        navigate(`/facilities/electrical/panels/${response.data.panel}`);
+      } else {
+        const response = await electricalTopologyAPI.createBreaker(form);
+        navigate(`/facilities/electrical/panels/${response.data.panel}`);
+      }
+    } catch (err: any) {
+      setError(extractErrorMessage(err, 'Failed to save breaker.'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <WorkspacePage
+      testId="power-breaker-form-page"
+      hero={{
+        eyebrow: 'Electrical · Breaker',
+        title: isEditMode ? 'Edit breaker' : 'New breaker',
+        description: 'Breakers live in a panel; circuits hang off of breakers.',
+        action: (
+          <Button variant="default" onClick={() => navigate(-1)}>
+            Cancel
+          </Button>
+        ),
+      }}
+    >
+      {error && (
+        <Alert color="red" icon={<IconAlertCircle size={16} />}>
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading breaker…</Text>
+        </Paper>
+      ) : (
+        <Paper withBorder p="md">
+          <form onSubmit={handleSubmit}>
+            <Stack gap="md">
+              <Select
+                label="Panel"
+                required
+                data={panels.map((p) => ({ value: String(p.id), label: `${p.name} @ ${p.location_name}` }))}
+                value={form.panel != null ? String(form.panel) : null}
+                onChange={(value) => setForm({ ...form, panel: value ? Number(value) : undefined })}
+                searchable
+              />
+              <Group grow>
+                <TextInput
+                  label="Position"
+                  required
+                  value={form.position ?? ''}
+                  onChange={(e) => setForm({ ...form, position: e.target.value })}
+                  placeholder="e.g. 12 or 14/16 for tandem"
+                />
+                <Select
+                  label="Pole count"
+                  data={POLE_OPTIONS}
+                  value={String(form.pole_count ?? 1)}
+                  onChange={(value) =>
+                    setForm({ ...form, pole_count: (Number(value) || 1) as 1 | 2 | 3 })
+                  }
+                />
+              </Group>
+              <Group grow>
+                <NumberInput
+                  label="Amperage"
+                  required
+                  value={form.amperage ?? 20}
+                  onChange={(value) =>
+                    setForm({ ...form, amperage: typeof value === 'number' ? value : 20 })
+                  }
+                  min={1}
+                  suffix=" A"
+                />
+                <Select
+                  label="Phase"
+                  data={PHASE_OPTIONS}
+                  value={form.phase ?? 'A'}
+                  onChange={(value) =>
+                    setForm({ ...form, phase: (value as PowerBreakerWritable['phase']) ?? 'A' })
+                  }
+                />
+              </Group>
+              <Select
+                label="Status"
+                data={STATUS_OPTIONS}
+                value={form.status ?? 'active'}
+                onChange={(value) =>
+                  setForm({ ...form, status: (value as PowerBreakerWritable['status']) ?? 'active' })
+                }
+              />
+              <TextInput
+                label="Label"
+                value={form.label ?? ''}
+                onChange={(e) => setForm({ ...form, label: e.target.value })}
+                placeholder="e.g. Wood shop dust collector"
+              />
+              <Textarea
+                label="Notes"
+                value={form.notes ?? ''}
+                onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                autosize
+                minRows={2}
+              />
+              <Group justify="flex-end">
+                <Button type="button" variant="default" onClick={() => navigate(-1)}>
+                  Cancel
+                </Button>
+                <Button type="submit" loading={saving}>
+                  {isEditMode ? 'Save changes' : 'Create breaker'}
+                </Button>
+              </Group>
+            </Stack>
+          </form>
+        </Paper>
+      )}
+    </WorkspacePage>
+  );
+};
+
+export default PowerBreakerFormPage;

--- a/frontend/src/pages/PowerCircuitFormPage.tsx
+++ b/frontend/src/pages/PowerCircuitFormPage.tsx
@@ -1,0 +1,223 @@
+/**
+ * Create / edit a PowerCircuit. Mounted at:
+ *   /facilities/electrical/breakers/:breakerId/circuits/new
+ *   /facilities/electrical/circuits/:id/edit
+ *
+ * In create-mode the ``breakerId`` from the URL pre-fills the parent
+ * breaker selector. ``max_load_amps`` defaults to 80% of the breaker
+ * amperage server-side when left blank (NEC continuous-load rule), so
+ * the field is optional.
+ */
+import {
+  Alert,
+  Button,
+  Group,
+  NumberInput,
+  Paper,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
+import { IconAlertCircle } from '@tabler/icons-react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import WorkspacePage from '../components/landing/WorkspacePage';
+import {
+  electricalTopologyAPI,
+  PowerBreakerDetail,
+  PowerCircuitWritable,
+} from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+const PowerCircuitFormPage: React.FC = () => {
+  const { id, breakerId } = useParams<{ id?: string; breakerId?: string }>();
+  const navigate = useNavigate();
+  const isEditMode = !!id;
+
+  const [breakers, setBreakers] = useState<PowerBreakerDetail[]>([]);
+  const [panelId, setPanelId] = useState<number | null>(null);
+  const [form, setForm] = useState<Partial<PowerCircuitWritable>>({
+    breaker: breakerId ? Number(breakerId) : undefined,
+    label: '',
+    conductor_size: '',
+    conductor_length_ft: null,
+    max_load_amps: null,
+    notes: '',
+    needs_review: false,
+  });
+  const [loading, setLoading] = useState(isEditMode);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    electricalTopologyAPI
+      .listBreakers()
+      .then((response) => setBreakers(response.data.results))
+      .catch((err) => console.warn('Failed to load breakers', err));
+  }, []);
+
+  const loadCircuit = useCallback(async () => {
+    if (!id) return;
+    try {
+      setLoading(true);
+      const response = await electricalTopologyAPI.getCircuit(id);
+      const c = response.data;
+      setPanelId(c.panel_id);
+      setForm({
+        breaker: c.breaker,
+        label: c.label,
+        conductor_size: c.conductor_size,
+        conductor_length_ft: c.conductor_length_ft,
+        max_load_amps: c.max_load_amps,
+        notes: c.notes,
+        needs_review: c.needs_review,
+      });
+      setError(null);
+    } catch (err: any) {
+      setError(extractErrorMessage(err, 'Failed to load circuit.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    if (isEditMode) loadCircuit();
+  }, [isEditMode, loadCircuit]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.breaker) {
+      setError('Breaker is required.');
+      return;
+    }
+    setError(null);
+    setSaving(true);
+    try {
+      let destPanelId: number | null = panelId;
+      if (isEditMode && id) {
+        const response = await electricalTopologyAPI.updateCircuit(id, form);
+        destPanelId = response.data.panel_id;
+      } else {
+        const response = await electricalTopologyAPI.createCircuit(form);
+        destPanelId = response.data.panel_id;
+      }
+      if (destPanelId != null) {
+        navigate(`/facilities/electrical/panels/${destPanelId}`);
+      } else {
+        navigate(-1);
+      }
+    } catch (err: any) {
+      setError(extractErrorMessage(err, 'Failed to save circuit.'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <WorkspacePage
+      testId="power-circuit-form-page"
+      hero={{
+        eyebrow: 'Electrical · Circuit',
+        title: isEditMode ? 'Edit circuit' : 'New circuit',
+        description:
+          'Circuits live on a breaker. Outlets land on circuits. Leave max-load blank to default to 80% of breaker amperage.',
+        action: (
+          <Button variant="default" onClick={() => navigate(-1)}>
+            Cancel
+          </Button>
+        ),
+      }}
+    >
+      {error && (
+        <Alert color="red" icon={<IconAlertCircle size={16} />}>
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading circuit…</Text>
+        </Paper>
+      ) : (
+        <Paper withBorder p="md">
+          <form onSubmit={handleSubmit}>
+            <Stack gap="md">
+              <Select
+                label="Breaker"
+                required
+                data={breakers.map((b) => ({
+                  value: String(b.id),
+                  label: `${b.panel_name} · pos ${b.position} (${b.amperage}A)`,
+                }))}
+                value={form.breaker != null ? String(form.breaker) : null}
+                onChange={(value) =>
+                  setForm({ ...form, breaker: value ? Number(value) : undefined })
+                }
+                searchable
+              />
+              <TextInput
+                label="Label"
+                value={form.label ?? ''}
+                onChange={(e) => setForm({ ...form, label: e.target.value })}
+                placeholder="e.g. Bench row 1"
+              />
+              <Group grow>
+                <TextInput
+                  label="Conductor size"
+                  value={form.conductor_size ?? ''}
+                  onChange={(e) => setForm({ ...form, conductor_size: e.target.value })}
+                  placeholder="e.g. 12 AWG"
+                />
+                <NumberInput
+                  label="Conductor length"
+                  value={form.conductor_length_ft ?? ''}
+                  onChange={(value) =>
+                    setForm({
+                      ...form,
+                      conductor_length_ft: typeof value === 'number' ? value : null,
+                    })
+                  }
+                  min={1}
+                  suffix=" ft"
+                />
+              </Group>
+              <NumberInput
+                label="Max load (continuous)"
+                description="Leave blank for NEC default (80% of breaker amperage)."
+                value={form.max_load_amps ?? ''}
+                onChange={(value) =>
+                  setForm({
+                    ...form,
+                    max_load_amps: typeof value === 'number' ? value : null,
+                  })
+                }
+                min={1}
+                suffix=" A"
+              />
+              <Textarea
+                label="Notes"
+                value={form.notes ?? ''}
+                onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                autosize
+                minRows={2}
+              />
+              <Group justify="flex-end">
+                <Button type="button" variant="default" onClick={() => navigate(-1)}>
+                  Cancel
+                </Button>
+                <Button type="submit" loading={saving}>
+                  {isEditMode ? 'Save changes' : 'Create circuit'}
+                </Button>
+              </Group>
+            </Stack>
+          </form>
+        </Paper>
+      )}
+    </WorkspacePage>
+  );
+};
+
+export default PowerCircuitFormPage;

--- a/frontend/src/pages/PowerOutletFormPage.tsx
+++ b/frontend/src/pages/PowerOutletFormPage.tsx
@@ -1,0 +1,259 @@
+/**
+ * Create / edit a PowerOutlet. Mounted at:
+ *   /facilities/electrical/circuits/:circuitId/outlets/new
+ *   /facilities/electrical/outlets/:id/edit
+ *
+ * In create-mode the ``circuitId`` from the URL pre-fills the parent
+ * circuit selector. ``outlet_type`` carries the NEMA receptacle code
+ * so the cable model can validate plug ↔ receptacle compatibility.
+ */
+import {
+  Alert,
+  Button,
+  Group,
+  Paper,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
+import { IconAlertCircle } from '@tabler/icons-react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import WorkspacePage from '../components/landing/WorkspacePage';
+import {
+  electricalTopologyAPI,
+  inventoryAPI,
+  PowerCircuitDetail,
+  PowerOutletWritable,
+} from '../services/api';
+import { Location } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+// NEMA receptacle codes — must match NEMA_PORT_TYPE_CHOICES on the
+// backend or the create call rejects.
+const OUTLET_TYPE_OPTIONS = [
+  { value: '5-15R', label: 'NEMA 5-15R (120V 15A)' },
+  { value: '5-20R', label: 'NEMA 5-20R (120V 20A)' },
+  { value: '6-15R', label: 'NEMA 6-15R (240V 15A)' },
+  { value: '6-20R', label: 'NEMA 6-20R (240V 20A)' },
+  { value: 'L5-15R', label: 'NEMA L5-15R (120V 15A locking)' },
+  { value: 'L5-20R', label: 'NEMA L5-20R (120V 20A locking)' },
+  { value: 'L6-20R', label: 'NEMA L6-20R (240V 20A locking)' },
+  { value: 'L6-30R', label: 'NEMA L6-30R (240V 30A locking)' },
+  { value: '14-30R', label: 'NEMA 14-30R (240V 30A)' },
+  { value: '14-50R', label: 'NEMA 14-50R (240V 50A)' },
+  { value: 'USB', label: 'USB charging' },
+  { value: 'OTHER', label: 'Other' },
+];
+
+const STATUS_OPTIONS: Array<{ value: PowerOutletWritable['status']; label: string }> = [
+  { value: 'active', label: 'Active' },
+  { value: 'inactive', label: 'Inactive' },
+  { value: 'capped', label: 'Capped / decommissioned' },
+];
+
+const PowerOutletFormPage: React.FC = () => {
+  const { id, circuitId } = useParams<{ id?: string; circuitId?: string }>();
+  const navigate = useNavigate();
+  const isEditMode = !!id;
+
+  const [circuits, setCircuits] = useState<PowerCircuitDetail[]>([]);
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [panelId, setPanelId] = useState<number | null>(null);
+  const [form, setForm] = useState<Partial<PowerOutletWritable>>({
+    circuit: circuitId ? Number(circuitId) : undefined,
+    outlet_type: '5-15R',
+    label: '',
+    location_description: '',
+    status: 'active',
+    notes: '',
+    needs_review: false,
+  });
+  const [loading, setLoading] = useState(isEditMode);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    Promise.all([
+      electricalTopologyAPI.listCircuits(),
+      inventoryAPI.listLocations(),
+    ])
+      .then(([circuitsResp, locationsResp]) => {
+        setCircuits(circuitsResp.data.results);
+        setLocations(locationsResp.data.results);
+      })
+      .catch((err) => console.warn('Failed to load options', err));
+  }, []);
+
+  const loadOutlet = useCallback(async () => {
+    if (!id) return;
+    try {
+      setLoading(true);
+      const response = await electricalTopologyAPI.getOutlet(id);
+      const o = response.data;
+      setForm({
+        circuit: o.circuit,
+        location: o.location,
+        outlet_type: o.outlet_type,
+        label: o.label,
+        location_description: o.location_description,
+        status: o.status,
+        notes: o.notes,
+        needs_review: o.needs_review,
+      });
+      // Look up the circuit so we can navigate back to its panel after save.
+      const circuit = await electricalTopologyAPI.getCircuit(o.circuit);
+      setPanelId(circuit.data.panel_id);
+      setError(null);
+    } catch (err: any) {
+      setError(extractErrorMessage(err, 'Failed to load outlet.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    if (isEditMode) loadOutlet();
+  }, [isEditMode, loadOutlet]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.circuit || !form.location) {
+      setError('Circuit and location are required.');
+      return;
+    }
+    setError(null);
+    setSaving(true);
+    try {
+      if (isEditMode && id) {
+        await electricalTopologyAPI.updateOutlet(id, form);
+      } else {
+        const response = await electricalTopologyAPI.createOutlet(form);
+        const circuit = await electricalTopologyAPI.getCircuit(response.data.circuit);
+        setPanelId(circuit.data.panel_id);
+      }
+      const destPanelId =
+        panelId ?? circuits.find((c) => c.id === form.circuit)?.panel_id ?? null;
+      if (destPanelId != null) {
+        navigate(`/facilities/electrical/panels/${destPanelId}`);
+      } else {
+        navigate(-1);
+      }
+    } catch (err: any) {
+      setError(extractErrorMessage(err, 'Failed to save outlet.'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <WorkspacePage
+      testId="power-outlet-form-page"
+      hero={{
+        eyebrow: 'Electrical · Outlet',
+        title: isEditMode ? 'Edit outlet' : 'New outlet',
+        description:
+          'Outlets live on a circuit at a physical location. The NEMA code is what cables match against.',
+        action: (
+          <Button variant="default" onClick={() => navigate(-1)}>
+            Cancel
+          </Button>
+        ),
+      }}
+    >
+      {error && (
+        <Alert color="red" icon={<IconAlertCircle size={16} />}>
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading outlet…</Text>
+        </Paper>
+      ) : (
+        <Paper withBorder p="md">
+          <form onSubmit={handleSubmit}>
+            <Stack gap="md">
+              <Select
+                label="Circuit"
+                required
+                data={circuits.map((c) => ({
+                  value: String(c.id),
+                  label: `${c.panel_name} · ${c.label || 'Circuit ' + c.id}`,
+                }))}
+                value={form.circuit != null ? String(form.circuit) : null}
+                onChange={(value) =>
+                  setForm({ ...form, circuit: value ? Number(value) : undefined })
+                }
+                searchable
+              />
+              <Select
+                label="Location"
+                required
+                data={locations.map((l) => ({ value: String(l.id), label: l.name }))}
+                value={form.location != null ? String(form.location) : null}
+                onChange={(value) =>
+                  setForm({ ...form, location: value ? Number(value) : undefined })
+                }
+                searchable
+              />
+              <Group grow>
+                <Select
+                  label="Outlet type (NEMA)"
+                  data={OUTLET_TYPE_OPTIONS}
+                  value={form.outlet_type ?? '5-15R'}
+                  onChange={(value) => setForm({ ...form, outlet_type: value ?? '5-15R' })}
+                  searchable
+                />
+                <Select
+                  label="Status"
+                  data={STATUS_OPTIONS}
+                  value={form.status ?? 'active'}
+                  onChange={(value) =>
+                    setForm({
+                      ...form,
+                      status: (value as PowerOutletWritable['status']) ?? 'active',
+                    })
+                  }
+                />
+              </Group>
+              <TextInput
+                label="Label"
+                value={form.label ?? ''}
+                onChange={(e) => setForm({ ...form, label: e.target.value })}
+                placeholder="e.g. NW-bench-1"
+              />
+              <TextInput
+                label="Location description"
+                value={form.location_description ?? ''}
+                onChange={(e) => setForm({ ...form, location_description: e.target.value })}
+                placeholder="e.g. east wall, 3 ft from corner"
+              />
+              <Textarea
+                label="Notes"
+                value={form.notes ?? ''}
+                onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                autosize
+                minRows={2}
+              />
+              <Group justify="flex-end">
+                <Button type="button" variant="default" onClick={() => navigate(-1)}>
+                  Cancel
+                </Button>
+                <Button type="submit" loading={saving}>
+                  {isEditMode ? 'Save changes' : 'Create outlet'}
+                </Button>
+              </Group>
+            </Stack>
+          </form>
+        </Paper>
+      )}
+    </WorkspacePage>
+  );
+};
+
+export default PowerOutletFormPage;

--- a/frontend/src/pages/PowerPanelDetailPage.tsx
+++ b/frontend/src/pages/PowerPanelDetailPage.tsx
@@ -11,6 +11,7 @@
 import {
   Badge,
   Box,
+  Button,
   Container,
   Group,
   Paper,
@@ -18,7 +19,7 @@ import {
   Table,
   Text,
 } from '@mantine/core';
-import { IconBolt, IconRouteAltLeft } from '@tabler/icons-react';
+import { IconBolt, IconEdit, IconPlus, IconRouteAltLeft } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
@@ -70,6 +71,27 @@ const PowerPanelDetailPage: React.FC = () => {
                   }`
                 : 'Loading panel topology…'
             }
+            action={
+              topology ? (
+                <Group gap="sm">
+                  <Button
+                    component={Link}
+                    to={`/facilities/electrical/panels/${topology.id}/edit`}
+                    variant="default"
+                    leftSection={<IconEdit size={16} />}
+                  >
+                    Edit panel
+                  </Button>
+                  <Button
+                    component={Link}
+                    to={`/facilities/electrical/panels/${topology.id}/breakers/new`}
+                    leftSection={<IconPlus size={16} />}
+                  >
+                    Add breaker
+                  </Button>
+                </Group>
+              ) : undefined
+            }
           />
 
           {error && (
@@ -88,12 +110,20 @@ const PowerPanelDetailPage: React.FC = () => {
 
           {topology && topology.breakers.length === 0 && (
             <Paper withBorder p="xl" radius="md">
-              <Stack gap="xs" align="center">
+              <Stack gap="sm" align="center">
                 <IconBolt size={28} stroke={1.6} />
                 <Text fw={500}>No breakers configured for this panel</Text>
-                <Text size="sm" c="dimmed">
-                  Add breakers via Django admin to populate this view.
+                <Text size="sm" c="dimmed" ta="center" maw={380}>
+                  Add the first breaker to start populating the panel. Circuits hang off
+                  breakers, outlets hang off circuits.
                 </Text>
+                <Button
+                  component={Link}
+                  to={`/facilities/electrical/panels/${topology.id}/breakers/new`}
+                  leftSection={<IconPlus size={16} />}
+                >
+                  Add first breaker
+                </Button>
               </Stack>
             </Paper>
           )}
@@ -120,7 +150,7 @@ const PowerPanelDetailPage: React.FC = () => {
                         {breaker.amperage}A · {breaker.pole_count}-pole · phase {breaker.phase}
                       </Text>
                     </Stack>
-                    <Group gap="xs">
+                    <Group gap="xs" wrap="wrap">
                       <Badge
                         color={breaker.status === 'on' ? 'green' : 'gray'}
                         variant="light"
@@ -138,13 +168,41 @@ const PowerPanelDetailPage: React.FC = () => {
                         <IconRouteAltLeft size={16} stroke={2.4} />
                         Trip impact
                       </Link>
+                      <Button
+                        component={Link}
+                        to={`/facilities/electrical/breakers/${breaker.id}/edit`}
+                        size="xs"
+                        variant="default"
+                        leftSection={<IconEdit size={14} />}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        component={Link}
+                        to={`/facilities/electrical/breakers/${breaker.id}/circuits/new`}
+                        size="xs"
+                        leftSection={<IconPlus size={14} />}
+                      >
+                        Add circuit
+                      </Button>
                     </Group>
                   </Group>
 
                   {breaker.circuits.length === 0 ? (
-                    <Text size="sm" c="dimmed">
-                      No circuits wired to this breaker yet.
-                    </Text>
+                    <Group gap="sm" align="center">
+                      <Text size="sm" c="dimmed">
+                        No circuits wired to this breaker yet.
+                      </Text>
+                      <Button
+                        component={Link}
+                        to={`/facilities/electrical/breakers/${breaker.id}/circuits/new`}
+                        size="xs"
+                        variant="light"
+                        leftSection={<IconPlus size={14} />}
+                      >
+                        Add circuit
+                      </Button>
+                    </Group>
                   ) : (
                     <Table withTableBorder withColumnBorders striped>
                       <Table.Thead>
@@ -153,7 +211,7 @@ const PowerPanelDetailPage: React.FC = () => {
                           <Table.Th>Conductor</Table.Th>
                           <Table.Th>Capacity</Table.Th>
                           <Table.Th>Outlets</Table.Th>
-                          <Table.Th>Load report</Table.Th>
+                          <Table.Th>Actions</Table.Th>
                         </Table.Tr>
                       </Table.Thead>
                       <Table.Tbody>
@@ -174,21 +232,43 @@ const PowerPanelDetailPage: React.FC = () => {
                               ) : (
                                 <Stack gap={2}>
                                   {circuit.outlets.map((outlet) => (
-                                    <Text key={outlet.id} size="sm">
-                                      {outlet.label || `Outlet ${outlet.id}`}
-                                      {outlet.location_name ? ` — ${outlet.location_name}` : ''}
-                                    </Text>
+                                    <Group key={outlet.id} gap="xs" wrap="nowrap">
+                                      <Text size="sm" style={{ flex: 1 }}>
+                                        {outlet.label || `Outlet ${outlet.id}`}
+                                        {outlet.location_name ? ` — ${outlet.location_name}` : ''}
+                                      </Text>
+                                      <Link
+                                        to={`/facilities/electrical/outlets/${outlet.id}/edit`}
+                                        aria-label={`Edit outlet ${outlet.label || outlet.id}`}
+                                      >
+                                        <IconEdit size={14} />
+                                      </Link>
+                                    </Group>
                                   ))}
                                 </Stack>
                               )}
                             </Table.Td>
                             <Table.Td>
-                              <Link
-                                to={`/facilities/electrical/circuits/${circuit.id}/load`}
-                                data-testid={`circuit-load-${circuit.id}`}
-                              >
-                                Load
-                              </Link>
+                              <Group gap="xs" wrap="wrap">
+                                <Link
+                                  to={`/facilities/electrical/circuits/${circuit.id}/load`}
+                                  data-testid={`circuit-load-${circuit.id}`}
+                                >
+                                  Load
+                                </Link>
+                                <Link
+                                  to={`/facilities/electrical/circuits/${circuit.id}/edit`}
+                                  aria-label={`Edit circuit ${circuit.label || circuit.id}`}
+                                >
+                                  Edit
+                                </Link>
+                                <Link
+                                  to={`/facilities/electrical/circuits/${circuit.id}/outlets/new`}
+                                  aria-label={`Add outlet to circuit ${circuit.label || circuit.id}`}
+                                >
+                                  + Outlet
+                                </Link>
+                              </Group>
                             </Table.Td>
                           </Table.Tr>
                         ))}

--- a/frontend/src/pages/PowerPanelDirectoryPage.tsx
+++ b/frontend/src/pages/PowerPanelDirectoryPage.tsx
@@ -8,6 +8,7 @@
 import {
   Badge,
   Box,
+  Button,
   Container,
   Group,
   Paper,
@@ -15,7 +16,7 @@ import {
   Stack,
   Text,
 } from '@mantine/core';
-import { IconAlertTriangle, IconBolt, IconSitemap } from '@tabler/icons-react';
+import { IconAlertTriangle, IconBolt, IconPlus, IconSitemap } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -71,6 +72,15 @@ const PowerPanelDirectoryPage: React.FC = () => {
             eyebrow="Electrical · Topology"
             title="Power panel directory"
             description="Every load center in the building. Open one to see its breakers, circuits, and the assets they feed."
+            action={
+              <Button
+                component={Link}
+                to="/facilities/electrical/panels/new"
+                leftSection={<IconPlus size={16} />}
+              >
+                New panel
+              </Button>
+            }
           />
 
           {error && (
@@ -99,13 +109,22 @@ const PowerPanelDirectoryPage: React.FC = () => {
             </Paper>
           ) : panels.length === 0 ? (
             <Paper withBorder p="xl" radius="md">
-              <Stack gap="xs" align="center">
+              <Stack gap="sm" align="center">
                 <IconSitemap size={28} stroke={1.6} />
                 <Text fw={500}>No power panels yet</Text>
-                <Text size="sm" c="dimmed" ta="center" maw={400}>
-                  Add a PowerPanel from Django admin to see it here. The legacy breaker/outlet
-                  inventory lives under the "Fixture inventory" card on the Electrical overview.
+                <Text size="sm" c="dimmed" ta="center" maw={420}>
+                  Add the first load center to start building the topology. Once a panel is in
+                  place, breakers / circuits / outlets land on top of it. The legacy
+                  breaker/outlet inventory lives under the "Fixture inventory" card on the
+                  Electrical overview.
                 </Text>
+                <Button
+                  component={Link}
+                  to="/facilities/electrical/panels/new"
+                  leftSection={<IconPlus size={16} />}
+                >
+                  Create first panel
+                </Button>
               </Stack>
             </Paper>
           ) : (

--- a/frontend/src/pages/PowerPanelFormPage.tsx
+++ b/frontend/src/pages/PowerPanelFormPage.tsx
@@ -1,0 +1,239 @@
+/**
+ * Create / edit a PowerPanel — top of the power-topology hierarchy.
+ * Mounted at:
+ *   /facilities/electrical/panels/new
+ *   /facilities/electrical/panels/:id/edit
+ */
+import {
+  Alert,
+  Button,
+  Group,
+  NumberInput,
+  Paper,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
+import { IconAlertCircle } from '@tabler/icons-react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import WorkspacePage from '../components/landing/WorkspacePage';
+import {
+  electricalTopologyAPI,
+  inventoryAPI,
+  PowerPanelPhase,
+  PowerPanelWritable,
+} from '../services/api';
+import { Location } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+const PHASE_OPTIONS: Array<{ value: PowerPanelPhase; label: string }> = [
+  { value: 'single', label: 'Single phase' },
+  { value: 'split', label: 'Split phase 120/240V' },
+  { value: 'three', label: 'Three phase' },
+];
+
+const PowerPanelFormPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const isEditMode = !!id;
+
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [form, setForm] = useState<Partial<PowerPanelWritable>>({
+    name: '',
+    phase_configuration: 'split',
+    voltage: 240,
+    main_breaker_amperage: null,
+    manufacturer: '',
+    model: '',
+    install_date: null,
+    notes: '',
+    needs_review: false,
+  });
+  const [loading, setLoading] = useState(isEditMode);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    inventoryAPI
+      .listLocations()
+      .then((response) => setLocations(response.data.results))
+      .catch((err) => console.warn('Failed to load locations', err));
+  }, []);
+
+  const loadPanel = useCallback(async () => {
+    if (!id) return;
+    try {
+      setLoading(true);
+      const response = await electricalTopologyAPI.getPanel(id);
+      const panel = response.data;
+      setForm({
+        location: panel.location,
+        name: panel.name,
+        phase_configuration: panel.phase_configuration,
+        voltage: panel.voltage,
+        main_breaker_amperage: panel.main_breaker_amperage,
+        manufacturer: panel.manufacturer,
+        model: panel.model,
+        install_date: panel.install_date,
+        notes: panel.notes,
+        needs_review: panel.needs_review,
+      });
+      setError(null);
+    } catch (err: any) {
+      setError(extractErrorMessage(err, 'Failed to load panel.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    if (isEditMode) loadPanel();
+  }, [isEditMode, loadPanel]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.name || !form.location) {
+      setError('Name and location are required.');
+      return;
+    }
+    setError(null);
+    setSaving(true);
+    try {
+      if (isEditMode && id) {
+        await electricalTopologyAPI.updatePanel(id, form);
+        navigate(`/facilities/electrical/panels/${id}`);
+      } else {
+        const response = await electricalTopologyAPI.createPanel(form);
+        navigate(`/facilities/electrical/panels/${response.data.id}`);
+      }
+    } catch (err: any) {
+      setError(extractErrorMessage(err, 'Failed to save panel.'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <WorkspacePage
+      testId="power-panel-form-page"
+      hero={{
+        eyebrow: 'Electrical · Topology',
+        title: isEditMode ? 'Edit power panel' : 'New power panel',
+        description: 'Load centers anchor the topology — everything else hangs off them.',
+        action: (
+          <Button variant="default" onClick={() => navigate(-1)}>
+            Cancel
+          </Button>
+        ),
+      }}
+    >
+      {error && (
+        <Alert color="red" icon={<IconAlertCircle size={16} />}>
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading panel…</Text>
+        </Paper>
+      ) : (
+        <Paper withBorder p="md">
+          <form onSubmit={handleSubmit}>
+            <Stack gap="md">
+              <TextInput
+                label="Name"
+                required
+                value={form.name ?? ''}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                placeholder="e.g. Sewing Panel A"
+              />
+              <Select
+                label="Location"
+                required
+                data={locations.map((loc) => ({ value: String(loc.id), label: loc.name }))}
+                value={form.location != null ? String(form.location) : null}
+                onChange={(value) =>
+                  setForm({ ...form, location: value ? Number(value) : undefined })
+                }
+                searchable
+                placeholder="Where the panel is mounted"
+              />
+              <Select
+                label="Phase configuration"
+                data={PHASE_OPTIONS}
+                value={form.phase_configuration ?? 'split'}
+                onChange={(value) =>
+                  setForm({ ...form, phase_configuration: (value as PowerPanelPhase) ?? 'split' })
+                }
+              />
+              <Group grow>
+                <NumberInput
+                  label="Voltage"
+                  value={form.voltage ?? 240}
+                  onChange={(value) =>
+                    setForm({ ...form, voltage: typeof value === 'number' ? value : 240 })
+                  }
+                  min={1}
+                  suffix=" V"
+                />
+                <NumberInput
+                  label="Main breaker amperage"
+                  description="Leave blank if no main / sub-fed"
+                  value={form.main_breaker_amperage ?? ''}
+                  onChange={(value) =>
+                    setForm({
+                      ...form,
+                      main_breaker_amperage: typeof value === 'number' ? value : null,
+                    })
+                  }
+                  min={1}
+                  suffix=" A"
+                />
+              </Group>
+              <Group grow>
+                <TextInput
+                  label="Manufacturer"
+                  value={form.manufacturer ?? ''}
+                  onChange={(e) => setForm({ ...form, manufacturer: e.target.value })}
+                />
+                <TextInput
+                  label="Model"
+                  value={form.model ?? ''}
+                  onChange={(e) => setForm({ ...form, model: e.target.value })}
+                />
+              </Group>
+              <TextInput
+                label="Install date"
+                type="date"
+                value={form.install_date ?? ''}
+                onChange={(e) => setForm({ ...form, install_date: e.target.value || null })}
+              />
+              <Textarea
+                label="Notes"
+                value={form.notes ?? ''}
+                onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                autosize
+                minRows={2}
+              />
+              <Group justify="flex-end">
+                <Button type="button" variant="default" onClick={() => navigate(-1)}>
+                  Cancel
+                </Button>
+                <Button type="submit" loading={saving}>
+                  {isEditMode ? 'Save changes' : 'Create panel'}
+                </Button>
+              </Group>
+            </Stack>
+          </form>
+        </Paper>
+      )}
+    </WorkspacePage>
+  );
+};
+
+export default PowerPanelFormPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2039,6 +2039,181 @@ export const electricalSafetyAPI = {
     api.get<AssetPowerChain>(`/assets/${assetId}/power-chain/`),
 };
 
+// ---------------------------------------------------------------------
+// Power-topology write API (oms-b25 [7/7]).
+// CRUD endpoints behind the new frontend form pages. Staff-only on the
+// server; the frontend doesn't try to gate UI for non-staff because the
+// form pages aren't reachable from the sidebar for non-staff users.
+// ---------------------------------------------------------------------
+
+export interface PowerPanelDetail {
+  id: number;
+  location: number;
+  location_name: string;
+  name: string;
+  phase_configuration: PowerPanelPhase;
+  voltage: number;
+  main_breaker_amperage: number | null;
+  manufacturer: string;
+  model: string;
+  install_date: string | null;
+  notes: string;
+  needs_review: boolean;
+  breaker_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export type PowerPanelWritable = Pick<
+  PowerPanelDetail,
+  | 'location'
+  | 'name'
+  | 'phase_configuration'
+  | 'voltage'
+  | 'main_breaker_amperage'
+  | 'manufacturer'
+  | 'model'
+  | 'install_date'
+  | 'notes'
+  | 'needs_review'
+>;
+
+export interface PowerBreakerDetail {
+  id: number;
+  panel: number;
+  panel_name: string;
+  position: string;
+  pole_count: 1 | 2 | 3;
+  amperage: number;
+  phase: 'A' | 'B' | 'C' | 'AB' | 'BC' | 'AC' | 'ABC';
+  status: 'active' | 'spare' | 'locked_out';
+  label: string;
+  notes: string;
+  needs_review: boolean;
+  circuit_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export type PowerBreakerWritable = Pick<
+  PowerBreakerDetail,
+  | 'panel'
+  | 'position'
+  | 'pole_count'
+  | 'amperage'
+  | 'phase'
+  | 'status'
+  | 'label'
+  | 'notes'
+  | 'needs_review'
+>;
+
+export interface PowerCircuitDetail {
+  id: number;
+  breaker: number;
+  breaker_label: string;
+  panel_id: number;
+  panel_name: string;
+  label: string;
+  conductor_size: string;
+  conductor_length_ft: number | null;
+  max_load_amps: number | null;
+  notes: string;
+  needs_review: boolean;
+  outlet_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export type PowerCircuitWritable = Pick<
+  PowerCircuitDetail,
+  | 'breaker'
+  | 'label'
+  | 'conductor_size'
+  | 'conductor_length_ft'
+  | 'max_load_amps'
+  | 'notes'
+  | 'needs_review'
+>;
+
+export interface PowerOutletDetail {
+  id: number;
+  circuit: number;
+  circuit_label: string;
+  location: number;
+  location_name: string;
+  outlet_type: string;
+  label: string;
+  location_description: string;
+  status: 'active' | 'inactive' | 'capped';
+  notes: string;
+  needs_review: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export type PowerOutletWritable = Pick<
+  PowerOutletDetail,
+  | 'circuit'
+  | 'location'
+  | 'outlet_type'
+  | 'label'
+  | 'location_description'
+  | 'status'
+  | 'notes'
+  | 'needs_review'
+>;
+
+export const electricalTopologyAPI = {
+  // Panels
+  listPanels: () =>
+    api.get<{ results: PowerPanelDetail[] }>('/electrical/panels-crud/'),
+  getPanel: (id: number | string) =>
+    api.get<PowerPanelDetail>(`/electrical/panels-crud/${id}/`),
+  createPanel: (data: Partial<PowerPanelWritable>) =>
+    api.post<PowerPanelDetail>('/electrical/panels-crud/', data),
+  updatePanel: (id: number | string, data: Partial<PowerPanelWritable>) =>
+    api.patch<PowerPanelDetail>(`/electrical/panels-crud/${id}/`, data),
+  deletePanel: (id: number | string) =>
+    api.delete(`/electrical/panels-crud/${id}/`),
+
+  // Breakers
+  listBreakers: (params?: { panel?: number | string }) =>
+    api.get<{ results: PowerBreakerDetail[] }>('/electrical/breakers-crud/', { params }),
+  getBreaker: (id: number | string) =>
+    api.get<PowerBreakerDetail>(`/electrical/breakers-crud/${id}/`),
+  createBreaker: (data: Partial<PowerBreakerWritable>) =>
+    api.post<PowerBreakerDetail>('/electrical/breakers-crud/', data),
+  updateBreaker: (id: number | string, data: Partial<PowerBreakerWritable>) =>
+    api.patch<PowerBreakerDetail>(`/electrical/breakers-crud/${id}/`, data),
+  deleteBreaker: (id: number | string) =>
+    api.delete(`/electrical/breakers-crud/${id}/`),
+
+  // Circuits
+  listCircuits: (params?: { breaker?: number | string }) =>
+    api.get<{ results: PowerCircuitDetail[] }>('/electrical/circuits-crud/', { params }),
+  getCircuit: (id: number | string) =>
+    api.get<PowerCircuitDetail>(`/electrical/circuits-crud/${id}/`),
+  createCircuit: (data: Partial<PowerCircuitWritable>) =>
+    api.post<PowerCircuitDetail>('/electrical/circuits-crud/', data),
+  updateCircuit: (id: number | string, data: Partial<PowerCircuitWritable>) =>
+    api.patch<PowerCircuitDetail>(`/electrical/circuits-crud/${id}/`, data),
+  deleteCircuit: (id: number | string) =>
+    api.delete(`/electrical/circuits-crud/${id}/`),
+
+  // Outlets
+  listOutlets: (params?: { circuit?: number | string }) =>
+    api.get<{ results: PowerOutletDetail[] }>('/electrical/outlets-crud/', { params }),
+  getOutlet: (id: number | string) =>
+    api.get<PowerOutletDetail>(`/electrical/outlets-crud/${id}/`),
+  createOutlet: (data: Partial<PowerOutletWritable>) =>
+    api.post<PowerOutletDetail>('/electrical/outlets-crud/', data),
+  updateOutlet: (id: number | string, data: Partial<PowerOutletWritable>) =>
+    api.patch<PowerOutletDetail>(`/electrical/outlets-crud/${id}/`, data),
+  deleteOutlet: (id: number | string) =>
+    api.delete(`/electrical/outlets-crud/${id}/`),
+};
+
 // LOTO (lockout / tagout) — oms-78j
 export type LOTODeviceType =
   | 'padlock'


### PR DESCRIPTION
## Summary

Closes the loop on the power-topology rollout: admins can now create
and edit ``PowerPanel`` / ``PowerBreaker`` / ``PowerCircuit`` /
``PowerOutlet`` from the frontend instead of dropping into Django
admin. The empty new visualization pages were the user-reported
\"didn't get pushed to the frontend\" feeling — they were there, just
unusable.

## Backend (all staff-gated)

- ``PowerPanelViewSet``  → ``/api/electrical/panels-crud/``  (full CRUD)
- ``PowerBreakerViewSet`` → ``/api/electrical/breakers-crud/`` (CRUD, ``?panel=`` filter)
- ``PowerCircuitViewSet`` → ``/api/electrical/circuits-crud/`` (CRUD, ``?breaker=`` filter; ``max_load_amps`` defaults to 80% of breaker amperage)
- ``PowerOutletViewSet``  → ``/api/electrical/outlets-crud/`` (CRUD, ``?circuit=`` filter)

The existing ``/api/electrical/panels/`` safety-API list stays the
canonical retrieval path; the new ``-crud/`` companions exist for
writes.

## Frontend

- ``PowerPanelFormPage`` — ``/panels/new`` + ``/panels/:id/edit``
- ``PowerBreakerFormPage`` — ``/panels/:panelId/breakers/new`` + ``/breakers/:id/edit``
- ``PowerCircuitFormPage`` — ``/breakers/:breakerId/circuits/new`` + ``/circuits/:id/edit``
- ``PowerOutletFormPage`` — ``/circuits/:circuitId/outlets/new`` + ``/outlets/:id/edit``
- ``PowerPanelDirectoryPage``: \"New panel\" CTA in the hero;
  empty state now offers a \"Create first panel\" button instead of
  pointing at Django admin.
- ``PowerPanelDetailPage``: hero gets \"Edit panel\" + \"Add breaker\";
  each breaker row gets \"Edit\" + \"Add circuit\"; each circuit row
  gets \"Edit\" + \"+ Outlet\"; per-outlet inline edit affordance.

All form pages reuse the ``<WorkspacePage>`` shell + ``<PageHero>``
pattern from the homepage rollout.

## Tests

- 19 new backend tests in ``test_power_topology_crud.py`` (perms,
  CRUD happy paths, filter params, NEC 80% default, unique-position
  constraint, delete).
- 3 frontend tests on ``PowerPanelFormPage`` (hero rendering,
  edit-mode prefill, submit/cancel buttons). End-to-end Mantine Select
  interaction is intentionally left for the e2e suite.
- 94/94 across ``electrical_circuits/`` + permission matrix +
  reorder views.

Permission matrix YAML refreshed; the markdown doc gets four new
rows under \"Power-topology safety queries\" calling out the
``-crud/`` companions explicitly.

## Test plan

- [x] ``pytest electrical_circuits/ config/tests/test_permission_matrix.py`` — 94/94
- [x] ``npm run build`` clean (warnings only)
- [x] ``CI=true npm test`` on PowerPanel + electrical-related suites — 20/20
- [x] ``pre-commit run`` — green
- [ ] CI green
- [ ] Smoke: log in as staff, click \"New panel\" → fill → save →
  click \"Add breaker\" → save → click \"Add circuit\" → save →
  click \"+ Outlet\" → save. End state: a full panel/breaker/circuit/outlet chain visible in ``/facilities/electrical/panels/:id``.