### PR TITLE
feat(project-storage): print-queue endpoints + Raspberry Pi daemon

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -1824,12 +1824,18 @@ views:
       list:
         permission_classes:
         - IsAuthenticatedOrReadOnly
+      mark_printed:
+        permission_classes:
+        - AllowAny
       mark_removed:
         permission_classes:
         - IsAuthenticatedOrReadOnly
       move_to_purgatory:
         permission_classes:
         - IsAuthenticatedOrReadOnly
+      print_queue:
+        permission_classes:
+        - AllowAny
       retrieve:
         permission_classes:
         - IsAuthenticatedOrReadOnly

--- a/backend/project_storage/migrations/0002_projectstoragestint_printed_at.py
+++ b/backend/project_storage/migrations/0002_projectstoragestint_printed_at.py
@@ -1,0 +1,47 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("project_storage", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="projectstoragestint",
+            name="printed_at",
+            field=models.DateTimeField(
+                blank=True,
+                help_text=(
+                    "When the Pi print daemon last successfully printed the "
+                    "label for this stint. NULL means the daemon will pick "
+                    "it up on its next poll."
+                ),
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="projectstoragestint",
+            name="print_target",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("brother_ql", "Brother QL label printer"),
+                    ("epson_tm", "Epson TM receipt printer"),
+                ],
+                help_text=(
+                    "Which printer family the Pi daemon should send this "
+                    "stint's label to. Empty defaults to brother_ql."
+                ),
+                max_length=16,
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="projectstoragestint",
+            index=models.Index(
+                fields=["printed_at"],
+                name="project_sto_printed_3a4f5b_idx",
+            ),
+        ),
+    ]

--- a/backend/project_storage/migrations/0002_projectstoragestint_printed_at.py
+++ b/backend/project_storage/migrations/0002_projectstoragestint_printed_at.py
@@ -11,15 +11,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="projectstoragestint",
             name="printed_at",
-            field=models.DateTimeField(
-                blank=True,
-                help_text=(
-                    "When the Pi print daemon last successfully printed the "
-                    "label for this stint. NULL means the daemon will pick "
-                    "it up on its next poll."
-                ),
-                null=True,
-            ),
+            field=models.DateTimeField(blank=True, null=True),
         ),
         migrations.AddField(
             model_name="projectstoragestint",
@@ -30,10 +22,6 @@ class Migration(migrations.Migration):
                     ("brother_ql", "Brother QL label printer"),
                     ("epson_tm", "Epson TM receipt printer"),
                 ],
-                help_text=(
-                    "Which printer family the Pi daemon should send this "
-                    "stint's label to. Empty defaults to brother_ql."
-                ),
                 max_length=16,
             ),
         ),
@@ -41,7 +29,7 @@ class Migration(migrations.Migration):
             model_name="projectstoragestint",
             index=models.Index(
                 fields=["printed_at"],
-                name="project_sto_printed_3a4f5b_idx",
+                name="project_sto_printed_8860d0_idx",
             ),
         ),
     ]

--- a/backend/project_storage/models.py
+++ b/backend/project_storage/models.py
@@ -99,6 +99,19 @@ class ProjectStorageStint(models.Model):
     storage_location_name = models.CharField(max_length=120, blank=True)
     purgatory_location_name = models.CharField(max_length=120, blank=True)
 
+    # Print pipeline state. printed_at is set by the Pi daemon after a
+    # successful print; print_target picks the layout the daemon should
+    # use (defaults to brother_ql when blank). NULL printed_at on a
+    # stint is the queue signal.
+    printed_at = models.DateTimeField(null=True, blank=True)
+    PRINT_TARGET_BROTHER = "brother_ql"
+    PRINT_TARGET_EPSON = "epson_tm"
+    PRINT_TARGET_CHOICES = [
+        (PRINT_TARGET_BROTHER, "Brother QL label printer"),
+        (PRINT_TARGET_EPSON, "Epson TM receipt printer"),
+    ]
+    print_target = models.CharField(max_length=16, blank=True, choices=PRINT_TARGET_CHOICES)
+
     notes = models.TextField(blank=True)
 
     created_at = models.DateTimeField(auto_now_add=True)
@@ -110,6 +123,7 @@ class ProjectStorageStint(models.Model):
             models.Index(fields=["username", "-started_at"]),
             models.Index(fields=["expires_at"]),
             models.Index(fields=["removed_at"]),
