### PR TITLE
feat(ui): landing-surface rollout — detail + dashboard pages (batch 4)

### DIFF
--- a/frontend/src/__tests__/pages/ForgeKeyDeviceDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyDeviceDetailPage.test.tsx
@@ -7,6 +7,7 @@
  *   - non-staff users get redirected
  *   - OTA disabled state
  */
+import { MantineProvider } from '@mantine/core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import ForgeKeyDeviceDetailPage from '../../pages/ForgeKeyDeviceDetailPage';
@@ -71,12 +72,14 @@ const buildDevice = (overrides: Partial<any> = {}) => ({
 
 const renderAt = (path: string) =>
   render(
-    <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route path="/facilities/forgekey-devices/:id" element={<ForgeKeyDeviceDetailPage />} />
-        <Route path="/" element={<div>home</div>} />
-      </Routes>
-    </MemoryRouter>,
+    <MantineProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/facilities/forgekey-devices/:id" element={<ForgeKeyDeviceDetailPage />} />
+          <Route path="/" element={<div>home</div>} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
   );
 
 const seedHappyPath = () => {

--- a/frontend/src/__tests__/pages/PurchaseOrderPage.test.tsx
+++ b/frontend/src/__tests__/pages/PurchaseOrderPage.test.tsx
@@ -3,6 +3,7 @@
  *  - oms-aq2: editable metadata + file attachments behaviors.
  *  - oms-74q: freeform PO line items render their description, not 'Unknown Item'.
  */
+import { MantineProvider } from '@mantine/core';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import PurchaseOrderPage from '../../pages/PurchaseOrderPage';
@@ -21,11 +22,13 @@ jest.mock('../../utils/dialogs', () => ({
 
 const renderPage = () =>
   render(
-    <MemoryRouter initialEntries={['/purchase-orders/po-1']}>
-      <Routes>
-        <Route path="/purchase-orders/:orderId" element={<PurchaseOrderPage />} />
-      </Routes>
-    </MemoryRouter>
+    <MantineProvider>
+      <MemoryRouter initialEntries={['/purchase-orders/po-1']}>
+        <Routes>
+          <Route path="/purchase-orders/:orderId" element={<PurchaseOrderPage />} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>
   );
 
 const baseOrder = {

--- a/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
+++ b/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
@@ -5,10 +5,12 @@
  * device. Polls the occupancy endpoint on a fixed interval; SSE/WebSocket
  * push is a follow-up. Staff/superuser only.
  */
+import { Paper, Text } from '@mantine/core';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Navigate, useParams } from 'react-router-dom';
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import DeviceControlsCard from '../components/DeviceControlsCard';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import {
   ForgeKeyCommandResponse,
   ForgeKeyDevice,
@@ -113,29 +115,43 @@ const ForgeKeyDeviceDetailPage: React.FC = () => {
   }
 
   if (!id) {
-    return <p style={{ padding: '1.5rem' }}>Missing device id.</p>;
+    return (
+      <WorkspacePage
+        testId="forgekey-device-detail-page"
+        hero={{
+          eyebrow: 'Facilities · ForgeKey device',
+          title: 'ForgeKey device',
+          description: 'Missing device id.',
+        }}
+      >
+        <Paper withBorder p="md">
+          <Text c="red">Missing device id.</Text>
+        </Paper>
+      </WorkspacePage>
+    );
   }
 
   return (
-    <div style={{ padding: '1.5rem', display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      <h1>ForgeKey Device</h1>
+    <WorkspacePage
+      testId="forgekey-device-detail-page"
+      hero={{
+        eyebrow: device
+          ? `Facilities · ForgeKey · ${device.device_type_name ?? 'device'}`
+          : 'Facilities · ForgeKey device',
+        title: device ? device.name || device.mac_address : 'ForgeKey device',
+        description: device
+          ? `${device.mac_address} · ${device.is_online ? 'Online' : 'Offline'} · last seen ${
+              device.last_seen ? new Date(device.last_seen).toLocaleString() : '—'
+            }`
+          : 'Loading device…',
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
       {loadError && <p style={{ color: '#c0392b' }}>{loadError}</p>}
       {loading && !device ? (
         <p>Loading…</p>
       ) : device ? (
         <>
-          <section>
-            <h2 style={{ marginBottom: '0.25rem' }}>{device.name || device.mac_address}</h2>
-            <p style={{ color: '#555', margin: 0, fontFamily: 'monospace' }}>
-              {device.mac_address} · {device.device_type_name ?? '—'}
-            </p>
-            <p style={{ color: '#555', margin: 0 }}>
-              Last seen: {device.last_seen ? new Date(device.last_seen).toLocaleString() : '—'} ·{' '}
-              <span style={{ color: device.is_online ? '#1f8a3a' : '#777' }}>
-                {device.is_online ? 'Online' : 'Offline'}
-              </span>
-            </p>
-          </section>
 
           <section aria-label="Occupancy chart">
             <h3>Occupancy (last 24h)</h3>
@@ -222,7 +238,8 @@ const ForgeKeyDeviceDetailPage: React.FC = () => {
       ) : (
         <p>Device not found.</p>
       )}
-    </div>
+      </div>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/LocationProblemDetailPage.tsx
+++ b/frontend/src/pages/LocationProblemDetailPage.tsx
@@ -4,8 +4,10 @@
  * Shows a single LocationProblem with reporter info, photo, paper-form
  * attachment, and promote-to-WO / resolve actions for staff.
  */
+import { Button, Paper, Text } from '@mantine/core';
 import React, { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import api, { locationProblemsAPI, maintenanceAPI } from '../services/api';
 import { LocationProblem, MaintenanceItem } from '../types';
 import { showError, showSuccess } from '../utils/dialogs';
@@ -138,15 +140,41 @@ const LocationProblemDetailPage: React.FC = () => {
     }
   };
 
-  if (loading) return <div className="page">Loading…</div>;
+  if (loading) {
+    return (
+      <WorkspacePage
+        testId="location-problem-detail-page"
+        hero={{
+          eyebrow: 'Maintenance · Location problem',
+          title: 'Location problem',
+          description: 'Loading…',
+        }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading problem…</Text>
+        </Paper>
+      </WorkspacePage>
+    );
+  }
   if (error || !problem) {
     return (
-      <div className="page">
-        <p className="error">{error || 'Problem not found.'}</p>
-        <Link to="/inventory/locations" className="btn-secondary">
-          Back to Locations
-        </Link>
-      </div>
+      <WorkspacePage
+        testId="location-problem-detail-page"
+        hero={{
+          eyebrow: 'Maintenance · Location problem',
+          title: 'Location problem',
+          description: error || 'Not found.',
+          action: (
+            <Button component={Link} to="/inventory/locations" variant="default">
+              Back to locations
+            </Button>
+          ),
+        }}
+      >
+        <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+          <Text>{error || 'Problem not found.'}</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
@@ -155,17 +183,16 @@ const LocationProblemDetailPage: React.FC = () => {
   const isResolved = problem.status === 'resolved' || problem.status === 'closed';
 
   return (
-    <div className="page location-problem-detail-page">
-      <header className="page-header">
-        <div>
-          <h1>Location Problem</h1>
-          <p>
-            <Link to={`/inventory/locations/${problem.location}`}>
-              {problem.location_name}
-            </Link>
-          </p>
-        </div>
-        <div className="header-actions">
+    <WorkspacePage
+      testId="location-problem-detail-page"
+      hero={{
+        eyebrow: `Maintenance · ${problem.location_name}`,
+        title: 'Location problem',
+        description: problem.severity_display,
+      }}
+    >
+      <div className="page location-problem-detail-page">
+        <div className="header-actions" style={{ marginBottom: '1rem' }}>
           <span
             className="lp-severity-badge"
             style={{
@@ -181,7 +208,6 @@ const LocationProblemDetailPage: React.FC = () => {
             {problem.status_display}
           </span>
         </div>
-      </header>
 
       <section className="detail-section">
         <h2>Description</h2>
@@ -334,7 +360,8 @@ const LocationProblemDetailPage: React.FC = () => {
           </div>
         </section>
       )}
-    </div>
+      </div>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/MaintenanceDashboard.tsx
+++ b/frontend/src/pages/MaintenanceDashboard.tsx
@@ -33,6 +33,7 @@ import {
 } from '@tabler/icons-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { maintenanceAPI, reorderAPI, workOrderAPI } from '../services/api';
 import { LowStockAlert, MaintenanceItem, WorkOrder, WorkOrderUploadResult } from '../types';
 import { parseYmd } from '../utils/dates';
@@ -433,60 +434,72 @@ const MaintenanceDashboard: React.FC = () => {
 
   if (loading) {
     return (
-      <Container py="xl">
+      <WorkspacePage
+        testId="maintenance-dashboard"
+        hero={{
+          eyebrow: 'Maintenance',
+          title: 'Preventive maintenance',
+          description: 'Loading…',
+        }}
+      >
         <Group justify="center">
           <Loader />
           <Text c="dimmed">Loading maintenance data…</Text>
         </Group>
-      </Container>
+      </WorkspacePage>
     );
   }
 
   return (
-    <Container size="xl" py="md">
-      <Group justify="space-between" mb="md">
-        <Title order={2}>Preventive Maintenance</Title>
-        <Group>
-          <Button
-            leftSection={<IconRefresh size={16} />}
-            variant="default"
-            size="sm"
-            onClick={loadData}
-            loading={loading}
-          >
-            Refresh
-          </Button>
-          <Button
-            leftSection={<IconPlus size={16} />}
-            size="sm"
-            onClick={openBulkConfirm}
-            loading={generatingBulk}
-          >
-            Generate Due Work Orders
-          </Button>
-          {isStaff && (
-            <FileButton
-              resetRef={resetPdfRef}
-              accept="application/pdf"
-              onChange={handlePdfUpload}
+    <WorkspacePage
+      testId="maintenance-dashboard"
+      hero={{
+        eyebrow: 'Maintenance',
+        title: 'Preventive maintenance',
+        description: 'Due PM tasks, open work orders, and bulk work-order generation.',
+        action: (
+          <Group gap="sm">
+            <Button
+              leftSection={<IconRefresh size={16} />}
+              variant="default"
+              size="sm"
+              onClick={loadData}
+              loading={loading}
             >
-              {(props) => (
-                <Button
-                  {...props}
-                  leftSection={<IconUpload size={16} />}
-                  variant="default"
-                  size="sm"
-                  loading={uploadingPdf}
-                  aria-label="Upload completed work order PDF"
-                >
-                  Upload PDF
-                </Button>
-              )}
-            </FileButton>
-          )}
-        </Group>
-      </Group>
-
+              Refresh
+            </Button>
+            <Button
+              leftSection={<IconPlus size={16} />}
+              size="sm"
+              onClick={openBulkConfirm}
+              loading={generatingBulk}
+            >
+              Generate due WOs
+            </Button>
+            {isStaff && (
+              <FileButton
+                resetRef={resetPdfRef}
+                accept="application/pdf"
+                onChange={handlePdfUpload}
+              >
+                {(props) => (
+                  <Button
+                    {...props}
+                    leftSection={<IconUpload size={16} />}
+                    variant="default"
+                    size="sm"
+                    loading={uploadingPdf}
+                    aria-label="Upload completed work order PDF"
+                  >
+                    Upload PDF
+                  </Button>
+                )}
+              </FileButton>
+            )}
+          </Group>
+        ),
+      }}
+    >
       {/* Stats row */}
       <SimpleGrid cols={{ base: 2, sm: 4 }} mb="lg">
         <StatCard
@@ -740,7 +753,7 @@ const MaintenanceDashboard: React.FC = () => {
           </Stack>
         )}
       </Modal>
-    </Container>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/MaintenanceItemFormPage.tsx
+++ b/frontend/src/pages/MaintenanceItemFormPage.tsx
@@ -22,6 +22,7 @@ import { FormInput } from '../components/forms/FormInput';
 import { FormLayout } from '../components/forms/FormLayout';
 import { FormNumberInput } from '../components/forms/FormNumberInput';
 import { FormTextarea } from '../components/forms/FormTextarea';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { maintenanceAPI } from '../services/api';
 import { MaintenanceMaterial } from '../types';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
@@ -170,21 +171,31 @@ const MaintenanceItemFormPage: React.FC = () => {
 
   if (loading) {
     return (
-      <Paper p="md">
-        <Text>Loading...</Text>
-      </Paper>
+      <WorkspacePage
+        testId="maintenance-item-form-page"
+        hero={{ eyebrow: 'Maintenance · PM task', title: 'PM task', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading task…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   return (
-    <Stack gap="md">
-      <Group justify="space-between">
-        <Title order={2}>{isEditMode ? 'Edit PM Task' : 'New PM Task'}</Title>
-        <Button variant="subtle" onClick={() => navigate(`/assets/${assetId}`)}>
-          Cancel
-        </Button>
-      </Group>
-
+    <WorkspacePage
+      testId="maintenance-item-form-page"
+      hero={{
+        eyebrow: 'Maintenance · PM task',
+        title: isEditMode ? 'Edit PM task' : 'New PM task',
+        description: 'A recurring preventive-maintenance task tied to a specific asset.',
+        action: (
+          <Button variant="default" onClick={() => navigate(`/assets/${assetId}`)}>
+            Cancel
+          </Button>
+        ),
+      }}
+    >
       {error && (
         <Alert icon={<IconAlertCircle size={16} />} title="Error" color="red">
           {error}
@@ -353,7 +364,7 @@ const MaintenanceItemFormPage: React.FC = () => {
           </Group>
         </Paper>
       </form>
-    </Stack>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/PurchaseOrderPage.tsx
+++ b/frontend/src/pages/PurchaseOrderPage.tsx
@@ -2,8 +2,10 @@
  * Purchase Order Management Page
  * View and manage purchase orders, including setting expected shipment dates for line items
  */
+import { Button, Paper, Text } from '@mantine/core';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { purchaseOrderAPI } from '../services/api';
 import '../styles/PurchaseOrderPage.css';
 import { formatDateOnly, formatYmd } from '../utils/dates';
@@ -381,41 +383,48 @@ const PurchaseOrderPage: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="purchase-order-page">
-        <div className="loading">Loading purchase order...</div>
-      </div>
+      <WorkspacePage
+        testId="purchase-order-page"
+        hero={{ eyebrow: 'Purchasing · Order', title: 'Purchase order', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading purchase order…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   if (error || !order) {
     return (
-      <div className="purchase-order-page">
-        <div className="error">
-          <h2>Error</h2>
-          <p>{error || 'Purchase order not found'}</p>
-        </div>
-      </div>
+      <WorkspacePage
+        testId="purchase-order-page"
+        hero={{
+          eyebrow: 'Purchasing · Order',
+          title: 'Purchase order',
+          description: error || 'Not found.',
+        }}
+      >
+        <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+          <Text>{error || 'Purchase order not found'}</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   return (
-    <div className="purchase-order-page">
-      <header className="po-header">
-        <div>
-          <h1>Purchase Order: {order.po_number}</h1>
-          <p className="po-supplier">Supplier: {order.supplier_details}</p>
-        </div>
+    <WorkspacePage
+      testId="purchase-order-page"
+      hero={{
+        eyebrow: `Purchasing · ${order.supplier_details}`,
+        title: `PO ${order.po_number}`,
+        description: order.status_label,
+        action: canMarkDelivered(order) && !markingDelivered ? (
+          <Button onClick={handleOpenMarkDelivered}>Mark as delivered</Button>
+        ) : undefined,
+      }}
+    >
+      <div className="purchase-order-page">
         <div className="po-status">
-          <span className={`status-badge status-${order.status}`}>{order.status_label}</span>
-          {canMarkDelivered(order) && !markingDelivered && (
-            <button
-              type="button"
-              className="btn-primary mark-delivered-button"
-              onClick={handleOpenMarkDelivered}
-            >
-              Mark as Delivered
-            </button>
-          )}
           {canVoidOrder(order) && (
             <button
               type="button"
@@ -427,7 +436,6 @@ const PurchaseOrderPage: React.FC = () => {
             </button>
           )}
         </div>
-      </header>
 
       {order.status === 'voided' && (
         <section className="po-voided-banner" aria-label="Voided purchase order">
@@ -915,7 +923,8 @@ const PurchaseOrderPage: React.FC = () => {
           </tbody>
         </table>
       </section>
-    </div>
+      </div>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/WebhookDetailPage.tsx
+++ b/frontend/src/pages/WebhookDetailPage.tsx
@@ -20,6 +20,7 @@ import {
 import { IconEdit, IconExternalLink, IconTestPipe, IconTrash } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { webhooksAPI } from '../services/api';
 import '../styles/WebhookDetailPage.css';
 import { Webhook, WebhookTestResult } from '../types';
@@ -166,43 +167,51 @@ const WebhookDetailPage: React.FC = () => {
 
   if (loading) {
     return (
-      <Paper p="md">
-        <Text>Loading...</Text>
-      </Paper>
+      <WorkspacePage
+        testId="webhook-detail-page"
+        hero={{ eyebrow: 'Settings · Webhook', title: 'Webhook', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading webhook…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   if (!webhook) {
     return (
-      <Paper p="md">
-        <Text>Webhook not found</Text>
-      </Paper>
+      <WorkspacePage
+        testId="webhook-detail-page"
+        hero={{ eyebrow: 'Settings · Webhook', title: 'Webhook', description: 'Not found.' }}
+      >
+        <Paper withBorder p="md">
+          <Text>Webhook not found.</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   return (
-    <div className="webhook-detail-page">
-      <Stack gap="md">
-        {/* Header */}
-        <Group justify="space-between">
-          <div>
-            <Title order={2}>{webhook.name}</Title>
-            <Text size="sm" c="dimmed">
-              {webhook.event_type_display}
-            </Text>
-          </div>
-          <Group>
+    <WorkspacePage
+      testId="webhook-detail-page"
+      hero={{
+        eyebrow: `Settings · Webhook · ${webhook.event_type_display}`,
+        title: webhook.name,
+        description: webhook.url,
+        action: (
+          <Group gap="sm">
             <Button
               leftSection={<IconTestPipe size={16} />}
               onClick={handleTest}
               loading={testing}
               variant="light"
             >
-              Test Webhook
+              Test
             </Button>
             <Button
               leftSection={<IconEdit size={16} />}
               onClick={() => navigate(`/settings/webhooks/${id}/edit`)}
+              variant="default"
             >
               Edit
             </Button>
@@ -215,10 +224,13 @@ const WebhookDetailPage: React.FC = () => {
               Delete
             </Button>
           </Group>
-        </Group>
-
-        {/* Status Badges */}
-        <Group>
+        ),
+      }}
+    >
+      <div className="webhook-detail-page">
+        <Stack gap="md">
+          {/* Status Badges */}
+          <Group>
           {webhook.is_active ? (
             <Badge color="green" size="lg">Active</Badge>
           ) : (
@@ -560,7 +572,8 @@ const WebhookDetailPage: React.FC = () => {
           </Stack>
         )}
       </Modal>
-    </div>
+      </div>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/WorkOrderPage.tsx
+++ b/frontend/src/pages/WorkOrderPage.tsx
@@ -36,6 +36,7 @@ import {
 } from '@tabler/icons-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { workOrderAPI } from '../services/api';
 import { WorkOrder, WorkOrderStatus } from '../types';
 import { formatDateOnly } from '../utils/dates';
@@ -327,23 +328,37 @@ const WorkOrderPage: React.FC = () => {
 
   if (loading) {
     return (
-      <Container py="xl">
+      <WorkspacePage
+        testId="work-order-page"
+        hero={{ eyebrow: 'Maintenance · Work order', title: 'Work order', description: 'Loading…' }}
+        containerSize="sm"
+      >
         <Group justify="center">
           <Loader />
           <Text c="dimmed">Loading work order…</Text>
         </Group>
-      </Container>
+      </WorkspacePage>
     );
   }
 
   if (!workOrder) {
     return (
-      <Container py="xl">
+      <WorkspacePage
+        testId="work-order-page"
+        hero={{
+          eyebrow: 'Maintenance · Work order',
+          title: 'Work order',
+          description: 'Not found.',
+          action: (
+            <Button variant="default" onClick={() => navigate('/maintenance/dashboard')}>
+              Back to dashboard
+            </Button>
+          ),
+        }}
+        containerSize="sm"
+      >
         <Text c="red">Work order not found.</Text>
-        <Button mt="sm" variant="default" onClick={() => navigate('/maintenance/dashboard')}>
-          Back to Dashboard
-        </Button>
-      </Container>
+      </WorkspacePage>
     );
   }
 
@@ -352,9 +367,17 @@ const WorkOrderPage: React.FC = () => {
   const allTasksDone = totalTasks > 0 && completedTasks === totalTasks;
 
   return (
-    <Container size="sm" py="md">
+    <WorkspacePage
+      testId="work-order-page"
+      hero={{
+        eyebrow: `Maintenance · ${workOrder.short_id}`,
+        title: workOrder.maintenance_item_title,
+        description: workOrder.asset_name ? `Asset: ${workOrder.asset_name}` : undefined,
+      }}
+      containerSize="sm"
+    >
       {/* Header */}
-      <Card withBorder p="md" radius="md" mb="md">
+      <Card withBorder p="md" radius="md">
         <Group justify="space-between" mb="xs" wrap="nowrap">
           <Box style={{ flex: 1, minWidth: 0 }}>
             <Group gap="xs" mb={4}>
@@ -921,7 +944,7 @@ const WorkOrderPage: React.FC = () => {
           </Group>
         </Stack>
       </Modal>
-    </Container>
+    </WorkspacePage>
   );
 };
 


### PR DESCRIPTION
## Summary

Continues the homepage-style migration onto the heavily-used detail
and dashboard surfaces.

## Pages migrated

- ``MaintenanceItemFormPage`` — PM task create/edit
- ``WorkOrderPage`` — work-order detail (the page maintenance staff
  hit daily)
- ``PurchaseOrderPage`` — PO detail; \"Mark as delivered\" hoisted
  into the hero
- ``WebhookDetailPage`` — Test / Edit / Delete actions consolidated
  in the hero
- ``LocationProblemDetailPage``
- ``ForgeKeyDeviceDetailPage`` — live device + occupancy chart
- ``MaintenanceDashboard`` — Refresh + Generate-due-WOs + Upload-PDF
  all moved into the hero action slot

Same shell + hero pattern as the prior rollout PRs. Bespoke
``<header className=\"page-header\">`` blocks dropped where they existed.

## Tests

- 23/23 affected suites pass
- Added ``MantineProvider`` wrappers to two suites
  (``PurchaseOrderPage``, ``ForgeKeyDeviceDetailPage``) that had been
  relying on pre-Mantine page chrome

## Test plan

- [x] ``CI=true npm test`` on affected suites — green
- [x] ``npm run build`` clean
- [x] ``pre-commit run`` — green
- [ ] CI green