### PR TITLE
feat(observability): explicit Sentry Cron monitors on all 5 Celery beat tasks

### DIFF
--- a/backend/analytics/tasks.py
+++ b/backend/analytics/tasks.py
@@ -14,6 +14,7 @@ from decimal import Decimal, InvalidOperation
 from email.mime.image import MIMEImage
 from typing import Iterable
 
+import sentry_sdk
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
@@ -221,6 +222,20 @@ def send_monthly_pulse(
 
 
 @shared_task(bind=True, ignore_result=True, name="analytics.send_monthly_pulse_email")
+@sentry_sdk.crons.monitor(
+    monitor_slug="analytics-monthly-pulse-email",
+    monitor_config={
+        # Fires at 09:00 America/Chicago on the 1st of each month. Failure
+        # threshold is 1 — board + staff expect this every month, so a
+        # missed run should page immediately.
+        "schedule": {"type": "crontab", "value": "0 9 1 * *"},
+        "timezone": "America/Chicago",
+        "checkin_margin": 60,
+        "max_runtime": 10,
+        "failure_issue_threshold": 1,
+        "recovery_threshold": 1,
+    },
+)
 def send_monthly_pulse_email(self):
     """Celery entry-point fired by Beat at 09:00 on the 1st of each month."""
     try:

--- a/backend/analytics/tasks.py
+++ b/backend/analytics/tasks.py
@@ -14,11 +14,11 @@ from decimal import Decimal, InvalidOperation
 from email.mime.image import MIMEImage
 from typing import Iterable
 
-import sentry_sdk
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 
+import sentry_sdk
 from celery import shared_task
 
 from .services.aggregation import category_spend, top_users, value_summary, wo_volume

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -639,7 +639,24 @@ if SENTRY_DSN:
         release=SENTRY_RELEASE,
         integrations=[
             DjangoIntegration(transaction_style="url"),
-            CeleryIntegration(monitor_beat_tasks=True),
+            CeleryIntegration(
+                # Auto-create Sentry Cron monitors for every periodic task
+                # that fires through Celery beat — anything in
+                # CELERY_BEAT_SCHEDULE gets a check-in for free.
+                monitor_beat_tasks=True,
+                # Tasks listed below have explicit @sentry_sdk.crons.monitor
+                # decorators with tuned margins / max_runtime /
+                # failure_issue_threshold. Excluding them here prevents a
+                # second auto-monitor with default config from cluttering
+                # the Crons UI.
+                exclude_beat_tasks=[
+                    "send-quarterly-donor-updates",
+                    "flag-expiring-vendor-compliance",
+                    "forgekey-mark-stale-devices-offline",
+                    "forgekey-prune-device-photos",
+                    "analytics-send-monthly-pulse",
+                ],
+            ),
             LoggingIntegration(event_level="ERROR"),
         ],
         traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,

--- a/backend/donations/tasks.py
+++ b/backend/donations/tasks.py
@@ -6,6 +6,7 @@ Handles quarterly email updates to donors.
 
 import logging
 
+import sentry_sdk
 from celery import shared_task
 
 from donations.models import Donation
@@ -15,6 +16,20 @@ logger = logging.getLogger(__name__)
 
 
 @shared_task
+@sentry_sdk.crons.monitor(
+    monitor_slug="donations-quarterly-donor-updates",
+    monitor_config={
+        # Beat schedule is 90 days (see CELERY_BEAT_SCHEDULE). One missed run
+        # is a real outage — donors expect quarterly statements — so failure
+        # threshold is 1 (alert on the first miss).
+        "schedule": {"type": "interval", "value": 90, "unit": "day"},
+        "timezone": "America/Chicago",
+        "checkin_margin": 60,
+        "max_runtime": 15,
+        "failure_issue_threshold": 1,
+        "recovery_threshold": 1,
+    },
+)
 def send_quarterly_donor_updates():
     """
     Send quarterly update emails to all donors who have received tax receipts.

--- a/backend/forgekey/tasks.py
+++ b/backend/forgekey/tasks.py
@@ -9,11 +9,11 @@ from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 from typing import Any, Dict, Optional
 
-import sentry_sdk
 from django.conf import settings
 from django.utils import timezone
 
 import paho.mqtt.client as mqtt
+import sentry_sdk
 from celery import shared_task
 
 from .models import ESP32Device, ESP32DevicePhoto, OccupancyEvent, PowerMeterReading

--- a/backend/forgekey/tasks.py
+++ b/backend/forgekey/tasks.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 from typing import Any, Dict, Optional
 
+import sentry_sdk
 from django.conf import settings
 from django.utils import timezone
 
@@ -632,6 +633,19 @@ def trigger_ota(
 
 
 @shared_task
+@sentry_sdk.crons.monitor(
+    monitor_slug="forgekey-prune-device-photos",
+    monitor_config={
+        # Daily ESP32DevicePhoto retention sweep. Two misses before alerting —
+        # photos accumulate slowly enough that a single missed day is fine.
+        "schedule": {"type": "interval", "value": 1, "unit": "day"},
+        "timezone": "America/Chicago",
+        "checkin_margin": 60,
+        "max_runtime": 10,
+        "failure_issue_threshold": 2,
+        "recovery_threshold": 1,
+    },
+)
 def prune_device_photos(retention_days: int = 30) -> Dict[str, Any]:
     """
     Delete ESP32DevicePhoto rows older than ``retention_days`` (default 30).
@@ -653,6 +667,21 @@ def prune_device_photos(retention_days: int = 30) -> Dict[str, Any]:
 
 
 @shared_task
+@sentry_sdk.crons.monitor(
+    monitor_slug="forgekey-mark-stale-devices-offline",
+    monitor_config={
+        # Every-30-min sweep that flips ESP32Device.is_online to False once
+        # last_seen exceeds threshold_hours. Three misses (90 min dark)
+        # before alerting — short enough to catch a wedged scheduler, long
+        # enough not to page on a single redis-broker hiccup.
+        "schedule": {"type": "interval", "value": 30, "unit": "minute"},
+        "timezone": "America/Chicago",
+        "checkin_margin": 5,
+        "max_runtime": 2,
+        "failure_issue_threshold": 3,
+        "recovery_threshold": 1,
+    },
+)
 def mark_stale_devices_offline(threshold_hours: int = 5) -> Dict[str, Any]:
     """Flip ``ESP32Device.is_online`` to False for devices whose ``last_seen``
     is older than ``threshold_hours`` (default 5).

--- a/backend/vendors/tasks.py
+++ b/backend/vendors/tasks.py
@@ -4,13 +4,13 @@ import logging
 from datetime import timedelta
 from typing import Dict, List
 
-import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core.mail import EmailMessage
 from django.db.models import Q
 from django.utils import timezone
 
+import sentry_sdk
 from celery import shared_task
 
 from .models import Vendor

--- a/backend/vendors/tasks.py
+++ b/backend/vendors/tasks.py
@@ -4,6 +4,7 @@ import logging
 from datetime import timedelta
 from typing import Dict, List
 
+import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core.mail import EmailMessage
@@ -82,6 +83,20 @@ def _format_digest(buckets: Dict[str, List[Vendor]]) -> str:
 
 
 @shared_task(name="vendors.flag_expiring_compliance")
+@sentry_sdk.crons.monitor(
+    monitor_slug="vendors-flag-expiring-compliance",
+    monitor_config={
+        # Daily TDLR / COI expiry digest to Logistics. Two consecutive misses
+        # before alerting — a single missed day rarely matters, but two
+        # days dark and we risk an expired-cert vendor slipping through.
+        "schedule": {"type": "interval", "value": 1, "unit": "day"},
+        "timezone": "America/Chicago",
+        "checkin_margin": 30,
+        "max_runtime": 5,
+        "failure_issue_threshold": 2,
+        "recovery_threshold": 1,
+    },
+)
 def flag_expiring_compliance() -> Dict[str, int]:
     """Email Logistics a digest of vendors with expiring/expired TDLR or COI.
 


### PR DESCRIPTION
## Summary

Adds `@sentry_sdk.crons.monitor` decorators with task-tuned `monitor_config` to every entry in `CELERY_BEAT_SCHEDULE`, so missed runs page in Sentry Crons instead of failing silently. `CeleryIntegration(monitor_beat_tasks=True)` continues to auto-cover any future beat task added without an explicit decorator.

## Per-task config

| Slug | Schedule | Margin | Max runtime | Fail threshold | Why |
|------|----------|--------|-------------|----------------|-----|
| `donations-quarterly-donor-updates` | 90-day interval | 60min | 15min | **1** | Quarterly donor statements — one miss is a real outage |
| `vendors-flag-expiring-compliance` | 1-day interval | 30min | 5min | 2 | Daily TDLR/COI digest; two dark days risks an expired vendor slipping through |
| `forgekey-mark-stale-devices-offline` | 30-min interval | 5min | 2min | 3 | ~90 min dark before alerting — catches a wedged scheduler without paging on a redis hiccup |
| `forgekey-prune-device-photos` | 1-day interval | 60min | 10min | 2 | Retention sweep; photos accumulate slowly so one missed day is fine |
| `analytics-monthly-pulse-email` | crontab `0 9 1 * *` America/Chicago | 60min | 10min | **1** | Board/staff expect it monthly — alert immediately on miss |

## Implementation notes

- Decorator order matters: `@shared_task` outermost (celery wraps the monitor wrapper, which wraps the function body), so check-ins fire whether the task is invoked via beat or ad-hoc.
- `CeleryIntegration` now passes `exclude_beat_tasks=[<5 schedule names>]` so we don't end up with **two** monitors per task (one auto-created from beat, one explicit) cluttering the Crons UI. Any beat task added without an explicit decorator still gets auto-monitored — opt-in tightening, not removal.

## Verification

- ✅ Each decorated module imports cleanly under Django 6.0.5 + sentry-sdk 2.60.0 (decorator + `@shared_task` stacking order works).
- ✅ 164 existing tests across `donations/`, `vendors/`, `analytics/`, `forgekey/` task suites pass unchanged.
- ✅ pre-commit (black, isort, ruff, bandit, django-upgrade) clean on all five touched files.

## Test plan

- [ ] After merge + deploy, the 30-min `forgekey-mark-stale-devices-offline` task is the fastest verification — within ~35 min, `https://highlighter.openmakersuite.net/organizations/sentry/crons/` should show the 5 monitors registered with status `ok`.
- [ ] Confirm no duplicate `celery-beat-*` monitors appear alongside the explicit slugs.
- [ ] Manually trigger one (`./manage.py shell` → `from forgekey.tasks import prune_device_photos; prune_device_photos.delay()`) to verify ad-hoc invocations also check in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)