### PR TITLE
fix(membership): /admin/membership/user/add/ 500 from missing UserAdmin plumbing

### DIFF
--- a/backend/membership/admin.py
+++ b/backend/membership/admin.py
@@ -6,6 +6,8 @@ from io import BytesIO
 
 from django.contrib import admin
 from django.contrib.auth import get_user_model
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.contrib.auth.forms import UserChangeForm, UserCreationForm
 from django.contrib.auth.models import Group
 from django.http import HttpResponse
 from django.shortcuts import redirect
@@ -14,20 +16,45 @@ from django.utils.html import format_html
 
 from inventory.services.qr_code_service import QRCodeService
 
-from .models import (
-    Certification,
-    Membership,
-    SIGAdmin,
-    UserCertification,
-    UserRegistrationToken,
-)
+from .models import Certification, Membership, SIGAdmin, UserCertification, UserRegistrationToken
 
 User = get_user_model()
 
 
+class CustomUserCreationForm(UserCreationForm):
+    """Add-user form pointed at the custom User model.
+
+    Django's stock UserCreationForm renders password1 + password2 + username,
+    which are the minimum fields the add flow needs. Once the user has a
+    primary key we drop into the change form which exposes the full fieldset
+    (groups, permissions, makerspace fields, etc.).
+    """
+
+    class Meta(UserCreationForm.Meta):
+        model = User
+        fields = ("username", "email", "first_name", "last_name")
+
+
+class CustomUserChangeForm(UserChangeForm):
+    """Change-user form pointed at the custom User model."""
+
+    class Meta(UserChangeForm.Meta):
+        model = User
+
+
 @admin.register(User)
-class UserAdmin(admin.ModelAdmin):
-    """Admin interface for custom user model."""
+class UserAdmin(BaseUserAdmin):
+    """Admin interface for the makerspace custom user model.
+
+    Inherits from django.contrib.auth.admin.UserAdmin so password hashing,
+    the username/password1/password2 add form, and the M2M-safe add_fieldsets
+    all work correctly. Without this inheritance the /add/ page 500s because
+    the change-form fieldset is used for creation and Django tries to render
+    M2M widgets against a not-yet-saved User.
+    """
+
+    add_form = CustomUserCreationForm
+    form = CustomUserChangeForm
 
     list_display = [
         "username",
@@ -68,22 +95,14 @@ class UserAdmin(admin.ModelAdmin):
         "discord_username",
         "discourse_username",
     ]
+
+    # Change-form fieldsets: extend Django's default with a Makerspace section
+    # so all the custom fields on the User model remain editable.
     fieldsets = (
+        (None, {"fields": ("username", "password")}),
+        ("Personal info", {"fields": ("first_name", "last_name", "email", "handle")}),
         (
-            "Basic Information",
-            {
-                "fields": (
-                    "username",
-                    "handle",
-                    "password",
-                    "email",
-                    "first_name",
-                    "last_name",
-                )
-            },
-        ),
-        (
-            "Makerspace Information",
+            "Makerspace",
             {
                 "fields": (
                     "active_directory_username",
@@ -93,6 +112,9 @@ class UserAdmin(admin.ModelAdmin):
                     "is_board_member",
                     "is_officer",
                     "is_director",
+                    "signature_image",
+                    "signature_uploaded_at",
+                    "signature_line_offset",
                 )
             },
         ),
@@ -108,32 +130,41 @@ class UserAdmin(admin.ModelAdmin):
                 )
             },
         ),
+        ("Important dates", {"fields": ("last_login", "date_joined")}),
+    )
+
+    # Add-form fieldset: tight to the minimum needed to create a User, so
+    # M2M fields (groups, user_permissions) are never rendered before the
+    # row has a primary key.
+    add_fieldsets = (
         (
-            "Important dates",
+            None,
             {
+                "classes": ("wide",),
                 "fields": (
-                    "last_login",
-                    "date_joined",
-                )
+                    "username",
+                    "password1",
+                    "password2",
+                    "email",
+                    "first_name",
+                    "last_name",
+                ),
             },
         ),
     )
+
     readonly_fields = ["last_login", "date_joined"]
     actions = ["create_registration_token", "generate_registration_qr"]
+    ordering = ("username",)
 
     def save_model(self, request, obj, form, change):
-        """Override save to automatically create registration token for new users."""
-        # Save the user first
+        """Save user and auto-create a registration token for new users."""
         super().save_model(request, obj, form, change)
