### PR TITLE
chore(renovate): roll non-major upgrades into a daily PR; fast-track vulns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,50 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "timezone": "America/Chicago",
+  "dependencyDashboard": true,
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 0,
+  "packageRules": [
+    {
+      "description": "Daily rollup PR for all patch + minor + digest updates. Renovate keeps rebasing it through the day as new updates arrive; CI runs once per rebase; auto-merge fires when green. The 24h release-age gate keeps us out of the npm/pypi malware-yank window — typo-squatted or compromised packages almost always get pulled within that window.",
+      "matchUpdateTypes": [
+        "patch",
+        "minor",
+        "digest",
+        "lockFileMaintenance"
+      ],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "renovate-rollup",
+      "schedule": [
+        "after 4am and before 7am"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "minimumReleaseAge": "24h"
+    },
+    {
+      "description": "Major updates stay one PR per package. They're breaking changes that need individual review and may need follow-up code edits; bundling them would mean a single bad major holds everything else hostage.",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "automerge": true,
+    "automergeType": "pr",
+    "platformAutomerge": true,
+    "schedule": [
+      "at any time"
+    ],
+    "labels": [
+      "security",
+      "renovate"
+    ],
+    "prPriority": 99
+  }
 }


### PR DESCRIPTION
## Why

`renovate.json` is currently bare `config:recommended` — one PR per package update, filed immediately. The backlog has hit the point where clearing it is a full-day exercise. You asked for two things:

1. A rollup so non-major updates don't fragment into N parallel PRs.
2. Security vulns fixed automatically without waiting for the rollup window.

## Three lanes

### Daily non-major rollup
- **Patch + minor + digest + lockFileMaintenance** updates collapse into one `renovate-rollup` PR that Renovate keeps rebasing through the day as new upgrades arrive.
- Scheduled for the **4-7am Central** window so CI runs while nobody's working and the PR is ready for auto-merge by morning.
- **Auto-merge on green CI** (GitHub platform auto-merge), gated by `minimumReleaseAge: "24h"` — long enough to dodge the compromise-and-yank cycle on npm/pypi typo-squats.

### Majors stay per-PR
- Breaking changes need individual review and often follow-up code edits; bundling them would let one bad major stall everything else.
- No auto-merge — you click the button.

### Security alerts bypass the rollup
- `vulnerabilityAlerts` fires immediately, ignores the schedule, **skips the release-age gate** (security fixes are time-sensitive and the patched version is known-good per the advisory).
- Auto-merge on green CI, labeled `security` + `renovate`, `prPriority: 99` so it jumps the queue.

## Side-effects worth knowing

- Renovate will auto-close the existing one-per-package PRs on its next run after this lands and refile them as the rolled-up PR.
- The rollup PR fails as a block. If one package breaks CI, the whole rollup is stuck until someone (probably me) bisects. Accepted trade-off — the wall-clock cost of clearing 14 separate PRs/day is worse.

## Test plan

- [x] `renovate.json` validates against the schema URL.
- [ ] After merge: Renovate runs, closes the existing per-package PRs, opens `renovate-rollup` if there are any pending non-major updates.
- [ ] Next vulnerability advisory: confirm it bypasses the rollup window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)