### PR TITLE
feat(ui): landing-surface rollout — public + admin surfaces (batch 5)

### DIFF
--- a/frontend/src/__tests__/pages/AssetDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/AssetDetailPage.test.tsx
@@ -1,6 +1,7 @@
 /**
  * Tests for AssetDetailPage component
  */
+import { MantineProvider } from '@mantine/core';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
@@ -179,9 +180,9 @@ describe('AssetDetailPage', () => {
 
   it('renders asset details', async () => {
     render(
-      <MemoryRouter>
+      <MantineProvider><MemoryRouter>
         <AssetDetailPage />
-      </MemoryRouter>
+      </MemoryRouter></MantineProvider>
     );
 
     await waitFor(() => {
@@ -195,9 +196,9 @@ describe('AssetDetailPage', () => {
 
   it('displays part replacement tracking', async () => {
     render(
-      <MemoryRouter>
+      <MantineProvider><MemoryRouter>
         <AssetDetailPage />
-      </MemoryRouter>
+      </MemoryRouter></MantineProvider>
     );
 
     await waitFor(() => {
@@ -213,9 +214,9 @@ describe('AssetDetailPage', () => {
 
   it('displays problem history', async () => {
     render(
-      <MemoryRouter>
+      <MantineProvider><MemoryRouter>
         <AssetDetailPage />
-      </MemoryRouter>
+      </MemoryRouter></MantineProvider>
     );
 
     await waitFor(() => {
@@ -228,9 +229,9 @@ describe('AssetDetailPage', () => {
 
   it('filters problems by status', async () => {
     render(
-      <MemoryRouter>
+      <MantineProvider><MemoryRouter>
         <AssetDetailPage />
-      </MemoryRouter>
+      </MemoryRouter></MantineProvider>
     );
 
     await waitFor(() => {
@@ -270,9 +271,9 @@ describe('AssetDetailPage', () => {
     });
 
     render(
-      <MemoryRouter>
+      <MantineProvider><MemoryRouter>
         <AssetDetailPage />
-      </MemoryRouter>
+      </MemoryRouter></MantineProvider>
     );
 
     await waitFor(() => {
@@ -289,9 +290,9 @@ describe('AssetDetailPage', () => {
 
   it('displays QR code when available', async () => {
     render(
-      <MemoryRouter>
+      <MantineProvider><MemoryRouter>
         <AssetDetailPage />
-      </MemoryRouter>
+      </MemoryRouter></MantineProvider>
     );
 
     await waitFor(() => {
@@ -320,9 +321,9 @@ describe('AssetDetailPage', () => {
     });
 
     render(
-      <MemoryRouter>
+      <MantineProvider><MemoryRouter>
         <AssetDetailPage />
-      </MemoryRouter>
+      </MemoryRouter></MantineProvider>
     );
 
     await waitFor(() => {
@@ -339,9 +340,9 @@ describe('AssetDetailPage', () => {
 
   it('hides asset tag section when not logged in', async () => {
     render(
-      <MemoryRouter>
+      <MantineProvider><MemoryRouter>
         <AssetDetailPage />
-      </MemoryRouter>
+      </MemoryRouter></MantineProvider>
     );
 
     await waitFor(() => {
@@ -362,9 +363,9 @@ describe('AssetDetailPage', () => {
 
     it('renders preview, size selector, and download link', async () => {
       render(
-        <MemoryRouter>
+        <MantineProvider><MemoryRouter>
           <AssetDetailPage />
-        </MemoryRouter>
+        </MemoryRouter></MantineProvider>
       );
 
       await waitFor(() => {
@@ -403,25 +404,27 @@ describe('AssetDetailPage', () => {
     );
 
     render(
-      <MemoryRouter>
+      <MantineProvider><MemoryRouter>
         <AssetDetailPage />
-      </MemoryRouter>
+      </MemoryRouter></MantineProvider>
     );
 
-    expect(screen.getByText('Loading asset details...')).toBeInTheDocument();
+    expect(screen.getByText(/Loading asset details/)).toBeInTheDocument();
   });
 
   it('shows error state', async () => {
     mockAssetsAPI.getAsset.mockRejectedValueOnce(new Error('Failed to load'));
 
     render(
-      <MemoryRouter>
+      <MantineProvider><MemoryRouter>
         <AssetDetailPage />
-      </MemoryRouter>
+      </MemoryRouter></MantineProvider>
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/Error:/)).toBeInTheDocument();
+      // Error string surfaces in the WorkspacePage hero description and
+      // the red panel underneath.
+      expect(screen.getAllByText(/Failed to load/i).length).toBeGreaterThan(0);
     });
   });
 
@@ -488,9 +491,9 @@ describe('AssetDetailPage', () => {
       } as any);
 
       render(
-        <MemoryRouter>
+        <MantineProvider><MemoryRouter>
           <AssetDetailPage />
-        </MemoryRouter>
+        </MemoryRouter></MantineProvider>
       );
 
       await waitFor(() => {
@@ -513,9 +516,9 @@ describe('AssetDetailPage', () => {
 
     it('does not render legacy maintenance_plan or condition_notes on the detail page', async () => {
       render(
-        <MemoryRouter>
+        <MantineProvider><MemoryRouter>
           <AssetDetailPage />
-        </MemoryRouter>
+        </MemoryRouter></MantineProvider>
       );
 
       await waitFor(() => {
@@ -591,9 +594,9 @@ describe('AssetDetailPage', () => {
 
     it('opens clone modal when Clone button is clicked', async () => {
       render(
-        <MemoryRouter>
+        <MantineProvider><MemoryRouter>
           <AssetDetailPage />
-        </MemoryRouter>
+        </MemoryRouter></MantineProvider>
       );
 
       const cloneButton = await screen.findByText('Clone to asset...');
@@ -620,9 +623,9 @@ describe('AssetDetailPage', () => {
       });
 
       render(
-        <MemoryRouter>
+        <MantineProvider><MemoryRouter>
           <AssetDetailPage />
-        </MemoryRouter>
+        </MemoryRouter></MantineProvider>
       );
 
       const cloneButton = await screen.findByText('Clone to asset...');
@@ -649,9 +652,9 @@ describe('AssetDetailPage', () => {
   describe('LOTO section (oms-78j AC-4)', () => {
     it('shows "No LOTO required" when no lockout configured', async () => {
       render(
-        <MemoryRouter>
+        <MantineProvider><MemoryRouter>
           <AssetDetailPage />
-        </MemoryRouter>
+        </MemoryRouter></MantineProvider>
       );
       await waitFor(() => {
         expect(screen.getByText(/Lockout \/ Tagout/)).toBeInTheDocument();
@@ -702,9 +705,9 @@ describe('AssetDetailPage', () => {
       });
 
       render(
-        <MemoryRouter>
+        <MantineProvider><MemoryRouter>
           <AssetDetailPage />
-        </MemoryRouter>
+        </MemoryRouter></MantineProvider>
       );
 
       await waitFor(() => {

--- a/frontend/src/__tests__/pages/TransparencyPage.test.tsx
+++ b/frontend/src/__tests__/pages/TransparencyPage.test.tsx
@@ -1,3 +1,4 @@
+import { MantineProvider } from '@mantine/core';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import TransparencyPage from '../../pages/TransparencyPage';
@@ -70,9 +71,9 @@ describe('TransparencyPage', () => {
     getTransparencyLedgerMock.mockResolvedValue({ data: mockTransparencyData });
 
     render(
-      <MemoryRouter>
+      <MantineProvider><MemoryRouter>
         <TransparencyPage />
-      </MemoryRouter>
+      </MemoryRouter></MantineProvider>
     );
 
     await waitFor(() => {

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -8,6 +8,7 @@ import { useForm } from '@mantine/form';
 import { modals } from '@mantine/modals';
 import dayjs from 'dayjs';
 import React, { useCallback, useEffect, useState } from 'react';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { assetsAPI, inventoryAPI, reorderAPI } from '../services/api';
 import '../styles/AdminDashboard.css';
 import { Asset, InventoryItem, ReorderRequest } from '../types';
@@ -337,15 +338,20 @@ const AdminDashboard: React.FC = () => {
   };
 
   return (
-    <div className="admin-dashboard">
-      <header className="dashboard-header">
-        <h1>Admin Dashboard</h1>
-        <div className="header-actions">
-          <button onClick={loadSupplierGroups} className="btn-secondary">
-            View by Supplier
-          </button>
-        </div>
-      </header>
+    <WorkspacePage
+      testId="admin-dashboard"
+      hero={{
+        eyebrow: 'Inventory · Admin',
+        title: 'Admin dashboard',
+        description: 'Reorder queue, supplier groups, and pending requests.',
+        action: (
+          <Button onClick={loadSupplierGroups} variant="default">
+            View by supplier
+          </Button>
+        ),
+      }}
+    >
+      <div className="admin-dashboard">
 
       <div className="filter-bar">
         <button
@@ -663,7 +669,8 @@ const AdminDashboard: React.FC = () => {
           </>
         )}
       </div>
-    </div>
+      </div>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/AssetDetailPage.tsx
+++ b/frontend/src/pages/AssetDetailPage.tsx
@@ -2,8 +2,10 @@
  * Asset Detail Page
  * Full page view for asset details with part tracking, problem history, maintenance, QR code, and lock/unlock controls
  */
+import { Badge, Button, Group, Paper, Text } from '@mantine/core';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import {
   AssetLOTORequirements,
   assetPartsAPI,
@@ -328,58 +330,81 @@ const AssetDetailPage: React.FC = () => {
   });
 
   if (loading) {
-    return <div className="asset-detail-loading">Loading asset details...</div>;
+    return (
+      <WorkspacePage
+        testId="asset-detail-page"
+        hero={{ eyebrow: 'Assets', title: 'Asset', description: 'Loading…' }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading asset details…</Text>
+        </Paper>
+      </WorkspacePage>
+    );
   }
 
   if (error || !asset) {
     return (
-      <div className="asset-detail-error">
-        <p>Error: {error || 'Asset not found'}</p>
-        <button onClick={() => navigate(-1)}>Go Back</button>
-      </div>
+      <WorkspacePage
+        testId="asset-detail-page"
+        hero={{
+          eyebrow: 'Assets',
+          title: 'Asset',
+          description: error || 'Not found.',
+          action: (
+            <Button variant="default" onClick={() => navigate(-1)}>
+              Go back
+            </Button>
+          ),
+        }}
+      >
+        <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+          <Text>{error || 'Asset not found'}</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   return (
-    <div className="asset-detail-page">
-      {/* Header */}
-      <div className="asset-detail-header">
-        <div className="asset-detail-header-left">
-          <button className="back-button" onClick={() => navigate(-1)}>
-            ← Back
-          </button>
-          <h1>{asset.name}</h1>
-          <span className={`status-badge ${getStatusBadgeClass(asset.status)}`}>
-            {getStatusLabel(asset.status)}
-          </span>
-        </div>
-        <div className="asset-detail-header-right">
-          {asset.can_unlock && (
-            <>
-              {asset.is_locked ? (
-                <button
-                  className="action-button unlock-button"
+    <WorkspacePage
+      testId="asset-detail-page"
+      hero={{
+        eyebrow: asset.asset_tag ? `Assets · ${asset.asset_tag}` : 'Assets',
+        title: asset.name,
+        description: getStatusLabel(asset.status),
+        action: (
+          <Group gap="sm">
+            {asset.can_unlock && (
+              asset.is_locked ? (
+                <Button
+                  variant="filled"
                   onClick={handleUnlock}
                   disabled={actionLoading === 'unlock'}
+                  loading={actionLoading === 'unlock'}
                 >
-                  {actionLoading === 'unlock' ? 'Unlocking...' : 'Unlock Asset'}
-                </button>
+                  Unlock asset
+                </Button>
               ) : (
-                <button
-                  className="action-button lock-button"
+                <Button
+                  variant="default"
                   onClick={handleLock}
                   disabled={actionLoading === 'lock'}
+                  loading={actionLoading === 'lock'}
                 >
-                  {actionLoading === 'lock' ? 'Locking...' : 'Lock Asset'}
-                </button>
-              )}
-            </>
-          )}
-          <button className="action-button edit-button" onClick={handleEdit}>
-            Edit Asset
-          </button>
-        </div>
-      </div>
+                  Lock asset
+                </Button>
+              )
+            )}
+            <Button onClick={handleEdit}>Edit asset</Button>
+          </Group>
+        ),
+      }}
+    >
+      <div className="asset-detail-page">
+        <Group gap="sm">
+          <Badge size="lg" radius="sm" variant="light">
+            {getStatusLabel(asset.status)}
+          </Badge>
+        </Group>
 
       {/* Asset Image */}
       {asset.image_url && (
@@ -1138,7 +1163,8 @@ const AssetDetailPage: React.FC = () => {
           </div>
         </div>
       )}
-    </div>
+      </div>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/TaxReceiptLookupPage.tsx
+++ b/frontend/src/pages/TaxReceiptLookupPage.tsx
@@ -3,6 +3,7 @@
  * Public-facing page for looking up tax receipts by serial number
  */
 import React, { useState } from 'react';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { donationsAPI } from '../services/api';
 import { TaxReceipt } from '../types';
 import '../styles/ScanPage.css';
@@ -59,14 +60,18 @@ const TaxReceiptLookupPage: React.FC = () => {
     formatDateOnly(dateString, { year: 'numeric', month: 'long', day: 'numeric' });
 
   return (
-    <div className="scan-page">
-      <div className="scan-container">
-        <h1>Tax Receipt Lookup</h1>
-        <p className="scan-subtitle">
-          Enter your tax receipt serial number to view and download your receipt
-        </p>
-
-        <form onSubmit={handleLookup} className="scan-form">
+    <WorkspacePage
+      testId="tax-receipt-lookup-page"
+      hero={{
+        eyebrow: 'Settings · Tax receipt',
+        title: 'Tax receipt lookup',
+        description: 'Enter your serial number to view and download your receipt.',
+      }}
+      containerSize="sm"
+    >
+      <div className="scan-page">
+        <div className="scan-container">
+          <form onSubmit={handleLookup} className="scan-form">
           <div className="form-group">
             <label htmlFor="serialNumber">Serial Number</label>
             <input
@@ -129,7 +134,8 @@ const TaxReceiptLookupPage: React.FC = () => {
           </div>
         )}
       </div>
-    </div>
+      </div>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/ThanksPage.tsx
+++ b/frontend/src/pages/ThanksPage.tsx
@@ -1,47 +1,56 @@
 /**
  * Thanks Page
- * Simple thank you page for non-authenticated users who submit reorder requests
+ * Simple thank-you page shown after an anonymous QR-scan reorder
+ * submission. Auto-redirects to the homepage after 5 seconds.
  */
+import { Box, Button, Container, Stack, Text, ThemeIcon, Title } from '@mantine/core';
+import { IconCheck } from '@tabler/icons-react';
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import '../styles/ThanksPage.css';
+
+import '../styles/landing.css';
 
 const ThanksPage: React.FC = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // Auto redirect to home after 5 seconds
     const timer = setTimeout(() => {
       navigate('/');
     }, 5000);
-
     return () => clearTimeout(timer);
   }, [navigate]);
 
   return (
-    <div className="thanks-page">
-      <div className="thanks-content">
-        <div className="success-icon">✓</div>
-        <h1>Thanks for letting us know!</h1>
-        <p>
-          Your reorder request has been submitted successfully.
-        </p>
-        <p>
-          Our inventory team will review your request and take appropriate action.
-        </p>
-        <div className="actions">
-          <button
-            onClick={() => navigate('/')}
-            className="btn-primary"
-          >
-            Back to Home
-          </button>
-        </div>
-        <p className="redirect-message">
-          Automatically redirecting to home in a few seconds...
-        </p>
-      </div>
-    </div>
+    <Box className="landing-surface" data-testid="thanks-page">
+      <Container size="sm" py="xl">
+        <Stack gap="lg" align="center" py="xl">
+          <ThemeIcon size={72} radius="xl" color="green" variant="light">
+            <IconCheck size={36} stroke={2} />
+          </ThemeIcon>
+          <Stack gap="xs" align="center">
+            <Text component="span" className="landing-eyebrow">
+              Reorder request received
+            </Text>
+            <Title
+              className="landing-display"
+              style={{ fontSize: 'clamp(1.8rem, 3vw, 2.4rem)', textAlign: 'center', margin: 0 }}
+            >
+              Thanks for letting us know
+            </Title>
+            <Text c="dimmed" ta="center" maw={420}>
+              Your reorder request has been submitted. Our inventory team will review it and
+              take appropriate action.
+            </Text>
+          </Stack>
+          <Button onClick={() => navigate('/')} size="md">
+            Back to home
+          </Button>
+          <Text c="dimmed" size="xs" ta="center">
+            Redirecting automatically in a few seconds…
+          </Text>
+        </Stack>
+      </Container>
+    </Box>
   );
 };
 

--- a/frontend/src/pages/ThirdPartyWorkOrderPage.tsx
+++ b/frontend/src/pages/ThirdPartyWorkOrderPage.tsx
@@ -40,6 +40,7 @@ import {
   ThirdPartyWorkOrderDto,
   ThirdPartyWorkOrderStatus,
 } from '../services/api';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const STATUS_TO_STEP: Record<ThirdPartyWorkOrderStatus, number> = {
@@ -111,50 +112,55 @@ const ThirdPartyWorkOrderPage: React.FC = () => {
 
   if (loading && !wo) {
     return (
-      <Container size="md" py="md">
+      <WorkspacePage
+        testId="third-party-work-order-page"
+        hero={{
+          eyebrow: 'Maintenance · Third-party WO',
+          title: 'Work order',
+          description: 'Loading…',
+        }}
+        containerSize="md"
+      >
         <Loader />
-      </Container>
+      </WorkspacePage>
     );
   }
 
   if (error || !wo) {
     return (
-      <Container size="md" py="md">
+      <WorkspacePage
+        testId="third-party-work-order-page"
+        hero={{
+          eyebrow: 'Maintenance · Third-party WO',
+          title: 'Work order',
+          description: error ?? 'Not found.',
+        }}
+        containerSize="md"
+      >
         <Alert color="red" icon={<IconAlertTriangle size={16} />}>
           {error ?? 'Work order not found'}
         </Alert>
-      </Container>
+      </WorkspacePage>
     );
   }
 
   const wf = wo.workflow;
 
   const renderHeader = (
-    <Group justify="space-between" align="flex-start" mb="md">
-      <Stack gap={4}>
-        <Title order={2}>
-          {wo.short_id} — {wo.title}
-        </Title>
-        <Text c="dimmed">
-          {wo.vendor_name} · {wo.work_type_display}
-          {wo.is_emergency && ' · Emergency'}
-        </Text>
-      </Stack>
-      <Group gap="xs">
-        <Badge color="blue" size="lg">
-          {wo.status_display}
+    <Group justify="flex-start" gap="xs" wrap="wrap" mb="md">
+      <Badge color="blue" size="lg">
+        {wo.status_display}
+      </Badge>
+      {wo.warranty_recovery && (
+        <Badge color="orange" variant="filled">
+          Warranty Recovery
         </Badge>
-        {wo.warranty_recovery && (
-          <Badge color="orange" variant="filled">
-            Warranty Recovery
-          </Badge>
-        )}
-        {wf.has_active_emergency_authorization && (
-          <Badge color="red" variant="filled">
-            Emergency Auth
-          </Badge>
-        )}
-      </Group>
+      )}
+      {wf.has_active_emergency_authorization && (
+        <Badge color="red" variant="filled">
+          Emergency Auth
+        </Badge>
+      )}
     </Group>
   );
 
@@ -513,7 +519,15 @@ const ThirdPartyWorkOrderPage: React.FC = () => {
   );
 
   return (
-    <Container size="md" py="md">
+    <WorkspacePage
+      testId="third-party-work-order-page"
+      hero={{
+        eyebrow: `Maintenance · Third-party WO · ${wo.short_id}`,
+        title: wo.title,
+        description: `${wo.vendor_name} · ${wo.work_type_display}${wo.is_emergency ? ' · Emergency' : ''}`,
+      }}
+      containerSize="md"
+    >
       {renderHeader}
       {actionError && (
         <Alert color="red" icon={<IconAlertTriangle size={16} />} mb="md">
@@ -543,7 +557,7 @@ const ThirdPartyWorkOrderPage: React.FC = () => {
           {stepClosed}
         </Stepper.Step>
       </Stepper>
-    </Container>
+    </WorkspacePage>
   );
 };
 

--- a/frontend/src/pages/TransparencyPage.tsx
+++ b/frontend/src/pages/TransparencyPage.tsx
@@ -2,8 +2,10 @@
  * Financial Transparency Page - Shows public spending information
  * Dedicated to makerspace transparency and community trust
  */
+import { Button, Paper, Text } from '@mantine/core';
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
 import { analyticsAPI } from '../services/api';
 import '../styles/TransparencyPage.css';
 
@@ -105,40 +107,51 @@ const TransparencyPage: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="transparency-page">
-        <div className="loading">
-          <div className="loading-spinner">🔄</div>
-          <p>Loading transparency data...</p>
-        </div>
-      </div>
+      <WorkspacePage
+        testId="transparency-page"
+        hero={{
+          eyebrow: 'Inventory',
+          title: 'Financial transparency',
+          description: 'Loading…',
+        }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading transparency data…</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   if (error || !data) {
     return (
-      <div className="transparency-page">
-        <div className="error">
-          <h2>⚠️ Unable to Load Transparency Data</h2>
-          <p>{error}</p>
-          <button onClick={() => window.location.reload()}>
-            Try Again
-          </button>
-        </div>
-      </div>
+      <WorkspacePage
+        testId="transparency-page"
+        hero={{
+          eyebrow: 'Inventory',
+          title: 'Financial transparency',
+          description: error || 'Unable to load transparency data.',
+          action: (
+            <Button onClick={() => window.location.reload()}>Try again</Button>
+          ),
+        }}
+      >
+        <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+          <Text>{error || 'Unable to load transparency data.'}</Text>
+        </Paper>
+      </WorkspacePage>
     );
   }
 
   return (
-    <div className="transparency-page">
-      <header className="transparency-header">
-        <h1>
-          <span className="icon">🔍</span>
-          Financial Transparency
-        </h1>
-        <p className="transparency-mission">
-          {data.summary.transparency_note}
-        </p>
-      </header>
+    <WorkspacePage
+      testId="transparency-page"
+      hero={{
+        eyebrow: 'Inventory · Public ledger',
+        title: 'Financial transparency',
+        description: data.summary.transparency_note,
+      }}
+    >
+      <div className="transparency-page">
 
       <div className="summary-section">
         <div className="summary-card">
@@ -391,7 +404,8 @@ const TransparencyPage: React.FC = () => {
           <a href="/tv-dashboard">← Back to Dashboard</a>
         </p>
       </footer>
-    </div>
+      </div>
+    </WorkspacePage>
   );
 };
 


### PR DESCRIPTION
## Summary

Continues the homepage-style migration. Six more surfaces — three
internal (asset detail, third-party WO, admin dashboard) and three
public (transparency ledger, tax-receipt lookup, post-scan thanks).

## Pages migrated

- ``AssetDetailPage`` — Edit / Lock / Unlock actions in the hero
- ``ThirdPartyWorkOrderPage`` — vendor / work-type / emergency flag
  in hero; stepper body stays clean
- ``AdminDashboard`` — \"View by supplier\" hoisted into hero
- ``TransparencyPage`` (public) — financial ledger
- ``TaxReceiptLookupPage`` (public) — donor self-service lookup
- ``ThanksPage`` (public) — post-QR-scan thank-you page; check-circle
  hero so it visually matches the rest of the public surfaces

## Tests

- 29 / 29 affected suites green
- ``MantineProvider`` wrappers added to AssetDetailPage +
  TransparencyPage tests
- Tightened Loading + Error matchers in AssetDetailPage (description
  now appears in both hero and panel)

## Test plan

- [x] ``CI=true npm test`` on affected suites — 29/29
- [x] ``npm run build`` clean
- [x] ``pre-commit run`` — green
- [ ] CI green