### PR TITLE
feat(electrical): DRF API for Disconnect + HardwiredConnection (PR 2/5)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -268,6 +268,58 @@ views:
       update:
         permission_classes:
         - IsAuthenticated
+  electrical_circuits.views.DisconnectViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      list:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+  electrical_circuits.views.HardwiredConnectionViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      list:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
   electrical_circuits.views.LightSwitchViewSet:
     actions:
       create:
@@ -360,6 +412,32 @@ views:
         permission_classes:
         - IsAuthenticated
         - IsStaffUser
+  electrical_circuits.views.PowerCableViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      destroy:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      list:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      retrieve:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
+      update:
+        permission_classes:
+        - IsAuthenticated
+        - IsStaffUser
   electrical_circuits.views.PowerCircuitViewSet:
     actions:
       create:
@@ -412,7 +490,7 @@ views:
         permission_classes:
         - IsAuthenticated
         - IsStaffUser
-  electrical_circuits.views.PowerCableViewSet:
+  electrical_circuits.views.PowerPanelViewSet:
     actions:
       create:
         permission_classes:
@@ -439,32 +517,6 @@ views:
         - IsAuthenticated
         - IsStaffUser
   electrical_circuits.views.PowerPortViewSet:
-    actions:
-      create:
-        permission_classes:
-        - IsAuthenticated
-        - IsStaffUser
-      destroy:
-        permission_classes:
-        - IsAuthenticated
-        - IsStaffUser
-      list:
-        permission_classes:
-        - IsAuthenticated
-        - IsStaffUser
-      partial_update:
-        permission_classes:
-        - IsAuthenticated
-        - IsStaffUser
-      retrieve:
-        permission_classes:
-        - IsAuthenticated
-        - IsStaffUser
-      update:
-        permission_classes:
-        - IsAuthenticated
-        - IsStaffUser
-  electrical_circuits.views.PowerPanelViewSet:
     actions:
       create:
         permission_classes:

--- a/backend/electrical_circuits/serializers.py
+++ b/backend/electrical_circuits/serializers.py
@@ -4,9 +4,14 @@ from django.contrib.contenttypes.models import ContentType
 
 from rest_framework import serializers
 
