### PR TITLE
chore(kodiak): wire `automerge` label to actually merge

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -9,3 +9,12 @@ version = 1
 always = true
 require_automerge_label = false
 branch_update_strategy = "merge"
+
+[merge]
+# Apply the existing `automerge` GH label to opt a PR in to auto-merge.
+# All required checks must still be green; this just removes the manual
+# "Squash and merge" click once they are.
+automerge_label = "automerge"
+# Match the recent convention in `git log` — every PR title carries
+# `(#N)` and history reads as one commit per PR.
+method = "squash"


### PR DESCRIPTION
## Summary

`.kodiak.toml` was configured to keep PR branches updated but had no `[merge]` section, so the `automerge` label (which already exists on the repo) was inert. This adds the minimal config to wire it up.

- `automerge_label = "automerge"` — apply the label to opt a PR in.
- `method = "squash"` — matches the convention in `git log`; every recent PR title carries `(#N)` and reads as one commit per PR.

No behavior change for PRs without the label. Unblocks step 5 of the upcoming Codex → Claude → Codex auto-sling pipeline (Codex applies `automerge` after review, Kodiak ships).

## Test plan

- [x] `pre-commit run --files .kodiak.toml` clean.
- [ ] After merge: open a low-stakes PR (e.g. a follow-up cleanup), apply the `automerge` label, confirm Kodiak squash-merges it once required checks go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)