### PR TITLE
fix(electrical): surface connected assets on panel detail page + rename 'Trip impact' to 'Loads'

### DIFF
--- a/backend/electrical_circuits/safety_views.py
+++ b/backend/electrical_circuits/safety_views.py
@@ -24,8 +24,13 @@ from rest_framework.views import APIView
 
 from inventory.models import Asset
 
-from .models import PowerBreaker, PowerCircuit, PowerPanel
-from .services.power_chain import get_devices_on_circuit, get_power_chain, get_trip_impact
+from .models import PowerBreaker, PowerCircuit, PowerOutlet, PowerPanel
+from .services.power_chain import (
+    assets_by_outlet,
+    get_devices_on_circuit,
+    get_power_chain,
+    get_trip_impact,
+)
 
 
 class IsStaffUser(BasePermission):
@@ -71,7 +76,7 @@ def _serialize_circuit(circuit: PowerCircuit) -> dict:
     }
 
 
-def _serialize_outlet(outlet) -> dict:
+def _serialize_outlet(outlet, connected_assets=None) -> dict:
     return {
         "id": outlet.pk,
         "label": outlet.label,
@@ -79,6 +84,7 @@ def _serialize_outlet(outlet) -> dict:
         "status": outlet.status,
         "location_id": outlet.location_id,
         "location_name": outlet.location.name if outlet.location_id else None,
+        "connected_assets": [_serialize_asset(a) for a in (connected_assets or [])],
     }
 
 
@@ -183,11 +189,23 @@ class PowerPanelTopologyView(APIView):
             )
         )
 
+        # Resolve {outlet_pk: [Asset]} once for every outlet on the panel
+        # so per-outlet serialization stays O(1). Cable lookups use a
+        # GenericForeignKey, so a naive prefetch_related path doesn't work
+        # — the dedicated resolver is the cheap route.
+        outlet_pks = list(
+            PowerOutlet.objects.filter(circuit__breaker__panel=panel).values_list("pk", flat=True)
+        )
+        outlet_assets = assets_by_outlet(outlet_pks)
+
         breakers_payload = []
         for breaker in breakers:
             circuits_payload = []
             for circuit in breaker.circuits.all():
