### PR TITLE
feat(inventory): curated /inventory landing — needs-attention rail + category groups

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,6 +51,7 @@ import ThermostatFormPage from './pages/ThermostatFormPage';
 import InventoryItemDetailPage from './pages/InventoryItemDetailPage';
 import InventoryItemFormPage from './pages/InventoryItemFormPage';
 import InventoryListPage from './pages/InventoryListPage';
+import InventoryOverviewPage from './pages/InventoryOverviewPage';
 import InventoryReportPage from './pages/InventoryReportPage';
 import InventoryReconciliationPage from './pages/InventoryReconciliationPage';
 import LocationDetailPage from './pages/LocationDetailPage';
@@ -192,7 +193,7 @@ function AppContent() {
           <Route path="/tv-logistics" element={<Navigate to="/facilities/logistics" replace />} />
 
           {/* Inventory Workspace */}
-          <Route path="/inventory" element={<WorkspaceLayout><HomePage /></WorkspaceLayout>} />
+          <Route path="/inventory" element={<WorkspaceLayout><InventoryOverviewPage /></WorkspaceLayout>} />
           <Route path="/dashboard" element={<WorkspaceLayout><DashboardPage /></WorkspaceLayout>} />
           <Route path="/inventory/items" element={<WorkspaceLayout><InventoryListPage /></WorkspaceLayout>} />
           <Route path="/inventory/items/new" element={<WorkspaceLayout><InventoryItemFormPage /></WorkspaceLayout>} />

--- a/frontend/src/pages/InventoryOverviewPage.tsx
+++ b/frontend/src/pages/InventoryOverviewPage.tsx
@@ -1,0 +1,260 @@
+/**
+ * Inventory Overview (`/inventory`).
+ *
+ * Curated landing for the inventory workspace: every item grouped by
+ * category, with a "Needs attention" rail at the top pinning anything
+ * flagged `needs_reorder` or already in a reorder pipeline. Replaces
+ * the temporary `<HomePage />` placeholder that the landing-surface
+ * migration (PR #60) left at this route.
+ *
+ * For the flat searchable / sortable / bulk-action table, see
+ * `<InventoryListPage />` at `/inventory/items` — this overview links
+ * out to that page via the hero "Browse all items" action.
+ */
+import {
+  Anchor,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Center,
+  Group,
+  Loader,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
+import { IconAlertTriangle, IconBoxSeam, IconPlus } from '@tabler/icons-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import WorkspacePage from '../components/landing/WorkspacePage';
+import { inventoryAPI } from '../services/api';
+import { Category, InventoryItem } from '../types';
+import { showError } from '../utils/dialogs';
+
+const UNCATEGORIZED = 'Uncategorized';
+
+type CategoryGroup = {
+  name: string;
+  items: InventoryItem[];
+};
+
+function flagged(item: InventoryItem): boolean {
+  return Boolean(item.needs_reorder) || Boolean(item.has_pending_reorder);
+}
+
+function statusBadge(item: InventoryItem) {
+  if (item.has_pending_reorder) {
+    return (
+      <Badge color="blue" variant="light">
+        Reorder pending
+      </Badge>
+    );
+  }
+  if (item.needs_reorder) {
+    return (
+      <Badge color="orange" variant="light">
+        Low stock
+      </Badge>
+    );
+  }
+  return null;
+}
+
+const ItemCard: React.FC<{ item: InventoryItem; onClick: () => void }> = ({ item, onClick }) => (
+  <Card
+    withBorder
+    padding="sm"
+    radius="md"
+    style={{ cursor: 'pointer' }}
+    onClick={onClick}
+    data-testid={`inventory-overview-item-${item.id}`}
+  >
+    <Stack gap={4}>
+      <Group justify="space-between" wrap="nowrap">
+        <Text fw={600} lineClamp={1}>
+          {item.name}
+        </Text>
+        {statusBadge(item)}
+      </Group>
+      <Text size="xs" c="dimmed" lineClamp={1}>
+        {item.sku || 'no SKU'} · {item.category_name || UNCATEGORIZED}
+      </Text>
+      <Text size="sm">
+        Stock: <b>{item.current_stock}</b>
+        {item.minimum_stock > 0 && (
+          <Text component="span" c="dimmed" size="sm">
+            {' '}
+            / min {item.minimum_stock}
+          </Text>
+        )}
+      </Text>
+    </Stack>
+  </Card>
+);
+
+const InventoryOverviewPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [items, setItems] = useState<InventoryItem[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        setLoading(true);
+        const [itemsRes, categoriesRes] = await Promise.all([
+          inventoryAPI.listItems(),
+          inventoryAPI.listCategories(),
+        ]);
+        if (cancelled) return;
+        const itemList = itemsRes.data?.results ?? [];
+        setItems(itemList.filter((i) => i.is_active !== false));
+        setCategories(categoriesRes.data?.results ?? []);
+      } catch (err) {
+        if (!cancelled) {
+          showError(
+            'The inventory overview failed to load. Try refreshing in a moment.',
+            'Could not load inventory',
+          );
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const flaggedItems = useMemo(
+    () =>
+      items
+        .filter(flagged)
+        .sort((a, b) => {
+          // pending reorders first (in flight, watch them), then low-stock by deficit
+          const aPending = a.has_pending_reorder ? 1 : 0;
+          const bPending = b.has_pending_reorder ? 1 : 0;
+          if (aPending !== bPending) return bPending - aPending;
+          const aDeficit = (a.minimum_stock || 0) - a.current_stock;
+          const bDeficit = (b.minimum_stock || 0) - b.current_stock;
+          return bDeficit - aDeficit;
+        }),
+    [items],
+  );
+
+  const categoryGroups = useMemo<CategoryGroup[]>(() => {
+    const byName = new Map<string, InventoryItem[]>();
+    for (const cat of categories) {
+      byName.set(cat.name, []);
+    }
+    for (const item of items) {
+      const name = item.category_name || UNCATEGORIZED;
+      if (!byName.has(name)) byName.set(name, []);
+      byName.get(name)!.push(item);
+    }
+    return Array.from(byName.entries())
+      .filter(([, list]) => list.length > 0)
+      .map(([name, list]) => ({
+        name,
+        items: list.slice().sort((a, b) => a.name.localeCompare(b.name)),
+      }))
+      .sort((a, b) => {
+        // Uncategorized last; everything else alphabetical.
+        if (a.name === UNCATEGORIZED) return 1;
+        if (b.name === UNCATEGORIZED) return -1;
+        return a.name.localeCompare(b.name);
+      });
+  }, [items, categories]);
+
+  const goItem = (id: string) => navigate(`/inventory/items/${id}`);
+
+  return (
+    <WorkspacePage
+      testId="inventory-overview-page"
+      hero={{
+        eyebrow: 'Inventory',
+        title: 'Overview',
+        description:
+          'Every item, grouped by category. Items needing attention surface at the top.',
+        action: (
+          <Group gap="sm">
+            <Button
+              variant="default"
+              leftSection={<IconBoxSeam size={16} />}
+              onClick={() => navigate('/inventory/items')}
+            >
+              Browse all items
+            </Button>
+            <Button
+              leftSection={<IconPlus size={16} />}
+              onClick={() => navigate('/inventory/items/new')}
+            >
+              Add new item
+            </Button>
+          </Group>
+        ),
+      }}
+    >
+      {loading ? (
+        <Center mih={240}>
+          <Loader />
+        </Center>
+      ) : items.length === 0 ? (
+        <Center mih={240}>
+          <Stack align="center" gap="xs">
+            <Text c="dimmed">No inventory items yet.</Text>
+            <Anchor onClick={() => navigate('/inventory/items/new')} component="button">
+              Add the first one
+            </Anchor>
+          </Stack>
+        </Center>
+      ) : (
+        <Stack gap="xl">
+          {flaggedItems.length > 0 && (
+            <Box data-testid="inventory-overview-needs-attention">
+              <Group gap="xs" mb="sm">
+                <IconAlertTriangle size={20} color="var(--mantine-color-orange-6)" />
+                <Title order={3}>Needs attention</Title>
+                <Badge color="orange" variant="filled" radius="sm">
+                  {flaggedItems.length}
+                </Badge>
+              </Group>
+              <Text c="dimmed" size="sm" mb="sm">
+                Items at or below their minimum, or with a reorder already
+                in flight.
+              </Text>
+              <SimpleGrid cols={{ base: 1, sm: 2, md: 3, lg: 4 }} spacing="sm">
+                {flaggedItems.map((item) => (
+                  <ItemCard key={item.id} item={item} onClick={() => goItem(item.id)} />
+                ))}
+              </SimpleGrid>
+            </Box>
+          )}
+
+          {categoryGroups.map((group) => (
+            <Box key={group.name} data-testid={`inventory-overview-category-${group.name}`}>
+              <Group gap="xs" mb="sm">
+                <Title order={3}>{group.name}</Title>
+                <Badge variant="light" radius="sm">
+                  {group.items.length}
+                </Badge>
+              </Group>
+              <SimpleGrid cols={{ base: 1, sm: 2, md: 3, lg: 4 }} spacing="sm">
+                {group.items.map((item) => (
+                  <ItemCard key={item.id} item={item} onClick={() => goItem(item.id)} />
+                ))}
+              </SimpleGrid>
+            </Box>
+          ))}
+        </Stack>
+      )}
+    </WorkspacePage>
+  );
+};
+
+export default InventoryOverviewPage;


### PR DESCRIPTION
## Problem

`/inventory` was rendering `<HomePage />` — the same component as `/` — because the landing-surface migration (PR #60, [[project_oms_landing_migration]]) wired it as a temporary placeholder and the real swap never happened. Visiting `/inventory` dropped you back at the homepage instead of, you know, your inventory.

The flat searchable table at `/inventory/items` (`<InventoryListPage>`) is great for power-user filtering but doesn't surface what needs attention or organize the catalog by category.

## Fix

New `<InventoryOverviewPage>` at `/inventory`:

- **"Needs attention" rail** at the top: every item where `needs_reorder` OR `has_pending_reorder` is true, ordered with pending reorders first, then by stock deficit. Orange "Low stock" or blue "Reorder pending" badges.
- **Category sections** below: alphabetical by category name, Uncategorized last. Each item card shows name, SKU, category, stock vs minimum.
- **Hero actions**: "Browse all items" → `/inventory/items` (the existing flat table), "Add new item" → `/inventory/items/new`.
- Click any item card → `<InventoryItemDetailPage>`.
- Loader while fetching; "No inventory items yet" empty state with a deep link to the add form; red toast on fetch failure.

## Implementation

- Pure presentation layer. No backend changes; reuses `inventoryAPI.listItems()` and `inventoryAPI.listCategories()` which already return `needs_reorder`, `has_pending_reorder`, and `category_name` on every item.
- Uses the canonical `<WorkspacePage>` shell so it stays visually continuous with every other workspace landing.
- One-line route swap in `App.tsx`: `<HomePage />` → `<InventoryOverviewPage />`.

## Verification

- ✅ `npm run typecheck`: no new errors in the touched files (pre-existing 50 errors on `main` from zod v4 / Asset-type drift, unrelated and tracked separately).
- ✅ `npm run build` (vite): builds clean in 2.88s; PWA precache regenerates.
- ✅ Pre-commit (whitespace, json/yaml checks) green on both files.

## Test plan

- [ ] After deploy, visit `/inventory` and confirm the new overview renders instead of the homepage.
- [ ] Confirm flagged items (anything with `needs_reorder=true` from `/inventory/items?low_stock=true`) appear in the top rail.
- [ ] Click an item card → lands on its detail page.
- [ ] Confirm "Browse all items" hero button reaches `/inventory/items`.
- [ ] Empty-database state: stand up a fresh dev DB, hit `/inventory`, confirm "No inventory items yet" with a working "Add the first one" link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)