### PR TITLE
style(sidebar): bring the navigation chrome up to the workspace aesthetic

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -247,6 +247,15 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed = false, isMobileOpen = f
           ✕
         </button>
       )}
+      <div className="sidebar-brand" data-testid="sidebar-brand">
+        <span className="sidebar-brand-chip" aria-hidden="true">
+          OM
+        </span>
+        <div className="sidebar-brand-text">
+          <span className="sidebar-brand-eyebrow">OpenMakerSuite</span>
+          <span className="sidebar-brand-title">Workspace</span>
+        </div>
+      </div>
       <nav className="sidebar-nav">
         {workspaceSections.map((section) => {
           if (!shouldShowSection(section)) return null;

--- a/frontend/src/styles/Sidebar.css
+++ b/frontend/src/styles/Sidebar.css
@@ -1,15 +1,38 @@
 /**
- * Sidebar Styles
+ * Sidebar — workspace navigation chrome.
+ *
+ * Visual direction: lifted from `styles/landing.css` so the sidebar
+ * lives in the same "refined editorial × industrial control panel"
+ * world as the workspace pages it navigates to. Warm-paper surface,
+ * IBM Plex Mono eyebrow on section headers, blue accent rule on the
+ * active item — same tokens, scoped to keep the cascade clean if
+ * landing.css ever moves.
  */
 .sidebar {
+  /* Surface tokens — kept locally so this file can render correctly
+     even on pages that don't import landing.css (the SPA mounts the
+     sidebar on every authenticated layout). */
+  --sb-surface-bg: #faf8f4;
+  --sb-card-bg: #ffffff;
+  --sb-border: rgba(15, 23, 42, 0.08);
+  --sb-rule: rgba(15, 23, 42, 0.06);
+  --sb-text: #111827;
+  --sb-muted: #4b5563;
+  --sb-eyebrow: #6b7280;
+  --sb-accent: #1971c2;
+  --sb-accent-soft: #e7f1fb;
+  --sb-chip-bg: #1a1a1a;
+  --sb-chip-fg: #f5f1e8;
+  --sb-mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, Consolas,
+    monospace;
+
   position: fixed;
   left: 0;
   top: 0;
   height: 100vh;
   width: 260px;
-  background-color: #fff;
-  border-right: 2px solid #e0e0e0;
-  box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
+  background: var(--sb-surface-bg);
+  border-right: 1px solid var(--sb-border);
   display: flex;
   flex-direction: column;
   transition: width 0.3s ease;
@@ -23,15 +46,80 @@
   width: 60px;
 }
 
+/* Brand strip at the top — gives the surface a focal point and keeps
+   the rest of the sidebar from feeling like a bare list. */
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 20px 16px 16px;
+  border-bottom: 1px solid var(--sb-rule);
+  background: var(--sb-card-bg);
+}
+
+.sidebar-brand-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
+  background: var(--sb-chip-bg);
+  color: var(--sb-chip-fg);
+  font-family: var(--sb-mono);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  flex-shrink: 0;
+}
+
+.sidebar-brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.sidebar-brand-eyebrow {
+  font-family: var(--sb-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--sb-eyebrow);
+}
+
+.sidebar-brand-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--sb-text);
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebar.collapsed .sidebar-brand {
+  padding: 16px 12px;
+}
+
+.sidebar.collapsed .sidebar-brand-text {
+  display: none;
+}
+
 .sidebar-nav {
   flex: 1;
   min-height: 300px;
-  padding: 16px 0 8px 0;
+  padding: 14px 10px 12px;
   overflow-y: auto;
 }
 
 .workspace-section {
-  margin-bottom: 4px;
+  margin-bottom: 2px;
+}
+
+.workspace-section + .workspace-section {
+  margin-top: 4px;
 }
 
 .section-header {
@@ -39,46 +127,68 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 12px 16px;
+  padding: 9px 10px;
   background: none;
   border: none;
+  border-radius: 8px;
   text-align: left;
   cursor: pointer;
-  color: #333;
-  font-size: 0.95rem;
+  color: var(--sb-text);
+  font-size: 0.83rem;
   font-weight: 600;
-  transition: background-color 0.2s, color 0.2s, transform 0.1s;
-  min-height: 44px;
+  font-family: var(--sb-mono);
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  transition: background-color 0.18s ease, color 0.18s ease,
+    transform 0.1s ease;
+  min-height: 40px;
   touch-action: manipulation;
   user-select: none;
-  -webkit-tap-highlight-color: rgba(102, 126, 234, 0.1);
+  -webkit-tap-highlight-color: var(--sb-accent-soft);
 }
 
 .section-header:hover {
-  background-color: #f5f5f5;
+  background-color: var(--sb-card-bg);
+  color: var(--sb-text);
 }
 
 .section-header:active {
   transform: scale(0.98);
-  background-color: #e8e8e8;
 }
 
 .section-header.active {
-  background-color: #e8edff;
-  color: #667eea;
+  background-color: var(--sb-accent-soft);
+  color: var(--sb-accent);
+}
+
+.section-header:focus-visible {
+  outline: 2px solid var(--sb-accent);
+  outline-offset: 2px;
 }
 
 .section-icon {
-  font-size: 1.2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  background: var(--sb-chip-bg);
+  color: var(--sb-chip-fg);
+  font-size: 0.95rem;
   flex-shrink: 0;
-  width: 24px;
-  text-align: center;
+}
+
+.section-header.active .section-icon {
+  background: var(--sb-accent);
+  color: #ffffff;
 }
 
 .section-label {
   flex: 1;
   white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .sidebar.collapsed .section-label {
@@ -87,10 +197,15 @@
 }
 
 .section-arrow {
-  font-size: 0.8rem;
-  color: #999;
-  transition: transform 0.2s;
+  font-size: 0.65rem;
+  color: var(--sb-eyebrow);
+  transition: transform 0.18s ease;
   flex-shrink: 0;
+  font-family: var(--sb-mono);
+}
+
+.section-header[aria-expanded="true"] .section-arrow {
+  color: var(--sb-accent);
 }
 
 .sidebar.collapsed .section-arrow {
@@ -101,55 +216,74 @@
   max-height: 0;
   overflow: hidden;
   transition: max-height 0.3s ease;
+  padding-left: 38px;
+  border-left: 1px solid transparent;
+  margin-left: 14px;
 }
 
 .section-items.expanded {
   max-height: 1000px;
+  border-left-color: var(--sb-rule);
+  padding-top: 4px;
+  padding-bottom: 4px;
 }
 
 .nav-item {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px 16px 10px 48px;
+  gap: 10px;
+  padding: 8px 12px;
+  margin: 2px 0;
   text-decoration: none;
-  color: #666;
-  font-size: 0.9rem;
-  transition: background-color 0.2s, color 0.2s, transform 0.1s;
-  border-left: 3px solid transparent;
-  min-height: 44px;
+  color: var(--sb-muted);
+  font-size: 0.875rem;
+  border-radius: 7px;
+  border-left: 2px solid transparent;
+  transition: background-color 0.18s ease, color 0.18s ease,
+    transform 0.1s ease;
+  min-height: 36px;
   touch-action: manipulation;
   user-select: none;
-  -webkit-tap-highlight-color: rgba(102, 126, 234, 0.1);
+  -webkit-tap-highlight-color: var(--sb-accent-soft);
 }
 
 .nav-item:hover {
-  background-color: #f5f5f5;
-  color: #667eea;
+  background-color: var(--sb-card-bg);
+  color: var(--sb-text);
 }
 
 .nav-item:active {
   transform: scale(0.98);
-  background-color: #e8e8e8;
+}
+
+.nav-item:focus-visible {
+  outline: 2px solid var(--sb-accent);
+  outline-offset: 2px;
 }
 
 .nav-item.active {
-  background-color: #e8edff;
-  color: #667eea;
-  border-left-color: #667eea;
-  font-weight: 500;
+  background-color: var(--sb-accent-soft);
+  color: var(--sb-accent);
+  border-left-color: var(--sb-accent);
+  font-weight: 600;
 }
 
 .item-icon {
-  font-size: 1rem;
+  font-size: 0.95rem;
   flex-shrink: 0;
-  width: 20px;
+  width: 18px;
   text-align: center;
+  opacity: 0.85;
+}
+
+.nav-item.active .item-icon {
+  opacity: 1;
 }
 
 .item-label {
   white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .sidebar.collapsed .item-label {
@@ -157,9 +291,16 @@
   width: 0;
 }
 
+.sidebar.collapsed .section-items {
+  padding-left: 0;
+  margin-left: 0;
+  border-left: none;
+}
+
 .sidebar.collapsed .nav-item {
-  padding: 10px;
+  padding: 8px;
   justify-content: center;
+  border-left: none;
 }
 
 /* Mobile close button */
@@ -167,7 +308,7 @@
   position: absolute;
   top: 12px;
   right: 12px;
-  background: rgba(0, 0, 0, 0.1);
+  background: rgba(15, 23, 42, 0.08);
   border: none;
   border-radius: 50%;
   width: 44px;
@@ -176,22 +317,22 @@
   align-items: center;
   justify-content: center;
   font-size: 1.5rem;
-  color: #333;
+  color: var(--sb-text);
   cursor: pointer;
   z-index: 1001;
   touch-action: manipulation;
   user-select: none;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0.1);
+  -webkit-tap-highlight-color: rgba(15, 23, 42, 0.12);
   transition: background-color 0.2s, transform 0.1s;
 }
 
 .sidebar-close-button:hover {
-  background: rgba(0, 0, 0, 0.15);
+  background: rgba(15, 23, 42, 0.14);
 }
 
 .sidebar-close-button:active {
   transform: scale(0.9);
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(15, 23, 42, 0.18);
 }
 
 /* Mobile backdrop */
