### PR TITLE
fix(ci): use 7-char short SHA for Sentry release ID to match runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,16 +335,25 @@ jobs:
             echo "⏭️  SENTRY_AUTH_TOKEN not set; skipping Sentry release + sourcemap upload."
             exit 0
           fi
+          # Match the release identifier the rest of the stack uses.
+          # deploy.sh exports `GIT_HASH=$(git rev-parse --short HEAD)`, the
+          # frontend bundle bakes that via VITE_GIT_HASH, and the backend
+          # Python SDK reads it as SENTRY_RELEASE. CI was using
+          # $GITHUB_SHA (40-char) which never matched the 7-char value
+          # events report — releases stayed empty and source-maps
+          # uploaded against the wrong identifier never resolved.
+          RELEASE_SHA="${GITHUB_SHA:0:7}"
+          echo "Sentry release: $RELEASE_SHA"
           SCLI="npx --yes @sentry/cli@2.39.1"
-          $SCLI releases new "$GITHUB_SHA" --project backend --project frontend
-          $SCLI releases files "$GITHUB_SHA" \
+          $SCLI releases new "$RELEASE_SHA" --project backend --project frontend
+          $SCLI releases files "$RELEASE_SHA" \
             upload-sourcemaps build/assets \
             --url-prefix "~/assets" \
             --rewrite \
             --validate \
             --project frontend
-          $SCLI releases set-commits "$GITHUB_SHA" --auto
-          $SCLI releases finalize "$GITHUB_SHA"
+          $SCLI releases set-commits "$RELEASE_SHA" --auto --commit "uid0/openmakersuite@$GITHUB_SHA"
+          $SCLI releases finalize "$RELEASE_SHA"
         env:
           SENTRY_URL: https://highlighter.openmakersuite.net
           SENTRY_ORG: sentry


### PR DESCRIPTION
## Problem

CI's Sentry release block uses the **40-char `\$GITHUB_SHA`**:

\`\`\`
releases new \$GITHUB_SHA
releases files \$GITHUB_SHA upload-sourcemaps ...
releases finalize \$GITHUB_SHA
\`\`\`

But the rest of the stack uses the **7-char short SHA**:

| Where | Source |
|---|---|
| \`deploy.sh\` | \`export GIT_HASH=\$(git rev-parse --short HEAD)\` |
| Frontend bundle | \`VITE_GIT_HASH=\$GIT_HASH\` (baked into JS at build) |
| Backend Python SDK | \`SENTRY_RELEASE = config('GIT_HASH', default='')\` |

So events from the running stack report a release like \`a3cd2d7\` that never matches the long-SHA release CI created. Two visible consequences uid0 noticed:

1. **Releases page shows both short-SHA and long-SHA entries side by side** — the long-SHA ones are empty (zero sessions, zero events) because nothing in the stack ever reports under that identifier.
2. **Source maps don't resolve** — they upload against the long SHA, browser requests them under the short SHA, no match → every JS stack trace stays minified.

## Fix

Compute \`RELEASE_SHA=\${GITHUB_SHA:0:7}\` once and use it everywhere in the release block. Also pass \`--commit uid0/openmakersuite@\$GITHUB_SHA\` to \`set-commits --auto\` so the auto-detected commit list still resolves against the full SHA (set-commits identifies commits, not the release).

\`deploy.sh\` already uses \`\$GIT_HASH\` (short) for its finalize call — the two finalize paths converge on the same identifier now.

## Test plan

- [ ] After merge, the next push to main triggers CI's release step. Verify in highlighter.openmakersuite.net/organizations/sentry/releases/ that the new release is short-SHA (7 chars), has source maps attached, and shows session counts within minutes.
- [ ] After deploy.sh runs on prod, the same release flips from \`created\` → \`released\` (no duplicate short-SHA / long-SHA entries).
- [ ] Trigger a frontend error; confirm the stack trace resolves to a real .tsx source line in Sentry instead of minified bundle coordinates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)