### PR TITLE
feat(observability): enable Sentry Profiling on backend + frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,9 @@ CELERY_BROKER_URL=redis://localhost:6379/0
 # Sentry Error Tracking (Backend)
 SENTRY_DSN=
 SENTRY_ENVIRONMENT=development
+# Continuous profiling sample rate (sentry-sdk 2.x). 1.0 = always on while
+# a transaction is active. Set to 0.0 to disable profiling locally.
+SENTRY_PROFILE_SESSION_SAMPLE_RATE=1.0
 
 # =====================================
 # FRONTEND CONFIGURATION

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -53,6 +53,12 @@ FRONTEND_URL=https://oms.example.com
 SENTRY_DSN=
 SENTRY_ENVIRONMENT=production
 VITE_SENTRY_DSN=
+# Profiling — continuous mode (sentry-sdk 2.x). 1.0 = every Django/Celery
+# worker process emits profiles while a trace is active. Drop toward 0.0
+# to reduce Sentry storage; the legacy SENTRY_PROFILES_SAMPLE_RATE remains
+# as a per-transaction escape hatch.
+SENTRY_PROFILE_SESSION_SAMPLE_RATE=1.0
+# SENTRY_PROFILES_SAMPLE_RATE=0.0
 
 # ForgeKey provisioning token — REQUIRED in production.
 # Shared secret ESP32 devices send in X-ForgeKey-Provisioning-Token at the

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,20 @@ repos:
       - id: bandit
         files: ^backend/
         exclude: ^(backend/.*migrations/|backend/.*tests.*)
-        args: ["-r", "-s", "B101", "backend"] # Match CI: skip B101 (assert_used) and B106 (hardcoded_password_funcarg)
+        # Match CI invocation in .github/workflows/ci.yml: skip B101
+        # (assert_used), B105 (hardcoded_password_string), B106
+        # (hardcoded_password_funcarg), and B308 (mark_safe); exclude
+        # tests and migrations from the recursive scan so local
+        # pre-commit and CI surface the same set of findings.
+        args:
+          [
+            "-r",
+            "-s",
+            "B101,B105,B106,B308",
+            "-x",
+            "*/tests/*,*/migrations/*",
+            "backend",
+          ]
 
   # Backend: Security checks - pip-audit (dependency vulnerabilities)
   - repo: local

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -648,6 +648,19 @@ SENTRY_RELEASE = config("GIT_HASH", default="") or None
 # sample, and the higher rate gives uid0 real coverage for finding
 # slow views + N+1 queries. Override via env if storage pressure climbs.
 SENTRY_TRACES_SAMPLE_RATE = config("SENTRY_TRACES_SAMPLE_RATE", default=0.5, cast=float)
+# Continuous profiling (sentry-sdk 2.x). `profile_session_sample_rate`
+# samples at the *session* (i.e. process) level rather than per-trace —
+# combined with `profile_lifecycle="trace"` the sampler only runs while
+# a transaction is active, so idle workers don't burn CPU on samples
+# that nothing will reference. 1.0 = every gunicorn/celery process that
+# emits traces also emits a profile; revisit if Sentry storage grows.
+SENTRY_PROFILE_SESSION_SAMPLE_RATE = config(
+    "SENTRY_PROFILE_SESSION_SAMPLE_RATE", default=1.0, cast=float
+)
+# Legacy transaction-bound profiling (deprecated in sentry-sdk 2.x but
+# still honoured). Left as an escape hatch for the operator — set this
+# instead of the session knob if the new continuous mode misbehaves on
+# a specific worker class.
 SENTRY_PROFILES_SAMPLE_RATE = config("SENTRY_PROFILES_SAMPLE_RATE", default=0.0, cast=float)
 
 if SENTRY_DSN:
@@ -665,6 +678,8 @@ if SENTRY_DSN:
         ],
         traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
         profiles_sample_rate=SENTRY_PROFILES_SAMPLE_RATE,
