### PR TITLE
fix(compose): share backend image across celery/mqtt_consumer/celery_beat (oms-8bsc5)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -83,9 +83,19 @@ services:
       - app-network
 
   backend:
+    # Canonical builder for the backend image. celery / mqtt_consumer /
+    # celery_beat reuse this image via `image: oms-backend:local` rather
+    # than each declaring their own `build:` block — that lets a single
+    # `docker compose build --no-cache backend` rebuild every backend-
+    # derived service at once. Previously each service had its own
+    # cached build, so `deploy.sh build --no-cache backend` left the
+    # worker containers on a stale image and `forgekey.tasks.<new_task>`
+    # raised KeyError in the worker registry (Sentry BACKEND-4, bd
+    # oms-8bsc5).
     build:
       context: ./backend
       dockerfile: Dockerfile.prod
+    image: oms-backend:local
     logging: *default-logging
     # --max-requests + --max-requests-jitter recycles each worker after ~1000
     # requests so any slow leak (paho buffer growth, sentry buffer, multipart
@@ -169,9 +179,10 @@ services:
       - app-network
 
   celery:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile.prod
+    # Reuse the backend image (see `backend.build` above). depends_on
+    # backend so compose creates that container — and runs its build —
+    # before this one starts.
+    image: oms-backend:local
     logging: *default-logging
     # --max-tasks-per-child mirrors the gunicorn --max-requests recycle so
     # per-task leaks in MQTT publish, image processing, etc. are bounded.
@@ -193,6 +204,8 @@ services:
       - CELERY_BROKER_URL=redis://redis:6379/0
       - SKIP_DB_MIGRATIONS=1
     depends_on:
+      backend:
+        condition: service_started
       db:
         condition: service_healthy
       redis:
@@ -213,9 +226,8 @@ services:
   # replicas would race on connection state and double-process every
   # message.
   mqtt_consumer:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile.prod
+    # Reuse the backend image (see `backend.build` above).
+    image: oms-backend:local
     logging: *default-logging
     command: python manage.py mqtt_consumer
     deploy:
@@ -235,6 +247,8 @@ services:
       - CELERY_BROKER_URL=redis://redis:6379/0
       - SKIP_DB_MIGRATIONS=1
     depends_on:
+      backend:
+        condition: service_started
       db:
         condition: service_healthy
       redis:
@@ -253,9 +267,9 @@ services:
     # broker double-fires every periodic task. Scale via
     # `--scale celery=N` if the worker pool needs more throughput, but
     # leave celery_beat at 1 replica.
-    build:
-      context: ./backend
-      dockerfile: Dockerfile.prod
+    #
+    # Reuses the backend image (see `backend.build` above).
+    image: oms-backend:local
     logging: *default-logging
     # --schedule keeps the shelved last_run_at outside /tmp so a container
     # restart doesn't reset every entry's timer (the 90-day donor task
@@ -286,6 +300,8 @@ services:
       # CELERY_BEAT_SCHEDULE.
       - SKIP_DB_MIGRATIONS=1
     depends_on:
+      backend:
+        condition: service_started
       redis:
         condition: service_healthy
       celery:


### PR DESCRIPTION
Closes [Sentry BACKEND-4](https://highlighter.openmakersuite.net/organizations/sentry/issues/4/) and bd \`oms-8bsc5\`.

## Root cause

celery, mqtt_consumer, and celery_beat each had their own \`build: { context: ./backend, dockerfile: Dockerfile.prod }\` block in \`docker-compose.prod.yml\`. Compose treated those as independent images, so \`docker compose build --no-cache backend\` (what deploy.sh runs) only rebuilt the backend service — the workers kept running whatever image they'd been built with on first \`compose up\`.

That's how BACKEND-4 happened: a new celery task landed in \`backend/forgekey/tasks.py\`, deploy.sh ran \`--no-cache backend\`, but celery_beat (newer image) scheduled the task and celery (older image) hit \`KeyError: 'forgekey.tasks.mark_stale_devices_offline'\` in its task registry. The worker's runtime tag said CPython 3.11.15 vs the backend's 3.14.5 — multiple Python-version deploys behind.

## Fix

Make backend the canonical builder (\`image: oms-backend:local\`) and have celery / mqtt_consumer / celery_beat reuse the same image via \`image: oms-backend:local\` with no \`build:\` block of their own.

- Compose runs the build exactly once when bringing the stack up.
- \`docker compose build --no-cache backend\` now rebuilds the image every worker container also uses.
- \`docker compose up -d\` picks up the new image for all four services.
- \`deploy.sh\` is unchanged — its existing \`--no-cache backend\` line is exactly what we want.
- \`flower\` is left alone (uses \`Dockerfile\` dev, not \`Dockerfile.prod\`).

\`depends_on: backend\` added to the three worker services so Compose creates the backend image before they try to start with it.

## Test plan

- [x] \`docker compose -f docker-compose.prod.yml config\` validates clean.
- [ ] CI green.
- [ ] After deploy: \`docker compose exec celery python -c "import sys; print(sys.version)"\` matches backend's Python version.
- [ ] BACKEND-4 stops recurring; new tasks added to backend/forgekey/tasks.py reach the worker registry on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)