### PR TITLE
fix(forgekey): mqtt_consumer mints server JWT to authenticate to EMQX  (BACKEND-5)

### DIFF
--- a/backend/forgekey/management/commands/mqtt_consumer.py
+++ b/backend/forgekey/management/commands/mqtt_consumer.py
@@ -38,7 +38,13 @@ import sentry_sdk
 
 from config.observability_redaction import redact
 from forgekey.models import DeviceFirmwareUpdate, ESP32Device, OccupancyEvent
-from forgekey.utils import normalize_mac_address, normalize_sensor_kind
+from forgekey.services.jwt_signing import JwtSigningError, is_jwt_signing_configured
+from forgekey.utils import (
+    SERVER_JWT_SUBJECT,
+    generate_server_jwt,
+    normalize_mac_address,
+    normalize_sensor_kind,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -561,7 +567,21 @@ class Command(BaseCommand):
             protocol=mqtt.MQTTv5,
         )
 
-        if settings.MQTT_BROKER_USERNAME:
+        # Prefer the server-JWT pattern (oms-y5p): a self-issued ES256 JWT
+        # signed with the device-JWT key. EMQX's JWT authenticator verifies
+        # it via the same JWKS endpoint at /api/forgekey/jwks/, so no
+        # separate user-management is required. Fall back to literal
+        # MQTT_BROKER_USERNAME / MQTT_BROKER_PASSWORD only when JWT signing
+        # is unconfigured — exists for dev rigs that haven't enrolled in
+        # JWT auth yet. Mirrors `forgekey.tasks.get_mqtt_client` exactly so
+        # the consumer and the publisher authenticate identically.
+        if is_jwt_signing_configured():
+            try:
+                client.username_pw_set(SERVER_JWT_SUBJECT, generate_server_jwt())
+            except JwtSigningError as exc:
+                logger.error("Failed to mint server JWT for MQTT consumer: %s", exc)
+                raise
+        elif settings.MQTT_BROKER_USERNAME:
             client.username_pw_set(
                 settings.MQTT_BROKER_USERNAME,
                 settings.MQTT_BROKER_PASSWORD,


### PR DESCRIPTION
## Symptom

Sentry **BACKEND-5** has been firing on a sustained reconnect loop — ~1 event per 35s, 1,974 since 2026-05-26T06:44Z. Live diagnosis on the production deploy host:

- EMQX container healthy, port 1883 bound.
- `mqtt_consumer` container can TCP-connect to `emqx:1883` from inside the docker network.
- Paho returns CONNACK **rc=5 "Bad user name or password"** repeatedly — paho's slow retry loop made it look like a TCP timeout in earlier triage.
- Side effect: outbound commands worked (the publisher in `forgekey.tasks.get_mqtt_client` correctly mints a server JWT), but **inbound device messages were never ingested** because the consumer that subscribes was dead. uid0 reported "can't send commands to MQTT devices" — that was the visible tip of the same root cause.

## Root cause

`mqtt_consumer.py:564` was the only MQTT client still authenticating with **literal `MQTT_BROKER_USERNAME` / `MQTT_BROKER_PASSWORD`**. Every other path in the codebase was migrated to the **server-JWT** pattern (oms-y5p) but the consumer never got the update. EMQX runs the JWT authenticator, so literal credentials are rejected.

## Fix

\`mqtt_consumer.py:handle\` now mirrors \`forgekey.tasks.get_mqtt_client:108\` exactly:

\`\`\`python
if is_jwt_signing_configured():
    try:
        client.username_pw_set(SERVER_JWT_SUBJECT, generate_server_jwt())
    except JwtSigningError as exc:
        logger.error("Failed to mint server JWT for MQTT consumer: %s", exc)
        raise
elif settings.MQTT_BROKER_USERNAME:
    client.username_pw_set(
        settings.MQTT_BROKER_USERNAME, settings.MQTT_BROKER_PASSWORD,
    )
\`\`\`

The fallback literal branch stays for dev rigs that haven't enrolled in JWT auth.

## Verification

- ✅ 30/30 tests in \`forgekey/tests/test_mqtt_consumer.py\` pass — fixture mocks \`paho.Client\` so the new branch is exercised without a real broker.
- ✅ \`black==26.5.1\` + \`isort==8.0.1\` clean (per [[feedback-oms-python-lint-version-drift]]).
- ✅ Reuses the exact same \`is_jwt_signing_configured()\` / \`generate_server_jwt()\` / \`SERVER_JWT_SUBJECT\` API that the publisher has been using successfully in prod.

## Test plan

- [ ] After merge + deploy, \`docker compose -f docker-compose.prod.yml ps mqtt_consumer\` should report **healthy**.
- [ ] \`docker compose logs --tail=20 mqtt_consumer\` should show "subscribed" lines and no "MQTT consumer connect failed" errors.
- [ ] Sentry BACKEND-5 should stop firing within minutes.
- [ ] Send a test command from a ForgeKey device detail page — confirm the device responds.
- [ ] Walk past an occupancy sensor — confirm a new \`OccupancyEvent\` row in the DB.

## Adjacent cleanup that's NOT in this PR

- \`.env\` on prod had stale \`MQTT_BROKER_USERNAME\` / \`MQTT_BROKER_PASSWORD\` lines and a stale \`MQTT_BROKER_HOST\` value that was unreachable from inside docker (corrected live in this session to \`MQTT_BROKER_HOST=emqx\`). The compose \`mqtt_consumer\` service should also pin \`MQTT_BROKER_HOST=emqx\` in its \`environment:\` block defensively, like the \`backend\` service already does — file as follow-up.
- \`forgekey.W001\` reports \`FORGEKEY_FIRMWARE_SIGNING_KEY\` is unset; OTA dispatches ship unsigned. Separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)