+        profile_session_sample_rate=SENTRY_PROFILE_SESSION_SAMPLE_RATE,
+        profile_lifecycle="trace",
         enable_logs=True,
         # Don't ship request bodies / user PII by default; the redactor in
         # config.observability_redaction handles fine-grained scrubbing for

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -25,6 +25,13 @@ if (sentryDsn) {
     release: import.meta.env.VITE_GIT_HASH || undefined,
     integrations: [
       Sentry.browserTracingIntegration(),
+      // Browser CPU profiling. Requires the `Document-Policy: js-profiling`
+      // response header on the HTML document — nginx (templates/default.conf
+      // .template) emits it; without that header the V8 sampler is
+      // disallowed and profiles silently come back empty. Sample rate
+      // below is relative to tracesSampleRate (so the effective profile
+      // rate is tracesSampleRate * profilesSampleRate).
+      Sentry.browserProfilingIntegration(),
       // Session Replay: maskAllText / blockAllMedia are off so the replay
       // is fully visible — this is an internal makerspace tool, not a
       // multi-tenant SaaS, so we accept the privacy trade-off in exchange
@@ -57,6 +64,11 @@ if (sentryDsn) {
     // Sentry's headroom and gives uid0 real coverage of slow renders +
     // axios call timing instead of a 10% sample.
     tracesSampleRate: 0.5,
+    // Profile every traced transaction. The effective profile rate is
+    // tracesSampleRate * profilesSampleRate, so this lands at ~25% of
+    // page-loads / route changes carrying a flame chart. Drop to 0.5 or
+    // 0.25 if Sentry storage gets tight.
+    profilesSampleRate: 1.0,
     // Replay every session and every error. Storage cost on a self-hosted
     // Sentry is tractable at this org's traffic; revisit if SeaweedFS fills up.
     replaysSessionSampleRate: 1.0,

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -40,6 +40,12 @@ server {
     index index.html;
 
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://highlighter.openmakersuite.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://i.ytimg.com https:; font-src 'self' data:; connect-src 'self' wss: https://highlighter.openmakersuite.net; frame-src 'self' https://www.wunderground.com https://embed.waze.com https://www.youtube.com https://www.youtube-nocookie.com; worker-src 'self' blob:; media-src 'self' https:;" always;
+    # Allow the V8 sampling profiler so @sentry/react browserProfilingIntegration()
+    # can collect flame charts. Without this header the SDK silently emits
+    # empty profiles. Document-Policy applies to the HTML document only;
+    # the static-asset location blocks below override `add_header` and so
+    # don't need (and shouldn't carry) this directive.
+    add_header Document-Policy "js-profiling" always;
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;


### PR DESCRIPTION
## Summary

Wires Sentry profiling end-to-end so flame charts land in the
self-hosted Sentry alongside traces — both Django/Celery and the
React SPA.

### Backend (Django + Celery, sentry-sdk 2.60)

- Switch from the legacy transaction-bound profiler to **continuous
  profiling**: `profile_session_sample_rate=1.0` with
  `profile_lifecycle="trace"`. The sampler only runs while a
  transaction is active, so idle workers don't burn CPU on samples
  that nothing will reference.
- Leave `profiles_sample_rate` available as a per-transaction
  escape hatch (default `0.0`) in case continuous mode misbehaves
  on a specific worker class.
- Surface the new knob in `.env.prod.example` + `.env.example`.

### Frontend (`@sentry/react` v10)

- Add `Sentry.browserProfilingIntegration()` to the integrations
  array and set `profilesSampleRate: 1.0` so every traced
  transaction carries a profile (effective rate is
  `tracesSampleRate * profilesSampleRate` ≈ 25% of page loads /
  SPA route changes).

### Nginx

- Emit `Document-Policy: js-profiling` on the HTML document so
  the V8 sampling profiler is permitted in the browser. **Without
  this header `@sentry/react` silently emits empty profiles** —
  this was the previous reason the integration wasn't on.

### Side fix

The `bandit` pre-commit args were drifted from CI's invocation
(only `-s B101`, no `*/tests/*` exclusion). Aligned with
`.github/workflows/ci.yml` so local pre-commit and CI surface the
same findings — pre-commit was failing locally on pre-existing
test-file hits that CI ignores.

## Test plan

- [ ] CI passes (backend lint, frontend lint + tests, prod-stack
      smoke).
- [ ] After deploy, confirm profiles appear in Sentry under the
      Backend project (Django + Celery transactions should show
      flame charts in the trace detail view).
- [ ] After deploy, confirm profiles appear under the Frontend
      project for page loads.
- [ ] `curl -I https://oms.example.com/` shows
      `Document-Policy: js-profiling` in the response headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)