### PR TITLE
fix(forgekey): suppress transient MQTT CONNACK noise on consumer startup  (BACKEND-6)

### DIFF
--- a/backend/forgekey/management/commands/mqtt_consumer.py
+++ b/backend/forgekey/management/commands/mqtt_consumer.py
@@ -55,6 +55,31 @@ logger = logging.getLogger(__name__)
 LOG_RATE_LIMIT_MAX_EVENTS = 60
 LOG_RATE_LIMIT_WINDOW_SECONDS = 300
 
+# Tolerance for transient CONNACK failures at consumer startup. EMQX's JWT
+# authenticator populates its JWKS cache asynchronously after a (re)start;
+# during that window every JWT-bearing CONNECT returns rc=5. The paho loop
+# retries on a backoff schedule and the consumer always recovers, so log
+# these as WARNING until either the consumer successfully connects or the
+# grace window expires. Past that point, rc!=0 escalates to ERROR (and
+# therefore Sentry-alertable).
+_STARTUP_GRACE_SECONDS = 60.0
+
+
+def _connack_log_level(first_connect_done: bool, elapsed_seconds: float) -> int:
+    """Return the log level to emit for a non-zero CONNACK return code.
+
+    Splits a transient startup failure (WARNING, won't page) from a
+    sustained or post-connect failure (ERROR, paging). Exported as a
+    module-level helper so the matrix is unit-testable without spinning
+    up the paho loop.
+    """
+    if first_connect_done:
+        return logging.ERROR
+    if elapsed_seconds < _STARTUP_GRACE_SECONDS:
+        return logging.WARNING
+    return logging.ERROR
+
+
 # Firmware-supplied log level strings → Python logging level ints + the
 # Sentry level wire format. Anything not in this map is treated as INFO.
 _LOG_LEVELS: dict[str, tuple[int, str]] = {
@@ -595,10 +620,34 @@ class Command(BaseCommand):
         ota_status_filter = f"{prefix}/+/ota/status"
         log_filter = f"{prefix}/+/logs"
 
+        # Startup grace window for CONNACK failures. EMQX's JWT authenticator
+        # populates its JWKS cache asynchronously after a (re)start; in that
+        # ~30s window every JWT-bearing CONNECT returns rc=5 "Not authorized".
+        # paho retries automatically and the consumer always recovers, but
+        # each rc!=0 used to log ERROR — that floods Sentry on every deploy
+        # (BACKEND-6: 174 events across one deploy window). Treat rc!=0 as
+        # WARNING until either (a) we've connected at least once, or (b) we
+        # exceed `_STARTUP_GRACE_SECONDS` without a successful connect, after
+        # which CONNACK failures escalate to ERROR.
+        connect_state = {
+            "started_at": time.monotonic(),
+            "first_connect_done": False,
+        }
+
         def on_connect(c, userdata, flags, rc, properties=None):
             if rc != 0:
-                logger.error("MQTT consumer connect failed rc=%s", rc)
+                elapsed = time.monotonic() - connect_state["started_at"]
+                level = _connack_log_level(connect_state["first_connect_done"], elapsed)
+                if level == logging.WARNING:
+                    logger.warning(
+                        "MQTT consumer connect failed rc=%s (startup, %.1fs elapsed); paho will retry",
+                        rc,
+                        elapsed,
+                    )
+                else:
+                    logger.error("MQTT consumer connect failed rc=%s", rc)
                 return
+            connect_state["first_connect_done"] = True
             logger.info(
                 "MQTT consumer connected to %s:%s; subscribing to %s, %s, %s, %s",
                 host,

--- a/backend/forgekey/tests/test_mqtt_consumer.py
+++ b/backend/forgekey/tests/test_mqtt_consumer.py
@@ -24,7 +24,9 @@ from django.utils import timezone
 import pytest
 
 from forgekey.management.commands.mqtt_consumer import (
+    _STARTUP_GRACE_SECONDS,
     LOG_RATE_LIMIT_MAX_EVENTS,
+    _connack_log_level,
     dispatch_message,
     handle_log_message,
     handle_occupancy_message,
@@ -452,3 +454,47 @@ class TestOccupancyEndpoint:
         url = f"/api/forgekey/devices/{device.id}/occupancy/?since=banana"
         response = admin_api_client.get(url)
         assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# CONNACK log-level matrix (BACKEND-6 — EMQX JWKS warm-up suppression)
+# ---------------------------------------------------------------------------
+
+
+class TestConnackLogLevel:
+    """The CONNACK-failure log level decides what's a Sentry issue vs noise.
+
+    EMQX takes ~30s after restart to populate its JWKS cache; during that
+    window every JWT-bearing CONNECT returns rc=5 even though the consumer
+    will recover on its own. Promoting those to ERROR fills Sentry with
+    transient startup events (BACKEND-6: 174 in a single deploy window).
+    The matrix:
+
+        * pre-first-connect + within grace window  → WARNING (don't page)
+        * pre-first-connect + grace expired        → ERROR (real outage)
+        * post-first-connect, any time             → ERROR (broker drop)
+    """
+
+    def test_transient_startup_failure_is_warning(self):
+        assert _connack_log_level(first_connect_done=False, elapsed_seconds=5.0) == logging.WARNING
+
+    def test_failure_at_grace_boundary_is_error(self):
+        # Sitting exactly on the boundary should escalate — anything older
+        # is a sustained outage worth paging on.
+        assert (
+            _connack_log_level(first_connect_done=False, elapsed_seconds=_STARTUP_GRACE_SECONDS)
+            == logging.ERROR
+        )
+
+    def test_sustained_failure_is_error(self):
+        assert (
+            _connack_log_level(
+                first_connect_done=False, elapsed_seconds=_STARTUP_GRACE_SECONDS + 30
+            )
+            == logging.ERROR
+        )
+
+    def test_post_connect_failure_is_error_regardless_of_elapsed(self):
+        # Once we've connected at least once, any subsequent rc!=0 is a
+        # broker drop / re-auth failure — that's real signal even at 1s.
+        assert _connack_log_level(first_connect_done=True, elapsed_seconds=1.0) == logging.ERROR


### PR DESCRIPTION
## Summary

Closes Sentry **BACKEND-6** (`MQTT consumer connect failed rc=Not authorized`).

EMQX populates its JWT authenticator's JWKS cache asynchronously
after a (re)start (the JWKS refresh interval defaults to 300s and
the initial fetch is on-demand). During that ~30s window every
JWT-bearing MQTT CONNECT returns rc=5 even though paho will retry
and the consumer always recovers on its own. Observed timeline in
this incident:

```
23:28:53  ERROR  MQTT consumer connect failed rc=Not authorized
23:28:54  ERROR  ...   (next paho retry, same result)
23:28:56  ERROR  ...
23:29:00  ERROR  ...
23:29:08  ERROR  ...
23:29:24  INFO   MQTT consumer connected to emqx:1883; subscribing to ...
```

Each rc!=0 hit `logger.error`, which the Sentry LoggingIntegration
(`event_level=logging.ERROR`) promotes to a Sentry issue. The
consumer ships ~5 startup ERRORs per deploy and BACKEND-6 had
accumulated 174 events across one deploy window for what is, in
practice, a benign startup race.

### Fix

Treat rc!=0 in the consumer's `on_connect` callback as **WARNING**
during a 60-second startup grace window (until first successful
connect). After that — or after we've connected at least once —
rc!=0 escalates to **ERROR** so a real broker drop or sustained
outage still pages.

The matrix:

| state | log level |
|---|---|
| pre-first-connect, elapsed < 60s | WARNING |
| pre-first-connect, elapsed ≥ 60s | ERROR |
| post-first-connect (broker drop) | ERROR |

Extracted into `_connack_log_level(first_connect_done, elapsed_seconds)`
so the four cases are unit-tested directly without driving the paho
loop. Existing tests cover the dispatch + persistence paths; this
adds `TestConnackLogLevel` covering each branch.

## Test plan

- [ ] CI passes (`Backend Tests` job picks up the new
      `TestConnackLogLevel` matrix).
- [ ] After deploy, watch the `mqtt_consumer` logs through one
      restart — startup-window failures appear as WARNING, the
      eventual successful connect appears as INFO, and BACKEND-6
      stops accumulating new events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)