### PR TITLE
fix(observability): re-enable Sentry SDK on backend + frontend

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -10,6 +10,11 @@ import dj_database_url
 from celery.schedules import crontab
 from decouple import config
 
+import sentry_sdk
+from sentry_sdk.integrations.celery import CeleryIntegration
+from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
+
 try:
     import passkeys
 
@@ -606,6 +611,42 @@ READYZ_REQUIRED_CHECKS = config(
     "READYZ_REQUIRED_CHECKS",
     default="database,cache,broker",
 )
+
+# Sentry error reporting. No-op when SENTRY_DSN is unset; in production the
+# DSN is set in `.env` and `scripts/validate-prod-env.sh` warns if it's
+# empty. `_check_telemetry` in `config/health.py` verifies reachability.
+#
+# - DjangoIntegration: captures unhandled view exceptions, 5xx, slow ORM.
+# - CeleryIntegration: captures task failures + propagates trace IDs across
+#   the Redis broker so a request → task chain shows up as one transaction.
+# - LoggingIntegration(event_level=ERROR): forwards logger.error / logger.exception
+#   calls as Sentry events. INFO/WARNING become breadcrumbs.
+SENTRY_DSN = config("SENTRY_DSN", default="")
+SENTRY_ENVIRONMENT = config("SENTRY_ENVIRONMENT", default="production" if not DEBUG else "development")
+SENTRY_RELEASE = config("GIT_HASH", default="") or None
+SENTRY_TRACES_SAMPLE_RATE = config("SENTRY_TRACES_SAMPLE_RATE", default=0.1, cast=float)
+SENTRY_PROFILES_SAMPLE_RATE = config("SENTRY_PROFILES_SAMPLE_RATE", default=0.0, cast=float)
+
+if SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        environment=SENTRY_ENVIRONMENT,
+        release=SENTRY_RELEASE,
+        integrations=[
+            DjangoIntegration(transaction_style="url"),
+            CeleryIntegration(monitor_beat_tasks=True),
+            LoggingIntegration(event_level="ERROR"),
+        ],
+        traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
+        profiles_sample_rate=SENTRY_PROFILES_SAMPLE_RATE,
+        # Don't ship request bodies / user PII by default; the redactor in
+        # config.observability_redaction handles fine-grained scrubbing for
+        # our own log/audit surfaces.
+        send_default_pii=False,
+    )
+    # Drop noisy framework warnings; let LoggingIntegration carry the real
+    # signal (logger.error / .exception in app code).
+    sentry_sdk.integrations.logging.ignore_logger("django.security.DisallowedHost")
 
 # Logging configuration
 LOGGING = {

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -7,10 +7,9 @@ from datetime import timedelta
 from pathlib import Path
 
 import dj_database_url
+import sentry_sdk
 from celery.schedules import crontab
 from decouple import config
-
-import sentry_sdk
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -622,7 +621,9 @@ READYZ_REQUIRED_CHECKS = config(
 # - LoggingIntegration(event_level=ERROR): forwards logger.error / logger.exception
 #   calls as Sentry events. INFO/WARNING become breadcrumbs.
 SENTRY_DSN = config("SENTRY_DSN", default="")
-SENTRY_ENVIRONMENT = config("SENTRY_ENVIRONMENT", default="production" if not DEBUG else "development")
+SENTRY_ENVIRONMENT = config(
+    "SENTRY_ENVIRONMENT", default="production" if not DEBUG else "development"
+)
 SENTRY_RELEASE = config("GIT_HASH", default="") or None
 SENTRY_TRACES_SAMPLE_RATE = config("SENTRY_TRACES_SAMPLE_RATE", default=0.1, cast=float)
 SENTRY_PROFILES_SAMPLE_RATE = config("SENTRY_PROFILES_SAMPLE_RATE", default=0.0, cast=float)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -48,6 +48,11 @@ cryptography==48.0.0
 # Email (Postmark via Anymail)
 django-anymail[postmark]==15.0
 
+# Error reporting / observability (Sentry). Replaces Highlight (oms-fjs)
+# after that integration was ripped out; backend init is in
+# `config/settings.py` and is a no-op unless SENTRY_DSN is set.
+sentry-sdk[django,celery]==2.18.0
+
 # Testing and Code Coverage
 coverage==7.14.0
 pytest==9.0.3

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@mantine/hooks": "^7.11.0",
         "@mantine/modals": "^7.17.8",
         "@mantine/notifications": "^7.17.8",
+        "@sentry/react": "^8.49.0",
         "@tabler/icons-react": "^3.35.0",
         "axios": "^1.16.0",
         "dayjs": "^1.11.10",
@@ -3737,6 +3738,98 @@
         "win32"
       ]
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.55.2.tgz",
+      "integrity": "sha512-GnKod+gL/Y+1FUM/RGV8q6le1CoyiGbT40MitEK7eVwWe+bfTRq1gN7ioupyHFMUg1RlQkDQ4/sENmio/uow5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.55.2.tgz",
+      "integrity": "sha512-XQy//NWbL0mLLM5w8wNDWMNpXz39VUyW2397dUrH8++kR63WhUVAvTOtL0o0GMVadSAzl1b08oHP9zSUNFQwcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.55.2.tgz",
+      "integrity": "sha512-+W43Z697EVe/OgpGW07B773sa8xO1UbpnW0Cr+E+3FMDb6ZbXlaBUoagPTUkkQPdwBe35SDh6r8y2M3EOPGbxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.55.2",
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.55.2.tgz",
+      "integrity": "sha512-P/jGiuR7dRLG9IzD/463fLgiibyYceauav/9prRG0ZxJm1AtuO02OKball2Fs3bbzdzwHCTlcsUuL2ivDF4b5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "8.55.2",
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.55.2.tgz",
+      "integrity": "sha512-xHuPIEKhx9zw5quWvv4YgZprnwoVMCfxIhmOIf6KJ9iizyUHeUDcKpLS59xERroqwX4RpvK+l/27AZu4zfZlzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.55.2",
+        "@sentry-internal/feedback": "8.55.2",
+        "@sentry-internal/replay": "8.55.2",
+        "@sentry-internal/replay-canvas": "8.55.2",
+        "@sentry/core": "8.55.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.2.tgz",
+      "integrity": "sha512-YlEBwybUcOQ/KjMHDmof1vwweVnBtBxYlQp7DE3fOdtW4pqqdHWTnTntQs4VgYfxzjJYgtkd9LHlGtg8qy+JVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "8.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.55.2.tgz",
+      "integrity": "sha512-1TPfKZYkJal2Dyt2W0tf1roOZmu7sqr6/dTqjdsuu2WgGTilMEreK26YqB8ROOYdMjkVJpNCcIKXQHyMp2eCwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "8.55.2",
+        "@sentry/core": "8.55.2",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
     "node_modules/@simple-libs/child-process-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
@@ -7008,6 +7101,21 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@mantine/hooks": "^7.11.0",
     "@mantine/modals": "^7.17.8",
     "@mantine/notifications": "^7.17.8",
+    "@sentry/react": "^8.49.0",
     "@tabler/icons-react": "^3.35.0",
     "axios": "^1.16.0",
     "dayjs": "^1.11.10",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 /**
  * Main App Component
  */
+import * as Sentry from '@sentry/react';
 import React from 'react';
 import { Navigate, Route, BrowserRouter as Router, Routes, useParams } from 'react-router-dom';
 import ErrorFallback from './components/ErrorFallback';
@@ -109,6 +110,9 @@ class ErrorBoundary extends React.Component<
   componentDidCatch(error: Error, info: React.ErrorInfo) {
     // eslint-disable-next-line no-console
     console.error('Uncaught error in render tree:', error, info);
+    // Report to Sentry with the React component stack as context.
+    // No-op when Sentry.init wasn't called (VITE_SENTRY_DSN unset).
+    Sentry.captureException(error, { contexts: { react: { componentStack: info.componentStack ?? '' } } });
   }
 
   resetError = () => this.setState({ error: null });

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,11 +5,28 @@ import '@mantine/dropzone/styles.css';
 import { ModalsProvider } from '@mantine/modals';
 import { Notifications } from '@mantine/notifications';
 import '@mantine/notifications/styles.css';
+import * as Sentry from '@sentry/react';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { NotificationProvider } from './contexts/NotificationContext';
 import './styles/index.css';
+
+// Sentry — no-op when VITE_SENTRY_DSN is unset. CSP already allows
+// *.ingest.sentry.io / sentry.io / sentry-cdn.com (nginx template).
+const sentryDsn = import.meta.env.VITE_SENTRY_DSN;
+if (sentryDsn) {
+  Sentry.init({
+    dsn: sentryDsn,
+    environment: import.meta.env.MODE,
+    release: import.meta.env.VITE_GIT_HASH || undefined,
+    integrations: [Sentry.browserTracingIntegration()],
+    tracesSampleRate: 0.1,
+    // Don't ship full request bodies; explicit logger.error / captureException
+    // calls in app code carry the curated context.
+    sendDefaultPii: false,
+  });
+}
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement


### PR DESCRIPTION
## Why

You reported 500s aren't reaching Sentry even though `SENTRY_DSN` is configured. Audit confirms:

- `backend/requirements.txt` has no `sentry-sdk`
- `backend/config/settings.py` never calls `sentry_sdk.init()`
- `frontend/package.json` has no `@sentry/react`
- `frontend/src/index.tsx` never calls `Sentry.init()`

Highlight rollout (#319) replaced Sentry across the stack; the Highlight removal (#565) forgot to put Sentry back. `_check_telemetry` in `config/health.py` only confirms the DSN env var looks reachable — it doesn't verify anything is actually being sent. So the readiness probe stayed green while errors silently vanished.

## What this changes

**Backend** (`backend/requirements.txt`, `backend/config/settings.py`):
- Adds `sentry-sdk[django,celery]==2.18.0`.
- `sentry_sdk.init()` guarded by `SENTRY_DSN` — no-op when unset (matches existing semantics, won't break local/dev deploys).
- Integrations:
  - `DjangoIntegration(transaction_style="url")` — unhandled view exceptions, 5xx, slow ORM
  - `CeleryIntegration(monitor_beat_tasks=True)` — task failures + cross-task trace propagation via Redis
  - `LoggingIntegration(event_level=ERROR)` — `logger.error` / `logger.exception` calls
- `send_default_pii=False`; the existing `config.observability_redaction.redact` helper still owns redaction of our own log/audit surfaces.
- Knobs via env: `SENTRY_ENVIRONMENT` (default: prod/dev based on DEBUG), `SENTRY_TRACES_SAMPLE_RATE` (0.1), `SENTRY_PROFILES_SAMPLE_RATE` (0.0). Release pulled from `GIT_HASH`.
- Drops `django.security.DisallowedHost` noise via `ignore_logger`.

**Frontend** (`frontend/package.json`, `frontend/src/index.tsx`, `frontend/src/App.tsx`):
- Adds `@sentry/react ^8.49.0`.
- `Sentry.init()` in `src/index.tsx` guarded by `VITE_SENTRY_DSN`. CSP already permits `*.ingest.sentry.io` / `sentry.io` / `*.sentry-cdn.com` (nginx template).
- `App.tsx` ErrorBoundary's `componentDidCatch` now calls `Sentry.captureException()` with the React component stack. Visual fallback UI unchanged.

## No new env vars required

`SENTRY_DSN` and `VITE_SENTRY_DSN` already exist in `.env` on prod — they just had nothing listening for them.

## Test plan

- [x] `pytest backend/config/tests/test_health.py backend/config/tests/test_deployment_validation.py` — 97 pass.
- [x] `vitest run src/__tests__/App.test.tsx src/__tests__/services/api.test.ts` — 55 pass.
- [x] `npm run build` clean; new bundle ships @sentry/react.
- [x] Smoke-tested settings.py with `SENTRY_DSN=https://abc@o0.ingest.sentry.io/123` — Sentry init OK.
- [ ] After deploy: trigger a deliberate 500 (e.g. `/api/raise/` or any view that throws) and confirm it appears in Sentry within ~30s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)