### PR TITLE
feat(navigation): dynamic breadcrumb labels via BreadcrumbContext

### DIFF
--- a/frontend/src/__tests__/components/Breadcrumbs.test.tsx
+++ b/frontend/src/__tests__/components/Breadcrumbs.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import Breadcrumbs from '../../components/Breadcrumbs';
+import { BreadcrumbProvider, useSetBreadcrumb } from '../../contexts/BreadcrumbContext';
 
 const renderWithRouter = (initialEntries = ['/']) => {
   return render(
@@ -12,6 +13,11 @@ const renderWithRouter = (initialEntries = ['/']) => {
       <Breadcrumbs />
     </MemoryRouter>
   );
+};
+
+const LabelSetter: React.FC<{ label: string | undefined }> = ({ label }) => {
+  useSetBreadcrumb(label);
+  return null;
 };
 
 describe('Breadcrumbs Component', () => {
@@ -100,6 +106,45 @@ describe('Breadcrumbs Component', () => {
     renderWithRouter(['/facilities/electrical/panels/42']);
     expect(screen.queryByText('42')).not.toBeInTheDocument();
     expect(screen.getByText(/panels/i)).toBeInTheDocument();
+  });
+
+  describe('dynamic label via BreadcrumbContext', () => {
+    it('replaces the trailing segment when a page registers a label', () => {
+      render(
+        <MemoryRouter initialEntries={['/inventory/assets/abc123/edit']}>
+          <BreadcrumbProvider>
+            <LabelSetter label="Bridgeport Mill" />
+            <Breadcrumbs />
+          </BreadcrumbProvider>
+        </MemoryRouter>,
+      );
+      // Trailing static "Edit" is swapped for the asset name.
+      expect(screen.queryByText(/^edit$/i)).not.toBeInTheDocument();
+      expect(screen.getByText('Bridgeport Mill')).toBeInTheDocument();
+      expect(screen.getByText('Bridgeport Mill')).toHaveAttribute('aria-current', 'page');
+      // Earlier segments are untouched.
+      expect(screen.getByText(/home/i)).toBeInTheDocument();
+      expect(screen.getByText(/assets/i)).toBeInTheDocument();
+    });
+
+    it('falls back to the static label when no dynamic label is set', () => {
+      render(
+        <MemoryRouter initialEntries={['/inventory/assets/abc123/edit']}>
+          <BreadcrumbProvider>
+            <LabelSetter label={undefined} />
+            <Breadcrumbs />
+          </BreadcrumbProvider>
+        </MemoryRouter>,
+      );
+      expect(screen.getByText(/^edit$/i)).toBeInTheDocument();
+    });
+
+    it('renders normally without a provider (safe no-op outside WorkspaceLayout)', () => {
+      // Breadcrumbs is also rendered in places where the provider isn't
+      // mounted (storybook, isolated tests). Verify it doesn't throw.
+      renderWithRouter(['/inventory/assets']);
+      expect(screen.getByText(/assets/i)).toBeInTheDocument();
+    });
   });
 });
 

--- a/frontend/src/components/Breadcrumbs.tsx
+++ b/frontend/src/components/Breadcrumbs.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import '../styles/Breadcrumbs.css';
 
+import { useBreadcrumbState } from '../contexts/BreadcrumbContext';
 import { getRouteEntry, isClickable, labelFor } from '../navigation/routeMap';
 
 interface BreadcrumbSegment {
@@ -26,6 +27,7 @@ const ID_LIKE = /^(\d+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{
 
 const Breadcrumbs: React.FC = () => {
   const location = useLocation();
+  const { currentLabel } = useBreadcrumbState();
 
   const breadcrumbs = React.useMemo<BreadcrumbSegment[]>(() => {
     const pathSegments = location.pathname.split('/').filter(Boolean);
@@ -50,6 +52,17 @@ const Breadcrumbs: React.FC = () => {
     return out;
   }, [location.pathname]);
 
+  // When a page has registered a dynamic label via useSetBreadcrumb, swap
+  // it in for the final segment so e.g. /assets/<uuid>/edit reads as
+  // "Home › Assets › <Asset name>" instead of "… › Edit".
+  const visibleBreadcrumbs = React.useMemo<BreadcrumbSegment[]>(() => {
+    if (!currentLabel || breadcrumbs.length === 0) return breadcrumbs;
+    const lastIndex = breadcrumbs.length - 1;
+    return breadcrumbs.map((crumb, index) =>
+      index === lastIndex ? { ...crumb, label: currentLabel } : crumb,
+    );
+  }, [breadcrumbs, currentLabel]);
+
   if (location.pathname === '/') {
     return null;
   }
@@ -57,8 +70,8 @@ const Breadcrumbs: React.FC = () => {
   return (
     <nav className="breadcrumbs" aria-label="Breadcrumb">
       <ol className="breadcrumb-list">
-        {breadcrumbs.map((crumb, index) => {
-          const isLast = index === breadcrumbs.length - 1;
+        {visibleBreadcrumbs.map((crumb, index) => {
+          const isLast = index === visibleBreadcrumbs.length - 1;
           const renderAsLink = !isLast && crumb.clickable;
 
           return (

--- a/frontend/src/components/WorkspaceLayout.tsx
+++ b/frontend/src/components/WorkspaceLayout.tsx
@@ -6,6 +6,7 @@ import { ActionIcon } from '@mantine/core';
 import { IconBell } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import { BreadcrumbProvider } from '../contexts/BreadcrumbContext';
 import { useCommandPalette } from '../hooks/useCommandPalette';
 import { useNotifications } from '../hooks/useNotifications';
 import '../styles/WorkspaceLayout.css';
@@ -128,71 +129,73 @@ const WorkspaceLayout: React.FC<WorkspaceLayoutProps> = ({ children }) => {
   }
 
   return (
-    <div className="workspace-layout">
-      {/* Mobile backdrop */}
-      {isMobile && isMobileOpen && (
-        <div
-          className="sidebar-backdrop"
-          onClick={closeMobileSidebar}
-          aria-hidden="true"
-        />
-      )}
-      <Sidebar
-        isCollapsed={isCollapsed}
-        isMobileOpen={isMobileOpen}
-        onClose={closeMobileSidebar}
-      />
-      <div className="workspace-content">
-        <div className="workspace-header">
-          <button
-            className={`menu-toggle ${!hasInteracted ? 'shimmer' : ''}`}
-            onClick={toggleSidebar}
-            aria-label={isMobile ? (isMobileOpen ? 'Close sidebar' : 'Open sidebar') : (isCollapsed ? 'Expand sidebar' : 'Collapse sidebar')}
-          >
-            ☰
-          </button>
-          <Link to="/" className="header-logo">
-            <span className="logo-icon">📦</span>
-            <span className="logo-text">DallasMakerspace</span>
-          </Link>
-          <Breadcrumbs />
-          <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '12px' }}>
-            <ActionIcon
-              variant="subtle"
-              size="lg"
-              onClick={() => setIsNotificationCenterOpen(true)}
-              aria-label="Open notifications"
-              style={{ position: 'relative' }}
-            >
-              <IconBell size={20} />
-              <NotificationBadge count={notifications.unreadCount} />
-            </ActionIcon>
-          </div>
-        </div>
-        {/* Banners */}
-        {notifications.banners.length > 0 && (
-          <div style={{ padding: '16px 20px 0' }}>
-            {notifications.banners.map((banner) => (
-              <NotificationBanner
-                key={banner.id}
-                banner={banner}
-                onDismiss={notifications.dismissBanner}
-              />
-            ))}
-          </div>
+    <BreadcrumbProvider>
+      <div className="workspace-layout">
+        {/* Mobile backdrop */}
+        {isMobile && isMobileOpen && (
+          <div
+            className="sidebar-backdrop"
+            onClick={closeMobileSidebar}
+            aria-hidden="true"
+          />
         )}
-        <main className="workspace-main">{children}</main>
+        <Sidebar
+          isCollapsed={isCollapsed}
+          isMobileOpen={isMobileOpen}
+          onClose={closeMobileSidebar}
+        />
+        <div className="workspace-content">
+          <div className="workspace-header">
+            <button
+              className={`menu-toggle ${!hasInteracted ? 'shimmer' : ''}`}
+              onClick={toggleSidebar}
+              aria-label={isMobile ? (isMobileOpen ? 'Close sidebar' : 'Open sidebar') : (isCollapsed ? 'Expand sidebar' : 'Collapse sidebar')}
+            >
+              ☰
+            </button>
+            <Link to="/" className="header-logo">
+              <span className="logo-icon">📦</span>
+              <span className="logo-text">DallasMakerspace</span>
+            </Link>
+            <Breadcrumbs />
+            <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '12px' }}>
+              <ActionIcon
+                variant="subtle"
+                size="lg"
+                onClick={() => setIsNotificationCenterOpen(true)}
+                aria-label="Open notifications"
+                style={{ position: 'relative' }}
+              >
+                <IconBell size={20} />
+                <NotificationBadge count={notifications.unreadCount} />
+              </ActionIcon>
+            </div>
+          </div>
+          {/* Banners */}
+          {notifications.banners.length > 0 && (
+            <div style={{ padding: '16px 20px 0' }}>
+              {notifications.banners.map((banner) => (
+                <NotificationBanner
+                  key={banner.id}
+                  banner={banner}
+                  onDismiss={notifications.dismissBanner}
+                />
+              ))}
+            </div>
+          )}
+          <main className="workspace-main">{children}</main>
+        </div>
+        <CommandPalette isOpen={commandPalette.isOpen} onClose={commandPalette.close} />
+        <NotificationCenter
+          isOpen={isNotificationCenterOpen}
+          onClose={() => setIsNotificationCenterOpen(false)}
+        />
+        <SessionExpiredBanner />
+        <div style={{ position: 'fixed', bottom: 16, left: 16, zIndex: 1050, maxWidth: 360 }}>
+          <OfflineIndicator />
+        </div>
       </div>
-      <CommandPalette isOpen={commandPalette.isOpen} onClose={commandPalette.close} />
-      <NotificationCenter
-        isOpen={isNotificationCenterOpen}
-        onClose={() => setIsNotificationCenterOpen(false)}
-      />
-      <SessionExpiredBanner />
-      <div style={{ position: 'fixed', bottom: 16, left: 16, zIndex: 1050, maxWidth: 360 }}>
-        <OfflineIndicator />
-      </div>
-    </div>
+    </BreadcrumbProvider>
   );
 };
 

--- a/frontend/src/contexts/BreadcrumbContext.tsx
+++ b/frontend/src/contexts/BreadcrumbContext.tsx
@@ -1,0 +1,60 @@
+/**
+ * Breadcrumb Context
+ *
+ * Lets a page register a dynamic label for the final breadcrumb segment.
+ * Routes like `/assets/<uuid>/edit` then read as "Home › Assets › <Asset name>"
+ * instead of "Home › Assets › Edit", without the routeMap needing to know
+ * about every resource id.
+ *
+ * Pages call `useSetBreadcrumb(label)` once their data has loaded.
+ * `<BreadcrumbProvider>` is mounted by `WorkspaceLayout`; consumers used
+ * outside a provider (tests, storybook) get a safe no-op.
+ */
+import React, {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+interface BreadcrumbState {
+  currentLabel: string | undefined;
+  setCurrentLabel: (label: string | undefined) => void;
+}
+
+const NOOP_STATE: BreadcrumbState = {
+  currentLabel: undefined,
+  setCurrentLabel: () => {},
+};
+
+const BreadcrumbContext = createContext<BreadcrumbState | null>(null);
+
+export const BreadcrumbProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [currentLabel, setLabel] = useState<string | undefined>(undefined);
+  const setCurrentLabel = useCallback((label: string | undefined) => {
+    setLabel(label);
+  }, []);
+
+  return (
+    <BreadcrumbContext.Provider value={{ currentLabel, setCurrentLabel }}>
+      {children}
+    </BreadcrumbContext.Provider>
+  );
+};
+
+export function useBreadcrumbState(): BreadcrumbState {
+  const ctx = useContext(BreadcrumbContext);
+  return ctx ?? NOOP_STATE;
+}
+
+export function useSetBreadcrumb(label: string | undefined): void {
+  const { setCurrentLabel } = useBreadcrumbState();
+  useEffect(() => {
+    setCurrentLabel(label);
+    return () => {
+      setCurrentLabel(undefined);
+    };
+  }, [label, setCurrentLabel]);
+}

--- a/frontend/src/pages/AssetFormPage.tsx
+++ b/frontend/src/pages/AssetFormPage.tsx
@@ -60,6 +60,7 @@ import { FormNumberInput } from '../components/forms/FormNumberInput';
 import { FormSelect } from '../components/forms/FormSelect';
 import { FormTextarea } from '../components/forms/FormTextarea';
 import WorkspacePage from '../components/landing/WorkspacePage';
+import { useSetBreadcrumb } from '../contexts/BreadcrumbContext';
 import {
   assetPartsAPI,
   assetsAPI,
@@ -99,6 +100,11 @@ const AssetFormPage: React.FC = () => {
   const [locations, setLocations] = useState<Location[]>([]);
   const [inventoryItems, setInventoryItems] = useState<InventoryItem[]>([]);
   const [sigs, setSigs] = useState<SIG[]>([]);
+  const [assetName, setAssetName] = useState<string | undefined>(undefined);
+
+  // Show the asset name as the trailing breadcrumb in edit mode, so the
+  // header reads "Home › Assets › <Asset name>" instead of "… › Edit".
+  useSetBreadcrumb(isEditMode ? assetName : undefined);
 
   const [showCreateCategory, setShowCreateCategory] = useState(false);
   const [newCategoryName, setNewCategoryName] = useState('');
@@ -188,6 +194,7 @@ const AssetFormPage: React.FC = () => {
         const response = await assetsAPI.getAsset(id);
         if (cancelled) return;
         const asset = response.data;
+        setAssetName(asset.name);
         reset({
           name: asset.name,
           description: asset.description || '',


### PR DESCRIPTION
## Summary

Lets pages register a label for the trailing breadcrumb segment so routes like `/inventory/assets/<uuid>/edit` read as **Home › Assets › Bridgeport Mill** instead of **… › Edit**.

- New `BreadcrumbContext` exposing `useSetBreadcrumb(label)` — pages set their label once data has loaded; the hook clears it on unmount.
- `Breadcrumbs` consumes the context and swaps the last segment's label when one is set; the existing static-routeMap path is unchanged when no label is registered.
- `WorkspaceLayout` mounts `<BreadcrumbProvider>` around the main layout. The hook is a safe no-op outside a provider (storybook, isolated tests).
- `AssetFormPage` is wired as the first consumer — shows the asset name in edit mode.

## Test plan

- [x] Frontend tests: `npm test -- --testPathPattern=Breadcrumbs` — 15 pass (3 new for dynamic-label behavior, including the "no provider mounted" safe path).
- [x] Production build: `npm run build` clean (catches CI-only TS strict errors that `tsc --skipLibCheck` misses).
- [ ] Manual smoke: visit `/inventory/assets/<id>/edit` after merge and confirm trailing crumb shows the asset name instead of "Edit".

🤖 Generated with [Claude Code](https://claude.com/claude-code)