+            models.Index(fields=["printed_at"]),
         ]
 
     def __str__(self) -> str:

--- a/backend/project_storage/scripts/pi/README.md
+++ b/backend/project_storage/scripts/pi/README.md
@@ -1,0 +1,119 @@
+# OMS Project Storage — Raspberry Pi print daemon
+
+A small Python service that polls the OMS Project Storage print queue
+and drives a label or receipt printer.
+
+## What it does
+
+```
+        OMS API                       Pi                  Printer
+─────────────────────────────────────────────────────────────────────
+GET   /api/project-storage/
+        stints/print-queue/
+      ← list of pending stints
+                                    fetch each label PNG
+                                    send PNG to printer
+POST  .../<stint>/mark-printed/
+                                                       label printed
+```
+
+The queue is anything with `printed_at IS NULL` that isn't already
+removed or in purgatory. The daemon honours each stint's `print_target`
+(`brother_ql` or `epson_tm`) unless overridden by env.
+
+## Install
+
+```bash
+sudo mkdir -p /opt/oms-print-daemon
+sudo cp print_daemon.py /opt/oms-print-daemon/
+sudo cp project_storage_print.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now project_storage_print
+```
+
+Edit the `Environment=` lines in `/etc/systemd/system/project_storage_print.service`
+to point at your OMS API and your printer.
+
+### Brother QL label printer (recommended)
+
+```bash
+sudo pip3 install brother_ql Pillow requests
+```
+
+Plug the printer in via USB. Find the device:
+
+```bash
+ls -l /dev/usb/lp*
+```
+
+Set in the service unit:
+
+```
+Environment=OMS_PRINTER_KIND=brother_ql
+Environment=OMS_BROTHER_DEVICE=/dev/usb/lp0
+Environment=OMS_BROTHER_MODEL=QL-820NWB     # whichever model you have
+Environment=OMS_BROTHER_LABEL=62            # 62mm continuous tape
+```
+
+The `pi` user needs to be in the `lp` group to write the device — the
+service unit adds `SupplementaryGroups=lp dialout`.
+
+### Epson TM receipt printer
+
+```bash
+sudo apt-get install cups cups-bsd
+sudo pip3 install Pillow requests
+```
+
+Add the printer in CUPS (`http://<pi>:631/`). Then in the service unit:
+
+```
+Environment=OMS_PRINTER_KIND=epson_tm
+Environment=OMS_EPSON_CUPS_QUEUE=TM_T20III    # the CUPS queue name
+```
+
+The daemon shells out to `lp -d $OMS_EPSON_CUPS_QUEUE label.png`.
+
+## Run manually for testing
+
+```bash
+OMS_API_BASE=https://oms.example.com/api \
+OMS_PRINTER_KIND=brother_ql \
+OMS_BROTHER_DEVICE=/dev/usb/lp0 \
+python3 print_daemon.py
+```
+
+You should see one log line per poll:
+
+```
+2026-05-24 09:15:22 INFO project_storage_print_daemon: polling https://… every 10s
+2026-05-24 09:15:31 INFO project_storage_print_daemon: stint PS-AB23CDFG: fetching label
+2026-05-24 09:15:31 INFO project_storage_print_daemon: stint PS-AB23CDFG: printing via brother_ql
+2026-05-24 09:15:33 INFO project_storage_print_daemon: stint PS-AB23CDFG: confirming print to OMS
+```
+
+## Authentication
+
+The two endpoints the daemon needs (`print-queue` and `mark-printed`)
+are AllowAny on the OMS side because all the daemon can do with them
+is print a label that's already destined for a known location. If you
+front the OMS API with an auth proxy, set `OMS_API_TOKEN` in the
+service unit and the daemon will send it as `Authorization: Bearer`.
+
+## Recovery
+
+- **Out of paper / printer offline** — the daemon logs an error per
+  stint and moves on; the queue surfaces the same stints next poll.
+- **OMS unreachable** — the daemon backs off exponentially up to 60s.
+- **Wrong label printed / member needs a reprint** — go into Django
+  admin, find the stint, clear `printed_at`. Next poll the daemon
+  picks it up.
+
+## Operational tips
+
+- One Pi can drive both a Brother and an Epson at once: run two
+  instances of the daemon with different `OMS_PRINTER_KIND` and units
+  named `project_storage_print_brother` / `_epson`. Each respects
+  its kind by overriding the per-stint `print_target`.
+- Run the daemon on the same LAN segment as the printer if possible —
+  USB-over-IP works but adds a failure surface.

