### PR TITLE
docs(forgekey): correct command topic in JWT docstring

### DIFF
--- a/backend/forgekey/services/jwt_signing.py
+++ b/backend/forgekey/services/jwt_signing.py
@@ -126,7 +126,7 @@ def make_command_jwt(*, mac: str, cmd: str, exp_seconds: int = 60) -> str:
     """Sign a short-TTL command JWT for a ForgeKey device.
 
     The JWT is the credential the firmware verifies before acting on a
-    `forgekey/<mac>/cmd` MQTT message — used by the locker / door /
+    `forgekey/<mac>/command` MQTT message — used by the locker / door /
     electronic-device pipeline (gh ForgeKey expansion, Phase 1).
 
     Payload shape: ``{"mac": ..., "cmd": ..., "exp": <unix-seconds>}``.


### PR DESCRIPTION
## Summary
- One-line docstring fix in `make_command_jwt`: the comment claimed firmware verifies on `forgekey/<mac>/cmd`, but `get_mqtt_command_topic` actually emits `forgekey/<mac>/command` (the topic the firmware now subscribes to per the matching ForgeKey PR).

## Test plan
- [ ] N/A — comment-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)