### PR TITLE
feat(inventory): show maintenance-record notes inline in the history table

### DIFF
--- a/frontend/src/__tests__/components/MaintenanceHistorySection.test.tsx
+++ b/frontend/src/__tests__/components/MaintenanceHistorySection.test.tsx
@@ -189,6 +189,73 @@ describe('MaintenanceHistorySection', () => {
     expect(mockedApi.maintenanceRecordsAPI.create).not.toHaveBeenCalled();
   });
 
+  describe('notes display', () => {
+    it('renders a notes sub-row when notes are present', async () => {
+      const withNotes = {
+        data: {
+          ...oneHistoricalRow.data,
+          results: [
+            {
+              ...oneHistoricalRow.data.results[0],
+              notes: 'replaced belt; next service due Q2 2025',
+            },
+          ],
+        },
+      };
+      mockedApi.assetsAPI.getMaintenanceHistory.mockResolvedValue(withNotes);
+      renderSection(false);
+      await waitFor(() => {
+        expect(screen.getByText('Annual HVAC service')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('history-row-notes-rec-1')).toBeInTheDocument();
+      expect(
+        screen.getByText('replaced belt; next service due Q2 2025'),
+      ).toBeInTheDocument();
+    });
+
+    it('omits the notes sub-row when notes are empty', async () => {
+      mockedApi.assetsAPI.getMaintenanceHistory.mockResolvedValue(oneHistoricalRow);
+      renderSection(false);
+      await waitFor(() => {
+        expect(screen.getByText('Annual HVAC service')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('history-row-notes-rec-1')).not.toBeInTheDocument();
+    });
+
+    it('omits the notes sub-row when notes are whitespace only', async () => {
+      const blankNotes = {
+        data: {
+          ...oneHistoricalRow.data,
+          results: [{ ...oneHistoricalRow.data.results[0], notes: '   \n  ' }],
+        },
+      };
+      mockedApi.assetsAPI.getMaintenanceHistory.mockResolvedValue(blankNotes);
+      renderSection(false);
+      await waitFor(() => {
+        expect(screen.getByText('Annual HVAC service')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('history-row-notes-rec-1')).not.toBeInTheDocument();
+    });
+
+    it('shows notes on workorder-source rows too', async () => {
+      const woWithNotes = {
+        data: {
+          ...oneWorkOrderRow.data,
+          results: [
+            { ...oneWorkOrderRow.data.results[0], notes: 'vendor invoice attached' },
+          ],
+        },
+      };
+      mockedApi.assetsAPI.getMaintenanceHistory.mockResolvedValue(woWithNotes);
+      renderSection(true);
+      await waitFor(() => {
+        expect(screen.getByText('Compressor swap')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('history-row-notes-wo-1')).toBeInTheDocument();
+      expect(screen.getByText('vendor invoice attached')).toBeInTheDocument();
+    });
+  });
+
   describe('historical row edit', () => {
     it('hides the Edit button from non-staff', async () => {
       mockedApi.assetsAPI.getMaintenanceHistory.mockResolvedValue(oneHistoricalRow);

--- a/frontend/src/components/assets/MaintenanceHistorySection.tsx
+++ b/frontend/src/components/assets/MaintenanceHistorySection.tsx
@@ -546,50 +546,75 @@ const MaintenanceHistorySection: React.FC<MaintenanceHistorySectionProps> = ({
             </thead>
             <tbody>
               {data.results.map((row) => (
-                <tr key={`${row.source}-${row.id}`} data-testid={`history-row-${row.id}`}>
-                  <td>{row.completed_on}</td>
-                  <td>{row.title}</td>
-                  <td>{performerLabel(row)}</td>
-                  <td>{row.cost != null ? `$${row.cost}` : '—'}</td>
-                  <td>{sourceLabel(row.source)}</td>
-                  <td>
-                    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-                      {row.detail_url && (
-                        <a href={row.detail_url}>Open WO</a>
-                      )}
-                      {row.attachment_url && (
-                        <a
-                          href={row.attachment_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          Attachment
-                        </a>
-                      )}
-                      {canManage && row.source === 'historical' && (
-                        <button
-                          type="button"
-                          onClick={() => openEdit(row)}
-                          data-testid={`history-row-edit-${row.id}`}
+                <React.Fragment key={`${row.source}-${row.id}`}>
+                  <tr data-testid={`history-row-${row.id}`}>
+                    <td>{row.completed_on}</td>
+                    <td>{row.title}</td>
+                    <td>{performerLabel(row)}</td>
+                    <td>{row.cost != null ? `$${row.cost}` : '—'}</td>
+                    <td>{sourceLabel(row.source)}</td>
+                    <td>
+                      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                        {row.detail_url && (
+                          <a href={row.detail_url}>Open WO</a>
+                        )}
+                        {row.attachment_url && (
+                          <a
+                            href={row.attachment_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            Attachment
+                          </a>
+                        )}
+                        {canManage && row.source === 'historical' && (
+                          <button
+                            type="button"
+                            onClick={() => openEdit(row)}
+                            data-testid={`history-row-edit-${row.id}`}
+                            style={{
+                              background: 'transparent',
+                              border: '1px solid #ccc',
+                              borderRadius: 4,
+                              padding: '2px 8px',
+                              cursor: 'pointer',
+                              fontSize: '0.85rem',
+                            }}
+                          >
+                            Edit notes / attachment
+                          </button>
+                        )}
+                        {!row.detail_url &&
+                          !row.attachment_url &&
+                          !(canManage && row.source === 'historical') &&
+                          '—'}
+                      </div>
+                    </td>
+                  </tr>
+                  {row.notes && row.notes.trim() && (
+                    <tr
+                      data-testid={`history-row-notes-${row.id}`}
+                      className="history-notes-row"
+                    >
+                      <td></td>
+                      <td colSpan={5}>
+                        <div
                           style={{
-                            background: 'transparent',
-                            border: '1px solid #ccc',
-                            borderRadius: 4,
-                            padding: '2px 8px',
-                            cursor: 'pointer',
-                            fontSize: '0.85rem',
+                            color: '#555',
+                            fontSize: '0.9em',
+                            whiteSpace: 'pre-wrap',
+                            padding: '0.25rem 0 0.5rem 0',
                           }}
                         >
-                          Edit notes / attachment
-                        </button>
-                      )}
-                      {!row.detail_url &&
-                        !row.attachment_url &&
-                        !(canManage && row.source === 'historical') &&
-                        '—'}
-                    </div>
-                  </td>
-                </tr>
+                          <span style={{ fontWeight: 600, marginRight: '0.5em' }}>
+                            Notes:
+                          </span>
+                          {row.notes}
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
               ))}
             </tbody>
           </table>


### PR DESCRIPTION
## Summary

#420 made notes editable; this PR makes them visible. When a maintenance-history row has non-empty notes, render them as a dimmed sub-row directly under the main row so users can read what they (or someone else) wrote without re-opening the edit panel.

- Whitespace-only notes are treated as empty (no sub-row).
- Applies to both `historical` and `workorder` source rows — both end up in the same history table; both deserve the same readability.
- Sub-row uses a stable testid (`history-row-notes-<id>`) so tests can lock the behavior in.

## Test plan

- [x] `react-scripts test --testPathPattern='MaintenanceHistorySection'` — 17/17 pass (13 existing + 4 new)
  - notes sub-row renders when notes are present
  - no sub-row when notes empty
  - no sub-row when notes are whitespace only
  - notes sub-row also renders for workorder-source rows
- [x] Pre-commit (tsc + npm test) green
- [ ] Manual: open an asset detail page, find a historical entry with notes (or click \"Edit notes / attachment\" and add one), confirm the notes appear under the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)