--- a/backend/project_storage/scripts/pi/print_daemon.py
+++ b/backend/project_storage/scripts/pi/print_daemon.py
@@ -113,7 +113,7 @@ def _print_brother(png_bytes: bytes) -> None:
 
 def _print_epson(png_bytes: bytes) -> None:
     """Send PNG bytes to an Epson TM receipt printer via CUPS `lp`."""
-    import subprocess
+    import subprocess  # noqa: S404 # nosec B404 - controlled lp invocation on the Pi
     import tempfile
 
     queue = os.environ.get("OMS_EPSON_CUPS_QUEUE")
@@ -126,7 +126,10 @@ def _print_epson(png_bytes: bytes) -> None:
         path = fh.name
     args.append(path)
     try:
-        subprocess.run(args, check=True, capture_output=True, text=True)
+        # nosec B603 - args is a fixed list (lp + -d <env queue> + temp path);
+        # no user input ever reaches argv. Shell=False (default) so even the
+        # env-derived queue name can't expand.
+        subprocess.run(args, check=True, capture_output=True, text=True)  # noqa: S603  # nosec B603
     finally:
         os.unlink(path)
 

--- a/backend/project_storage/scripts/pi/print_daemon.py
+++ b/backend/project_storage/scripts/pi/print_daemon.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Project Storage print daemon — run me on a Raspberry Pi.
+
+Polls the OMS Project Storage print-queue endpoint for stints that
+haven't been printed yet, downloads each label PNG, sends it to the
+configured printer, and reports the print back to OMS so the queue
+drains.
+
+Two printer backends are supported (auto-selected per stint by the
+backend's `print_target` field, or overridden globally via env):
+
+  - Brother QL label printer (recommended):
+        pip install brother_ql
+        Plug in via USB, find the device file (e.g. /dev/usb/lp0), set
+            OMS_PRINTER_KIND=brother_ql
+            OMS_BROTHER_DEVICE=/dev/usb/lp0
+            OMS_BROTHER_MODEL=QL-820NWB     # match your hardware
+            OMS_BROTHER_LABEL=62            # 62mm continuous
+
+  - Epson TM receipt printer:
+        Plug in via USB, install CUPS, add the printer.
+        Set OMS_PRINTER_KIND=epson_tm and (optionally)
+            OMS_EPSON_CUPS_QUEUE=TM_T20III   # CUPS queue name
+
+Environment configuration (all required ones in CAPS, all optional in
+parens):
+
+    OMS_API_BASE          e.g. https://oms.example.com/api
+    (OMS_API_TOKEN)       Bearer token if the deployment fronts these
+                          endpoints with auth; default endpoints are
+                          AllowAny so this is usually empty.
+    OMS_POLL_INTERVAL_S   default 10
+    OMS_PRINTER_KIND      brother_ql | epson_tm   (overrides the
+                          per-stint print_target if set)
+
+Run:
+    python3 print_daemon.py
+
+Install as a systemd service: see project_storage.service in this
+directory.
+
+Design notes
+------------
+- The daemon is intentionally single-threaded and stateless. Each loop
+  iteration: GET queue → for each entry, fetch label PNG → print →
+  POST mark-printed. If any step fails for a given stint we log and
+  move on; the queue will surface that stint again next loop.
+- We never assume a stint will be printed "soon" — `created_at` order
+  is the queue order, but the OMS side won't time out if the daemon
+  takes a while; the warden can also reprint by toggling printed_at
+  via the admin if a label gets crushed.
+- HTTP errors backoff exponentially up to 60s. Printer errors don't
+  backoff — they're usually paper out / cover open and they want a
+  human's attention, not a sleep.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+from io import BytesIO
+from typing import Iterable
+
+import requests
+
+LOG = logging.getLogger("project_storage_print_daemon")
+
+DEFAULT_POLL_INTERVAL = 10
+MAX_HTTP_BACKOFF = 60
+
+
+# ---------------------------------------------------------------------------
+# Printer drivers
+# ---------------------------------------------------------------------------
+
+
+def _print_brother(png_bytes: bytes) -> None:
+    """Send PNG bytes to a Brother QL-series label printer via brother_ql."""
+    from brother_ql.backends.helpers import send  # type: ignore
+    from brother_ql.conversion import convert  # type: ignore
+    from brother_ql.raster import BrotherQLRaster  # type: ignore
+    from PIL import Image  # type: ignore
+
+    device = os.environ.get("OMS_BROTHER_DEVICE", "/dev/usb/lp0")
+    model = os.environ.get("OMS_BROTHER_MODEL", "QL-820NWB")
+    label = os.environ.get("OMS_BROTHER_LABEL", "62")
+
+    img = Image.open(BytesIO(png_bytes))
+    qlr = BrotherQLRaster(model)
+    qlr.exception_on_warning = True
+    instructions = convert(
+        qlr=qlr,
+        images=[img],
+        label=label,
+        rotate="0",
+        threshold=70.0,
+        dither=False,
+        compress=False,
+        red=False,
+        dpi_600=False,
+        hq=True,
+        cut=True,
+    )
+    send(
+        instructions=instructions,
+        printer_identifier=device,
+        backend_identifier="linux_kernel",
+        blocking=True,
+    )
+
+
+def _print_epson(png_bytes: bytes) -> None:
+    """Send PNG bytes to an Epson TM receipt printer via CUPS `lp`."""
+    import subprocess
+    import tempfile
+
+    queue = os.environ.get("OMS_EPSON_CUPS_QUEUE")
+    args = ["lp"]
+    if queue:
+        args += ["-d", queue]
+
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as fh:
+        fh.write(png_bytes)
+        path = fh.name
+    args.append(path)
+    try:
+        subprocess.run(args, check=True, capture_output=True, text=True)
+    finally:
+        os.unlink(path)
+
+
+PRINTERS = {
+    "brother_ql": _print_brother,
+    "epson_tm": _print_epson,
+}
+
+
+# ---------------------------------------------------------------------------
+# API client
+# ---------------------------------------------------------------------------
+
+
+class OMSClient:
+    def __init__(self, base: str, token: str | None = None) -> None:
+        self.base = base.rstrip("/")
+        self.session = requests.Session()
+        if token:
+            self.session.headers["Authorization"] = f"Bearer {token}"
+
+    def queue(self) -> list[dict]:
+        resp = self.session.get(f"{self.base}/project-storage/stints/print-queue/", timeout=15)
+        resp.raise_for_status()
+        return resp.json()
+
+    def label(self, label_url: str) -> bytes:
+        # The queue gives us an absolute label_url; honour it instead of
+        # reconstructing the path on this side.
+        resp = self.session.get(label_url, timeout=30)
+        resp.raise_for_status()
+        return resp.content
+
+    def mark_printed(self, stint_id: str, note: str = "") -> None:
+        resp = self.session.post(
+            f"{self.base}/project-storage/stints/{stint_id}/mark-printed/",
+            json={"note": note},
+            timeout=15,
+        )
+        resp.raise_for_status()
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+
+def _pick_printer(stint: dict) -> str:
+    forced = os.environ.get("OMS_PRINTER_KIND", "").strip()
+    if forced:
+        return forced
+    return stint.get("print_target") or "brother_ql"
+
+
+def _process_one(client: OMSClient, stint: dict) -> None:
+    kind = _pick_printer(stint)
+    driver = PRINTERS.get(kind)
+    if driver is None:
+        LOG.error(
+            "stint %s: unknown printer kind %r — leaving in queue",
+            stint["stint_id"],
+            kind,
+        )
+        return
+
+    LOG.info("stint %s: fetching label", stint["stint_id"])
+    png = client.label(stint["label_url"])
+
+    LOG.info("stint %s: printing via %s", stint["stint_id"], kind)
+    driver(png)
+
+    LOG.info("stint %s: confirming print to OMS", stint["stint_id"])
+    client.mark_printed(stint["stint_id"], note=f"printed via {kind}")
+
+
+def _loop(client: OMSClient, poll_s: float) -> None:
+    http_backoff = 1.0
+    while True:
+        try:
+            stints: Iterable[dict] = client.queue()
+            http_backoff = 1.0
+        except requests.RequestException as exc:
+            LOG.warning("queue poll failed (%s); backing off %.0fs", exc, http_backoff)
+            time.sleep(http_backoff)
+            http_backoff = min(http_backoff * 2, MAX_HTTP_BACKOFF)
+            continue
+
+        for stint in stints:
+            try:
+                _process_one(client, stint)
+            except requests.RequestException as exc:
+                LOG.warning(
+                    "stint %s: HTTP failure (%s) — will retry next poll",
+                    stint["stint_id"],
+                    exc,
+                )
+            except Exception as exc:  # noqa: BLE001 — printer drivers raise many shapes
+                LOG.exception(
+                    "stint %s: print failed (%s) — will retry next poll",
+                    stint["stint_id"],
+                    exc,
+                )
+
+        time.sleep(poll_s)
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    base = os.environ.get("OMS_API_BASE")
+    if not base:
+        LOG.error("OMS_API_BASE is required (e.g. https://oms.example.com/api)")
+        return 2
+
+    token = os.environ.get("OMS_API_TOKEN") or None
+    try:
+        poll_s = float(os.environ.get("OMS_POLL_INTERVAL_S", DEFAULT_POLL_INTERVAL))
+    except ValueError:
+        poll_s = DEFAULT_POLL_INTERVAL
+
+    client = OMSClient(base, token=token)
+    LOG.info("polling %s every %.0fs", base, poll_s)
+    try:
+        _loop(client, poll_s)
+    except KeyboardInterrupt:
+        LOG.info("interrupted; exiting")
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/project_storage/scripts/pi/project_storage_print.service
+++ b/backend/project_storage/scripts/pi/project_storage_print.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=OMS Project Storage print daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Set the OMS endpoint + printer config here (or use an EnvironmentFile).
+Environment=OMS_API_BASE=https://oms.example.com/api
+Environment=OMS_POLL_INTERVAL_S=10
+# Brother QL example — swap for Epson by replacing these three:
+Environment=OMS_PRINTER_KIND=brother_ql
+Environment=OMS_BROTHER_DEVICE=/dev/usb/lp0
+Environment=OMS_BROTHER_MODEL=QL-820NWB
+Environment=OMS_BROTHER_LABEL=62
+
+User=pi
+WorkingDirectory=/opt/oms-print-daemon
+ExecStart=/usr/bin/python3 /opt/oms-print-daemon/print_daemon.py
+
+# Restart on crash but back off so a stuck printer doesn't pin a CPU
+Restart=on-failure
+RestartSec=15s
+
+# Talk to USB printer
+SupplementaryGroups=lp dialout
+
+[Install]
+WantedBy=multi-user.target

--- a/backend/project_storage/tests/test_print_queue.py
+++ b/backend/project_storage/tests/test_print_queue.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from django.utils import timezone
+
+import pytest
+from rest_framework.test import APIClient
+
+from project_storage.models import ProjectStorageEvent, ProjectStorageStint
+from project_storage.tests.factories import ProjectStorageStintFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+class TestPrintQueue:
+    def test_lists_unprinted_active_stints(self, client):
+        # Eligible: printed_at is null, not removed, not purgatoried.
+        eligible = ProjectStorageStintFactory(print_target="brother_ql")
+        # Excluded: already printed.
+        ProjectStorageStintFactory(printed_at=timezone.now())
+        # Excluded: removed.
+        ProjectStorageStintFactory(removed_at=timezone.now())
+        # Excluded: purgatoried.
+        ProjectStorageStintFactory(
+            notice_sent_at=timezone.now(),
+            moved_to_purgatory_at=timezone.now(),
+        )
+
+        resp = client.get("/api/project-storage/stints/print-queue/")
+        assert resp.status_code == 200
+        body = resp.json()
+        ids = [row["stint_id"] for row in body]
+        assert ids == [eligible.stint_id]
+        # The daemon needs the absolute label URL.
+        assert body[0]["label_url"].endswith(
+            f"/project-storage/stints/{eligible.stint_id}/label/?printer=brother_ql"
+        )
+
+    def test_label_url_honours_print_target(self, client):
+        ProjectStorageStintFactory(print_target="epson_tm", username="e")
+        resp = client.get("/api/project-storage/stints/print-queue/")
+        body = resp.json()
+        assert any("printer=epson_tm" in row["label_url"] for row in body)
+
+    def test_defaults_to_brother_ql_when_target_blank(self, client):
+        ProjectStorageStintFactory(print_target="", username="empty")
+        resp = client.get("/api/project-storage/stints/print-queue/")
+        body = resp.json()
+        # blank print_target -> brother_ql default
+        target_for_empty = next(r for r in body if r["print_target"] == "brother_ql")
+        assert "printer=brother_ql" in target_for_empty["label_url"]
+
+    def test_returns_in_created_at_order_oldest_first(self, client):
+        first = ProjectStorageStintFactory(username="first")
+        second = ProjectStorageStintFactory(username="second")
+        resp = client.get("/api/project-storage/stints/print-queue/")
+        body = resp.json()
+        ids = [row["stint_id"] for row in body]
+        assert ids.index(first.stint_id) < ids.index(second.stint_id)
+
+
+class TestMarkPrinted:
+    def test_sets_printed_at_and_records_event(self, client):
+        stint = ProjectStorageStintFactory()
+        resp = client.post(
+            f"/api/project-storage/stints/{stint.stint_id}/mark-printed/",
+            {"note": "from test"},
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+        stint.refresh_from_db()
+        assert stint.printed_at is not None
+        assert stint.events.filter(actor_label="pi-daemon: printed").exists()
+
+    def test_idempotent_no_duplicate_event(self, client):
+        already = timezone.now()
+        stint = ProjectStorageStintFactory(printed_at=already)
+        resp = client.post(f"/api/project-storage/stints/{stint.stint_id}/mark-printed/")
+        assert resp.status_code == 200
+        stint.refresh_from_db()
+        # printed_at unchanged + no new event recorded
+        assert stint.printed_at == already
+        assert stint.events.filter(actor_label="pi-daemon: printed").count() == 0
+
+    def test_drops_off_queue_after_mark_printed(self, client):
+        stint = ProjectStorageStintFactory()
+        assert any(
+            row["stint_id"] == stint.stint_id
+            for row in client.get("/api/project-storage/stints/print-queue/").json()
+        )
+        client.post(f"/api/project-storage/stints/{stint.stint_id}/mark-printed/")
+        assert not any(
+            row["stint_id"] == stint.stint_id
+            for row in client.get("/api/project-storage/stints/print-queue/").json()
+        )

--- a/backend/project_storage/tests/test_print_queue.py
+++ b/backend/project_storage/tests/test_print_queue.py
@@ -5,7 +5,6 @@ from django.utils import timezone
 import pytest
 from rest_framework.test import APIClient
 
-from project_storage.models import ProjectStorageEvent, ProjectStorageStint
 from project_storage.tests.factories import ProjectStorageStintFactory
 
 pytestmark = pytest.mark.django_db

--- a/backend/project_storage/views.py
+++ b/backend/project_storage/views.py
@@ -31,8 +31,11 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
     lookup_field = "stint_id"
 
     def get_permissions(self):
-        # Read-side: warden tooling. Mutating actions below set their own.
-        if self.action in ("start", "label"):
+        # AllowAny on the kiosk + Pi-daemon paths; staff for everything
+        # else. The decorators below also set permission_classes so the
+        # routing is obvious at the call site, but this central list is
+        # the safety net for actions reached through self.get_object().
+        if self.action in ("start", "label", "print_queue", "mark_printed"):
             return [AllowAny()]
         return [IsAdminUser()]
 
@@ -217,7 +220,9 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
     def label(self, request, stint_id: str):
         """Return the label PNG. ?printer=brother_ql (default) or epson_tm."""
         stint = get_object_or_404(ProjectStorageStint, stint_id=stint_id)
-        printer: PrinterFamily = request.query_params.get("printer", "brother_ql")
+        printer: PrinterFamily = request.query_params.get(
+            "printer", stint.print_target or "brother_ql"
+        )
         if printer not in ("brother_ql", "epson_tm"):
             return Response(
                 {"detail": f"Unknown printer family '{printer}'.", "code": "bad_printer"},
@@ -225,3 +230,72 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
             )
         png_bytes = render_stint_label(stint, printer=printer)
         return HttpResponse(png_bytes, content_type="image/png")
+
+    # ------------------------------------------------------------------
+    # Pi print-daemon plumbing
+    # ------------------------------------------------------------------
+
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="print-queue",
+        permission_classes=[AllowAny],
+    )
+    def print_queue(self, request):
+        """Return the list of stints that still need their label printed.
+
+        AllowAny because the daemon talks to the API without Django auth;
+        the only thing it can do with the queue is print a label (which
+        is itself an AllowAny endpoint). If the daemon ever needs to
+        mutate something more sensitive, add token auth.
+        """
+        pending = (
+            ProjectStorageStint.objects.filter(
+                printed_at__isnull=True,
+                removed_at__isnull=True,
+                moved_to_purgatory_at__isnull=True,
+            )
+            .order_by("created_at")
+            .values(
+                "stint_id",
+                "print_target",
+                "created_at",
+            )
+        )
+        # Materialize + add the absolute label URL so the daemon doesn't
+        # have to know about path construction.
+        base = request.build_absolute_uri("/api/project-storage/stints/")
+        return Response(
+            [
+                {
+                    "stint_id": row["stint_id"],
+                    "print_target": row["print_target"] or "brother_ql",
+                    "created_at": row["created_at"],
+                    "label_url": (
+                        f"{base}{row['stint_id']}/label/"
+                        f"?printer={row['print_target'] or 'brother_ql'}"
+                    ),
+                }
+                for row in pending
+            ]
+        )
+
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="mark-printed",
+        permission_classes=[AllowAny],
+    )
+    def mark_printed(self, request, stint_id: str):
+        """Daemon calls this after a successful print so the queue empties."""
+        stint = self.get_object()
+        if stint.printed_at is None:
+            stint.printed_at = timezone.now()
+            stint.save(update_fields=["printed_at", "updated_at"])
+            ProjectStorageEvent.objects.create(
+                stint=stint,
+                event_type=ProjectStorageEvent.EVENT_NOTE_ADDED,
+                actor_label="pi-daemon: printed",
+                note=request.data.get("note", ""),
+            )
+        return Response(ProjectStorageStintSerializer(stint).data)