-                outlets_payload = [_serialize_outlet(o) for o in circuit.outlets.all()]
+                outlets_payload = [
+                    _serialize_outlet(o, connected_assets=outlet_assets.get(o.pk, []))
+                    for o in circuit.outlets.all()
+                ]
                 circuits_payload.append(
                     {
                         **_serialize_circuit(circuit),

--- a/backend/electrical_circuits/services/power_chain.py
+++ b/backend/electrical_circuits/services/power_chain.py
@@ -176,6 +176,87 @@ def _assets_for_outlets(outlet_pks: Iterable[int]) -> QuerySet[Asset]:
     return Asset.objects.filter(pk__in=asset_ids).distinct()
 
 
+def assets_by_outlet(outlet_pks: Iterable[int]) -> dict[int, list[Asset]]:
+    """Return ``{outlet_pk: [Asset, ...]}`` for the given outlets.
+
+    Used by the panel topology view to surface "what is plugged in here?"
+    per outlet without N+1 query fanout. Outlets with no cabled asset are
+    present in the result with an empty list, so callers can rely on
+    ``.get(pk, [])`` semantics being unnecessary.
+
+    Only connected power cables are walked (``status='connected'``,
+    ``cable_type='power'``). Decommissioned or planned cables don't count
+    as a live load.
+    """
+
+    outlet_pks = list(outlet_pks)
+    result: dict[int, list[Asset]] = {pk: [] for pk in outlet_pks}
+    if not outlet_pks:
+        return result
+
+    outlet_ct = _power_outlet_ct()
+    port_ct = _power_port_ct()
+
+    cables = (
+        Cable.objects.filter(
+            cable_type=Cable.CABLE_TYPE_POWER,
+            status=Cable.STATUS_CONNECTED,
+        )
+        .filter(_cable_endpoint_q(outlet_ct, [str(pk) for pk in outlet_pks]))
+        .only(
+            "endpoint_a_content_type_id",
+            "endpoint_a_object_id",
+            "endpoint_b_content_type_id",
+            "endpoint_b_object_id",
+        )
+    )
+
+    # outlet_pk -> {port_pk, ...}
+    outlet_to_ports: dict[int, set[int]] = {}
+    all_port_ids: set[int] = set()
+    for cable in cables:
+        if (
+            cable.endpoint_a_content_type_id == outlet_ct.id
+            and cable.endpoint_b_content_type_id == port_ct.id
+        ):
+            outlet_pk = int(cable.endpoint_a_object_id)
+            port_pk = int(cable.endpoint_b_object_id)
+        elif (
+            cable.endpoint_b_content_type_id == outlet_ct.id
+            and cable.endpoint_a_content_type_id == port_ct.id
+        ):
+            outlet_pk = int(cable.endpoint_b_object_id)
+            port_pk = int(cable.endpoint_a_object_id)
+        else:
+            continue
+        outlet_to_ports.setdefault(outlet_pk, set()).add(port_pk)
+        all_port_ids.add(port_pk)
+
+    if not all_port_ids:
+        return result
+
+    # Bulk-load ports + assets in two queries.
+    port_to_asset_id = dict(
+        PowerPort.objects.filter(pk__in=all_port_ids).values_list("pk", "asset_id")
+    )
+    asset_ids = {aid for aid in port_to_asset_id.values() if aid is not None}
+    assets_by_id = {a.pk: a for a in Asset.objects.filter(pk__in=asset_ids)}
+
+    for outlet_pk, port_pks in outlet_to_ports.items():
+        seen: set = set()
+        for port_pk in port_pks:
+            asset_id = port_to_asset_id.get(port_pk)
+            if asset_id is None or asset_id in seen:
+                continue
+            asset = assets_by_id.get(asset_id)
+            if asset is None:
+                continue
+            seen.add(asset_id)
+            result.setdefault(outlet_pk, []).append(asset)
+
+    return result
+
+
 def get_devices_on_circuit(circuit: PowerCircuit) -> QuerySet[Asset]:
     """Return Assets whose PowerPort is cabled to any outlet on this circuit."""
 
@@ -225,6 +306,7 @@ __all__ = [
     "get_devices_on_circuit",
     "get_devices_on_breaker",
     "get_trip_impact",
+    "assets_by_outlet",
     "PowerPanel",
     "PowerBreaker",
     "PowerCircuit",

--- a/backend/electrical_circuits/tests/test_safety_api.py
+++ b/backend/electrical_circuits/tests/test_safety_api.py
@@ -246,6 +246,38 @@ def test_panel_topology_returns_full_tree(staff_client, topology):
     assert outlet_labels == ["bench-1", "bench-2"]
 
 
+def test_panel_topology_surfaces_connected_assets_per_outlet(staff_client, topology, db):
+    """Each outlet that has a cable→port→asset path reports the asset
+    inline under `connected_assets`; outlets with no cable report `[]`.
+    """
+
+    # Add a third outlet on the same circuit with no cable attached.
+    bare_outlet = PowerOutlet.objects.create(
+        circuit=topology["circuit"], location=topology["loc"], label="bench-bare"
+    )
+
+    url = reverse("electrical-panel-topology", args=[topology["panel"].pk])
+    resp = staff_client.get(url)
+    assert resp.status_code == 200
+    outlets = {o["label"]: o for o in resp.json()["breakers"][0]["circuits"][0]["outlets"]}
+
+    # bench-1 has the critical Server cabled in
+    bench_1 = outlets["bench-1"]
+    assert len(bench_1["connected_assets"]) == 1
+    asset = bench_1["connected_assets"][0]
+    assert asset["name"] == "Server"
+    assert asset["is_critical"] is True
+    assert asset["id"] == str(topology["asset_critical"].pk)
+
+    # bench-2 has the non-critical Lamp
+    bench_2 = outlets["bench-2"]
+    assert [a["name"] for a in bench_2["connected_assets"]] == ["Lamp"]
+
+    # bench-bare has no cable, so connected_assets is an empty list
+    assert outlets["bench-bare"]["connected_assets"] == []
+    assert bare_outlet.pk == outlets["bench-bare"]["id"]
+
+
 def test_panel_topology_exposes_subpanel_hierarchy(staff_client, topology):
     """A sub-panel fed by an upstream circuit reports its parent in
     `fed_by_summary`; the parent reports the child in `downstream_panels`.

--- a/frontend/src/__tests__/pages/PowerPanelDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/PowerPanelDetailPage.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Tests for PowerPanelDetailPage.
+ *
+ * Covers the per-outlet asset surfacing (connected_assets sub-line) and
+ * the "Loads" rename of the per-breaker action that used to read "Trip
+ * impact" — see oms-twnhlv.
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import PowerPanelDetailPage from '../../pages/PowerPanelDetailPage';
+import * as api from '../../services/api';
+
+jest.mock('../../services/api');
+
+const baseBreaker = {
+  id: 5,
+  panel_id: 1,
+  panel_name: 'Sewing A',
+  position: '12',
+  amperage: 20,
+  phase: 'A',
+  pole_count: 1,
+  status: 'on',
+  review_status: 'ok',
+  review_note: '',
+  label: 'Bench row 1',
+};
+
+const baseTopology = {
+  id: 1,
+  name: 'Sewing A',
+  location_id: 10,
+  location_name: 'Sewing Room',
+  phase_configuration: 'split',
+  voltage: 240,
+  main_breaker_amperage: 100,
+  breaker_type: '',
+  numbering_direction: 'top_down',
+  fed_by_summary: null,
+  downstream_panels: [],
+  breakers: [
+    {
+      ...baseBreaker,
+      circuits: [
+        {
+          id: 50,
+          label: 'Bench row 1',
+          breaker_id: 5,
+          max_load_amps: 16,
+          conductor_size: '12 AWG',
+          outlets: [
+            {
+              id: 101,
+              label: 'NW-bench-1',
+              outlet_type: '5-15R',
+              status: 'active',
+              location_id: 10,
+              location_name: 'Wood Shop',
+              connected_assets: [
+                { id: 'a1', name: 'Bridgeport Mill', asset_tag: 'TAG-1', is_critical: false },
+                { id: 'a2', name: 'Drill press', asset_tag: 'TAG-2', is_critical: false },
+              ],
+            },
+            {
+              id: 102,
+              label: 'NW-bench-2',
+              outlet_type: '5-15R',
+              status: 'active',
+              location_id: 10,
+              location_name: 'Wood Shop',
+              connected_assets: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const renderAt = (path: string) =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route
+            path="/facilities/electrical/panels/:id"
+            element={<PowerPanelDetailPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('PowerPanelDetailPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders connected assets inline under outlets and uses the "Loads" label', async () => {
+    (api.electricalSafetyAPI.getPanelTopology as jest.Mock).mockResolvedValue({
+      data: baseTopology,
+    });
+
+    renderAt('/facilities/electrical/panels/1?view=list');
+
+    // Wait for the breaker row to land.
+    expect(await screen.findByTestId('breaker-row-5')).toBeInTheDocument();
+
+    // The per-breaker action row now says "Loads" instead of "Trip impact".
+    const loadsLink = screen.getByTestId('breaker-loads-5');
+    expect(loadsLink).toHaveTextContent('Loads');
+    expect(loadsLink).toHaveAttribute(
+      'href',
+      '/facilities/electrical/breakers/5/trip-impact',
+    );
+    expect(screen.queryByText('Trip impact')).not.toBeInTheDocument();
+
+    // Outlet with connected_assets surfaces both names, linked to the
+    // asset detail page.
+    const outletAssets = screen.getByTestId('outlet-101-assets');
+    expect(within(outletAssets).getByText('Bridgeport Mill')).toBeInTheDocument();
+    expect(within(outletAssets).getByText('Drill press')).toBeInTheDocument();
+
+    const millLink = screen.getByTestId('outlet-asset-a1');
+    expect(millLink).toHaveAttribute('href', '/assets/a1');
+
+    // The empty-list outlet renders no asset sub-line and no "no assets" noise.
+    expect(screen.queryByTestId('outlet-102-assets')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/BreakerTripImpactPage.tsx
+++ b/frontend/src/pages/BreakerTripImpactPage.tsx
@@ -50,7 +50,7 @@ const BreakerTripImpactPage: React.FC = () => {
         <Stack gap="xl">
           <PageHero
             eyebrow={impact ? `Electrical · ${impact.breaker.panel_name}` : 'Electrical'}
-            title={impact ? `Trip impact · breaker ${impact.breaker.position}` : 'Trip impact'}
+            title={impact ? `Loads on breaker ${impact.breaker.position}` : 'Loads'}
             description="What loses power if this breaker is opened. Verify before maintenance."
           />
 

--- a/frontend/src/pages/PowerPanelDetailPage.tsx
+++ b/frontend/src/pages/PowerPanelDetailPage.tsx
@@ -328,11 +328,11 @@ const PowerPanelDetailPage: React.FC = () => {
                       <Link
                         to={`/facilities/electrical/breakers/${breaker.id}/trip-impact`}
                         className="landing-arrow"
-                        data-testid={`breaker-trip-impact-${breaker.id}`}
+                        data-testid={`breaker-loads-${breaker.id}`}
                         style={{ textDecoration: 'none' }}
                       >
                         <IconRouteAltLeft size={16} stroke={2.4} />
-                        Trip impact
+                        Loads
                       </Link>
                       <Button
                         component={Link}
@@ -396,20 +396,49 @@ const PowerPanelDetailPage: React.FC = () => {
                                   no outlets
                                 </Text>
                               ) : (
-                                <Stack gap={2}>
+                                <Stack gap={6}>
                                   {circuit.outlets.map((outlet) => (
-                                    <Group key={outlet.id} gap="xs" wrap="nowrap">
-                                      <Text size="sm" style={{ flex: 1 }}>
-                                        {outlet.label || `Outlet ${outlet.id}`}
-                                        {outlet.location_name ? ` — ${outlet.location_name}` : ''}
-                                      </Text>
-                                      <Link
-                                        to={`/facilities/electrical/outlets/${outlet.id}/edit`}
-                                        aria-label={`Edit outlet ${outlet.label || outlet.id}`}
-                                      >
-                                        <IconEdit size={14} />
-                                      </Link>
-                                    </Group>
+                                    <Stack key={outlet.id} gap={2}>
+                                      <Group gap="xs" wrap="nowrap">
+                                        <Text size="sm" style={{ flex: 1 }}>
+                                          {outlet.label || `Outlet ${outlet.id}`}
+                                          {outlet.location_name
+                                            ? ` — ${outlet.location_name}`
+                                            : ''}
+                                        </Text>
+                                        <Link
+                                          to={`/facilities/electrical/outlets/${outlet.id}/edit`}
+                                          aria-label={`Edit outlet ${outlet.label || outlet.id}`}
+                                        >
+                                          <IconEdit size={14} />
+                                        </Link>
+                                      </Group>
+                                      {outlet.connected_assets &&
+                                        outlet.connected_assets.length > 0 && (
+                                          <Stack
+                                            gap={0}
+                                            pl="md"
+                                            data-testid={`outlet-${outlet.id}-assets`}
+                                          >
+                                            {outlet.connected_assets.map((asset) => (
+                                              <Text
+                                                key={asset.id}
+                                                size="xs"
+                                                c="dimmed"
+                                                component="div"
+                                              >
+                                                <span aria-hidden="true">•&nbsp;</span>
+                                                <Link
+                                                  to={`/assets/${asset.id}`}
+                                                  data-testid={`outlet-asset-${asset.id}`}
+                                                >
+                                                  {asset.name}
+                                                </Link>
+                                              </Text>
+                                            ))}
+                                          </Stack>
+                                        )}
+                                    </Stack>
                                   ))}
                                 </Stack>
                               )}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2113,6 +2113,7 @@ export interface PowerOutletNode {
   status: string;
   location_id: number | null;
   location_name: string | null;
+  connected_assets: PowerSafetyAsset[];
 }
 
 export interface PowerCircuitNode {


### PR DESCRIPTION
## Summary

On the panel detail page, each breaker now shows the assets actually plugged into its outlets (walking the cordset chain: outlet → cable → port → asset). The per-breaker action labeled "Trip impact" is renamed to **Loads** — the data was already there, just behind a label that read like a what-if calculator. Operators can now answer "what's on this breaker?" without leaving the panel page.

## Test plan

- [x] Backend: panel topology test extended to assert `connected_assets` appears under outlets (polecat-reported: 42 electrical tests green).
- [x] Frontend: `PowerPanelDetailPage.test.tsx` exercises the inline asset render (polecat-reported).
- [x] Pre-push hook 651/651 (polecat-reported).
- [ ] CI: full backend + frontend test suites.

Fixes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)