### PR TITLE
chore(frontend): silence fs.F_OK deprecation via patch-package

### DIFF
--- a/frontend/patches/react-dev-utils+12.0.1.patch
+++ b/frontend/patches/react-dev-utils+12.0.1.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-dev-utils/checkRequiredFiles.js b/node_modules/react-dev-utils/checkRequiredFiles.js
+index 9799cf6..3293818 100644
+--- a/node_modules/react-dev-utils/checkRequiredFiles.js
++++ b/node_modules/react-dev-utils/checkRequiredFiles.js
+@@ -16,7 +16,7 @@ function checkRequiredFiles(files) {
+   try {
+     files.forEach(filePath => {
+       currentFilePath = filePath;
+-      fs.accessSync(filePath, fs.F_OK);
++      fs.accessSync(filePath, fs.constants.F_OK);
+     });
+     return true;
+   } catch (err) {


### PR DESCRIPTION
## Summary

Deploys have been emitting:

```
(node:NN) DeprecationWarning: fs.F_OK is deprecated, use fs.constants.F_OK instead
```

The source is `react-dev-utils/checkRequiredFiles.js:19`, which `react-scripts@5` pulls in. `react-dev-utils` is at 12.0.1 (the latest published version) and effectively unmaintained, so a real dependency bump isn't available.

Fix uses the project's existing **patch-package** workflow — a one-line patch replacing `fs.F_OK` with `fs.constants.F_OK`. Applied automatically on every `npm ci` / `npm install` via the existing post-install hook.

## What about the caniuse-lite "outdated" suggestion?

`package.json` already has a `prebuild` script that runs `npx --yes update-browserslist-db@latest` before every build, and the committed `package-lock.json` already resolves `caniuse-lite` to the current release (1.0.30001792). No additional change is needed there — the warning at deploy time is informational, not a prompt, and the prebuild handles freshness going forward.

## Test plan

- [x] `npm ci` shows `react-dev-utils@12.0.1 ✔` (patch applied during postinstall)
- [x] `CI=true TZ=America/Chicago npx react-scripts test --maxWorkers=4 --watchAll=false` — 587/587 pass, 80/80 suites
- [ ] Manual: deploy and confirm the deprecation warning no longer appears in build logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)