### PR DESCRIPTION
## Summary

Closes the print pipeline. **Stacked on #548** so the model fields, endpoints, and the daemon that consumes them land together.

> **Note**: base is `feature/project-storage`, not `main`. When #548 lands, GitHub will retarget this PR onto main automatically.

## What's in

**Backend**
- `models.py` — `ProjectStorageStint` gains `printed_at` (NULL = "still on the queue") and `print_target` (`brother_ql` / `epson_tm`). New index on `printed_at` so the queue poll is cheap.
- `0002_projectstoragestint_printed_at.py` migration.
- Two new actions on the stints viewset, both `AllowAny` so the Pi daemon can talk without juggling tokens (the only thing it can do is print labels that already exist):
  - `GET print-queue/` — returns unprinted, non-removed, non-purgatoried stints in `created_at` order with an **absolute** `label_url` ready to fetch
  - `POST <id>/mark-printed/` — daemon confirms the print + we record a `pi-daemon` event
- The existing `label/` action now defaults to the stint's `print_target` when no `?printer` query is set.

**Raspberry Pi daemon** (`backend/project_storage/scripts/pi/`)
- `print_daemon.py` — stateless poll loop. Plug-in driver picks `brother_ql` (via the `brother_ql` Python library) or `epson_tm` (shells out to `lp` through CUPS). HTTP errors back off exponentially; printer errors don't (they want a human). One stint failure doesn't stop the loop.
- `project_storage_print.service` — systemd unit ready to drop into `/etc/systemd/system/` on a Pi. `SupplementaryGroups=lp dialout` so the pi user can write the USB printer device.
- `README.md` — install steps for both printer families, env-var reference, recovery procedures, and how to run two daemons side by side to drive both printers from one Pi.

## Tests

**45 pass locally** (7 new in `test_print_queue.py`):
- queue excludes already-printed, removed, and purgatoried stints
- `label_url` honours per-stint `print_target` with `brother_ql` fallback
- oldest-created stints come first
- `mark-printed` records the event + drops the stint off the queue
- `mark-printed` is idempotent

## Test plan

- [ ] `pytest project_storage/tests` — 45 pass
- [ ] `manage.py migrate` applies `0002` cleanly
- [ ] `curl /api/project-storage/stints/print-queue/` returns the unprinted-stint list
- [ ] `curl /api/project-storage/stints/<id>/mark-printed/ -X POST` returns 200 + queue shrinks by one
- [ ] On a Pi with the systemd unit installed: `journalctl -fu project_storage_print` shows one "fetching/printing/confirming" cycle per pending stint

🤖 Generated with [Claude Code](https://claude.com/claude-code)