### PR TITLE
feat(observability): Sentry Logs beta + User Feedback widget + backend release tagging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,7 +105,7 @@ repos:
     hooks:
       - id: npm-test
         name: npm test
-        entry: bash -c 'cd frontend && npm test -- --coverage --ci --watchAll=false'
+        entry: bash -c 'cd frontend && npm run test:ci:coverage'
         language: system
         files: ^frontend/src/.*\.(ts|tsx|js|jsx)$
         pass_filenames: false

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -2,6 +2,7 @@
 Django settings for makerspace inventory management system.
 """
 
+import logging
 import sys
 from datetime import timedelta
 from pathlib import Path
@@ -618,8 +619,9 @@ READYZ_REQUIRED_CHECKS = config(
 # - DjangoIntegration: captures unhandled view exceptions, 5xx, slow ORM.
 # - CeleryIntegration: captures task failures + propagates trace IDs across
 #   the Redis broker so a request → task chain shows up as one transaction.
-# - LoggingIntegration(event_level=ERROR): forwards logger.error / logger.exception
-#   calls as Sentry events. INFO/WARNING become breadcrumbs.
+# - LoggingIntegration: ERROR → Sentry events (alertable). INFO+ → Sentry
+#   Logs (searchable, no alerting) once enable_logs is on, so debug-shaped
+#   signal lands in the Logs UI without paging anyone.
 SENTRY_DSN = config("SENTRY_DSN", default="")
 SENTRY_ENVIRONMENT = config(
     "SENTRY_ENVIRONMENT", default="production" if not DEBUG else "development"
@@ -640,10 +642,14 @@ if SENTRY_DSN:
         integrations=[
             DjangoIntegration(transaction_style="url"),
             CeleryIntegration(monitor_beat_tasks=True),
-            LoggingIntegration(event_level="ERROR"),
+            LoggingIntegration(
+                event_level=logging.ERROR,
+                sentry_logs_level=logging.INFO,
+            ),
         ],
         traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
         profiles_sample_rate=SENTRY_PROFILES_SAMPLE_RATE,
+        enable_logs=True,
         # Don't ship request bodies / user PII by default; the redactor in
         # config.observability_redaction handles fine-grained scrubbing for
         # our own log/audit surfaces.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -117,6 +117,12 @@ services:
       - .env
     environment:
       - DEBUG=0
+      # GIT_HASH propagates into Sentry's `release` field so events from
+      # Python (backend, celery, mqtt_consumer, celery_beat) get attributed
+      # to the same release tag the frontend bundle was built with — that's
+      # what powers per-release Session Health, regression detection, and
+      # the "first seen in release X" issue grouping.
+      - GIT_HASH=${GIT_HASH:-}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-makerspace}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-makerspace_inventory}
       - REDIS_URL=redis://redis:6379/0
       - CELERY_BROKER_URL=redis://redis:6379/0
@@ -188,6 +194,12 @@ services:
       - .env
     environment:
       - DEBUG=0
+      # GIT_HASH propagates into Sentry's `release` field so events from
+      # Python (backend, celery, mqtt_consumer, celery_beat) get attributed
+      # to the same release tag the frontend bundle was built with — that's
+      # what powers per-release Session Health, regression detection, and
+      # the "first seen in release X" issue grouping.
+      - GIT_HASH=${GIT_HASH:-}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-makerspace}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-makerspace_inventory}
       - REDIS_URL=redis://redis:6379/0
       - CELERY_BROKER_URL=redis://redis:6379/0
@@ -230,6 +242,12 @@ services:
       - .env
     environment:
       - DEBUG=0
+      # GIT_HASH propagates into Sentry's `release` field so events from
+      # Python (backend, celery, mqtt_consumer, celery_beat) get attributed
+      # to the same release tag the frontend bundle was built with — that's
+      # what powers per-release Session Health, regression detection, and
+      # the "first seen in release X" issue grouping.
+      - GIT_HASH=${GIT_HASH:-}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-makerspace}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-makerspace_inventory}
       - REDIS_URL=redis://redis:6379/0
       - CELERY_BROKER_URL=redis://redis:6379/0
@@ -278,6 +296,12 @@ services:
       - .env
     environment:
       - DEBUG=0
+      # GIT_HASH propagates into Sentry's `release` field so events from
+      # Python (backend, celery, mqtt_consumer, celery_beat) get attributed
+      # to the same release tag the frontend bundle was built with — that's
+      # what powers per-release Session Health, regression detection, and
+      # the "first seen in release X" issue grouping.
+      - GIT_HASH=${GIT_HASH:-}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-makerspace}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-makerspace_inventory}
       - REDIS_URL=redis://redis:6379/0
       - CELERY_BROKER_URL=redis://redis:6379/0

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -32,6 +32,23 @@ if (sentryDsn) {
         maskAllText: false,
         blockAllMedia: false,
       }),
+      // Floating "Report a Bug" widget. When a member files a report, the
+      // SDK auto-links the active Session Replay so uid0 can watch what the
+      // member did right before clicking. autoInject:true renders the
+      // default trigger button bottom-right; per-page customization can use
+      // Sentry.getFeedback()?.attachTo(el) later.
+      Sentry.feedbackIntegration({
+        autoInject: true,
+        showBranding: false,
+        colorScheme: 'system',
+        enableScreenshot: true,
+        triggerLabel: 'Report a Bug',
+        formTitle: 'Report a Bug',
+        submitButtonLabel: 'Send Report',
+        messagePlaceholder:
+          "What happened? Steps to reproduce help — uid0 will see your screen recording from the last minute.",
+        successMessageText: 'Thanks — your report and session replay are on their way to uid0.',
+      }),
     ],
     // 0.5 = 50% of page navigations and SPA route changes emit a full
     // transaction. At this org's traffic that's well within self-hosted
@@ -42,6 +59,11 @@ if (sentryDsn) {
     // Sentry is tractable at this org's traffic; revisit if SeaweedFS fills up.
     replaysSessionSampleRate: 1.0,
     replaysOnErrorSampleRate: 1.0,
+    // Opt into the Logs beta — Sentry.logger.{info,warn,error}(...) ships
+    // structured log entries (searchable, no alerting) alongside events.
+    // Self-hosted instance has ourlogs-enabled, ourlogs-ingestion, and
+    // ourlogs-stats turned on for the `sentry` org.
+    enableLogs: true,
     // Don't ship full request bodies; explicit logger.error / captureException
     // calls in app code carry the curated context.
     sendDefaultPii: false,


### PR DESCRIPTION
## Summary

Opts both Sentry SDKs into the **Logs beta**, wires the **User Feedback widget** on the frontend (auto-attached to Session Replay), and closes the **backend release-tagging gap** so Session Health works on the `backend` project too.

### Backend (`backend/config/settings.py`)
- `enable_logs=True` on `sentry_sdk.init`.
- `LoggingIntegration(event_level=ERROR, sentry_logs_level=INFO)` — ERROR+ remain alertable Sentry **events**; INFO+ ship as Sentry **Logs** (searchable, no alerting).

### Frontend (`frontend/src/index.tsx`)
- `enableLogs: true` — top-level option in @sentry/react v10. `Sentry.logger.{info,warn,error}` now ships logs.
- `Sentry.feedbackIntegration({...})` — floating "Report a Bug" button bottom-right. With `replayIntegration` already in the integration list, each submitted report **auto-links to its session replay** so uid0 can watch what the member did right before clicking. OMS-flavored copy; `showBranding: false`.

### Backend release tagging (`docker-compose.prod.yml`)
- `GIT_HASH=${GIT_HASH:-}` added to **backend / celery / mqtt_consumer / celery_beat** service environment blocks. Frontend already had `VITE_GIT_HASH` as a build arg. Backend was sending events with `release=None` because the env var wasn't piped through compose, so **Session Health on the `backend` Sentry project was empty**. Now both projects tag against the same `${GIT_HASH}` `deploy.sh` exports.

### Pre-commit (`.pre-commit-config.yaml`)
- Fixed the `npm-test` hook entry — was using CRA flags (`--ci --watchAll=false`) that vitest doesn't accept. Switched to `npm run test:ci:coverage`. Latent bug since the CRA→Vite migration in #565/#566.

## Why this matters

- **Logs** unlocks searchable per-request log lines without burning event quota or generating alert noise. `logger.info("device %s issued grant", device.id)` is now visible in the Logs UI.
- **User Feedback + Replay** turns "the app broke" tickets into watchable reproductions — the member clicks Report, the replay of the last ~60s ships with it.
- **Release health** lets uid0 see crash-free session rate per deploy and catch regressions tied to a specific release. Was working frontend-only.

## Verification

- ✅ Backend `settings.py` imports cleanly under Django 6.0.5 + sentry-sdk 2.60.0.
- ✅ Frontend typecheck: no new errors in `index.tsx`. Pre-existing zod-v4 + Asset-type errors on `main` unaffected by this PR.
- ✅ `docker compose config` resolves `GIT_HASH` correctly in all four backend services + frontend build.
- ✅ Verified self-hosted Sentry has `ourlogs-enabled`, `ourlogs-ingestion`, `ourlogs-stats` features on `sentry` org (queried via API).
- ✅ Confirmed PR #585's release `9a5d424…` is already registered in Sentry with both projects attached, so the post-rotation CI release tagging works.

## Test plan

- [ ] After merge + deploy, hit highlighter.openmakersuite.net → Logs → backend project; confirm INFO log lines from a sample request show up.
- [ ] Confirm Sentry.logger.info called from any React component lands in frontend Logs.
- [ ] Open OMS in browser → click the floating "Report a Bug" button bottom-right → file a test report → confirm replay attached in Sentry UI.
- [ ] Check `https://highlighter.openmakersuite.net/organizations/sentry/releases/` 24h after deploy; both `frontend` and `backend` should show non-zero session counts on the new release.

## Follow-ups (not in this PR)

- Celery Beat cron monitors + `@sentry_sdk.crons.monitor` decorators on the four high-value scheduled tasks — tracking in task #26.
- The pre-existing typecheck failures (zod v4 + Asset type drift) need their own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)