### PR TITLE
fix(pwa,nginx): scope SW navigations to SPA-only; redirect bare /admin

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,29 @@ const config: UserConfig & { test?: unknown } = {
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
         maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
+        // The SPA shell (`/index.html`) is the navigation fallback for any
+        // unmatched route the SW intercepts. Without an explicit denylist,
+        // workbox's NavigationRoute hands the cached shell back for every
+        // navigation, including Django admin and DRF endpoints, which then
+        // render blank because React-Router has no route for them. The
+        // denylist makes the SW pass those requests straight through to the
+        // network (→ nginx → Django).
+        navigateFallback: '/index.html',
+        navigateFallbackDenylist: [
+          /^\/api\//,
+          /^\/admin(\/|$)/,
+          /^\/auth\//,
+          /^\/webhooks\//,
+          /^\/flower\//,
+          /^\/mqttadmin\//,
+          /^\/django-static\//,
+          /^\/media\//,
+          /^\/\.well-known\//,
+          // Anything that looks like a file (has an extension other than
+          // the SPA-route style of `/foo.bar` in code) — let workbox serve
+          // it from precache or fetch it.
+          /\.[A-Za-z0-9]{1,8}$/,
+        ],
       },
       manifest: false,
     }),

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -61,6 +61,13 @@ server {
         proxy_redirect off;
     }
 
+    # Slashless /admin must redirect to /admin/ before the SPA catch-all sees
+    # it — otherwise the React shell loads, React-Router has no route for
+    # /admin, and the service worker can cache the resulting blank page.
+    location = /admin {
+        return 301 $scheme://$host/admin/;
+    }
+
     location /admin/ {
         proxy_pass http://backend;
         proxy_set_header Host $host;


### PR DESCRIPTION
## What's happening

After the Vite migration (#565) shipped a real PWA service worker — CRA's `public/sw.js` was never actually registered, so we effectively had no SW before — workbox's `NavigationRoute` started intercepting every navigation in the browser and serving the precached SPA shell (`/index.html`) as the fallback for unmatched routes. That includes:

- `/admin/` (Django admin)
- `/api/*` (DRF)
- `/auth/passkey/*`, `/webhooks/*`, `/flower/*`, `/mqttadmin/*`, `/django-static/*`, `/media/*`

All of those rendered as a blank React shell (react-router has no route for them) and the SW cached the blank result for next time. uid0 hit this trying to open Django admin after a deploy.

Adjacent issue: typing `/admin` (no trailing slash) was falling into the SPA catch-all in nginx (`location /admin/` is a prefix match that requires the slash), which compounded the SW-cache issue.

## What this changes

1. **`frontend/vite.config.ts`** — add `workbox.navigateFallbackDenylist` for every backend-served prefix plus anything that looks like a file extension. The SW now passes those requests straight through to network → nginx → Django, instead of fabricating an `index.html` response. The SPA shell precache and offline mutation queue (`utils/offlineQueue.ts`) for the scan / project-storage / personal-storage flows are unchanged.

2. **`nginx/templates/default.conf.template`** — add `location = /admin { return 301 \$scheme://\$host/admin/; }` before the `/admin/` proxy block so slashless requests don't fall to the SPA catch-all.

Verified `build/sw.js` has the denylist baked in.

## Operator note after deploy

Existing browsers have the old SW cached. `registerType: 'autoUpdate'` will install the new SW on next page load, but the new rules only take effect after the user reloads. For an immediate fix on a stuck browser: DevTools → Application → Service Workers → Unregister, then refresh.

## Test plan

- [x] `npm run build` is green; PWA bundle regenerated with denylist visible in `build/sw.js`.
- [ ] CI green.
- [ ] After deploy + SW refresh: `/admin/` reaches Django, `/admin` 301s to `/admin/`, scan flows still work offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)