@@ -201,7 +342,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(15, 23, 42, 0.45);
   z-index: 999;
   animation: fadeIn 0.3s ease;
 }
@@ -223,7 +364,7 @@
     transform: translateX(-100%);
     transition: transform 0.3s ease;
     z-index: 1000;
-    box-shadow: 2px 0 12px rgba(0, 0, 0, 0.15);
+    box-shadow: 6px 0 24px -10px rgba(15, 23, 42, 0.25);
   }
 
   .sidebar.mobile-open {
@@ -235,15 +376,14 @@
     max-width: 85vw;
   }
 
-  /* Hide close button on desktop */
+  .sidebar-close-button {
+    display: flex;
+  }
+}
+
+@media (min-width: 769px) {
   .sidebar-close-button {
     display: none;
-  }
-
-  @media (max-width: 768px) {
-    .sidebar-close-button {
-      display: flex;
-    }
   }
 }
 
@@ -253,15 +393,24 @@
 }
 
 .sidebar-nav::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: transparent;
 }
 
 .sidebar-nav::-webkit-scrollbar-thumb {
-  background: #ccc;
+  background: rgba(15, 23, 42, 0.18);
   border-radius: 3px;
 }
 
 .sidebar-nav::-webkit-scrollbar-thumb:hover {
-  background: #999;
+  background: rgba(15, 23, 42, 0.28);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .sidebar,
+  .section-header,
+  .nav-item,
+  .section-arrow,
+  .section-items {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary

Workspace pages already moved to the landing/editorial design
(`styles/landing.css`), but the sidebar stayed on its original
white-on-grey list cosmetic. This PR pulls the sidebar into the same
design language without changing any behaviour:

- Warm-paper surface (#faf8f4) matching `.landing-surface`.
- Sticky brand strip at the top with a dark editorial chip ("OM") +
  IBM Plex Mono eyebrow over the workspace title — gives the panel a
  focal point.
- Section headers use the mono eyebrow treatment (uppercase, 0.07em
  letter-spacing). Section icon sits in a rounded dark chip (white
  when the section is active).
- Items rendered as soft pills with a blue accent border-left only
  on the active item; nested under a thin rule so the hierarchy
  reads without indentation alone.
- Real focus-visible outlines so keyboard users can see focus.
- Neutral scrollbar (was harsh grey).
- `prefers-reduced-motion` disables transitions.

`Sidebar.tsx` only gains the brand DOM nodes (`data-testid="sidebar-brand"`).
Routing / auth gating / expand-collapse / mobile swipe / collapsed
mode widths all unchanged.

## Test plan

- [ ] CI passes (Frontend Lint + Tests; the existing Sidebar.test.tsx
      doesn't depend on classnames so should keep passing).
- [ ] Manually compare collapsed vs expanded states on desktop +
      mobile viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)