### PR TITLE
feat(electrical): panel layout view + printable directory + phase auto-calc

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import PowerBreakerFormPage from './pages/PowerBreakerFormPage';
 import PowerCircuitFormPage from './pages/PowerCircuitFormPage';
 import PowerOutletFormPage from './pages/PowerOutletFormPage';
 import PowerPanelDetailPage from './pages/PowerPanelDetailPage';
+import PowerPanelPrintPage from './pages/PowerPanelPrintPage';
 import PowerPanelDirectoryPage from './pages/PowerPanelDirectoryPage';
 import PowerPanelFormPage from './pages/PowerPanelFormPage';
 import FixtureScanPage from './pages/FixtureScanPage';
@@ -214,6 +215,9 @@ function AppContent() {
           <Route path="/facilities/electrical/panels" element={<WorkspaceLayout><PowerPanelDirectoryPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/panels/new" element={<WorkspaceLayout><PowerPanelFormPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/panels/:id" element={<WorkspaceLayout><PowerPanelDetailPage /></WorkspaceLayout>} />
+          {/* Print directory route renders bare — no workspace chrome — so the
+              browser print dialog emits a clean letter-size cabinet directory. */}
+          <Route path="/facilities/electrical/panels/:id/print" element={<PowerPanelPrintPage />} />
           <Route path="/facilities/electrical/panels/:id/edit" element={<WorkspaceLayout><PowerPanelFormPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/panels/:panelId/breakers/new" element={<WorkspaceLayout><PowerBreakerFormPage /></WorkspaceLayout>} />
           <Route path="/facilities/electrical/breakers/:id/edit" element={<WorkspaceLayout><PowerBreakerFormPage /></WorkspaceLayout>} />

--- a/frontend/src/__tests__/utils/computePhase.test.ts
+++ b/frontend/src/__tests__/utils/computePhase.test.ts
@@ -1,0 +1,106 @@
+import { computePhase } from '../../utils/computePhase';
+
+describe('utils/computePhase', () => {
+  describe('single-phase panels', () => {
+    it('always returns A regardless of slot', () => {
+      expect(computePhase({ position: '1', poleCount: 1, panelPhase: 'single' })).toBe('A');
+      expect(computePhase({ position: '12', poleCount: 1, panelPhase: 'single' })).toBe('A');
+      expect(computePhase({ position: '40', poleCount: 1, panelPhase: 'single' })).toBe('A');
+    });
+  });
+
+  describe('split-phase panels', () => {
+    // Row index pattern (2-slot stride): slots 1&2=row0, slots 3&4=row1,
+    // 5&6=row2, ... Phase alternates A/B per row.
+    it.each([
+      ['1', 'A'],
+      ['2', 'A'],
+      ['3', 'B'],
+      ['4', 'B'],
+      ['5', 'A'],
+      ['6', 'A'],
+      ['7', 'B'],
+      ['8', 'B'],
+      ['11', 'B'],
+      ['12', 'B'],
+    ])('1-pole at slot %s → %s', (position, expected) => {
+      expect(computePhase({ position, poleCount: 1, panelPhase: 'split' })).toBe(expected);
+    });
+
+    it.each([
+      ['1', 'AB'],
+      ['2', 'AB'],
+      ['3', 'AB'],
+      ['5', 'AB'],
+    ])('2-pole at slot %s → %s (always AB on split phase)', (position, expected) => {
+      expect(computePhase({ position, poleCount: 2, panelPhase: 'split' })).toBe(expected);
+    });
+  });
+
+  describe('three-phase panels', () => {
+    // Row index pattern: rows cycle A/B/C every 2 slots same side.
+    it.each([
+      ['1', 'A'],
+      ['3', 'B'],
+      ['5', 'C'],
+      ['7', 'A'],
+      ['9', 'B'],
+      ['11', 'C'],
+      ['2', 'A'],
+      ['4', 'B'],
+      ['6', 'C'],
+      ['8', 'A'],
+    ])('1-pole at slot %s → %s', (position, expected) => {
+      expect(computePhase({ position, poleCount: 1, panelPhase: 'three' })).toBe(expected);
+    });
+
+    it('2-pole at slot 1 → AB', () => {
+      expect(computePhase({ position: '1', poleCount: 2, panelPhase: 'three' })).toBe('AB');
+    });
+
+    it('2-pole at slot 3 → BC', () => {
+      expect(computePhase({ position: '3', poleCount: 2, panelPhase: 'three' })).toBe('BC');
+    });
+
+    it('2-pole at slot 5 → AC (wraps C→A; sorted alphabetically)', () => {
+      expect(computePhase({ position: '5', poleCount: 2, panelPhase: 'three' })).toBe('AC');
+    });
+
+    it('3-pole at slot 1 → ABC', () => {
+      expect(computePhase({ position: '1', poleCount: 3, panelPhase: 'three' })).toBe('ABC');
+    });
+
+    it('3-pole at slot 5 → ABC (wraps and de-dups)', () => {
+      expect(computePhase({ position: '5', poleCount: 3, panelPhase: 'three' })).toBe('ABC');
+    });
+  });
+
+  describe('bail-out cases', () => {
+    it('returns null for tandem positions', () => {
+      expect(computePhase({ position: '14/16', poleCount: 1, panelPhase: 'split' })).toBeNull();
+      expect(computePhase({ position: '1-3', poleCount: 1, panelPhase: 'split' })).toBeNull();
+    });
+
+    it('returns null for empty position', () => {
+      expect(computePhase({ position: '', poleCount: 1, panelPhase: 'split' })).toBeNull();
+    });
+
+    it('returns null for non-numeric position', () => {
+      expect(computePhase({ position: 'abc', poleCount: 1, panelPhase: 'split' })).toBeNull();
+    });
+
+    it('returns null for slot 0 / negative slots', () => {
+      expect(computePhase({ position: '0', poleCount: 1, panelPhase: 'split' })).toBeNull();
+    });
+  });
+
+  describe('pole count clamping', () => {
+    it('clamps pole count below 1 to 1', () => {
+      expect(computePhase({ position: '1', poleCount: 0, panelPhase: 'split' })).toBe('A');
+    });
+
+    it('clamps pole count above 3 to 3', () => {
+      expect(computePhase({ position: '1', poleCount: 5, panelPhase: 'three' })).toBe('ABC');
+    });
+  });
+});

--- a/frontend/src/components/PanelLayoutGrid.tsx
+++ b/frontend/src/components/PanelLayoutGrid.tsx
@@ -1,0 +1,285 @@
+/**
+ * Spatial 2-column rendering of a power panel — odds on the left,
+ * evens on the right, mirroring how breakers are physically arranged
+ * inside the cabinet.
+ *
+ * Multi-pole breakers (2P stoves, 240V dryers, 3P industrial) visually
+ * span their occupied slots. Tandem positions (e.g. "14/16") render at
+ * both listed slots.
+ *
+ * Two density modes:
+ *   - "interactive" — used by the panel detail page; includes circuit
+ *     summaries and edit affordances.
+ *   - "print" — stripped-down cabinet directory for printing and
+ *     taping inside the cabinet door.
+ */
+import { Badge, Group, Paper, Stack, Text } from '@mantine/core';
+import { IconBolt, IconEdit } from '@tabler/icons-react';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { PowerBreakerNode, PowerPanelTopology } from '../services/api';
+
+export type PanelLayoutDensity = 'interactive' | 'print';
+
+interface SlotCell {
+  slot: number;
+  breaker: PowerBreakerNode | null;
+  /**
+   * Number of vertical cells this slot occupies. >1 means the breaker
+   * is multi-pole and the following same-side slot(s) are continuation
+   * rows owned by this breaker.
+   */
+  rowSpan: number;
+  /**
+   * True when this slot is covered by a multi-pole breaker rooted at
+   * an earlier slot. Such cells render as an empty continuation marker.
+   */
+  isContinuation: boolean;
+}
+
+interface SlotPair {
+  left: SlotCell;
+  right: SlotCell;
+}
+
+/**
+ * Parse a position string into one or more numeric slot numbers.
+ * Accepts plain integers ("12") and tandem forms ("14/16", "14-16").
+ * Returns an empty array for unparseable input so the caller can fall
+ * back gracefully.
+ */
+function parsePositions(position: string): number[] {
+  if (!position) return [];
+  const parts = position.split(/[/\-,\s]+/).filter(Boolean);
+  const nums: number[] = [];
+  for (const p of parts) {
+    const n = parseInt(p, 10);
+    if (Number.isFinite(n) && n > 0) nums.push(n);
+  }
+  return nums;
+}
+
+/**
+ * Compute the slot grid for a panel.
+ *
+ * Strategy: for every breaker, work out which slot numbers it occupies
+ * (tandem positions from `position`, or primary slot + skip-2 for each
+ * additional pole on `pole_count`). Then build a sparse map and bucket
+ * into left (odd) / right (even) columns by slot number parity.
+ */
+function buildSlotPairs(topology: PowerPanelTopology): SlotPair[] {
+  // slotNumber -> { breaker, isContinuation }
+  const occupancy = new Map<number, { breaker: PowerBreakerNode; primary: boolean }>();
+
+  for (const breaker of topology.breakers) {
+    const parsed = parsePositions(breaker.position);
+    if (parsed.length === 0) continue;
+    const primary = parsed[0];
+    occupancy.set(primary, { breaker, primary: true });
+
+    if (parsed.length > 1) {
+      // Tandem: every listed slot is "primary" for that breaker (one
+      // physical breaker, two listed slot numbers).
+      for (let i = 1; i < parsed.length; i++) {
+        occupancy.set(parsed[i], { breaker, primary: false });
+      }
+    } else if (breaker.pole_count > 1) {
+      // Multi-pole: next pole_count-1 same-side slots are continuations.
+      for (let i = 1; i < breaker.pole_count; i++) {
+        occupancy.set(primary + i * 2, { breaker, primary: false });
+      }
+    }
+  }
+
+  // Determine grid size. Round up to even to keep both columns balanced.
+  // Minimum 12 slots — that's a 6-circuit subpanel; anything smaller
+  // probably means a misconfigured panel and 12 still renders cleanly.
+  let maxSlot = 12;
+  Array.from(occupancy.keys()).forEach((slot) => {
+    if (slot > maxSlot) maxSlot = slot;
+  });
+  if (maxSlot % 2 !== 0) maxSlot += 1;
+
+  const cellFor = (slot: number): SlotCell => {
+    const entry = occupancy.get(slot);
+    if (!entry) {
+      return { slot, breaker: null, rowSpan: 1, isContinuation: false };
+    }
+    if (!entry.primary) {
+      return { slot, breaker: entry.breaker, rowSpan: 1, isContinuation: true };
+    }
+    // Compute row span only for true (non-tandem) multi-pole breakers.
+    // Tandem positions list each slot explicitly and each gets its
+    // own row, so row span stays 1 in that case.
+    const parsed = parsePositions(entry.breaker.position);
+    const span = parsed.length > 1 ? 1 : entry.breaker.pole_count;
+    return { slot, breaker: entry.breaker, rowSpan: span, isContinuation: false };
+  };
+
+  const pairs: SlotPair[] = [];
+  // Pair odds (left) with the next-higher even (right): (1,2), (3,4), ...
+  for (let odd = 1; odd <= maxSlot; odd += 2) {
+    pairs.push({ left: cellFor(odd), right: cellFor(odd + 1) });
+  }
+  return pairs;
+}
+
+function breakerSummary(breaker: PowerBreakerNode): string {
+  const parts: string[] = [];
+  if (breaker.label) parts.push(breaker.label);
+  parts.push(`${breaker.amperage}A`);
+  if (breaker.pole_count > 1) parts.push(`${breaker.pole_count}P`);
+  return parts.join(' · ');
+}
+
+function circuitSummary(breaker: PowerBreakerNode): string {
+  const circuitCount = breaker.circuits.length;
+  if (circuitCount === 0) return 'no circuits wired';
+  const outletCount = breaker.circuits.reduce((acc, c) => acc + c.outlets.length, 0);
+  const labels = breaker.circuits
+    .map((c) => c.label)
+    .filter((l): l is string => Boolean(l))
+    .slice(0, 2);
+  const head = labels.length > 0 ? labels.join(', ') : `${circuitCount} circuit${circuitCount === 1 ? '' : 's'}`;
+  return outletCount > 0 ? `${head} · ${outletCount} outlet${outletCount === 1 ? '' : 's'}` : head;
+}
+
+interface CellProps {
+  cell: SlotCell;
+  density: PanelLayoutDensity;
+  side: 'left' | 'right';
+}
+
+const SlotBlock: React.FC<CellProps> = ({ cell, density, side }) => {
+  const { slot, breaker, isContinuation } = cell;
+  const slotLabel = (
+    <Text fw={700} size={density === 'print' ? 'md' : 'sm'} ff="monospace">
+      {String(slot).padStart(2, ' ')}
+    </Text>
+  );
+
+  if (isContinuation && breaker) {
+    return (
+      <Paper
+        withBorder
+        p={density === 'print' ? 'xs' : 'sm'}
+        radius="sm"
+        data-testid={`slot-${slot}`}
+        data-continuation="true"
+        style={{ borderStyle: 'dashed', minHeight: density === 'print' ? 36 : 56 }}
+      >
+        <Group gap="xs" wrap="nowrap" align="center">
+          {slotLabel}
+          <Text size="xs" c="dimmed" fs="italic">
+            tied to slot {parsePositions(breaker.position)[0]}
+          </Text>
+        </Group>
+      </Paper>
+    );
+  }
+
+  if (!breaker) {
+    return (
+      <Paper
+        withBorder
+        p={density === 'print' ? 'xs' : 'sm'}
+        radius="sm"
+        data-testid={`slot-${slot}`}
+        data-empty="true"
+        style={{ minHeight: density === 'print' ? 36 : 56, background: 'rgba(0,0,0,0.02)' }}
+      >
+        <Group gap="xs" wrap="nowrap" align="center">
+          {slotLabel}
+          <Text size="xs" c="dimmed">
+            spare
+          </Text>
+        </Group>
+      </Paper>
+    );
+  }
+
+  const statusColor = breaker.status === 'active' ? 'green' : breaker.status === 'locked_out' ? 'red' : 'gray';
+
+  return (
+    <Paper
+      withBorder
+      p={density === 'print' ? 'xs' : 'sm'}
+      radius="sm"
+      data-testid={`slot-${slot}`}
+      data-breaker-id={breaker.id}
+      style={{ minHeight: density === 'print' ? 36 : 56 }}
+    >
+      <Stack gap={density === 'print' ? 2 : 4}>
+        <Group gap="xs" wrap="nowrap" justify="space-between" align="flex-start">
+          <Group gap="xs" wrap="nowrap" align="center">
+            {slotLabel}
+            <Text fw={600} size={density === 'print' ? 'sm' : 'sm'}>
+              {breakerSummary(breaker)}
+            </Text>
+          </Group>
+          {density === 'interactive' && (
+            <Group gap={4} wrap="nowrap">
+              <Badge size="xs" color={statusColor} variant="light" radius="sm">
+                {breaker.status}
+              </Badge>
+              <Link
+                to={`/facilities/electrical/breakers/${breaker.id}/edit`}
+                aria-label={`Edit breaker ${breaker.label || slot}`}
+                style={{ display: 'inline-flex', alignItems: 'center', color: 'inherit' }}
+              >
+                <IconEdit size={14} />
+              </Link>
+            </Group>
+          )}
+        </Group>
+        <Text size={density === 'print' ? 'xs' : 'xs'} c="dimmed" style={{ paddingLeft: density === 'print' ? 0 : 4 }}>
+          {circuitSummary(breaker)}
+        </Text>
+      </Stack>
+      {/* Layout helper: ensure right-side cells visually nudge from the spine. */}
+      <span data-side={side} style={{ display: 'none' }} />
+    </Paper>
+  );
+};
+
+export interface PanelLayoutGridProps {
+  topology: PowerPanelTopology;
+  density?: PanelLayoutDensity;
+}
+
+const PanelLayoutGrid: React.FC<PanelLayoutGridProps> = ({ topology, density = 'interactive' }) => {
+  const pairs = buildSlotPairs(topology);
+
+  if (topology.breakers.length === 0) {
+    return (
+      <Paper withBorder p="xl" radius="md">
+        <Stack gap="sm" align="center">
+          <IconBolt size={28} stroke={1.6} />
+          <Text fw={500}>No breakers configured for this panel</Text>
+        </Stack>
+      </Paper>
+    );
+  }
+
+  return (
+    <div
+      className={`panel-layout-grid panel-layout-grid--${density}`}
+      data-testid="panel-layout-grid"
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr',
+        gap: density === 'print' ? 6 : 10,
+      }}
+    >
+      {pairs.map((pair) => (
+        <React.Fragment key={`${pair.left.slot}-${pair.right.slot}`}>
+          <SlotBlock cell={pair.left} density={density} side="left" />
+          <SlotBlock cell={pair.right} density={density} side="right" />
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};
+
+export default PanelLayoutGrid;

--- a/frontend/src/pages/PowerBreakerFormPage.tsx
+++ b/frontend/src/pages/PowerBreakerFormPage.tsx
@@ -28,6 +28,7 @@ import {
   PowerBreakerWritable,
   PowerPanelDetail,
 } from '../services/api';
+import { computePhase } from '../utils/computePhase';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const POLE_OPTIONS = [
@@ -72,6 +73,45 @@ const PowerBreakerFormPage: React.FC = () => {
   const [loading, setLoading] = useState(isEditMode);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Track whether the operator has hand-picked the phase. Once they
+  // override, we stop overwriting from the position/pole_count auto-calc
+  // so we don't second-guess a deliberate choice.
+  const [phaseManuallySet, setPhaseManuallySet] = useState(isEditMode);
+  const [autoPhaseHint, setAutoPhaseHint] = useState<string | null>(null);
+
+  const selectedPanel = panels.find((p) => p.id === form.panel) ?? null;
+
+  // Auto-populate phase from panel config + position + pole count.
+  // Bails out cleanly when the position is tandem or unparseable
+  // (computePhase returns null) so manual entries aren't clobbered.
+  useEffect(() => {
+    if (phaseManuallySet || !selectedPanel) {
+      setAutoPhaseHint(null);
+      return;
+    }
+    const computed = computePhase({
+      position: form.position ?? '',
+      poleCount: form.pole_count ?? 1,
+      panelPhase: selectedPanel.phase_configuration,
+    });
+    if (computed === null) {
+      setAutoPhaseHint(
+        /[/-]/.test(form.position ?? '')
+          ? 'Auto-calc skipped for tandem positions — set phase manually.'
+          : null,
+      );
+      return;
+    }
+    setAutoPhaseHint(
+      `Auto-set from ${selectedPanel.phase_configuration} panel · slot ${form.position} · ${form.pole_count}-pole`,
+    );
+    setForm((prev) => (prev.phase === computed ? prev : { ...prev, phase: computed }));
+  }, [
+    selectedPanel,
+    form.position,
+    form.pole_count,
+    phaseManuallySet,
+  ]);
 
   useEffect(() => {
     electricalTopologyAPI
@@ -200,11 +240,29 @@ const PowerBreakerFormPage: React.FC = () => {
                   label="Phase"
                   data={PHASE_OPTIONS}
                   value={form.phase ?? 'A'}
-                  onChange={(value) =>
-                    setForm({ ...form, phase: (value as PowerBreakerWritable['phase']) ?? 'A' })
+                  description={
+                    phaseManuallySet
+                      ? 'Manually set — reset below to re-enable auto-calc'
+                      : autoPhaseHint ?? undefined
                   }
+                  onChange={(value) => {
+                    setPhaseManuallySet(true);
+                    setForm({ ...form, phase: (value as PowerBreakerWritable['phase']) ?? 'A' });
+                  }}
                 />
               </Group>
+              {phaseManuallySet && !isEditMode && (
+                <Group justify="flex-end" gap="xs">
+                  <Button
+                    type="button"
+                    variant="subtle"
+                    size="xs"
+                    onClick={() => setPhaseManuallySet(false)}
+                  >
+                    Re-enable phase auto-calc
+                  </Button>
+                </Group>
+              )}
               <Select
                 label="Status"
                 data={STATUS_OPTIONS}

--- a/frontend/src/pages/PowerPanelDetailPage.tsx
+++ b/frontend/src/pages/PowerPanelDetailPage.tsx
@@ -15,20 +15,38 @@ import {
   Container,
   Group,
   Paper,
+  SegmentedControl,
   Stack,
   Table,
   Text,
 } from '@mantine/core';
-import { IconBolt, IconEdit, IconPlus, IconRouteAltLeft } from '@tabler/icons-react';
+import { IconBolt, IconEdit, IconPlus, IconPrinter, IconRouteAltLeft } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
 
 import PageHero from '../components/landing/PageHero';
+import PanelLayoutGrid from '../components/PanelLayoutGrid';
 import { electricalSafetyAPI, PowerPanelTopology } from '../services/api';
 import '../styles/landing.css';
 
+type PanelView = 'panel' | 'list';
+
+const isPanelView = (v: string | null): v is PanelView => v === 'panel' || v === 'list';
+
 const PowerPanelDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const viewParam = searchParams.get('view');
+  const view: PanelView = isPanelView(viewParam) ? viewParam : 'panel';
+  const setView = (next: PanelView) => {
+    const params = new URLSearchParams(searchParams);
+    if (next === 'panel') {
+      params.delete('view');
+    } else {
+      params.set('view', next);
+    }
+    setSearchParams(params, { replace: true });
+  };
   const [topology, setTopology] = useState<PowerPanelTopology | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -75,6 +93,16 @@ const PowerPanelDetailPage: React.FC = () => {
               topology ? (
                 <Group gap="sm">
                   <Button
+                    component="a"
+                    href={`/facilities/electrical/panels/${topology.id}/print`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    variant="default"
+                    leftSection={<IconPrinter size={16} />}
+                  >
+                    Print directory
+                  </Button>
+                  <Button
                     component={Link}
                     to={`/facilities/electrical/panels/${topology.id}/edit`}
                     variant="default"
@@ -93,6 +121,25 @@ const PowerPanelDetailPage: React.FC = () => {
               ) : undefined
             }
           />
+
+          {topology && topology.breakers.length > 0 && (
+            <Group justify="space-between" align="center" wrap="wrap">
+              <SegmentedControl
+                data={[
+                  { label: 'Panel layout', value: 'panel' },
+                  { label: 'List', value: 'list' },
+                ]}
+                value={view}
+                onChange={(v) => setView(v as PanelView)}
+                data-testid="panel-view-toggle"
+              />
+              <Text size="sm" c="dimmed">
+                {view === 'panel'
+                  ? 'Odds left, evens right — mirrors the physical panel'
+                  : 'One card per breaker with full circuit detail'}
+              </Text>
+            </Group>
+          )}
 
           {error && (
             <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
@@ -128,7 +175,12 @@ const PowerPanelDetailPage: React.FC = () => {
             </Paper>
           )}
 
+          {topology && topology.breakers.length > 0 && view === 'panel' && (
+            <PanelLayoutGrid topology={topology} density="interactive" />
+          )}
+
           {topology &&
+            view === 'list' &&
             topology.breakers.map((breaker) => (
               <Paper
                 key={breaker.id}

--- a/frontend/src/pages/PowerPanelPrintPage.tsx
+++ b/frontend/src/pages/PowerPanelPrintPage.tsx
@@ -1,0 +1,114 @@
+/**
+ * Standalone printable panel directory at
+ * `/facilities/electrical/panels/:id/print`.
+ *
+ * Rendered without the workspace shell / sidebar so the page prints
+ * directly to a clean letter-size sheet that fits inside the cabinet
+ * door. The user lands here from the "Print directory" button on the
+ * panel detail page (opened in a new tab) and then hits Cmd+P / Ctrl+P.
+ *
+ * Print CSS lives in styles/panel-print.css.
+ */
+import { Box, Button, Group, Stack, Text } from '@mantine/core';
+import { IconPrinter } from '@tabler/icons-react';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import PanelLayoutGrid from '../components/PanelLayoutGrid';
+import { electricalSafetyAPI, PowerPanelTopology } from '../services/api';
+import '../styles/panel-print.css';
+
+const PowerPanelPrintPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [topology, setTopology] = useState<PowerPanelTopology | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    electricalSafetyAPI
+      .getPanelTopology(id)
+      .then((response) => {
+        if (cancelled) return;
+        setTopology(response.data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err?.response?.data?.detail || 'Failed to load panel topology.');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  if (error) {
+    return (
+      <Box p="xl" data-testid="panel-print-error">
+        <Text c="red">{error}</Text>
+      </Box>
+    );
+  }
+
+  if (!topology) {
+    return (
+      <Box p="xl">
+        <Text c="dimmed">Loading panel directory…</Text>
+      </Box>
+    );
+  }
+
+  const subtitle = [
+    topology.location_name,
+    `${topology.voltage}V`,
+    `${topology.phase_configuration} phase`,
+    topology.main_breaker_amperage ? `${topology.main_breaker_amperage}A main` : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  return (
+    <Box className="panel-print-page" data-testid="panel-print-page" p="xl">
+      <Stack gap="md">
+        <Group justify="space-between" align="flex-start" className="panel-print-no-print">
+          <div>
+            <Text size="sm" c="dimmed">
+              Printable cabinet directory
+            </Text>
+            <Text size="xs" c="dimmed">
+              Use your browser's print dialog (Cmd/Ctrl+P) and choose letter / A4.
+            </Text>
+          </div>
+          <Button
+            variant="default"
+            leftSection={<IconPrinter size={16} />}
+            onClick={() => window.print()}
+          >
+            Print
+          </Button>
+        </Group>
+
+        <Stack gap={2} className="panel-print-header">
+          <Text size="xl" fw={700}>
+            {topology.name}
+          </Text>
+          <Text size="sm" c="dimmed">
+            {subtitle}
+          </Text>
+        </Stack>
+
+        <PanelLayoutGrid topology={topology} density="print" />
+
+        <Group justify="space-between" className="panel-print-footer">
+          <Text size="xs" c="dimmed">
+            Generated from OMS · panel #{topology.id}
+          </Text>
+          <Text size="xs" c="dimmed">
+            {new Date().toISOString().slice(0, 10)}
+          </Text>
+        </Group>
+      </Stack>
+    </Box>
+  );
+};
+
+export default PowerPanelPrintPage;

--- a/frontend/src/styles/panel-print.css
+++ b/frontend/src/styles/panel-print.css
@@ -1,0 +1,59 @@
+/* Print stylesheet for the panel directory page.
+ * Goal: a single letter-size page that fits inside a typical residential
+ * load-center door. Strips chrome, tightens spacing, forces black text. */
+
+.panel-print-page {
+  max-width: 8in;
+  margin: 0 auto;
+}
+
+@media print {
+  /* Hide the workspace shell + the in-page toolbar so only the directory
+   * itself reaches the paper. WorkspaceLayout isn't applied to this route
+   * but we still strip any global app chrome that leaks through. */
+  body * {
+    visibility: hidden;
+  }
+
+  .panel-print-page,
+  .panel-print-page * {
+    visibility: visible;
+  }
+
+  .panel-print-page {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 0.4in !important;
+  }
+
+  .panel-print-no-print {
+    display: none !important;
+  }
+
+  /* Tighten the grid for print. */
+  .panel-layout-grid--print {
+    gap: 4px !important;
+    color: #000 !important;
+  }
+
+  .panel-layout-grid--print .mantine-Paper-root {
+    border-color: #000 !important;
+    background: #fff !important;
+    color: #000 !important;
+    box-shadow: none !important;
+  }
+
+  /* Force readable fonts on paper. */
+  .panel-print-page,
+  .panel-print-page * {
+    color: #000 !important;
+    background: transparent !important;
+  }
+
+  @page {
+    size: letter;
+    margin: 0.4in;
+  }
+}

--- a/frontend/src/utils/computePhase.ts
+++ b/frontend/src/utils/computePhase.ts
@@ -1,0 +1,80 @@
+/**
+ * Compute the expected phase for a breaker at a given panel slot.
+ *
+ * Convention: US load-center "2-slot stride" layout where each pair of
+ * vertically-adjacent same-side slots taps the same phase. Walking down
+ * one side, rows alternate between phases:
+ *
+ *   Split-phase:  row 0=A, row 1=B, row 2=A, row 3=B, ...
+ *   Three-phase:  row 0=A, row 1=B, row 2=C, row 3=A, row 4=B, ...
+ *
+ * `rowIndex(slot)` is `floor((slot - 1) / 2)`, which works for both odd
+ * (left column) and even (right column) slots and gives the same row
+ * index for the horizontally-adjacent pair (1↔2, 3↔4, ...).
+ *
+ * Multi-pole breakers span `pole_count` consecutive same-side slots,
+ * which map to consecutive rows. The resulting phase string is the
+ * alphabetical concatenation of the covered single phases — matching
+ * the model's PHASE_CHOICES ("A", "B", "C", "AB", "BC", "AC", "ABC").
+ *
+ * Returns null when auto-calc isn't safe (tandem positions like "14/16"
+ * where both slots share a single bus tap, or unparseable positions).
+ */
+import type { PowerPanelPhase } from '../services/api';
+
+type SinglePhase = 'A' | 'B' | 'C';
+export type ComputedPhase = 'A' | 'B' | 'C' | 'AB' | 'BC' | 'AC' | 'ABC';
+
+const SINGLE_PHASES: SinglePhase[] = ['A', 'B', 'C'];
+
+/**
+ * Parse the first integer slot out of a position string. Returns null
+ * when the position is empty/non-numeric or carries a tandem separator
+ * ("/" or "-"), because tandem slots break the row-index model.
+ */
+function primarySlot(position: string): number | null {
+  if (!position) return null;
+  if (/[/-]/.test(position)) return null; // tandem — bail out
+  const n = parseInt(position.trim(), 10);
+  if (!Number.isFinite(n) || n < 1) return null;
+  return n;
+}
+
+function rowIndex(slot: number): number {
+  return Math.floor((slot - 1) / 2);
+}
+
+function phaseForRow(row: number, config: PowerPanelPhase): SinglePhase {
+  if (config === 'single') return 'A';
+  const modulus = config === 'three' ? 3 : 2;
+  return SINGLE_PHASES[((row % modulus) + modulus) % modulus];
+}
+
+/**
+ * Returns the auto-calculated phase string, or null when we should NOT
+ * auto-fill (tandem position, missing inputs, single-phase always-A).
+ *
+ * Single-phase panels return 'A' for every well-formed input so the
+ * caller can still pre-populate the field rather than leave it blank.
+ */
+export function computePhase(args: {
+  position: string;
+  poleCount: number;
+  panelPhase: PowerPanelPhase;
+}): ComputedPhase | null {
+  const { position, poleCount, panelPhase } = args;
+  const slot = primarySlot(position);
+  if (slot === null) return null;
+  const poles = Math.max(1, Math.min(3, poleCount || 1));
+
+  const covered = new Set<SinglePhase>();
+  const startRow = rowIndex(slot);
+  for (let i = 0; i < poles; i++) {
+    covered.add(phaseForRow(startRow + i, panelPhase));
+  }
+
+  // Concatenate in canonical A,B,C order so "C+A" comes out as "AC" —
+  // matches the model's PHASE_CHOICES ("AB", "BC", "AC", "ABC").
+  const ordered = SINGLE_PHASES.filter((p) => covered.has(p)).join('');
+  return ordered as ComputedPhase;
+}


### PR DESCRIPTION
## Summary
Three improvements to the PowerPanel UX, all on `/facilities/electrical/panels/<id>`:

### 1. Panel layout view (new default)
- Spatial 2-column grid mirroring the physical cabinet — odds on the left, evens on the right.
- Multi-pole breakers visually span their slots (2P at slot 1 → one cell over slots 1 + 3).
- Tandem positions like `"14/16"` render at both listed slots.
- Toggle via SegmentedControl: Panel layout (default) ↔ List (the existing card view, preserved).
- View choice persisted in `?view=` URL param for sharing/bookmarking.

### 2. Printable cabinet directory
- New route `/facilities/electrical/panels/<id>/print` rendered without any workspace chrome.
- Uses the same `PanelLayoutGrid` in `density="print"` mode (no edit affordances, tighter spacing).
- `@media print` CSS strips everything but the directory and fits a letter-size sheet.
- "Print directory" button on the panel detail page opens the print view in a new tab.

### 3. Phase auto-calc on the breaker form
- When user enters position + pole count, the Phase field auto-populates from the panel's `phase_configuration` using the standard 2-slot-stride layout:
  - `single` → always `A`
  - `split` → `A`/`B` alternating per row (slot 1+2=A, 3+4=B, 5+6=A, ...)
  - `three` → `A`/`B`/`C` cycling per row
- Multi-pole breakers concatenate covered phases (2P at slot 1 split → `AB`; 3P at slot 1 three → `ABC`; 2P at slot 5 three → `AC` after C→A wrap).
- User can override the auto-set value; once they do, auto-calc stops second-guessing them. "Re-enable phase auto-calc" button restores it.
- Tandem positions (`14/16`) skip auto-calc and ask the user to set phase manually.
- Pure logic isolated in `utils/computePhase.ts` with **36 unit tests** covering single/split/three configurations, multi-pole, wraps, and bail-out cases.

## Test plan
- [ ] Open `/facilities/electrical/panels/<id>` — defaults to Panel layout. Toggle to List preserves existing card view.
- [ ] Verify multi-pole breaker (e.g. 2-pole at slot 1) shows in slot 1 with continuation cell at slot 3.
- [ ] Verify spare slots render as empty cells.
- [ ] Click "Print directory" → new tab opens `/print`, hit Cmd+P / Ctrl+P → preview shows clean letter-size cabinet directory with no app chrome.
- [ ] Create a new breaker; entering position 1 on a split-phase panel pre-fills `Phase A`. Change to 2-pole — flips to `AB`. Manually pick `B` — auto-calc disables. "Re-enable phase auto-calc" restores it.
- [ ] On a 3-phase panel: position 5, 2-pole → `AC` (verifies the C→A wrap & alphabetical sort).

## Follow-ups (not in this PR — separate work)
- Sub-panel hierarchy (mark a panel as fed by a parent panel's circuit)
- Breaker status flags (red/grey for stale/moved circuits)
- Offline editing support

🤖 Generated with [Claude Code](https://claude.com/claude-code)