+from loto.models import LOTODevice
+from loto.serializers import LOTODeviceSerializer
+
 from .models import (
     Breaker,
     Cable,
+    Disconnect,
+    HardwiredConnection,
     LightSwitch,
     NetworkDrop,
     Outlet,
@@ -276,6 +281,9 @@ class PowerOutletSerializer(serializers.ModelSerializer):
 
     location_name = serializers.CharField(source="location.name", read_only=True)
     circuit_label = serializers.SerializerMethodField()
+    disconnect_label = serializers.CharField(
+        source="disconnect.label", read_only=True, allow_null=True
+    )
 
     class Meta:
         model = PowerOutlet
@@ -285,6 +293,8 @@ class PowerOutletSerializer(serializers.ModelSerializer):
             "circuit_label",
             "location",
             "location_name",
+            "disconnect",
+            "disconnect_label",
             "outlet_type",
             "label",
             "location_description",
@@ -298,6 +308,89 @@ class PowerOutletSerializer(serializers.ModelSerializer):
 
     def get_circuit_label(self, obj) -> str:
         return obj.circuit.label or f"Circuit #{obj.circuit_id}"
+
+
+class DisconnectSerializer(serializers.ModelSerializer):
+    """Read/write serializer for Disconnect rows.
+
+    Reads expose denormalized panel / breaker / circuit context so the
+    frontend can render a disconnect row without a follow-up tree walk.
+    Writes accept a list of LOTODevice ids via the dedicated
+    ``required_loto_device_ids`` field; the read shape carries the full
+    LOTODevice payloads under ``required_loto_devices``.
+    """
+
+    location_name = serializers.CharField(source="location.name", read_only=True, allow_null=True)
+    circuit_label = serializers.CharField(source="circuit.label", read_only=True)
+    breaker_position = serializers.CharField(source="circuit.breaker.position", read_only=True)
+    panel_name = serializers.CharField(source="circuit.breaker.panel.name", read_only=True)
+    required_loto_devices = LOTODeviceSerializer(many=True, read_only=True)
+    required_loto_device_ids = serializers.PrimaryKeyRelatedField(
+        many=True,
+        write_only=True,
+        queryset=LOTODevice.objects.all(),
+        source="required_loto_devices",
+        required=False,
+    )
+
+    class Meta:
+        model = Disconnect
+        fields = [
+            "id",
+            "circuit",
+            "circuit_label",
+            "panel_name",
+            "breaker_position",
+            "location",
+            "location_name",
+            "label",
+            "disconnect_type",
+            "amperage",
+            "fuse_size",
+            "is_lockable",
+            "photo",
+            "notes",
+            "required_loto_devices",
+            "required_loto_device_ids",
+            "needs_review",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+
+class HardwiredConnectionSerializer(serializers.ModelSerializer):
+    """Read/write serializer for HardwiredConnection rows.
+
+    The upstream circuit is reachable via ``disconnect.circuit`` on the
+    model, but callers expect it at the top level — we surface it as a
+    read-only convenience so the frontend doesn't have to double-hop
+    through the disconnect payload.
+    """
+
+    asset_name = serializers.CharField(source="asset.name", read_only=True)
+    disconnect_label = serializers.CharField(source="disconnect.label", read_only=True)
+    circuit = serializers.PrimaryKeyRelatedField(source="disconnect.circuit", read_only=True)
+    circuit_label = serializers.CharField(source="disconnect.circuit.label", read_only=True)
+
+    class Meta:
+        model = HardwiredConnection
+        fields = [
+            "id",
+            "asset",
+            "asset_name",
+            "disconnect",
+            "disconnect_label",
+            "circuit",
+            "circuit_label",
+            "conductor_size",
+            "conductor_length_ft",
+            "notes",
+            "needs_review",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at"]
 
 
 class NetworkDropSerializer(serializers.ModelSerializer):

--- a/backend/electrical_circuits/tests/test_disconnect_api.py
+++ b/backend/electrical_circuits/tests/test_disconnect_api.py
@@ -1,0 +1,299 @@
+"""
+API tests for the DisconnectViewSet (PR 2/5 of disconnect-promotion).
+
+Covers the staff-only CRUD surface, the nested panel/breaker/circuit
+denormalization on read, LOTODevice round-tripping via the dedicated
+``required_loto_device_ids`` write field, and the list filter params
+(``circuit``, ``location``, ``disconnect_type``, ``needs_review``).
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+import pytest
+from rest_framework.test import APIClient
+
+from electrical_circuits.models import Disconnect, PowerBreaker, PowerCircuit, PowerPanel
+from inventory.tests.factories import LocationFactory
+from loto.models import LOTODevice
+
+User = get_user_model()
+
+
+@pytest.fixture
+def staff_client(db):
+    user = User.objects.create_user(
+        username="disc-staff", email="disc-staff@example.com", password="pw", is_staff=True
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def member_client(db):
+    user = User.objects.create_user(
+        username="disc-member",
+        email="disc-member@example.com",
+        password="pw",
+        is_staff=False,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def loc(db):
+    return LocationFactory(name="Disconnect Room")
+
+
+@pytest.fixture
+def circuit(db, loc):
+    panel = PowerPanel.objects.create(location=loc, name="Disc panel")
+    breaker = PowerBreaker.objects.create(panel=panel, position="7", amperage=40)
+    return PowerCircuit.objects.create(breaker=breaker, label="dust collector")
+
+
+@pytest.fixture
+def disconnect(db, circuit, loc):
+    return Disconnect.objects.create(
+        circuit=circuit,
+        location=loc,
+        label="Dust collector disconnect",
+        disconnect_type=Disconnect.DISCONNECT_TYPE_UNFUSED,
+        amperage=40,
+    )
+
+
+# ---------------------------------------------------------------------
+# Permissions
+# ---------------------------------------------------------------------
+
+
+def test_list_rejects_anonymous(api_client):
+    assert api_client.get(reverse("disconnect-list")).status_code == 401
+
+
+def test_list_rejects_non_staff(member_client):
+    assert member_client.get(reverse("disconnect-list")).status_code == 403
+
+
+def test_create_rejects_non_staff(member_client, circuit, loc):
+    resp = member_client.post(
+        reverse("disconnect-list"),
+        {
+            "circuit": circuit.pk,
+            "location": loc.pk,
+            "label": "x",
+            "disconnect_type": Disconnect.DISCONNECT_TYPE_TOGGLE,
+        },
+        format="json",
+    )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------
+# Read shape — nested denormalization
+# ---------------------------------------------------------------------
+
+
+def test_retrieve_includes_denormalized_chain(staff_client, disconnect):
+    resp = staff_client.get(reverse("disconnect-detail", args=[disconnect.pk]))
+    assert resp.status_code == 200, resp.content
+    body = resp.json()
+    assert body["circuit"] == disconnect.circuit_id
+    assert body["circuit_label"] == disconnect.circuit.label
+    assert body["breaker_position"] == disconnect.circuit.breaker.position
+    assert body["panel_name"] == disconnect.circuit.breaker.panel.name
+    assert body["location_name"] == disconnect.location.name
+    assert body["required_loto_devices"] == []
+
+
+def test_retrieve_with_loto_devices_surfaces_nested_payload(staff_client, disconnect, loc):
+    device = LOTODevice.objects.create(
+        device_type=LOTODevice.DEVICE_PADLOCK,
+        label="Red padlock 1",
+        location=loc,
+    )
+    disconnect.required_loto_devices.add(device)
+    resp = staff_client.get(reverse("disconnect-detail", args=[disconnect.pk]))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["required_loto_devices"]) == 1
+    payload = body["required_loto_devices"][0]
+    assert payload["id"] == device.pk
+    assert payload["label"] == "Red padlock 1"
+
+
+# ---------------------------------------------------------------------
+# Write paths
+# ---------------------------------------------------------------------
+
+
+def test_create_round_trips(staff_client, circuit, loc):
+    resp = staff_client.post(
+        reverse("disconnect-list"),
+        {
+            "circuit": circuit.pk,
+            "location": loc.pk,
+            "label": "Welder disconnect",
+            "disconnect_type": Disconnect.DISCONNECT_TYPE_FUSED,
+            "fuse_size": "30A class J",
+            "amperage": 30,
+        },
+        format="json",
+    )
+    assert resp.status_code == 201, resp.content
+    body = resp.json()
+    assert body["label"] == "Welder disconnect"
+    assert body["disconnect_type"] == "fused"
+    assert body["fuse_size"] == "30A class J"
+    assert Disconnect.objects.filter(label="Welder disconnect").exists()
+
+
+def test_create_with_loto_devices(staff_client, circuit, loc):
+    d1 = LOTODevice.objects.create(
+        device_type=LOTODevice.DEVICE_PADLOCK, label="lock-1", location=loc
+    )
+    d2 = LOTODevice.objects.create(
+        device_type=LOTODevice.DEVICE_PADLOCK, label="lock-2", location=loc
+    )
+    resp = staff_client.post(
+        reverse("disconnect-list"),
+        {
+            "circuit": circuit.pk,
+            "location": loc.pk,
+            "label": "Welder disconnect",
+            "disconnect_type": Disconnect.DISCONNECT_TYPE_UNFUSED,
+            "required_loto_device_ids": [d1.pk, d2.pk],
+        },
+        format="json",
+    )
+    assert resp.status_code == 201, resp.content
+    created = Disconnect.objects.get(label="Welder disconnect")
+    assert set(created.required_loto_devices.values_list("pk", flat=True)) == {d1.pk, d2.pk}
+
+
+def test_create_with_none_type_allows_blank_location(staff_client, circuit):
+    """``disconnect_type=none`` means the breaker serves as the disconnect — no
+    physical switch on the wall, so the operator can omit ``location``."""
+    resp = staff_client.post(
+        reverse("disconnect-list"),
+        {
+            "circuit": circuit.pk,
+            "label": "Inline / breaker-only",
+            "disconnect_type": Disconnect.DISCONNECT_TYPE_NONE,
+            "is_lockable": False,
+        },
+        format="json",
+    )
+    assert resp.status_code == 201, resp.content
+    assert Disconnect.objects.get(label="Inline / breaker-only").location_id is None
+
+
+def test_patch_updates_fields(staff_client, disconnect):
+    resp = staff_client.patch(
+        reverse("disconnect-detail", args=[disconnect.pk]),
+        {"label": "Renamed"},
+        format="json",
+    )
+    assert resp.status_code == 200, resp.content
+    disconnect.refresh_from_db()
+    assert disconnect.label == "Renamed"
+
+
+def test_delete_works(staff_client, disconnect):
+    resp = staff_client.delete(reverse("disconnect-detail", args=[disconnect.pk]))
+    assert resp.status_code == 204
+    assert not Disconnect.objects.filter(pk=disconnect.pk).exists()
+
+
+# ---------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------
+
+
+def test_filter_by_circuit(staff_client, circuit, loc):
+    panel_b = PowerPanel.objects.create(location=loc, name="Panel B")
+    breaker_b = PowerBreaker.objects.create(panel=panel_b, position="1", amperage=20)
+    circuit_b = PowerCircuit.objects.create(breaker=breaker_b)
+    Disconnect.objects.create(
+        circuit=circuit,
+        location=loc,
+        label="on-A",
+        disconnect_type=Disconnect.DISCONNECT_TYPE_TOGGLE,
+    )
+    Disconnect.objects.create(
+        circuit=circuit_b,
+        location=loc,
+        label="on-B",
+        disconnect_type=Disconnect.DISCONNECT_TYPE_TOGGLE,
+    )
+    resp = staff_client.get(reverse("disconnect-list"), {"circuit": circuit.pk})
+    assert resp.status_code == 200
+    rows = resp.json()["results"]
+    assert {row["label"] for row in rows} == {"on-A"}
+
+
+def test_filter_by_location(staff_client, circuit):
+    loc_a = LocationFactory(name="LocA")
+    loc_b = LocationFactory(name="LocB")
+    Disconnect.objects.create(
+        circuit=circuit,
+        location=loc_a,
+        label="in-A",
+        disconnect_type=Disconnect.DISCONNECT_TYPE_TOGGLE,
+    )
+    Disconnect.objects.create(
+        circuit=circuit,
+        location=loc_b,
+        label="in-B",
+        disconnect_type=Disconnect.DISCONNECT_TYPE_TOGGLE,
+    )
+    resp = staff_client.get(reverse("disconnect-list"), {"location": loc_a.pk})
+    assert resp.status_code == 200
+    rows = resp.json()["results"]
+    assert {row["label"] for row in rows} == {"in-A"}
+
+
+def test_filter_by_disconnect_type(staff_client, circuit, loc):
+    Disconnect.objects.create(
+        circuit=circuit,
+        location=loc,
+        label="fused-1",
+        disconnect_type=Disconnect.DISCONNECT_TYPE_FUSED,
+        fuse_size="30A",
+    )
+    Disconnect.objects.create(
+        circuit=circuit,
+        location=loc,
+        label="toggle-1",
+        disconnect_type=Disconnect.DISCONNECT_TYPE_TOGGLE,
+    )
+    resp = staff_client.get(reverse("disconnect-list"), {"disconnect_type": "fused"})
+    assert resp.status_code == 200
+    rows = resp.json()["results"]
+    assert {row["label"] for row in rows} == {"fused-1"}
+
+
+def test_filter_by_needs_review(staff_client, circuit, loc):
+    Disconnect.objects.create(
+        circuit=circuit,
+        location=loc,
+        label="ok",
+        disconnect_type=Disconnect.DISCONNECT_TYPE_TOGGLE,
+    )
+    Disconnect.objects.create(
+        circuit=circuit,
+        location=loc,
+        label="flagged",
+        disconnect_type=Disconnect.DISCONNECT_TYPE_TOGGLE,
+        needs_review=True,
+    )
+    resp = staff_client.get(reverse("disconnect-list"), {"needs_review": "true"})
+    assert resp.status_code == 200
+    rows = resp.json()["results"]
+    assert {row["label"] for row in rows} == {"flagged"}

--- a/backend/electrical_circuits/tests/test_hardwired_connection_api.py
+++ b/backend/electrical_circuits/tests/test_hardwired_connection_api.py
@@ -1,0 +1,243 @@
+"""
+API tests for HardwiredConnectionViewSet (PR 2/5 of disconnect-promotion).
+
+Covers staff-only CRUD, the convenience read fields that surface the
+upstream circuit through the disconnect, the ``?asset=`` and
+``?disconnect=`` filters, and the new ``hardwired_connections`` field
+on the asset detail payload.
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+import pytest
+from rest_framework.test import APIClient
+
+from electrical_circuits.models import (
+    Disconnect,
+    HardwiredConnection,
+    PowerBreaker,
+    PowerCircuit,
+    PowerPanel,
+)
+from inventory.tests.factories import AssetFactory, LocationFactory
+
+User = get_user_model()
+
+
+@pytest.fixture
+def staff_client(db):
+    user = User.objects.create_user(
+        username="hw-staff", email="hw-staff@example.com", password="pw", is_staff=True
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def member_client(db):
+    user = User.objects.create_user(
+        username="hw-member",
+        email="hw-member@example.com",
+        password="pw",
+        is_staff=False,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _make_disconnect(
+    *,
+    label="Test disconnect",
+    disconnect_type=Disconnect.DISCONNECT_TYPE_UNFUSED,
+    circuit_label="C1",
+):
+    loc = LocationFactory()
+    panel = PowerPanel.objects.create(location=loc, name=f"P-{loc.pk}")
+    breaker = PowerBreaker.objects.create(panel=panel, position="1", amperage=30)
+    circuit = PowerCircuit.objects.create(breaker=breaker, label=circuit_label)
+    return Disconnect.objects.create(
+        circuit=circuit,
+        location=loc,
+        label=label,
+        disconnect_type=disconnect_type,
+    )
+
+
+@pytest.fixture
+def disconnect(db):
+    return _make_disconnect()
+
+
+@pytest.fixture
+def asset(db):
+    return AssetFactory(name="Dust collector", asset_tag="A-HW-1")
+
+
+# ---------------------------------------------------------------------
+# Permissions
+# ---------------------------------------------------------------------
+
+
+def test_list_rejects_anonymous(api_client):
+    assert api_client.get(reverse("hardwired-connection-list")).status_code == 401
+
+
+def test_list_rejects_non_staff(member_client):
+    assert member_client.get(reverse("hardwired-connection-list")).status_code == 403
+
+
+def test_create_rejects_non_staff(member_client, asset, disconnect):
+    resp = member_client.post(
+        reverse("hardwired-connection-list"),
+        {"asset": str(asset.id), "disconnect": disconnect.pk},
+        format="json",
+    )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------
+# Read shape
+# ---------------------------------------------------------------------
+
+
+def test_retrieve_surfaces_circuit_and_disconnect_labels(staff_client, asset, disconnect):
+    hc = HardwiredConnection.objects.create(asset=asset, disconnect=disconnect)
+    resp = staff_client.get(reverse("hardwired-connection-detail", args=[hc.pk]))
+    assert resp.status_code == 200, resp.content
+    body = resp.json()
+    assert body["asset"] == str(asset.id)
+    assert body["asset_name"] == asset.name
+    assert body["disconnect"] == disconnect.pk
+    assert body["disconnect_label"] == disconnect.label
+    # circuit is surfaced read-only via disconnect.circuit
+    assert body["circuit"] == disconnect.circuit_id
+    assert body["circuit_label"] == disconnect.circuit.label
+
+
+# ---------------------------------------------------------------------
+# Write paths
+# ---------------------------------------------------------------------
+
+
+def test_create_round_trips(staff_client, asset, disconnect):
+    resp = staff_client.post(
+        reverse("hardwired-connection-list"),
+        {
+            "asset": str(asset.id),
+            "disconnect": disconnect.pk,
+            "conductor_size": "10 AWG",
+            "conductor_length_ft": 25,
+        },
+        format="json",
+    )
+    assert resp.status_code == 201, resp.content
+    hc = HardwiredConnection.objects.get(asset=asset, disconnect=disconnect)
+    assert hc.conductor_size == "10 AWG"
+    assert hc.conductor_length_ft == 25
+
+
+def test_create_with_none_type_disconnect(staff_client, asset):
+    """``disconnect_type='none'`` (breaker serves) is a valid feed: every
+    hardwired load still resolves through one Disconnect row even when no
+    physical switch exists."""
+    none_disc = _make_disconnect(
+        label="No-switch disconnect",
+        disconnect_type=Disconnect.DISCONNECT_TYPE_NONE,
+    )
+    resp = staff_client.post(
+        reverse("hardwired-connection-list"),
+        {"asset": str(asset.id), "disconnect": none_disc.pk},
+        format="json",
+    )
+    assert resp.status_code == 201, resp.content
+    body = resp.json()
+    assert body["disconnect"] == none_disc.pk
+    assert body["circuit"] == none_disc.circuit_id
+
+
+def test_duplicate_asset_disconnect_pair_is_rejected(staff_client, asset, disconnect):
+    HardwiredConnection.objects.create(asset=asset, disconnect=disconnect)
+    resp = staff_client.post(
+        reverse("hardwired-connection-list"),
+        {"asset": str(asset.id), "disconnect": disconnect.pk},
+        format="json",
+    )
+    assert resp.status_code == 400
+
+
+def test_patch_updates_fields(staff_client, asset, disconnect):
+    hc = HardwiredConnection.objects.create(asset=asset, disconnect=disconnect)
+    resp = staff_client.patch(
+        reverse("hardwired-connection-detail", args=[hc.pk]),
+        {"conductor_size": "8 AWG"},
+        format="json",
+    )
+    assert resp.status_code == 200, resp.content
+    hc.refresh_from_db()
+    assert hc.conductor_size == "8 AWG"
+
+
+def test_delete_works(staff_client, asset, disconnect):
+    hc = HardwiredConnection.objects.create(asset=asset, disconnect=disconnect)
+    resp = staff_client.delete(reverse("hardwired-connection-detail", args=[hc.pk]))
+    assert resp.status_code == 204
+    assert not HardwiredConnection.objects.filter(pk=hc.pk).exists()
+
+
+# ---------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------
+
+
+def test_filter_by_asset(staff_client, asset, disconnect):
+    other_asset = AssetFactory(name="Other", asset_tag="A-HW-2")
+    other_disc = _make_disconnect(label="other")
+    HardwiredConnection.objects.create(asset=asset, disconnect=disconnect)
+    HardwiredConnection.objects.create(asset=other_asset, disconnect=other_disc)
+    resp = staff_client.get(reverse("hardwired-connection-list"), {"asset": str(asset.id)})
+    assert resp.status_code == 200
+    rows = resp.json()["results"]
+    assert len(rows) == 1
+    assert rows[0]["asset"] == str(asset.id)
+
+
+def test_filter_by_disconnect(staff_client, asset):
+    a = _make_disconnect(label="a-disc")
+    b = _make_disconnect(label="b-disc")
+    HardwiredConnection.objects.create(asset=asset, disconnect=a)
+    other_asset = AssetFactory(asset_tag="A-HW-3")
+    HardwiredConnection.objects.create(asset=other_asset, disconnect=b)
+    resp = staff_client.get(reverse("hardwired-connection-list"), {"disconnect": a.pk})
+    assert resp.status_code == 200
+    rows = resp.json()["results"]
+    assert len(rows) == 1
+    assert rows[0]["disconnect"] == a.pk
+
+
+# ---------------------------------------------------------------------
+# Asset detail surfacing
+# ---------------------------------------------------------------------
+
+
+def test_asset_detail_includes_hardwired_connections(staff_client, asset, disconnect):
+    HardwiredConnection.objects.create(asset=asset, disconnect=disconnect, conductor_size="10 AWG")
+    resp = staff_client.get(reverse("asset-detail", args=[asset.id]))
+    assert resp.status_code == 200, resp.content
+    body = resp.json()
+    assert "hardwired_connections" in body
+    assert len(body["hardwired_connections"]) == 1
+    payload = body["hardwired_connections"][0]
+    assert payload["disconnect"] == disconnect.pk
+    assert payload["disconnect_label"] == disconnect.label
+    assert payload["conductor_size"] == "10 AWG"
+
+
+def test_asset_detail_empty_hardwired_connections(staff_client, asset):
+    resp = staff_client.get(reverse("asset-detail", args=[asset.id]))
+    assert resp.status_code == 200
+    assert resp.json()["hardwired_connections"] == []

--- a/backend/electrical_circuits/urls.py
+++ b/backend/electrical_circuits/urls.py
@@ -13,6 +13,8 @@ from .safety_views import (
 )
 from .views import (
     BreakerViewSet,
+    DisconnectViewSet,
+    HardwiredConnectionViewSet,
     LightSwitchViewSet,
     NetworkDropListReportView,
     NetworkDropViewSet,
@@ -31,6 +33,12 @@ router.register(r"breakers", BreakerViewSet, basename="breaker")
 router.register(r"outlets", OutletViewSet, basename="outlet")
 router.register(r"light-switches", LightSwitchViewSet, basename="light-switch")
 router.register(r"network-drops", NetworkDropViewSet, basename="network-drop")
+router.register(r"disconnects", DisconnectViewSet, basename="disconnect")
+router.register(
+    r"hardwired-connections",
+    HardwiredConnectionViewSet,
+    basename="hardwired-connection",
+)
 
 # Power-topology CRUD router — separate prefix from the legacy router so
 # the legacy /breakers and /outlets keep their existing shape. Mounted

--- a/backend/electrical_circuits/views.py
+++ b/backend/electrical_circuits/views.py
@@ -12,6 +12,8 @@ from rest_framework.views import APIView
 from .models import (
     Breaker,
     Cable,
+    Disconnect,
+    HardwiredConnection,
     LightSwitch,
     NetworkDrop,
     Outlet,
@@ -24,6 +26,8 @@ from .models import (
 from .safety_views import IsStaffUser
 from .serializers import (
     BreakerSerializer,
+    DisconnectSerializer,
+    HardwiredConnectionSerializer,
     LightSwitchSerializer,
     NetworkDropSerializer,
     OutletSerializer,
@@ -245,6 +249,72 @@ class PowerPortViewSet(viewsets.ModelViewSet):
         asset_id = self.request.query_params.get("asset")
         if asset_id:
             qs = qs.filter(asset_id=asset_id)
+        return qs
+
+
+class DisconnectViewSet(viewsets.ModelViewSet):
+    """``/api/electrical-circuits/disconnects/`` — full CRUD for disconnects.
+
+    Staff-only (consistent with the rest of the power-chain edit surface).
+    Supports ``?circuit=``, ``?location=``, ``?disconnect_type=``, and
+    ``?needs_review=`` query params on the list endpoint so the
+    Disconnect management UI can scope the table.
+    """
+
+    permission_classes = [IsAuthenticated, IsStaffUser]
+    serializer_class = DisconnectSerializer
+    queryset = (
+        Disconnect.objects.select_related(
+            "circuit__breaker__panel",
+            "location",
+        )
+        .prefetch_related("required_loto_devices")
+        .order_by("location__name", "label")
+    )
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        params = self.request.query_params
+        circuit_id = params.get("circuit")
+        if circuit_id:
+            qs = qs.filter(circuit_id=circuit_id)
+        location_id = params.get("location")
+        if location_id:
+            qs = qs.filter(location_id=location_id)
+        disconnect_type = params.get("disconnect_type")
+        if disconnect_type:
+            qs = qs.filter(disconnect_type=disconnect_type)
+        needs_review = params.get("needs_review")
+        if needs_review is not None:
+            truthy = needs_review.lower() in ("1", "true", "yes")
+            qs = qs.filter(needs_review=truthy)
+        return qs
+
+
+class HardwiredConnectionViewSet(viewsets.ModelViewSet):
+    """``/api/electrical-circuits/hardwired-connections/`` — full CRUD.
+
+    Staff-only. Supports ``?asset=`` and ``?disconnect=`` filters so the
+    asset detail page (and the Disconnect detail page) can fetch the
+    relevant connection rows without scanning the whole table.
+    """
+
+    permission_classes = [IsAuthenticated, IsStaffUser]
+    serializer_class = HardwiredConnectionSerializer
+    queryset = HardwiredConnection.objects.select_related(
+        "asset",
+        "disconnect__circuit__breaker__panel",
+    ).order_by("asset__name")
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        params = self.request.query_params
+        asset_id = params.get("asset")
+        if asset_id:
+            qs = qs.filter(asset_id=asset_id)
+        disconnect_id = params.get("disconnect")
+        if disconnect_id:
+            qs = qs.filter(disconnect_id=disconnect_id)
         return qs
 
 

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -999,10 +999,13 @@ class AssetSerializer(serializers.ModelSerializer):
         # inventory.models).
         from electrical_circuits.serializers import HardwiredConnectionSerializer
 
-        connections = obj.hardwired_connections.select_related(
-            "asset",
-            "disconnect__circuit__breaker__panel",
-        ).order_by("disconnect__label")
+        # Use the prefetched cache (AssetViewSet prefetches
+        # `hardwired_connections__disconnect__circuit__breaker__panel`).
+        # Sorting in Python avoids re-issuing the query.
+        connections = sorted(
+            obj.hardwired_connections.all(),
+            key=lambda c: (c.disconnect.label or "", c.pk),
+        )
         return HardwiredConnectionSerializer(connections, many=True).data
 
 

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -702,6 +702,13 @@ class AssetSerializer(serializers.ModelSerializer):
     # Power / electrical computed flag
     is_forgekey_managed = serializers.ReadOnlyField()
 
+    # Hardwired power feeds (PR oms-0v4b41) — surfaces the new
+    # HardwiredConnection rows on the asset detail payload alongside
+    # the existing cordset/PowerCable rendering. Writes still go through
+    # the dedicated /hardwired-connections/ endpoint; this field is
+    # read-only.
+    hardwired_connections = serializers.SerializerMethodField()
+
     class Meta:
         model = Asset
         fields = [
@@ -747,6 +754,7 @@ class AssetSerializer(serializers.ModelSerializer):
             "is_chargeable",
             "mac_address",
             # Power / electrical
+            "hardwired_connections",
             "power_draw_watts",
             "wiring_type",
             "suite",
@@ -984,6 +992,18 @@ class AssetSerializer(serializers.ModelSerializer):
             return obj.manual_pdf.url if obj.manual_pdf else None
         except Exception:
             return None
+
+    def get_hardwired_connections(self, obj):
+        # Lazy import — inventory must not import electrical_circuits at
+        # module load (circular: electrical_circuits.models depends on
+        # inventory.models).
+        from electrical_circuits.serializers import HardwiredConnectionSerializer
+
+        connections = obj.hardwired_connections.select_related(
+            "asset",
+            "disconnect__circuit__breaker__panel",
+        ).order_by("disconnect__label")
+        return HardwiredConnectionSerializer(connections, many=True).data
 
 
 class AssetProblemPhotoSerializer(serializers.ModelSerializer):

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -1157,7 +1157,11 @@ class AssetViewSet(viewsets.ModelViewSet):
 
     queryset = (
         Asset.objects.select_related("inventory_item", "category", "location", "manufacturer")
-        .prefetch_related("asset_parts__part", "asset_parts__part__category")
+        .prefetch_related(
+            "asset_parts__part",
+            "asset_parts__part__category",
+            "hardwired_connections__disconnect__circuit__breaker__panel",
+        )
         .all()
     )
     serializer_class = AssetSerializer

--- a/docs/API_PERMISSION_MATRIX.md
+++ b/docs/API_PERMISSION_MATRIX.md
@@ -267,6 +267,8 @@ below are public.
 | any | `electrical-circuits/outlets/...` | member | Inventory of outlets. |
 | any | `electrical-circuits/light-switches/...` | member | Inventory of light switches. |
 | any | `electrical-circuits/network-drops/...` | member | Inventory of network drops. |
+| any | `electrical-circuits/disconnects/...` | staff | `DisconnectViewSet` — full CRUD on Disconnect rows for hardwired loads. Supports `?circuit=`, `?location=`, `?disconnect_type=`, and `?needs_review=` filters on list. |
+| any | `electrical-circuits/hardwired-connections/...` | staff | `HardwiredConnectionViewSet` — full CRUD on the Asset ↔ Disconnect feed rows. Supports `?asset=` and `?disconnect=` filters on list. |
 | GET | `electrical-circuits/reports/panel-directory.pdf` | member | Printable panel directory PDF. |
 | GET | `electrical-circuits/reports/network-drop-list.pdf` | member | Printable network drop list PDF. |
 


### PR DESCRIPTION
## Summary

Adds the HTTP surface for the Disconnect + HardwiredConnection models that landed in PR 1 (#433): serializers, viewsets, URL routes, asset detail surfacing, and matching permission-matrix entries. No other behavior changes — these models simply become readable/writable via the API for PR 3 (frontend editor split) to consume.

This is **PR 2 of 5** in the Disconnect-promotion effort (#431).

## Test plan

- [x] 27 new API tests in `backend/electrical_circuits/tests/` (polecat-reported green: 155/155 across electrical_circuits + permission matrix).
- [x] `pre-commit run --all-files` clean (polecat-reported).
- [ ] CI: backend tests + permission-matrix sync.

Fixes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)