### PR TITLE
feat(reports): blend third-party WO costs into asset TCO report

### DIFF
--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -1699,6 +1699,9 @@ class AssetTcoReportSerializer(serializers.Serializer):
     unscheduled_maintenance_cost = serializers.DecimalField(max_digits=12, decimal_places=2)
     repair_cost = serializers.DecimalField(max_digits=12, decimal_places=2)
     tco = serializers.DecimalField(max_digits=12, decimal_places=2)
+    preventive_maintenance_cost = serializers.DecimalField(max_digits=12, decimal_places=2)
+    vendor_maintenance_cost = serializers.DecimalField(max_digits=12, decimal_places=2)
+    total_maintenance_cost_90d = serializers.DecimalField(max_digits=12, decimal_places=2)
 
 
 class LocationReconcileItemSerializer(serializers.ModelSerializer):

--- a/backend/inventory/tests/test_tco.py
+++ b/backend/inventory/tests/test_tco.py
@@ -184,3 +184,166 @@ class TestAssetTcoReport:
 
         ids = [row["asset_id"] for row in response.data]
         assert ids.index(str(pricey.id)) < ids.index(str(cheap.id))
+
+
+def _closed_vendor_wo(
+    asset,
+    *,
+    allocated_cost,
+    closed_days_ago=10,
+    status_value=None,
+    share_pct=Decimal("100"),
+):
+    """Create a ThirdPartyWorkOrder bypassing the state machine and link it to
+    ``asset`` with the given ``allocated_cost``. Used for TCO rollup tests."""
+    from maintenance_orders.models import ThirdPartyWorkOrder, ThirdPartyWorkOrderAsset
+    from vendors.models import Vendor
+
+    vendor, _ = Vendor.objects.get_or_create(
+        name="TCO Test Vendor",
+        defaults={"vendor_kind": Vendor.KIND_HVAC},
+    )
+    wo = ThirdPartyWorkOrder.objects.create(
+        title="Vendor work",
+        vendor=vendor,
+        asset=asset,
+    )
+    wo.status = status_value or ThirdPartyWorkOrder.STATUS_CLOSED
+    if closed_days_ago is not None:
+        wo.closed_at = timezone.now() - timedelta(days=closed_days_ago)
+    wo.save(update_fields=["status", "closed_at"])
+    return ThirdPartyWorkOrderAsset.objects.create(
+        work_order=wo,
+        asset=asset,
+        share_pct=share_pct,
+        allocated_cost=allocated_cost,
+    )
+
+
+@pytest.mark.integration
+class TestAssetTcoVendorRollup:
+    """ThirdPartyWorkOrderAsset.allocated_cost rolls into vendor_maintenance_cost
+    and total_maintenance_cost_90d when the parent WO is closed in the window."""
+
+    def test_vendor_only_asset_reports_vendor_cost(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Vendor Only", asset_tag="A-V01")
+        _closed_vendor_wo(asset, allocated_cost=Decimal("250.00"), closed_days_ago=5)
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+
+        row = {r["asset_id"]: r for r in response.data}[str(asset.id)]
+        assert Decimal(row["preventive_maintenance_cost"]) == Decimal("0.00")
+        assert Decimal(row["vendor_maintenance_cost"]) == Decimal("250.00")
+        assert Decimal(row["total_maintenance_cost_90d"]) == Decimal("250.00")
+
+    def test_blended_preventive_and_vendor_cost(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Mixed", asset_tag="A-MIX")
+
+        mi = MaintenanceItem.objects.create(
+            asset=asset,
+            title="Quarterly PM",
+            interval_days=90,
+            estimated_cost=Decimal("100.00"),
+        )
+        _create_completed_wo(mi, completed_at=timezone.now() - timedelta(days=7))
+        _closed_vendor_wo(asset, allocated_cost=Decimal("300.00"), closed_days_ago=3)
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+
+        row = {r["asset_id"]: r for r in response.data}[str(asset.id)]
+        assert Decimal(row["preventive_maintenance_cost"]) == Decimal("100.00")
+        assert Decimal(row["vendor_maintenance_cost"]) == Decimal("300.00")
+        assert Decimal(row["total_maintenance_cost_90d"]) == Decimal("400.00")
+
+    def test_multi_asset_po_allocates_per_asset(self, authenticated_client):
+        """One vendor WO covering two assets — each row gets its own allocated_cost,
+        not the parent WO's full invoice."""
+        from maintenance_orders.models import ThirdPartyWorkOrder, ThirdPartyWorkOrderAsset
+        from vendors.models import Vendor
+
+        client, _ = authenticated_client
+        asset_a = AssetFactory(name="Split A", asset_tag="A-SPA")
+        asset_b = AssetFactory(name="Split B", asset_tag="A-SPB")
+
+        vendor, _ = Vendor.objects.get_or_create(
+            name="Split Vendor", defaults={"vendor_kind": Vendor.KIND_HVAC}
+        )
+        wo = ThirdPartyWorkOrder.objects.create(
+            title="Two-asset truck roll", vendor=vendor, asset=asset_a
+        )
+        wo.status = ThirdPartyWorkOrder.STATUS_CLOSED
+        wo.closed_at = timezone.now() - timedelta(days=2)
+        wo.save(update_fields=["status", "closed_at"])
+
+        ThirdPartyWorkOrderAsset.objects.create(
+            work_order=wo,
+            asset=asset_a,
+            share_pct=Decimal("60"),
+            allocated_cost=Decimal("180.00"),
+        )
+        ThirdPartyWorkOrderAsset.objects.create(
+            work_order=wo,
+            asset=asset_b,
+            share_pct=Decimal("40"),
+            allocated_cost=Decimal("120.00"),
+        )
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+        rows = {r["asset_id"]: r for r in response.data}
+        assert Decimal(rows[str(asset_a.id)]["vendor_maintenance_cost"]) == Decimal("180.00")
+        assert Decimal(rows[str(asset_b.id)]["vendor_maintenance_cost"]) == Decimal("120.00")
+
+    def test_cancelled_vendor_wo_excluded(self, authenticated_client):
+        from maintenance_orders.models import ThirdPartyWorkOrder
+
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Cancelled Vendor", asset_tag="A-CXL")
+        _closed_vendor_wo(
+            asset,
+            allocated_cost=Decimal("999.00"),
+            closed_days_ago=5,
+            status_value=ThirdPartyWorkOrder.STATUS_CANCELLED,
+        )
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+
+        row = {r["asset_id"]: r for r in response.data}[str(asset.id)]
+        assert Decimal(row["vendor_maintenance_cost"]) == Decimal("0.00")
+        assert Decimal(row["total_maintenance_cost_90d"]) == Decimal("0.00")
+
+    def test_vendor_wo_outside_window_excluded(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Old Vendor", asset_tag="A-OLD")
+        _closed_vendor_wo(asset, allocated_cost=Decimal("500.00"), closed_days_ago=120)
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+
+        row = {r["asset_id"]: r for r in response.data}[str(asset.id)]
+        assert Decimal(row["vendor_maintenance_cost"]) == Decimal("0.00")
+
+    def test_open_vendor_wo_excluded(self, authenticated_client):
+        """A WO still in financial_review (not yet closed) is excluded — its
+        closed_at is null even if allocated_cost has been materialized."""
+        from maintenance_orders.models import ThirdPartyWorkOrder
+
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Pending Vendor", asset_tag="A-PND")
+        _closed_vendor_wo(
+            asset,
+            allocated_cost=Decimal("420.00"),
+            closed_days_ago=None,
+            status_value=ThirdPartyWorkOrder.STATUS_FINANCIAL_REVIEW,
+        )
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+
+        row = {r["asset_id"]: r for r in response.data}[str(asset.id)]
+        assert Decimal(row["vendor_maintenance_cost"]) == Decimal("0.00")

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -4349,21 +4349,45 @@ class AssetReportViewSet(viewsets.ViewSet):
         Returns one row per asset with maintenance_days_last_90 (distinct calendar
         days where any work order overlapped the window, plus today if the asset
         is currently in MAINTENANCE status), bucketed cost components, and the
-        tco total. Sorted by tco DESC. Repair cost is reserved for future use
-        (AssetProblem does not yet carry cost fields).
+        tco total. Sorted by total_maintenance_cost_90d DESC.
+
+        Cost components:
+        - scheduled_maintenance_cost / unscheduled_maintenance_cost: preventive
+          maintenance via internal WorkOrder + WorkOrderMaterialUsage.
+        - vendor_maintenance_cost: third-party WO spend allocated to this asset
+          via ThirdPartyWorkOrderAsset.allocated_cost (only closed records, since
+          earlier statuses don't have allocated_cost materialized yet).
+        - preventive_maintenance_cost: scheduled + unscheduled (alias).
+        - total_maintenance_cost_90d: preventive + vendor (the headline figure).
+        - tco: scheduled + unscheduled + repair (legacy; preserved for callers
+          that haven't migrated to the blended figure).
+        - repair_cost: reserved for future use (AssetProblem doesn't carry cost).
         """
         from django.db.models import Prefetch
+
+        from maintenance_orders.models import ThirdPartyWorkOrder, ThirdPartyWorkOrderAsset
 
         from .serializers import AssetTcoReportSerializer
 
         today = timezone.now().date()
         window_start = today - timedelta(days=90)
 
+        vendor_link_qs = ThirdPartyWorkOrderAsset.objects.select_related("work_order").filter(
+            work_order__status=ThirdPartyWorkOrder.STATUS_CLOSED,
+            work_order__closed_at__date__gte=window_start,
+            work_order__closed_at__date__lte=today,
+        )
+
         assets = Asset.objects.all().prefetch_related(
             Prefetch(
                 "maintenance_items__work_orders",
                 queryset=WorkOrder.objects.prefetch_related("material_usage__material"),
-            )
+            ),
+            Prefetch(
+                "third_party_work_order_links",
+                queryset=vendor_link_qs,
+                to_attr="_tco_vendor_links",
+            ),
         )
 
         rows = []
@@ -4399,11 +4423,21 @@ class AssetReportViewSet(viewsets.ViewSet):
                                         * usage.material.estimated_cost_per_unit
                                     )
 
+            vendor = Decimal("0.00")
+            for link in getattr(asset, "_tco_vendor_links", []):
+                if link.allocated_cost is not None:
+                    vendor += link.allocated_cost
+                    wo_closed = link.work_order.closed_at
+                    if wo_closed is not None:
+                        days_set.add(wo_closed.date())
+
             if asset.status == Asset.MAINTENANCE:
                 days_set.add(today)
 
             repair = Decimal("0.00")
             tco_total = scheduled + unscheduled + repair
+            preventive_total = scheduled + unscheduled
+            total_90d = preventive_total + vendor
 
             rows.append(
                 {
@@ -4415,10 +4449,13 @@ class AssetReportViewSet(viewsets.ViewSet):
                     "unscheduled_maintenance_cost": unscheduled,
                     "repair_cost": repair,
                     "tco": tco_total,
+                    "preventive_maintenance_cost": preventive_total,
+                    "vendor_maintenance_cost": vendor,
+                    "total_maintenance_cost_90d": total_90d,
                 }
             )
 
-        rows.sort(key=lambda r: r["tco"], reverse=True)
+        rows.sort(key=lambda r: r["total_maintenance_cost_90d"], reverse=True)
         serializer = AssetTcoReportSerializer(rows, many=True)
         return Response(serializer.data)
 

--- a/frontend/src/pages/AssetReportPage.tsx
+++ b/frontend/src/pages/AssetReportPage.tsx
@@ -144,7 +144,9 @@ const AssetReportPage: React.FC = () => {
   const sortedUtilization = useMemo(() => sortData(utilization), [utilization, sortField, sortDirection]);
   const sortedTco = useMemo(() => {
     if (!sortField) {
-      return [...tcoRows].sort((a, b) => Number(b.tco) - Number(a.tco));
+      return [...tcoRows].sort(
+        (a, b) => Number(b.total_maintenance_cost_90d) - Number(a.total_maintenance_cost_90d),
+      );
     }
     const sorted = [...tcoRows];
     sorted.sort((a, b) => {
@@ -156,6 +158,9 @@ const AssetReportPage: React.FC = () => {
         'unscheduled_maintenance_cost',
         'repair_cost',
         'tco',
+        'preventive_maintenance_cost',
+        'vendor_maintenance_cost',
+        'total_maintenance_cost_90d',
       ];
       if (numericFields.includes(sortField)) {
         aVal = Number(aVal);
@@ -173,8 +178,10 @@ const AssetReportPage: React.FC = () => {
 
   const tcoHighlightThreshold = useMemo(() => {
     if (tcoRows.length === 0) return Infinity;
-    const sorted = [...tcoRows].sort((a, b) => Number(b.tco) - Number(a.tco));
-    return Number(sorted[Math.min(sorted.length - 1, 2)].tco);
+    const sorted = [...tcoRows].sort(
+      (a, b) => Number(b.total_maintenance_cost_90d) - Number(a.total_maintenance_cost_90d),
+    );
+    return Number(sorted[Math.min(sorted.length - 1, 2)].total_maintenance_cost_90d);
   }, [tcoRows]);
 
   const handleExport = () => {
@@ -194,10 +201,11 @@ const AssetReportPage: React.FC = () => {
     return Number.isFinite(num) ? num.toFixed(2) : '0.00';
   };
 
-  const tcoRowColor = (tcoValue: string) => {
-    const num = Number(tcoValue);
+  const tcoRowColor = (totalValue: string) => {
+    const num = Number(totalValue);
     if (!Number.isFinite(num) || num <= 0) return undefined;
-    if (num >= tcoHighlightThreshold && num >= Number(sortedTco[0]?.tco ?? 0) * 0.8) {
+    const topTotal = Number(sortedTco[0]?.total_maintenance_cost_90d ?? 0);
+    if (num >= tcoHighlightThreshold && num >= topTotal * 0.8) {
       return 'red.0';
     }
     if (num >= tcoHighlightThreshold) return 'orange.0';
@@ -406,11 +414,13 @@ const AssetReportPage: React.FC = () => {
         <Tabs.Panel value="tco" pt="md">
           <Stack gap="xs">
             <Text size="sm" c="dimmed">
-              Per-asset cost over the last 90 days. Top spenders are highlighted so
-              you can decide where to invest, retire, or replace. Sort by any column.
+              Per-asset cost over the last 90 days. Preventive is in-house maintenance
+              (Scheduled + Unscheduled); Vendor is third-party WO spend allocated per
+              asset. Total = Preventive + Vendor. Top spenders are highlighted so you
+              can decide where to invest, retire, or replace. Sort by any column.
             </Text>
             <Paper withBorder>
-              <Table.ScrollContainer minWidth={1100}>
+              <Table.ScrollContainer minWidth={1300}>
                 <Table highlightOnHover>
                   <Table.Thead>
                     <Table.Tr>
@@ -429,38 +439,45 @@ const AssetReportPage: React.FC = () => {
                       <Table.Th style={{ cursor: 'pointer' }} onClick={() => handleSort('unscheduled_maintenance_cost')}>
                         Unscheduled $
                       </Table.Th>
-                      <Table.Th style={{ cursor: 'pointer' }} onClick={() => handleSort('repair_cost')}>
-                        Repair $
+                      <Table.Th style={{ cursor: 'pointer' }} onClick={() => handleSort('preventive_maintenance_cost')}>
+                        Preventive $
                       </Table.Th>
-                      <Table.Th style={{ cursor: 'pointer' }} onClick={() => handleSort('tco')}>
-                        TCO
+                      <Table.Th style={{ cursor: 'pointer' }} onClick={() => handleSort('vendor_maintenance_cost')}>
+                        Vendor $
+                      </Table.Th>
+                      <Table.Th style={{ cursor: 'pointer' }} onClick={() => handleSort('total_maintenance_cost_90d')}>
+                        Total (90d)
                       </Table.Th>
                     </Table.Tr>
                   </Table.Thead>
                   <Table.Tbody>
                     {loading ? (
                       <Table.Tr>
-                        <Table.Td colSpan={7} style={{ textAlign: 'center' }}>
+                        <Table.Td colSpan={8} style={{ textAlign: 'center' }}>
                           <Text>Loading...</Text>
                         </Table.Td>
                       </Table.Tr>
                     ) : sortedTco.length === 0 ? (
                       <Table.Tr>
-                        <Table.Td colSpan={7} style={{ textAlign: 'center' }}>
+                        <Table.Td colSpan={8} style={{ textAlign: 'center' }}>
                           <Text>No TCO data available</Text>
                         </Table.Td>
                       </Table.Tr>
                     ) : (
                       sortedTco.map((item) => (
-                        <Table.Tr key={item.asset_id} bg={tcoRowColor(item.tco)}>
+                        <Table.Tr
+                          key={item.asset_id}
+                          bg={tcoRowColor(item.total_maintenance_cost_90d)}
+                        >
                           <Table.Td>{item.asset_name}</Table.Td>
                           <Table.Td>{item.asset_tag || '-'}</Table.Td>
                           <Table.Td>{item.maintenance_days_last_90}</Table.Td>
                           <Table.Td>${formatMoney(item.scheduled_maintenance_cost)}</Table.Td>
                           <Table.Td>${formatMoney(item.unscheduled_maintenance_cost)}</Table.Td>
-                          <Table.Td>${formatMoney(item.repair_cost)}</Table.Td>
+                          <Table.Td>${formatMoney(item.preventive_maintenance_cost)}</Table.Td>
+                          <Table.Td>${formatMoney(item.vendor_maintenance_cost)}</Table.Td>
                           <Table.Td>
-                            <Text fw={600}>${formatMoney(item.tco)}</Text>
+                            <Text fw={600}>${formatMoney(item.total_maintenance_cost_90d)}</Text>
                           </Table.Td>
                         </Table.Tr>
                       ))

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -985,6 +985,9 @@ export interface AssetTco {
   unscheduled_maintenance_cost: string;
   repair_cost: string;
   tco: string;
+  preventive_maintenance_cost: string;
+  vendor_maintenance_cost: string;
+  total_maintenance_cost_90d: string;
 }
 
 // Dashboard Widget Types


### PR DESCRIPTION
## Summary

- Asset TCO report now rolls up `ThirdPartyWorkOrderAsset.allocated_cost` alongside the existing internal preventive-maintenance cost, so vendor work is no longer invisible.
- Three new fields on `AssetTcoReportSerializer`: `preventive_maintenance_cost`, `vendor_maintenance_cost`, `total_maintenance_cost_90d`. Existing fields preserved for back-compat.
- Frontend TCO tab shows Preventive / Vendor / Total columns. Sort + row-highlight now track the blended total.
- No N+1 regression — vendor links are prefetched in the same query batch.

Scope decisions, codified in tests:
- Only `STATUS_CLOSED` third-party WOs contribute (`VALIDATED` / `FINANCIAL_REVIEW` have null `closed_at`, so no window check; `CANCELLED` excluded by intent).
- Multi-asset POs split correctly via `ThirdPartyWorkOrderAsset.allocated_cost`, not the parent invoice total.
- A vendor WO's `closed_at` also feeds `maintenance_days_last_90`.

Fixes #414

## Test plan

- [x] `pytest backend/inventory/tests/test_tco.py` — 11/11 pass (5 existing + 6 new)
- [x] `pre-commit run --files ...` — black / isort / ruff / bandit / django-upgrade / TS compile all pass
- [ ] Frontend `npm run build` — couldn't run locally (no node_modules in the worktree); CI will catch any TS/Mantine issues
- [ ] Visual check on the TCO tab once deployed — confirm new columns render, sort works, highlight colors track the new total

🤖 Generated with [Claude Code](https://claude.com/claude-code)