### PR TITLE
chore(observability): bump Sentry tracesSampleRate 0.1 → 0.5 on backend + frontend

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -625,7 +625,11 @@ SENTRY_ENVIRONMENT = config(
     "SENTRY_ENVIRONMENT", default="production" if not DEBUG else "development"
 )
 SENTRY_RELEASE = config("GIT_HASH", default="") or None
-SENTRY_TRACES_SAMPLE_RATE = config("SENTRY_TRACES_SAMPLE_RATE", default=0.1, cast=float)
+# 0.5 = 50% of requests / tasks emit a full transaction. Makerspace
+# traffic is well under any rate that'd strain Sentry storage at this
+# sample, and the higher rate gives uid0 real coverage for finding
+# slow views + N+1 queries. Override via env if storage pressure climbs.
+SENTRY_TRACES_SAMPLE_RATE = config("SENTRY_TRACES_SAMPLE_RATE", default=0.5, cast=float)
 SENTRY_PROFILES_SAMPLE_RATE = config("SENTRY_PROFILES_SAMPLE_RATE", default=0.0, cast=float)
 
 if SENTRY_DSN:

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -33,7 +33,11 @@ if (sentryDsn) {
         blockAllMedia: false,
       }),
     ],
-    tracesSampleRate: 0.1,
+    // 0.5 = 50% of page navigations and SPA route changes emit a full
+    // transaction. At this org's traffic that's well within self-hosted
+    // Sentry's headroom and gives uid0 real coverage of slow renders +
+    // axios call timing instead of a 10% sample.
+    tracesSampleRate: 0.5,
     // Replay every session and every error. Storage cost on a self-hosted
     // Sentry is tractable at this org's traffic; revisit if SeaweedFS fills up.
     replaysSessionSampleRate: 1.0,


### PR DESCRIPTION
0.1 was the conservative pick at rollout (PR #575 / #577). Real traffic shows it's leaving most of the slow views / N+1s / slow axios calls invisible. 0.5 gives uid0 real coverage without stressing self-hosted Sentry storage at this org's request volume.

Backend stays env-driven via \`SENTRY_TRACES_SAMPLE_RATE\` so dialing back to 0.1 is a one-line \`.env\` edit if SeaweedFS pressure climbs. Frontend stays hardcoded for now (no VITE_ override yet — happy to add if needed).

## Side note for the follow-up

Verified \`ourlogs-enabled\` + \`ourlogs-ingestion\` are TRUE for the \`sentry\` org on highlighter.openmakersuite.net (Sentry self-hosted 26.5.0). So the Logs beta is reachable; the next PR can opt the backend + frontend SDKs into \`_experiments={enable_logs: true}\` and start shipping structured log entries alongside the perf traces.

## Test plan

- [ ] CI green.
- [ ] After deploy: Sentry "Performance" tab shows ~5x more transactions per unit time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)