### PR TITLE
fix(dev): add celery_beat to docker-compose so periodic tasks fire

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,32 @@ services:
       redis:
         condition: service_healthy
 
+  celery_beat:
+    # Periodic-task scheduler. Without this, CELERY_BEAT_SCHEDULE entries
+    # never fire — most visibly, mark_stale_devices_offline never runs and
+    # ForgeKey devices show is_online=True forever after first contact.
+    # In-memory schedule state (no --schedule path) is fine for dev; on
+    # container restart the timers reset, which is OK since dev sessions
+    # are short.
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    command: celery -A config beat -l info
+    volumes:
+      - ./backend:/app
+    environment:
+      - DEBUG=1
+      - DATABASE_URL=postgresql://makerspace:${POSTGRES_PASSWORD:-development_password_only}@db:5432/makerspace_inventory
+      - REDIS_URL=redis://redis:6379/0
+      - CELERY_BROKER_URL=redis://redis:6379/0
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      celery:
+        condition: service_started
+
   flower:
     build:
       context: ./backend


### PR DESCRIPTION
## Summary
- ForgeKey devices in dev showed `is_online=True` for days after going silent because nothing was flipping them offline. Root cause: `forgekey.tasks.mark_stale_devices_offline` is the only path that ever sets `is_online=False`, and it runs via celery beat — but the dev `docker-compose.yml` had no `celery_beat` service. Prod (`docker-compose.prod.yml`) already had one.
- Same gap silently disabled every other `CELERY_BEAT_SCHEDULE` entry in dev (daily photo prune, daily vendor compliance digest, quarterly donor updates, monthly analytics pulse).

## Changes
- New `celery_beat` service in `docker-compose.yml` that mirrors the worker's env + code mount and runs `celery -A config beat -l info`. In-memory schedule state (no `--schedule` path) is fine for dev — short-lived sessions tolerate reset timers.

## Test plan
- [ ] `docker compose up -d celery_beat` — service starts cleanly
- [ ] `docker compose logs -f celery_beat` — see beat sending `forgekey.tasks.mark_stale_devices_offline` every 30 min
- [ ] Pick a device with `is_online=True` and `last_seen` > 5h old; within 30 min of beat starting, that row flips to `is_online=False`
- [ ] Sanity-check the rest: `docker compose logs celery_beat | grep "Sending due task"` shows the photo-prune, vendor-compliance, etc. entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)