### PR TITLE
feat(deploy): finalize Sentry release at end of deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -223,6 +223,34 @@ else
     echo "❌ Django static files NOT found!"
 fi
 
+# Finalize the Sentry release. The CI release-tagging step in
+# .github/workflows/ci.yml already creates `${GIT_HASH}` against the
+# backend + frontend projects on push to main, but the release stays in
+# the `created` state until something marks it deployed. Calling
+# `sentry-cli releases finalize` here flips it to `released` once the
+# stack is actually serving traffic, so the Sentry UI shows accurate
+# crash-free-by-release windows and the deploy timestamp lines up with
+# the rolling event stream.
+#
+# Soft-fails: never block a deploy on Sentry's REST API being reachable.
+# Requires SENTRY_AUTH_TOKEN (from .env) and the npx-shipped sentry-cli;
+# if either is missing, we skip with a hint rather than abort.
+if [ -n "${SENTRY_AUTH_TOKEN:-}" ] && [ -n "${GIT_HASH:-}" ] && [ "${GIT_HASH}" != "dev" ]; then
+    echo "📡 Finalizing Sentry release ${GIT_HASH}..."
+    if command -v npx >/dev/null 2>&1; then
+        SENTRY_URL="${SENTRY_URL:-https://highlighter.openmakersuite.net}" \
+        SENTRY_ORG="${SENTRY_ORG:-sentry}" \
+        SENTRY_AUTH_TOKEN="${SENTRY_AUTH_TOKEN}" \
+            npx --yes @sentry/cli@2.39.1 releases finalize "${GIT_HASH}" \
+                --project backend --project frontend \
+            || echo "⚠️  Sentry release finalize failed (non-fatal) — check token / network."
+    else
+        echo "⚠️  npx not found — skipping Sentry release finalize."
+    fi
+else
+    echo "ℹ️  Skipping Sentry release finalize (SENTRY_AUTH_TOKEN unset or GIT_HASH=dev)."
+fi
+
 echo "✅ Deployment complete!"
 echo ""
 echo "📍 Your application is now running at:"


### PR DESCRIPTION
## Summary

CI already creates the Sentry release `${GIT_HASH}` against the backend + frontend projects on every push to main. That release stays in the `created` state until something marks it deployed. This commit adds the missing **finalize** step at the end of `deploy.sh` so each successful production deploy flips its release to `released`.

## Why

- Sentry's crash-free-by-release windows compute against the deploy timestamp, not the create timestamp — without `finalize`, the metric is off.
- The Sentry UI shows "Created X minutes ago / Not deployed" until finalized.
- The rolling event stream aligns release boundaries with deploys instead of with CI builds.

## Soft-fail design

The call is wrapped to **never** block a deploy on Sentry being reachable:

- skipped when `SENTRY_AUTH_TOKEN` is unset (local dev / CI smoke that runs deploy.sh without prod creds)
- skipped when `GIT_HASH=dev` (the placeholder when not in a git tree)
- non-zero exit from `sentry-cli` becomes a `⚠️` warning, not an abort

Reuses `npx --yes @sentry/cli@2.39.1` so no static binary needs to be baked into the deploy host.

## Verification

- ✅ `bash -n deploy.sh` — syntax clean.
- ✅ Manual local dry-run with `SENTRY_AUTH_TOKEN=""` confirms the skip path triggers.
- 🟡 Real finalize verification waits for the next prod deploy after this lands.

## Test plan

- [ ] After merge + first deploy, visit `highlighter.openmakersuite.net/organizations/sentry/releases/` and confirm the new release shows a `released` timestamp matching the deploy log.
- [ ] Confirm `Crash-free sessions` widget on the release page populates (a few minutes lag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)