### PR TITLE
ci(docker): parallelize compose build to halve docker-build wall-clock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,9 +412,20 @@ jobs:
           docker volume prune -f 2>/dev/null || true
 
       - name: Build and test with docker compose
+        env:
+          POSTGRES_PASSWORD: test_password_for_ci_only
+          # COMPOSE_BAKE delegates `compose build` to `buildx bake`, which
+          # parallelizes per-service builds across BuildKit workers
+          # instead of running them sequentially. Backend + frontend +
+          # nginx (~3 builds today) drop from serial to concurrent.
+          COMPOSE_BAKE: "true"
+          DOCKER_BUILDKIT: "1"
         run: |
-          # Start services
-          docker compose up -d --build
+          # Pre-build in parallel, then `up` with --no-build so the
+          # serial-build path inside compose-up is skipped. Saves ~1/2
+          # of build wall-clock when frontend + backend rebuild together.
+          docker compose build --parallel
+          docker compose up -d --no-build
 
           # Wait for services to be healthy
           timeout 300 bash -c 'while [[ "$(docker compose ps -q | xargs docker inspect -f "{{.State.Health.Status}}" 2>/dev/null | grep -v healthy | wc -l)" != "0" ]]; do sleep 5; done'
@@ -424,8 +435,6 @@ jobs:
 
           # Run tests in Docker environment
           docker compose exec -T backend pytest -v
-        env:
-          POSTGRES_PASSWORD: test_password_for_ci_only
 
       - name: Show logs on failure
         if: failure()


### PR DESCRIPTION
## Summary

The \`Docker Build Test\` CI job ran \`docker compose up -d --build\` which builds each service sequentially. Backend + frontend + nginx are three independent images — no inter-image dependencies — so the serial path was pure wait time.

## Change

\`\`\`yaml
env:
  COMPOSE_BAKE: "true"
  DOCKER_BUILDKIT: "1"
run: |
  docker compose build --parallel
  docker compose up -d --no-build
  ...
\`\`\`

- \`docker compose build --parallel\` schedules service builds concurrently.
- \`COMPOSE_BAKE=true\` makes compose delegate to \`docker buildx bake\`, which fans builds across BuildKit workers instead of one-at-a-time.
- \`--no-build\` on \`up\` skips the redundant build-check loop now that images are pre-built.

## Expected impact

The docker-build job's wall-clock drops from **sum(backend + frontend + nginx)** to **max(slowest single build) + small bake overhead**. Frontend (vite/rolldown) is the longest leg today, so this is roughly a 2× speedup on this job.

No semantic change — the same images get built with the same args; only the scheduling differs.

## Verification

- ✅ \`python3 -c "import yaml; yaml.safe_load(...)"\` clean.
- ✅ \`COMPOSE_BAKE\` requires Docker Compose ≥ v2.22 / Buildx ≥ v0.13; both are on GitHub-hosted ubuntu-latest runners.

## Test plan

- [ ] After merge, watch the next \`Docker Build Test\` job. Expect the "Build and test with docker compose" step duration to drop noticeably (~30-90s depending on cache state).
- [ ] All other behavior unchanged: services come up, healthchecks pass, pytest runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)