### PR TITLE
feat(electrical): asset power-chain CRUD from the frontend

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -412,6 +412,58 @@ views:
         permission_classes:
         - IsAuthenticated
         - IsStaffUser
+  electrical_circuits.views.PowerCableViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      list:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+  electrical_circuits.views.PowerPortViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      list:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
   electrical_circuits.views.PowerPanelViewSet:
     actions:
       create:

--- a/backend/electrical_circuits/serializers.py
+++ b/backend/electrical_circuits/serializers.py
@@ -1,9 +1,12 @@
 """DRF serializers for electrical circuits and network drops."""
 
+from django.contrib.contenttypes.models import ContentType
+
 from rest_framework import serializers
 
 from .models import (
     Breaker,
+    Cable,
     LightSwitch,
     NetworkDrop,
     Outlet,
@@ -11,6 +14,7 @@ from .models import (
     PowerCircuit,
     PowerOutlet,
     PowerPanel,
+    PowerPort,
 )
 
 
@@ -265,3 +269,137 @@ class NetworkDropSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
         read_only_fields = ["id", "created_at", "updated_at"]
+
+
+class PowerPortSerializer(serializers.ModelSerializer):
+    """Full read/write serializer for PowerPort."""
+
+    asset_name = serializers.CharField(source="asset.name", read_only=True)
+
+    class Meta:
+        model = PowerPort
+        fields = [
+            "id",
+            "asset",
+            "asset_name",
+            "label",
+            "port_type",
+            "max_draw_amps",
+            "notes",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+
+class PowerCableSerializer(serializers.ModelSerializer):
+    """Write a power Cable using simple ``outlet`` + ``port`` fields.
+
+    Hides the generic-foreign-key plumbing from API consumers: callers POST
+    ``{"outlet": <PowerOutlet id>, "port": <PowerPort id>, ...}`` and the
+    serializer translates that into endpoint_a / endpoint_b on save. Reads
+    expose the same flat shape plus the resolved names so the frontend can
+    render a chain row without follow-up queries.
+    """
+
+    outlet = serializers.IntegerField(write_only=True)
+    port = serializers.IntegerField(write_only=True)
+    outlet_id = serializers.SerializerMethodField()
+    outlet_label = serializers.SerializerMethodField()
+    port_id = serializers.SerializerMethodField()
+    port_label = serializers.SerializerMethodField()
+    asset_id = serializers.SerializerMethodField()
+    asset_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Cable
+        fields = [
+            "id",
+            "outlet",
+            "port",
+            "outlet_id",
+            "outlet_label",
+            "port_id",
+            "port_label",
+            "asset_id",
+            "asset_name",
+            "color",
+            "length_ft",
+            "label",
+            "status",
+            "notes",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+    def _outlet_obj(self, obj: Cable) -> PowerOutlet | None:
+        for endpoint in (obj.endpoint_a, obj.endpoint_b):
+            if isinstance(endpoint, PowerOutlet):
+                return endpoint
+        return None
+
+    def _port_obj(self, obj: Cable) -> PowerPort | None:
+        for endpoint in (obj.endpoint_a, obj.endpoint_b):
+            if isinstance(endpoint, PowerPort):
+                return endpoint
+        return None
+
+    def get_outlet_id(self, obj: Cable) -> int | None:
+        o = self._outlet_obj(obj)
+        return o.pk if o else None
+
+    def get_outlet_label(self, obj: Cable) -> str | None:
+        o = self._outlet_obj(obj)
+        return str(o) if o else None
+
+    def get_port_id(self, obj: Cable) -> int | None:
+        p = self._port_obj(obj)
+        return p.pk if p else None
+
+    def get_port_label(self, obj: Cable) -> str | None:
+        p = self._port_obj(obj)
+        return p.label if p else None
+
+    def get_asset_id(self, obj: Cable):
+        p = self._port_obj(obj)
+        return str(p.asset_id) if p else None
+
+    def get_asset_name(self, obj: Cable) -> str | None:
+        p = self._port_obj(obj)
+        return p.asset.name if p else None
+
+    def _resolve_endpoints(self, validated):
+        outlet_pk = validated.pop("outlet")
+        port_pk = validated.pop("port")
+        try:
+            outlet = PowerOutlet.objects.get(pk=outlet_pk)
+        except PowerOutlet.DoesNotExist as exc:
+            raise serializers.ValidationError({"outlet": "PowerOutlet not found."}) from exc
+        try:
+            port = PowerPort.objects.get(pk=port_pk)
+        except PowerPort.DoesNotExist as exc:
+            raise serializers.ValidationError({"port": "PowerPort not found."}) from exc
+        outlet_ct = ContentType.objects.get_for_model(PowerOutlet)
+        port_ct = ContentType.objects.get_for_model(PowerPort)
+        validated.update(
+            {
+                "cable_type": Cable.CABLE_TYPE_POWER,
+                "endpoint_a_content_type": outlet_ct,
+                "endpoint_a_object_id": str(outlet.pk),
+                "endpoint_b_content_type": port_ct,
+                "endpoint_b_object_id": str(port.pk),
+            }
+        )
+        return validated
+
+    def create(self, validated_data):
+        validated_data = self._resolve_endpoints(validated_data)
+        return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        if "outlet" in validated_data or "port" in validated_data:
+            validated_data.setdefault("outlet", self.get_outlet_id(instance))
+            validated_data.setdefault("port", self.get_port_id(instance))
+            validated_data = self._resolve_endpoints(validated_data)
+        return super().update(instance, validated_data)

--- a/backend/electrical_circuits/tests/test_power_topology_crud.py
+++ b/backend/electrical_circuits/tests/test_power_topology_crud.py
@@ -247,3 +247,146 @@ def test_list_power_outlets_filtered_by_circuit(staff_client, loc):
     rows = resp.json()["results"]
     assert len(rows) == 1
     assert rows[0]["circuit"] == c1.pk
+
+
+# ---------------------------------------------------------------------------
+# PowerPort + PowerCable CRUD — backs the asset-side power-chain edit UI.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def asset(db):
+    from inventory.tests.factories import AssetFactory
+
+    return AssetFactory(name="Lathe", asset_tag="A-PC1")
+
+
+@pytest.fixture
+def power_outlet(db, loc):
+    panel = PowerPanel.objects.create(name="P1", location=loc)
+    breaker = PowerBreaker.objects.create(panel=panel, position="A-01", amperage=20)
+    circuit = PowerCircuit.objects.create(breaker=breaker, label="C1")
+    return PowerOutlet.objects.create(circuit=circuit, location=loc, label="O1")
+
+
+@pytest.mark.django_db
+class TestPowerPortCRUD:
+    def test_staff_can_create_port(self, staff_client, asset):
+        url = reverse("powerport-list")
+        resp = staff_client.post(
+            url,
+            {"asset": str(asset.id), "label": "Main", "port_type": "5-15R"},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.data
+        assert str(resp.data["asset"]) == str(asset.id)
+        assert resp.data["label"] == "Main"
+        assert resp.data["asset_name"] == asset.name
+
+    def test_filter_by_asset(self, staff_client, asset):
+        from electrical_circuits.models import PowerPort
+        from inventory.tests.factories import AssetFactory
+
+        PowerPort.objects.create(asset=asset, label="Main", port_type="5-15R")
+        other = AssetFactory(name="Other")
+        PowerPort.objects.create(asset=other, label="Main", port_type="5-15R")
+
+        resp = staff_client.get(reverse("powerport-list"), {"asset": str(asset.id)})
+        assert resp.status_code == 200
+        rows = resp.data["results"] if isinstance(resp.data, dict) else resp.data
+        assert len(rows) == 1
+        assert str(rows[0]["asset"]) == str(asset.id)
+
+    def test_non_staff_cannot_create(self, non_staff_client, asset):
+        resp = non_staff_client.post(
+            reverse("powerport-list"),
+            {"asset": str(asset.id), "label": "Main", "port_type": "5-15R"},
+            format="json",
+        )
+        assert resp.status_code == 403
+
+    def test_unique_label_per_asset(self, staff_client, asset):
+        from electrical_circuits.models import PowerPort
+
+        PowerPort.objects.create(asset=asset, label="Main", port_type="5-15R")
+        resp = staff_client.post(
+            reverse("powerport-list"),
+            {"asset": str(asset.id), "label": "Main", "port_type": "5-15R"},
+            format="json",
+        )
+        assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+class TestPowerCableCRUD:
+    def _make_port(self, asset, label="Main"):
+        from electrical_circuits.models import PowerPort
+
+        return PowerPort.objects.create(asset=asset, label=label, port_type="5-15R")
+
+    def test_create_power_cable_via_flat_fields(self, staff_client, asset, power_outlet):
+        port = self._make_port(asset)
+        resp = staff_client.post(
+            reverse("powercable-list"),
+            {
+                "outlet": power_outlet.pk,
+                "port": port.pk,
+                "status": "connected",
+                "length_ft": 6,
+            },
+            format="json",
+        )
+        assert resp.status_code == 201, resp.data
+        assert resp.data["outlet_id"] == power_outlet.pk
+        assert resp.data["port_id"] == port.pk
+        assert str(resp.data["asset_id"]) == str(asset.id)
+        assert resp.data["asset_name"] == asset.name
+
+    def test_filter_by_asset_returns_only_that_assets_cables(
+        self, staff_client, asset, power_outlet
+    ):
+        from inventory.tests.factories import AssetFactory
+
+        port_a = self._make_port(asset, "Main")
+        staff_client.post(
+            reverse("powercable-list"),
+            {"outlet": power_outlet.pk, "port": port_a.pk},
+            format="json",
+        )
+
+        other = AssetFactory(name="Other")
+        port_b = self._make_port(other, "Main")
+        staff_client.post(
+            reverse("powercable-list"),
+            {"outlet": power_outlet.pk, "port": port_b.pk},
+            format="json",
+        )
+
+        resp = staff_client.get(reverse("powercable-list"), {"asset": str(asset.id)})
+        assert resp.status_code == 200
+        rows = resp.data["results"] if isinstance(resp.data, dict) else resp.data
+        assert len(rows) == 1
+        assert str(rows[0]["asset_id"]) == str(asset.id)
+
+    def test_non_staff_cannot_create(self, non_staff_client, asset, power_outlet):
+        port = self._make_port(asset)
+        resp = non_staff_client.post(
+            reverse("powercable-list"),
+            {"outlet": power_outlet.pk, "port": port.pk},
+            format="json",
+        )
+        assert resp.status_code == 403
+
+    def test_delete_unwires_chain(self, staff_client, asset, power_outlet):
+        port = self._make_port(asset)
+        created = staff_client.post(
+            reverse("powercable-list"),
+            {"outlet": power_outlet.pk, "port": port.pk},
+            format="json",
+        )
+        cable_id = created.data["id"]
+        resp = staff_client.delete(reverse("powercable-detail", args=[cable_id]))
+        assert resp.status_code == 204
+        list_resp = staff_client.get(reverse("powercable-list"), {"asset": str(asset.id)})
+        rows = list_resp.data["results"] if isinstance(list_resp.data, dict) else list_resp.data
+        assert rows == []

--- a/backend/electrical_circuits/urls.py
+++ b/backend/electrical_circuits/urls.py
@@ -19,9 +19,11 @@ from .views import (
     OutletViewSet,
     PanelDirectoryReportView,
     PowerBreakerViewSet,
+    PowerCableViewSet,
     PowerCircuitViewSet,
     PowerOutletViewSet,
     PowerPanelViewSet,
+    PowerPortViewSet,
 )
 
 router = DefaultRouter()
@@ -38,6 +40,8 @@ power_router = DefaultRouter()
 power_router.register(r"panels-crud", PowerPanelViewSet, basename="powerpanel")
 power_router.register(r"breakers-crud", PowerBreakerViewSet, basename="powerbreaker")
 power_router.register(r"circuits-crud", PowerCircuitViewSet, basename="powercircuit")
+power_router.register(r"ports-crud", PowerPortViewSet, basename="powerport")
+power_router.register(r"power-cables-crud", PowerCableViewSet, basename="powercable")
 power_router.register(r"outlets-crud", PowerOutletViewSet, basename="poweroutlet")
 
 urlpatterns = [

--- a/backend/electrical_circuits/views.py
+++ b/backend/electrical_circuits/views.py
@@ -1,5 +1,6 @@
 """DRF viewsets for electrical circuits and network drops."""
 
+from django.db import models
 from django.db.models import Count
 from django.http import HttpResponse
 
@@ -10,6 +11,7 @@ from rest_framework.views import APIView
 
 from .models import (
     Breaker,
+    Cable,
     LightSwitch,
     NetworkDrop,
     Outlet,
@@ -17,6 +19,7 @@ from .models import (
     PowerCircuit,
     PowerOutlet,
     PowerPanel,
+    PowerPort,
 )
 from .safety_views import IsStaffUser
 from .serializers import (
@@ -25,9 +28,11 @@ from .serializers import (
     NetworkDropSerializer,
     OutletSerializer,
     PowerBreakerSerializer,
+    PowerCableSerializer,
     PowerCircuitSerializer,
     PowerOutletSerializer,
     PowerPanelSerializer,
+    PowerPortSerializer,
 )
 from .utils.panel_directory_pdf import generate_network_drop_list_pdf, generate_panel_directory_pdf
 
@@ -219,4 +224,70 @@ class PowerOutletViewSet(viewsets.ModelViewSet):
         circuit_id = self.request.query_params.get("circuit")
         if circuit_id:
             qs = qs.filter(circuit_id=circuit_id)
+        return qs
+
+
+class PowerPortViewSet(viewsets.ModelViewSet):
+    """``/api/electrical/ports-crud/`` — full CRUD for asset PowerPorts.
+
+    Supports ``?asset=<uuid>`` to scope the list to a single asset, which
+    is the only query the frontend needs today (the AssetPowerChainPage
+    edit affordance asks "what ports does this asset already have?" before
+    offering to create more).
+    """
+
+    permission_classes = [IsAuthenticated, IsStaffUser]
+    serializer_class = PowerPortSerializer
+    queryset = PowerPort.objects.select_related("asset").order_by("asset__name", "label")
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        asset_id = self.request.query_params.get("asset")
+        if asset_id:
+            qs = qs.filter(asset_id=asset_id)
+        return qs
+
+
+class PowerCableViewSet(viewsets.ModelViewSet):
+    """``/api/electrical/power-cables-crud/`` — full CRUD for power cables.
+
+    Restricted to power cables (filters Cable by cable_type=power). The
+    serializer hides the generic-foreign-key plumbing — callers POST a
+    flat ``{"outlet": <id>, "port": <id>, ...}`` shape.
+
+    Supports ``?asset=<uuid>`` and ``?port=<id>`` filters so the frontend
+    can render the chain rows for one asset without loading the whole
+    cable table.
+    """
+
+    permission_classes = [IsAuthenticated, IsStaffUser]
+    serializer_class = PowerCableSerializer
+    queryset = Cable.objects.filter(cable_type=Cable.CABLE_TYPE_POWER).order_by("-created_at")
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        port_id = self.request.query_params.get("port")
+        if port_id:
+            from django.contrib.contenttypes.models import ContentType
+
+            port_ct = ContentType.objects.get_for_model(PowerPort)
+            qs = qs.filter(
+                models.Q(endpoint_a_content_type=port_ct, endpoint_a_object_id=str(port_id))
+                | models.Q(endpoint_b_content_type=port_ct, endpoint_b_object_id=str(port_id))
+            )
+        asset_id = self.request.query_params.get("asset")
+        if asset_id:
+            from django.contrib.contenttypes.models import ContentType
+
+            port_ct = ContentType.objects.get_for_model(PowerPort)
+            port_ids = list(
+                PowerPort.objects.filter(asset_id=asset_id).values_list("pk", flat=True)
+            )
+            if not port_ids:
+                return qs.none()
+            string_ids = [str(p) for p in port_ids]
+            qs = qs.filter(
+                models.Q(endpoint_a_content_type=port_ct, endpoint_a_object_id__in=string_ids)
+                | models.Q(endpoint_b_content_type=port_ct, endpoint_b_object_id__in=string_ids)
+            )
         return qs

--- a/frontend/src/pages/AssetPowerChainEditor.tsx
+++ b/frontend/src/pages/AssetPowerChainEditor.tsx
@@ -1,0 +1,339 @@
+/**
+ * Inline editor for an asset's power chain — replaces the prior "use the
+ * Django admin" instruction with a form-driven flow.
+ *
+ * Two affordances:
+ *   1. Add a PowerPort to the asset (label, NEMA type, optional max draw).
+ *   2. Wire a PowerPort to a PowerOutlet by creating a power Cable, or
+ *      tear an existing cable down.
+ *
+ * Staff-gated: the form only renders for `is_staff`. The backend enforces
+ * the same gate; this is a UX hide, not a security boundary.
+ */
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Group,
+  NumberInput,
+  Paper,
+  Select,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+  Tooltip,
+} from '@mantine/core';
+import { IconPlugConnected, IconTrash, IconUnlink } from '@tabler/icons-react';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import {
+  PowerCableDetail,
+  PowerOutletDetail,
+  PowerPortDetail,
+  electricalTopologyAPI,
+} from '../services/api';
+import { showError, showSuccess } from '../utils/dialogs';
+
+const NEMA_TYPES: { value: string; label: string }[] = [
+  { value: '5-15R', label: '5-15R (standard 120V 15A)' },
+  { value: '5-20R', label: '5-20R (120V 20A)' },
+  { value: '6-15R', label: '6-15R (240V 15A)' },
+  { value: '6-20R', label: '6-20R (240V 20A)' },
+  { value: 'L5-30R', label: 'L5-30R (locking 120V 30A)' },
+  { value: 'L6-30R', label: 'L6-30R (locking 240V 30A)' },
+  { value: 'C13', label: 'C13 (PDU appliance)' },
+  { value: 'C19', label: 'C19 (PDU high-current)' },
+  { value: 'other', label: 'Other' },
+];
+
+interface Props {
+  assetId: string;
+  isStaff: boolean;
+  onChange: () => void;
+}
+
+function unwrap<T>(payload: { results: T[] } | T[]): T[] {
+  if (Array.isArray(payload)) return payload;
+  return payload?.results ?? [];
+}
+
+export const AssetPowerChainEditor: React.FC<Props> = ({ assetId, isStaff, onChange }) => {
+  const [ports, setPorts] = useState<PowerPortDetail[]>([]);
+  const [cables, setCables] = useState<PowerCableDetail[]>([]);
+  const [outlets, setOutlets] = useState<PowerOutletDetail[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const [portLabel, setPortLabel] = useState('Main');
+  const [portType, setPortType] = useState('5-15R');
+  const [portMaxAmps, setPortMaxAmps] = useState<number | ''>('');
+
+  const [cablePortId, setCablePortId] = useState<string | null>(null);
+  const [cableOutletId, setCableOutletId] = useState<string | null>(null);
+  const [cableLengthFt, setCableLengthFt] = useState<number | ''>('');
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [portsResp, cablesResp, outletsResp] = await Promise.all([
+        electricalTopologyAPI.listPorts({ asset: assetId }),
+        electricalTopologyAPI.listPowerCables({ asset: assetId }),
+        electricalTopologyAPI.listOutlets(),
+      ]);
+      setPorts(unwrap(portsResp.data));
+      setCables(unwrap(cablesResp.data));
+      setOutlets(unwrap(outletsResp.data) as PowerOutletDetail[]);
+    } catch (err: any) {
+      showError(err?.response?.data?.error?.message || 'Failed to load power-chain editor');
+    } finally {
+      setLoading(false);
+    }
+  }, [assetId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleCreatePort = async () => {
+    if (!portLabel.trim()) {
+      showError('Port label is required');
+      return;
+    }
+    try {
+      await electricalTopologyAPI.createPort({
+        asset: assetId,
+        label: portLabel.trim(),
+        port_type: portType,
+        max_draw_amps: portMaxAmps === '' ? null : String(portMaxAmps),
+      });
+      showSuccess(`Port "${portLabel}" added`);
+      setPortLabel('Main');
+      setPortMaxAmps('');
+      refresh();
+      onChange();
+    } catch (err: any) {
+      showError(err?.response?.data?.error?.message || 'Failed to create port');
+    }
+  };
+
+  const handleDeletePort = async (id: number) => {
+    try {
+      await electricalTopologyAPI.deletePort(id);
+      showSuccess('Port removed');
+      refresh();
+      onChange();
+    } catch (err: any) {
+      showError(err?.response?.data?.error?.message || 'Failed to delete port');
+    }
+  };
+
+  const handleConnect = async () => {
+    if (!cablePortId || !cableOutletId) {
+      showError('Pick a port and an outlet');
+      return;
+    }
+    try {
+      await electricalTopologyAPI.createPowerCable({
+        port: Number(cablePortId),
+        outlet: Number(cableOutletId),
+        length_ft: cableLengthFt === '' ? null : Number(cableLengthFt),
+        status: 'connected',
+      });
+      showSuccess('Connected');
+      setCablePortId(null);
+      setCableOutletId(null);
+      setCableLengthFt('');
+      refresh();
+      onChange();
+    } catch (err: any) {
+      showError(err?.response?.data?.error?.message || 'Failed to connect cable');
+    }
+  };
+
+  const handleDisconnect = async (id: number) => {
+    try {
+      await electricalTopologyAPI.deletePowerCable(id);
+      showSuccess('Disconnected');
+      refresh();
+      onChange();
+    } catch (err: any) {
+      showError(err?.response?.data?.error?.message || 'Failed to disconnect');
+    }
+  };
+
+  if (!isStaff) {
+    return null;
+  }
+
+  const outletOptions = outlets.map((o) => ({
+    value: String(o.id),
+    label: `${o.label} (${o.location_name || 'unknown'})`,
+  }));
+  const portOptions = ports.map((p) => ({
+    value: String(p.id),
+    label: `${p.label} (${p.port_type})`,
+  }));
+
+  return (
+    <Paper withBorder p="md" radius="md" data-testid="asset-power-chain-editor">
+      <Stack gap="md">
+        <Title order={4}>Edit power chain</Title>
+
+        <Stack gap="xs">
+          <Text size="sm" fw={500}>
+            Ports on this asset
+          </Text>
+          {ports.length === 0 ? (
+            <Text size="sm" c="dimmed">
+              No ports defined. Add one below before wiring it to an outlet.
+            </Text>
+          ) : (
+            <Stack gap={4}>
+              {ports.map((p) => (
+                <Group key={p.id} justify="space-between">
+                  <Group gap="xs">
+                    <IconPlugConnected size={14} />
+                    <Text size="sm">{p.label}</Text>
+                    <Badge size="xs" variant="light">
+                      {p.port_type}
+                    </Badge>
+                    {p.max_draw_amps && (
+                      <Text size="xs" c="dimmed">
+                        max {p.max_draw_amps} A
+                      </Text>
+                    )}
+                  </Group>
+                  <Tooltip label="Delete port">
+                    <ActionIcon
+                      variant="subtle"
+                      color="red"
+                      onClick={() => handleDeletePort(p.id)}
+                      aria-label={`Delete port ${p.label}`}
+                    >
+                      <IconTrash size={14} />
+                    </ActionIcon>
+                  </Tooltip>
+                </Group>
+              ))}
+            </Stack>
+          )}
+        </Stack>
+
+        <Paper withBorder p="sm" radius="sm" bg="gray.0">
+          <Stack gap="xs">
+            <Text size="sm" fw={500}>
+              Add port
+            </Text>
+            <Group grow align="flex-end">
+              <TextInput
+                label="Label"
+                value={portLabel}
+                onChange={(e) => setPortLabel(e.currentTarget.value)}
+                placeholder="Main / PSU 1 / etc."
+              />
+              <Select
+                label="Type"
+                value={portType}
+                onChange={(v) => setPortType(v ?? '5-15R')}
+                data={NEMA_TYPES}
+                searchable
+              />
+              <NumberInput
+                label="Max amps"
+                value={portMaxAmps}
+                onChange={(v) =>
+                  setPortMaxAmps(typeof v === 'number' ? v : v === '' ? '' : Number(v))
+                }
+                placeholder="optional"
+                min={0}
+                decimalScale={2}
+              />
+              <Button onClick={handleCreatePort} disabled={loading}>
+                Add port
+              </Button>
+            </Group>
+          </Stack>
+        </Paper>
+
+        <Stack gap="xs">
+          <Text size="sm" fw={500}>
+            Cables
+          </Text>
+          {cables.length === 0 ? (
+            <Text size="sm" c="dimmed">
+              No cables connected. Use the form below to wire a port to an outlet.
+            </Text>
+          ) : (
+            <Stack gap={4}>
+              {cables.map((c) => (
+                <Group key={c.id} justify="space-between">
+                  <Text size="sm">
+                    Port <b>{c.port_label || `#${c.port_id}`}</b> → outlet{' '}
+                    <b>{c.outlet_label || `#${c.outlet_id}`}</b>
+                    {c.length_ft ? ` (${c.length_ft} ft)` : ''}
+                    {c.status !== 'connected' ? (
+                      <Badge size="xs" ml="xs" color="gray">
+                        {c.status}
+                      </Badge>
+                    ) : null}
+                  </Text>
+                  <Tooltip label="Disconnect">
+                    <ActionIcon
+                      variant="subtle"
+                      color="red"
+                      onClick={() => handleDisconnect(c.id)}
+                      aria-label={`Disconnect cable ${c.id}`}
+                    >
+                      <IconUnlink size={14} />
+                    </ActionIcon>
+                  </Tooltip>
+                </Group>
+              ))}
+            </Stack>
+          )}
+        </Stack>
+
+        <Paper withBorder p="sm" radius="sm" bg="gray.0">
+          <Stack gap="xs">
+            <Text size="sm" fw={500}>
+              Connect port → outlet
+            </Text>
+            <Group grow align="flex-end">
+              <Select
+                label="Port"
+                value={cablePortId}
+                onChange={setCablePortId}
+                data={portOptions}
+                placeholder={ports.length === 0 ? 'Add a port first' : 'select port'}
+                disabled={ports.length === 0}
+                searchable
+              />
+              <Select
+                label="Outlet"
+                value={cableOutletId}
+                onChange={setCableOutletId}
+                data={outletOptions}
+                placeholder="select outlet"
+                searchable
+              />
+              <NumberInput
+                label="Length (ft)"
+                value={cableLengthFt}
+                onChange={(v) =>
+                  setCableLengthFt(typeof v === 'number' ? v : v === '' ? '' : Number(v))
+                }
+                min={0}
+                placeholder="optional"
+              />
+              <Button onClick={handleConnect} disabled={loading || ports.length === 0}>
+                Connect
+              </Button>
+            </Group>
+          </Stack>
+        </Paper>
+      </Stack>
+    </Paper>
+  );
+};
+
+export default AssetPowerChainEditor;

--- a/frontend/src/pages/AssetPowerChainPage.tsx
+++ b/frontend/src/pages/AssetPowerChainPage.tsx
@@ -29,10 +29,11 @@ import {
   IconRouteAltLeft,
   IconSitemap,
 } from '@tabler/icons-react';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import PageHero from '../components/landing/PageHero';
+import AssetPowerChainEditor from './AssetPowerChainEditor';
 import { AssetPowerChain, assetsAPI, electricalSafetyAPI } from '../services/api';
 import { Asset } from '../types';
 import '../styles/landing.css';
@@ -82,31 +83,38 @@ const AssetPowerChainPage: React.FC = () => {
     };
   }, []);
 
+  const loadChain = useCallback(
+    (id: string) => {
+      let cancelled = false;
+      setLoading(true);
+      setError(null);
+      electricalSafetyAPI
+        .getAssetPowerChain(id)
+        .then((response) => {
+          if (cancelled) return;
+          setChain(response.data);
+        })
+        .catch((err) => {
+          if (cancelled) return;
+          setError(err?.response?.data?.detail || 'Failed to load power chain.');
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+      return () => {
+        cancelled = true;
+      };
+    },
+    [],
+  );
+
   useEffect(() => {
     if (!assetId) {
       setChain(null);
       setError(null);
       return;
     }
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    electricalSafetyAPI
-      .getAssetPowerChain(assetId)
-      .then((response) => {
-        if (cancelled) return;
-        setChain(response.data);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        setError(err?.response?.data?.detail || 'Failed to load power chain.');
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
+    return loadChain(assetId);
   }, [assetId]);
 
   const assetOptions = useMemo(
@@ -207,8 +215,7 @@ const AssetPowerChainPage: React.FC = () => {
                     <IconAlertCircle size={24} />
                     <Text fw={500}>This asset is not wired into a power topology.</Text>
                     <Text size="sm" c="dimmed" ta="center" maw={420}>
-                      Add a PowerPort and a Cable from the port to an outlet via Django admin to
-                      see the chain.
+                      Add a port below and wire it to an outlet to see the chain.
                     </Text>
                   </Stack>
                 </Paper>
@@ -267,6 +274,12 @@ const AssetPowerChainPage: React.FC = () => {
                   </Timeline>
                 </Paper>
               )}
+
+              <AssetPowerChainEditor
+                assetId={chain.asset.id}
+                isStaff={localStorage.getItem('is_staff') === 'true' || localStorage.getItem('is_superuser') === 'true'}
+                onChange={() => loadChain(chain.asset.id)}
+              />
             </Stack>
           )}
         </Stack>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2344,7 +2344,72 @@ export const electricalTopologyAPI = {
     api.patch<PowerOutletDetail>(`/electrical/outlets-crud/${id}/`, data),
   deleteOutlet: (id: number | string) =>
     api.delete(`/electrical/outlets-crud/${id}/`),
+
+  // Power ports (per-asset)
+  listPorts: (params?: { asset?: string }) =>
+    api.get<{ results: PowerPortDetail[] } | PowerPortDetail[]>('/electrical/ports-crud/', { params }),
+  createPort: (data: Partial<PowerPortWritable>) =>
+    api.post<PowerPortDetail>('/electrical/ports-crud/', data),
+  updatePort: (id: number, data: Partial<PowerPortWritable>) =>
+    api.patch<PowerPortDetail>(`/electrical/ports-crud/${id}/`, data),
+  deletePort: (id: number) =>
+    api.delete(`/electrical/ports-crud/${id}/`),
+
+  // Power cables (PowerOutlet ↔ PowerPort)
+  listPowerCables: (params?: { asset?: string; port?: number }) =>
+    api.get<{ results: PowerCableDetail[] } | PowerCableDetail[]>('/electrical/power-cables-crud/', { params }),
+  createPowerCable: (data: PowerCableWritable) =>
+    api.post<PowerCableDetail>('/electrical/power-cables-crud/', data),
+  deletePowerCable: (id: number) =>
+    api.delete(`/electrical/power-cables-crud/${id}/`),
 };
+
+export interface PowerPortDetail {
+  id: number;
+  asset: string;
+  asset_name: string;
+  label: string;
+  port_type: string;
+  max_draw_amps: string | null;
+  notes: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PowerPortWritable {
+  asset: string;
+  label: string;
+  port_type: string;
+  max_draw_amps?: string | number | null;
+  notes?: string;
+}
+
+export interface PowerCableDetail {
+  id: number;
+  outlet_id: number;
+  outlet_label: string | null;
+  port_id: number;
+  port_label: string | null;
+  asset_id: string | null;
+  asset_name: string | null;
+  color: string;
+  length_ft: number | null;
+  label: string;
+  status: string;
+  notes: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PowerCableWritable {
+  outlet: number;
+  port: number;
+  color?: string;
+  length_ft?: number | null;
+  label?: string;
+  status?: string;
+  notes?: string;
+}
 
 // LOTO (lockout / tagout) — oms-78j
 export type LOTODeviceType =


### PR DESCRIPTION
## Summary

- Two new backend ViewSets unblock the last admin-only step of the power-chain topology:
  - `POST/GET/PATCH/DELETE /api/electrical/ports-crud/` for `PowerPort`
  - `POST/GET/DELETE /api/electrical/power-cables-crud/` for `Cable` (filtered to `cable_type=power`)
  - The cable endpoint takes flat `{outlet, port}` integer fields; the serializer resolves the generic FK content types internally, so the frontend never touches `ContentType`.
- Inline `AssetPowerChainEditor` on `/facilities/electrical/power-chain[/<assetId>]` lets staff:
  - Add / delete `PowerPort` rows on the selected asset
  - Connect a port to an outlet (creates a power Cable)
  - Disconnect (deletes the Cable)
- 8 new tests in `test_power_topology_crud.py`; all 95 electrical tests pass locally.
- Permission gate: `IsAuthenticated, IsStaffUser` on both new endpoints, mirroring the rest of the power-topology CRUD.

Closes uid0's "I shouldn't need to go to the django admin to add an asset's power chain" ask.

## Test plan

- [x] `pytest backend/electrical_circuits/tests/ --no-cov -q` — 95/95 pass
- [x] `pre-commit run --files ...` — black / isort / ruff / bandit / django-upgrade / TypeScript compile all pass
- [ ] Frontend `npm run build` — couldn't run locally (no node_modules in the worktree); CI will catch any TS/Mantine issues
- [ ] Manual smoke: open `/facilities/electrical/power-chain`, pick an asset with no chain, add a port + connect to an outlet, confirm the timeline populates. Then disconnect and confirm the empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)