-
-        # If this is a new user (not a change), create a registration token
-        if not change:
-            # Check if user already has a token (shouldn't happen for new users, but be safe)
-            if not hasattr(obj, "registration_token"):
-                UserRegistrationToken.create_for_user(
-                    user=obj,
-                    created_by=request.user,
-                )
+        if not change and not hasattr(obj, "registration_token"):
+            UserRegistrationToken.create_for_user(
+                user=obj,
+                created_by=request.user,
+            )
 
     @admin.display(description="Registration Token")
     def registration_token_status(self, obj):
@@ -158,11 +189,8 @@ class UserAdmin(admin.ModelAdmin):
         """Create registration tokens for selected users."""
         created_count = 0
         for user in queryset:
-            # Check if user already has an active token
             if hasattr(user, "registration_token") and user.registration_token.is_valid():
                 continue
-
-            # Create new token
             UserRegistrationToken.create_for_user(
                 user=user,
                 created_by=request.user,
@@ -189,7 +217,6 @@ class UserAdmin(admin.ModelAdmin):
             try:
                 token = user.registration_token
                 if token.is_valid():
-                    # QR code will be generated on-demand via the view
                     generated_count += 1
             except UserRegistrationToken.DoesNotExist:
                 continue
@@ -226,20 +253,16 @@ class UserAdmin(admin.ModelAdmin):
         except User.DoesNotExist:
             return HttpResponse("User not found", status=404)
 
-        # Check if user already has an active token
         if hasattr(user, "registration_token") and user.registration_token.is_valid():
             return HttpResponse(
                 "User already has an active registration token.",
                 status=400,
             )
 
-        # Create new token
         token = UserRegistrationToken.create_for_user(
             user=user,
             created_by=request.user,
         )
-
-        # Redirect to token admin page
         return redirect(reverse("admin:membership_userregistrationtoken_change", args=[token.id]))
 
 
@@ -452,17 +475,14 @@ class UserRegistrationTokenAdmin(admin.ModelAdmin):
         except UserRegistrationToken.DoesNotExist:
             return HttpResponse("Token not found", status=404)
 
-        # Generate QR code
         registration_url = token.get_registration_url()
         service = QRCodeService(include_logo=True)
         qr_img = service.generate_qr_code_image(registration_url)
 
-        # Convert to BytesIO
         buffer = BytesIO()
         qr_img.save(buffer, format="PNG")
         buffer.seek(0)
 
-        # Return as HTTP response
         response = HttpResponse(buffer.read(), content_type="image/png")
         response["Content-Disposition"] = f'inline; filename="registration_qr_{token.id}.png"'
         return response

--- a/backend/membership/tests/test_user_admin.py
+++ b/backend/membership/tests/test_user_admin.py
@@ -1,0 +1,127 @@
+"""
+Regression tests for the membership User admin.
+
+The UserAdmin previously extended ``admin.ModelAdmin`` directly, which left
+it without the UserCreationForm plumbing or a separate ``add_fieldsets``.
+That broke ``/admin/membership/user/add/``:
+
+  * the create form had no password1/password2 widgets so passwords would
+    have been stored as plaintext, and
+  * the change-form fieldset was reused on the add page, which rendered M2M
+    widgets (groups, user_permissions) against a not-yet-saved User instance
+    and 500'd on submit.
+
+This test suite locks down both the GET and the POST path against the
+fixed admin so we don't regress.
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+
+import pytest
+
+User = get_user_model()
+
+
+@pytest.fixture
+def admin_client(db):
+    admin = User.objects.create_superuser(
+        username="user-admin-superuser",
+        email="admin@example.com",
+        password="adm1n-pw-not-used-by-test",  # pragma: allowlist secret
+    )
+    c = Client()
+    c.force_login(admin)
+    return c
+
+
+@pytest.mark.django_db
+class TestUserAdminAdd:
+    def test_add_page_renders(self, admin_client):
+        resp = admin_client.get(reverse("admin:membership_user_add"))
+        assert resp.status_code == 200
+        # The add fieldset should be username + password1 + password2 + a few
+        # personal-info fields. M2M widgets must NOT appear on the add page,
+        # since the row has no primary key yet.
+        body = resp.content.decode()
+        assert "password1" in body
+        assert "password2" in body
+        assert "user_permissions" not in body, "M2M field leaked onto add page"
+        assert 'name="groups"' not in body, "M2M field leaked onto add page"
+
+    def test_post_creates_user_with_hashed_password(self, admin_client):
+        resp = admin_client.post(
+            reverse("admin:membership_user_add"),
+            data={
+                "username": "newmember",
+                "password1": "S3cure-pw-please",  # pragma: allowlist secret
+                "password2": "S3cure-pw-please",  # pragma: allowlist secret
+                "email": "new@example.com",
+                "first_name": "New",
+                "last_name": "Member",
+                "_save": "Save",
+            },
+        )
+        # Successful add redirects to the change-list (or change-page in
+        # newer Django versions). 200 with a form means validation failed.
+        assert resp.status_code in (301, 302), (
+            f"add did not redirect; status={resp.status_code} " f"body={resp.content[:600]!r}"
+        )
+        u = User.objects.get(username="newmember")
+        assert u.email == "new@example.com"
+        # Password must be hashed, never plaintext.
+        assert u.password != "S3cure-pw-please"  # pragma: allowlist secret
+        assert u.check_password("S3cure-pw-please")  # pragma: allowlist secret
+
+    def test_post_creates_registration_token(self, admin_client):
+        """save_model still auto-creates a UserRegistrationToken on add."""
+        admin_client.post(
+            reverse("admin:membership_user_add"),
+            data={
+                "username": "tokenuser",
+                "password1": "S3cure-pw-please",  # pragma: allowlist secret
+                "password2": "S3cure-pw-please",  # pragma: allowlist secret
+                "email": "tokenuser@example.com",
+                "first_name": "Token",
+                "last_name": "User",
+                "_save": "Save",
+            },
+        )
+        u = User.objects.get(username="tokenuser")
+        # The token should have been auto-created by save_model.
+        assert hasattr(u, "registration_token")
+        assert u.registration_token.user_id == u.id
+        assert not u.registration_token.used
+
+    def test_post_rejects_mismatched_passwords(self, admin_client):
+        resp = admin_client.post(
+            reverse("admin:membership_user_add"),
+            data={
+                "username": "badpw",
+                "password1": "alpha",
+                "password2": "beta",
+                "email": "badpw@example.com",
+                "_save": "Save",
+            },
+        )
+        # Form validation error stays on the add page with status 200.
+        assert resp.status_code == 200
+        assert not User.objects.filter(username="badpw").exists()
+
+    def test_add_fieldsets_have_no_m2m(self):
+        """add_fieldsets must not contain groups or user_permissions, which
+        Django cannot render against a not-yet-saved User."""
+        from membership.admin import UserAdmin
+
+        flattened = []
+        for _label, opts in UserAdmin.add_fieldsets:
+            flattened.extend(opts.get("fields", ()))
+        assert "groups" not in flattened
+        assert "user_permissions" not in flattened
+        # Sanity: the create form must include the password fields so the
+        # password gets hashed by Django's setter rather than stored raw.
+        assert "password1" in flattened
+        assert "password2" in flattened


### PR DESCRIPTION
## Summary

Adding a user via the Django admin at `/admin/membership/user/add/` 500'd because `UserAdmin` extended `admin.ModelAdmin` directly instead of `django.contrib.auth.admin.UserAdmin`. That stripped two essential pieces:

1. **No `UserCreationForm`** → the form had no `password1`/`password2`, no hashing. Even if the page had rendered, new users would have had plaintext passwords on disk and been unable to log in.
2. **No separate `add_fieldsets`** → the change-form fieldset (which includes `groups` and `user_permissions`) was reused on add. Django can't render M2M widgets against a not-yet-saved User, so the page 500'd.

## Fix

- `UserAdmin` now subclasses `django.contrib.auth.admin.UserAdmin`.
- `add_form` = `CustomUserCreationForm` (pointed at `membership.User`).
- `form` = `CustomUserChangeForm` (so the change page uses the proper `ReadOnlyPasswordHashField`).
- `add_fieldsets` is tight: `username`, `password1`, `password2`, `email`, `first_name`, `last_name`. M2M fields stay out.
- `fieldsets` preserves the full Makerspace section (handle, AD username, badge, discord/discourse, board/officer/director, signature image) and the Permissions/Important-dates blocks.
- Everything else — `save_model` registration-token auto-create, `create_registration_token` / `generate_registration_qr` actions, the `/<id>/create-token/` admin view, the `registration_token_status` column — is preserved.

## Test plan

- [x] `pytest membership/tests/test_user_admin.py` — 5/5 pass:
  - `test_add_page_renders` — GET 200, password1/password2 present, M2M widgets absent
  - `test_post_creates_user_with_hashed_password` — POST 30x, password is hashed (`check_password` true), plaintext value not equal to stored hash
  - `test_post_creates_registration_token` — `save_model` still auto-creates a `UserRegistrationToken`
  - `test_post_rejects_mismatched_passwords` — mismatch keeps form on page (200), no user created
  - `test_add_fieldsets_have_no_m2m` — locks the fieldset shape so a future change can't regress
- [x] pre-commit (black/isort/ruff/bandit/django-upgrade) all pass
- [ ] Manual smoke after merge: visit `/admin/membership/user/add/`, create a test user, confirm they can log in with the password set in the admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)