### PR TITLE
fix(deploy): restart EMQX after backend recreate to refresh JWKS cache

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -205,6 +205,17 @@ sleep 5
 echo "🔄 Restarting nginx to pick up frontend changes..."
 $COMPOSE restart nginx
 
+# Restart EMQX so its JWKS cache re-fetches against the freshly-recreated
+# backend container. When `docker compose up -d` recreates `backend`, the
+# container's IP changes; EMQX may still hold a stale connection pool /
+# DNS entry and the JWKS refresh (every 300s) hits nxdomain. With an
+# empty key cache, every device + server JWT then fails with CONNACK
+# rc=5 "Not authorized" — Sentry BACKEND-6, diagnosed live this cycle.
+# Cheap restart: ~5s; device mTLS listener reconnects from each device's
+# end on backoff.
+echo "🔄 Restarting EMQX to refresh JWKS cache against the new backend..."
+$COMPOSE restart emqx
+
 # Verify frontend build
 echo "🔍 Verifying frontend build..."
 if $COMPOSE exec -T nginx ls -la /app/frontend/index.html >/dev/null 2>&1; then


### PR DESCRIPTION
## Problem

Sentry **BACKEND-6** has fired twice now on a sustained \`CONNACK rc=5 \"Not authorized\"\` loop, each time after a deploy that recreated the \`backend\` container.

## Root cause (diagnosed live this cycle)

1. \`docker compose up -d\` recreated \`backend\` — IP changes.
2. During the brief recreate window EMQX's JWKS refresh fired and got **nxdomain** resolving \`backend\`.
3. EMQX kept the **empty** key cache from that failed refresh.
4. With no public key, EMQX rejected every server JWT and every device CONNECT (oms-y5p / forgekey auth flow runs through the same JWT authenticator).
5. JWKS \`refresh_interval\` is 300s, but the stale connection pool kept hitting the old DNS entry — cache never recovered until EMQX itself was restarted.

## Fix

Add a \`docker compose restart emqx\` after the existing \`restart nginx\` step. Mirrors the same pattern — both restart a container that depends on freshly-recreated backend state. Cheap (~5s); device mTLS listener reconnects from each device's end on its own backoff.

## Verification

- ✅ \`bash -n deploy.sh\` — syntax clean.
- ✅ Manually confirmed live: restarting EMQX after this morning's deploy cleared the empty JWKS cache and the consumer reconnected within 15s. BACKEND-6 has been quiet since (resolved).

## Test plan

- [ ] On the next \`./deploy.sh\` run, watch the new "🔄 Restarting EMQX..." step succeed.
- [ ] \`docker compose logs --tail=20 mqtt_consumer\` after deploy should show \`subscribing to forgekey/+/+/occupancy ...\` with no \`Not authorized\` errors.
- [ ] BACKEND-6 should stay resolved in Sentry.

## Adjacent observation

EMQX's JWKS HTTP client appears to hold a stale connection pool / DNS entry past the \`refresh_interval\`. The proper fix upstream would be to flush the resolver on a 5xx/nxdomain. Until then, the deploy-side restart is the smallest reliable mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)