### PR TITLE
fix(electrical): asset power-chain reachable + PDF reports actually load

### DIFF
--- a/frontend/src/components/landing/CapabilityCard.tsx
+++ b/frontend/src/components/landing/CapabilityCard.tsx
@@ -49,14 +49,20 @@ const CapabilityCard: React.FC<CapabilityCardProps> = ({
   badge,
   ctaLabel = 'Open',
   testId,
-}) => (
-  <Link
-    to={to}
-    className="landing-capability-card"
-    data-testid={testId ?? `capability-card-${to}`}
-    aria-label={title}
-    style={{ padding: '1.4rem' }}
-  >
+}) => {
+  // Backend endpoints (api/*, /media/*, /static/*) and *.pdf / *.csv
+  // downloads must use a real <a href>, not a SPA <Link>, otherwise React
+  // Router intercepts the click and the browser never makes the HTTP
+  // request. Detect those and emit an anchor; SPA routes stay on <Link>.
+  const isExternal =
+    to.startsWith('/api/') ||
+    to.startsWith('/media/') ||
+    to.startsWith('/static/') ||
+    to.startsWith('http://') ||
+    to.startsWith('https://') ||
+    /\.(pdf|csv|xlsx?|json)(\?|$)/i.test(to);
+
+  const innerContent = (
     <Stack gap="md" style={{ height: '100%' }}>
       <Group justify="space-between" align="flex-start" wrap="nowrap">
         <Box className="landing-icon-chip" aria-hidden>
@@ -90,7 +96,35 @@ const CapabilityCard: React.FC<CapabilityCardProps> = ({
         </span>
       </Box>
     </Stack>
-  </Link>
-);
+  );
+
+  if (isExternal) {
+    return (
+      <a
+        href={to}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="landing-capability-card"
+        data-testid={testId ?? `capability-card-${to}`}
+        aria-label={title}
+        style={{ padding: '1.4rem' }}
+      >
+        {innerContent}
+      </a>
+    );
+  }
+
+  return (
+    <Link
+      to={to}
+      className="landing-capability-card"
+      data-testid={testId ?? `capability-card-${to}`}
+      aria-label={title}
+      style={{ padding: '1.4rem' }}
+    >
+      {innerContent}
+    </Link>
+  );
+};
 
 export default CapabilityCard;

--- a/frontend/src/pages/AssetDetailPage.tsx
+++ b/frontend/src/pages/AssetDetailPage.tsx
@@ -6,6 +6,7 @@ import { Badge, Button, Group, Paper, Text } from '@mantine/core';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import MaintenanceHistorySection from '../components/assets/MaintenanceHistorySection';
+import AssetPowerChainEditor from './AssetPowerChainEditor';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import {
   AssetLOTORequirements,
@@ -1001,6 +1002,33 @@ const AssetDetailPage: React.FC = () => {
             canManage={isLoggedIn && localStorage.getItem('is_staff') === 'true'}
           />
         )}
+
+        {id &&
+          (localStorage.getItem('is_staff') === 'true' ||
+            localStorage.getItem('is_superuser') === 'true') && (
+            <section className="asset-detail-section">
+              <h2>Power chain</h2>
+              <p style={{ marginTop: 0, color: '#666' }}>
+                Wire this asset into the electrical topology by adding power ports and
+                connecting them to outlets. The outlet&apos;s circuit and breaker chain
+                are then traceable end-to-end. Full timeline view at{' '}
+                <a href={`/facilities/electrical/power-chain/${id}`}>
+                  /facilities/electrical/power-chain
+                </a>
+                .
+              </p>
+              <AssetPowerChainEditor
+                assetId={id}
+                isStaff={
+                  localStorage.getItem('is_staff') === 'true' ||
+                  localStorage.getItem('is_superuser') === 'true'
+                }
+                onChange={() => {
+                  /* editor manages its own refresh */
+                }}
+              />
+            </section>
+          )}
 
         {/* QR Code */}
         <section className="asset-detail-section">


### PR DESCRIPTION
## Summary

Two distinct bugs uid0 ran into back-to-back on the electrical surface.

### 1. \"How do I add a circuit to an asset?\"

The power-chain editor (`AssetPowerChainEditor`) was only reachable via `/facilities/electrical/power-chain[/<assetId>]`. The asset detail page at `/assets/<id>` had **zero references to it** — no link, no embed, no hint. A staff user looking at an asset had no obvious way to wire it to a breaker/circuit/outlet.

**Fix:** embed `AssetPowerChainEditor` directly on `AssetDetailPage`, behind the same `is_staff`/`is_superuser` localStorage gate the standalone page already uses. Includes a back-pointer link to the standalone page for the chain-timeline visualization.

### 2. `/api/electrical-circuits/reports/network-drop-list.pdf` (and the sibling `panel-directory.pdf`) never loaded

`ElectricalOverviewPage` uses `CapabilityCard` for each section/report. `CapabilityCard` was always rendering `<Link to={...}>` from `react-router-dom`. When `to` is an absolute backend path like `/api/electrical-circuits/reports/network-drop-list.pdf`, the SPA router intercepts the click and tries to route within the bundle — the browser never actually GETs the backend URL. So both PDF cards \"did nothing\" on click.

Backend view was fine — `pytest electrical_circuits/tests/test_reports_pdf.py -k network` passes 6/6.

**Fix:** `CapabilityCard` now detects \"external\" targets — `to` starting with `/api/`, `/media/`, `/static/`, `http://`, `https://`, or ending in `.pdf` / `.csv` / `.xls(x)` / `.json` — and renders them as `<a href target=\"_blank\" rel=\"noopener noreferrer\">` so the browser actually issues the request. SPA-internal targets continue to use `<Link>`.

## Test plan

- [x] `pytest backend/electrical_circuits/tests/` — 95/95 pass (full electrical suite, unchanged)
- [x] `react-scripts test --testPathPattern='ElectricalOverviewPage|CapabilityCard|AssetDetailPage|PowerChain'` — 27/27 pass across 3 suites
- [x] Pre-commit: black / isort / ruff / bandit / django-upgrade / TypeScript compilation check / npm test all pass
- [ ] Manual: log in as staff, open `/assets/<id>`, scroll past Maintenance History — confirm a Power chain section is present with the editor controls. Add a port, connect to an outlet. Go back to `/facilities/electrical/power-chain/<id>` and confirm the timeline reflects the change.
- [ ] Manual: open `/facilities/electrical` and click the \"Panel directory PDF\" + \"Network-drop report PDF\" cards. Confirm both download/open the PDF in a new tab instead of doing nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)