### PR TITLE
fix(inventory): item detail page renders even when sibling fetches fail

### DIFF
--- a/frontend/src/pages/InventoryItemDetailPage.tsx
+++ b/frontend/src/pages/InventoryItemDetailPage.tsx
@@ -47,29 +47,46 @@ const InventoryItemDetailPage: React.FC = () => {
   const loadData = async () => {
     if (!id) return;
 
-    try {
-      setLoading(true);
-      const [itemRes, usageLogsRes, reorderRes, assetsRes] = await Promise.all([
-        inventoryAPI.getItem(id),
-        inventoryAPI.getUsageLogs(id),
-        reorderAPI.listRequests({ status: undefined }),
-        assetsAPI.listAssets({ inventory_item: id }),
-      ]);
+    setLoading(true);
+    // Use allSettled so the page still renders the item when a sibling
+    // call (usage logs, reorder history, linked assets) fails. Previously
+    // any one of these rejecting would short-circuit the whole try-block
+    // and show "Item not found" even though the item exists — uid0 hit
+    // this on items with no linked-assets filter match where assetsAPI
+    // returned a 400.
+    const [itemRes, usageLogsRes, reorderRes, assetsRes] = await Promise.allSettled([
+      inventoryAPI.getItem(id),
+      inventoryAPI.getUsageLogs(id),
+      reorderAPI.listRequests({ status: undefined }),
+      assetsAPI.listAssets({ inventory_item: id }),
+    ]);
 
-      setItem(itemRes.data);
-      setUsageLogs(usageLogsRes.data.results || []);
-      
-      // Filter reorder requests for this item
-      const allRequests = reorderRes.data.results || [];
-      const itemRequests = allRequests.filter((req) => req.item === id);
-      setReorderHistory(itemRequests);
-
-      setLinkedAssets(assetsRes.data.results || []);
-    } catch (err) {
-      console.error('Error loading item details:', err);
-    } finally {
-      setLoading(false);
+    if (itemRes.status === 'fulfilled') {
+      setItem(itemRes.value.data);
+    } else {
+      console.error('Error loading item:', itemRes.reason);
     }
+
+    if (usageLogsRes.status === 'fulfilled') {
+      setUsageLogs(usageLogsRes.value.data.results || []);
+    } else {
+      console.error('Error loading usage logs:', usageLogsRes.reason);
+    }
+
+    if (reorderRes.status === 'fulfilled') {
+      const allRequests = reorderRes.value.data.results || [];
+      setReorderHistory(allRequests.filter((req) => req.item === id));
+    } else {
+      console.error('Error loading reorder requests:', reorderRes.reason);
+    }
+
+    if (assetsRes.status === 'fulfilled') {
+      setLinkedAssets(assetsRes.value.data.results || []);
+    } else {
+      console.error('Error loading linked assets:', assetsRes.reason);
+    }
+
+    setLoading(false);
   };
 
   const handleGenerateQR = async () => {


### PR DESCRIPTION
## Problem

Visiting `/inventory/items/3e158ba1-0205-4f39-ad13-aaf38ace3fa3` shows **"Item not found."** even though the item exists. Diagnosed live: `GET /api/inventory/items/3e158ba1-.../` returns 200 with the full payload. The bug is on the frontend.

## Root cause

`InventoryItemDetailPage.loadData` wraps four parallel fetches in `Promise.all`:

```ts
const [itemRes, usageLogsRes, reorderRes, assetsRes] = await Promise.all([
  inventoryAPI.getItem(id),
  inventoryAPI.getUsageLogs(id),
  reorderAPI.listRequests({ status: undefined }),
  assetsAPI.listAssets({ inventory_item: id }),
]);
```

If **any one** of those four rejects — usage logs missing for this item, reorder list permission denied, linked-assets filter not accepted — the whole `try` block short-circuits to `catch`, `setItem` never runs, and the `if (!item)` branch renders "Item not found." That's three different failure modes silently masquerading as a missing item.

## Fix

Switch to `Promise.allSettled` and handle each fetch independently. Failed siblings log to the console and leave the corresponding section empty; the item itself still renders. The "Item not found" path stays reachable but only fires when the item fetch itself fails (its real meaning).

## Verification

- ✅ `npm run typecheck` back to baseline (no new errors).
- ✅ `npm run build` clean.

## Test plan

- [ ] After merge + deploy, hit the item URL that was failing — confirm the item renders with name + description.
- [ ] Confirm the tabs (Usage Logs, Reorder History, Linked Assets) either populate or are empty without breaking the page.
- [ ] Try an actual nonexistent UUID (`/inventory/items/00000000-...`) — confirm "Item not found." still shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)