### PR TITLE
fix(frontend): pass VITE_SENTRY_DSN through to the docker build

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -347,6 +347,10 @@ services:
         - VITE_API_URL=/api
         - VITE_GIT_HASH=${GIT_HASH}
         - VITE_GITHUB_URL=${GITHUB_URL:-https://github.com/uid0/openmakersuite}
+        # Sentry DSN must reach the build step (vite inlines VITE_* at
+        # bundling). Without this `Sentry.init` silently no-ops in prod
+        # because import.meta.env.VITE_SENTRY_DSN is undefined.
+        - VITE_SENTRY_DSN=${VITE_SENTRY_DSN:-}
     logging: *default-logging
     volumes:
       - frontend_build:/app/frontend

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -15,12 +15,19 @@ COPY . .
 ARG VITE_API_URL
 ARG VITE_GIT_HASH=dev
 ARG VITE_GITHUB_URL=https://github.com/uid0/openmakersuite
+# Sentry DSN must be inlined at build time (vite handles VITE_* by
+# string-replacing import.meta.env.VITE_* at bundling). Default to
+# empty so a deploy without the env var still builds (`Sentry.init`
+# no-ops on empty DSN per index.tsx); set in .env on rigs that want
+# crash reporting + session replays.
+ARG VITE_SENTRY_DSN=
 
 # Set environment variables for build. Vite inlines VITE_* into the bundle
 # at build time — these args must reach the docker-build CI step (oms-78t).
 ENV VITE_API_URL=$VITE_API_URL
 ENV VITE_GIT_HASH=$VITE_GIT_HASH
 ENV VITE_GITHUB_URL=$VITE_GITHUB_URL
+ENV VITE_SENTRY_DSN=$VITE_SENTRY_DSN
 
 # Debug: Print the git hash being used (remove in production if desired)
 RUN echo "Building with VITE_GIT_HASH=$VITE_GIT_HASH"


### PR DESCRIPTION
## Problem

After PR #594 landed and the new CSP was deployed, Session Replays + browser errors **still didn't show up in Sentry**. Field-confirmed on the live deploy:

\`\`\`
$ grep -l highlighter /app/frontend/assets/*.js
$ # no matches
\`\`\`

The DSN never made it into the bundle. \`import.meta.env.VITE_SENTRY_DSN\` resolved to \`undefined\`, so the guard in \`frontend/src/index.tsx\`:

\`\`\`ts
const sentryDsn = import.meta.env.VITE_SENTRY_DSN;
if (sentryDsn) {
  Sentry.init({ ... });  // ← never runs in prod
}
\`\`\`

silently no-op'd. The whole Sentry frontend pipeline has been dark since deploy — replays, transactions, and browser errors were never being captured. The Python SDK on the backend made it look like Sentry was working because server-side events were arriving.

## Root cause

Vite inlines \`VITE_*\` env vars into the bundle at build time (string-replaces \`import.meta.env.VITE_*\`). Three things must line up:

1. The value present in \`.env\` at deploy time ✅ (uid0 set it)
2. The Dockerfile declaring \`ARG VITE_SENTRY_DSN\` + \`ENV VITE_SENTRY_DSN=\$VITE_SENTRY_DSN\` so \`npm run build\` sees it
3. docker-compose passing it through \`frontend.build.args\`

Steps 2 and 3 were never done — only \`VITE_API_URL\`, \`VITE_GIT_HASH\`, \`VITE_GITHUB_URL\` were wired through.

## Fix

\`frontend/Dockerfile.prod\` adds:

\`\`\`dockerfile
ARG VITE_SENTRY_DSN=
ENV VITE_SENTRY_DSN=\$VITE_SENTRY_DSN
\`\`\`

Default empty so an operator without a Sentry instance still gets a working build; \`Sentry.init\` no-ops on empty DSN per existing index.tsx guard.

\`docker-compose.prod.yml\` \`frontend.build.args\` adds:

\`\`\`yaml
- VITE_SENTRY_DSN=\${VITE_SENTRY_DSN:-}
\`\`\`

Pairs with #594 (CSP fix). **Both are needed**: without the DSN in the bundle the SDK never initializes; without the CSP allowance the SDK can't POST.

## Verification

- ✅ Compose \`config\` resolves \`VITE_SENTRY_DSN\` on the frontend build args.
- ✅ After deploy, \`grep -l highlighter /app/frontend/assets/*.js\` should match — currently empty.

## Test plan

- [ ] After merge, on the deploy host run \`cd openmakersuite && git pull && docker compose -f docker-compose.prod.yml build --no-cache frontend && docker compose up -d frontend && docker compose restart nginx\`.
- [ ] Reload OMS in a browser with DevTools open. Confirm POST to \`highlighter.openmakersuite.net/api/2/envelope/\` in the Network tab.
- [ ] Within ~1 minute, replays should appear in highlighter.openmakersuite.net/organizations/sentry/replays/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)