### PR TITLE
fix(frontend): add .dockerignore to stop host node_modules shadowing image build

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+build
+dist
+coverage
+.cache
+playwright-report
+test-results
+.env
+.env.*
+!.env.example
+*.log
+.DS_Store


### PR DESCRIPTION
## Summary

Found the root cause of the deploy-host \`vite build\` failure that surfaced after #565 squash-merged.

\`frontend/Dockerfile.prod\` does:

\`\`\`dockerfile
COPY package*.json ./
RUN npm ci --production=false
COPY . .
\`\`\`

The trailing \`COPY . .\` was silently copying the host's \`frontend/node_modules\` directory **over** the fresh install one step earlier. On a deploy host whose host-side \`node_modules\` predates the Vite migration (i.e. has CRA-era rollup without \`./parseAst\` in its \`exports\`), the image ends up with that stale tree and \`vite build\` immediately dies with \`ERR_PACKAGE_PATH_NOT_EXPORTED\`.

CI and my dev box both missed this:
- CI runs \`actions/checkout\` into an empty workspace, so there's no host \`node_modules\` to leak in.
- My dev box's host \`node_modules\` happens to be the post-Vite tree, so the COPY overlay is a no-op.

This is also a long-standing footgun for anyone running \`docker compose build\` after \`npm install\`-ing on the host.

## Fix

Add \`frontend/.dockerignore\` excluding \`node_modules\`, plus the standard list of build artifacts, coverage, playwright reports, and secrets. The COPY now only carries source, so the \`npm ci\` result is the only \`node_modules\` in the image.

## Deploy-host recovery

After this PR lands, the deploy host should also blow away the stale tree once so future \`docker compose build\` is fully clean:

\`\`\`bash
cd ~/openmakersuite
git pull --ff-only
rm -rf frontend/node_modules    # may need docker run --rm -v \$PWD/frontend:/app ... if owned by root
docker compose -f docker-compose.prod.yml build --no-cache --pull frontend
\`\`\`

## Test plan

- [x] \`docker compose -f docker-compose.prod.yml build --no-cache frontend\` works locally (it does either way — local host node_modules is post-Vite).
- [ ] Verified on deploy host (uid0).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)