### PR TITLE
fix(analytics): make metric-snapshot resilient to absent tables  (BACKEND-8)

### DIFF
--- a/backend/analytics/tasks.py
+++ b/backend/analytics/tasks.py
@@ -16,6 +16,7 @@ from typing import Iterable
 
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
+from django.db.utils import DataError, OperationalError, ProgrammingError
 from django.template.loader import render_to_string
 
 import sentry_sdk
@@ -264,6 +265,23 @@ METRIC_SNAPSHOT_NAMES: tuple[str, ...] = (
 )
 
 
+def _safe_count(name: str, fn) -> int:
+    """Run ``fn()`` (typically a ``.count()`` queryset call) and return its
+    integer result, or 0 if the query raises a database error.
+
+    The snapshot task is best-effort observability — if a gauge can't be
+    computed (e.g. the underlying table doesn't exist in this environment
+    yet, BACKEND-8) we still want every other gauge to ship rather than
+    losing the whole tick. The error is logged so it surfaces in Sentry
+    Logs without paging.
+    """
+    try:
+        return int(fn())
+    except (ProgrammingError, OperationalError, DataError) as exc:
+        logger.warning("metric snapshot: %s failed (%s); reporting 0", name, exc)
+        return 0
+
+
 def _collect_metric_snapshot() -> dict[str, int]:
     """Query the current value of every gauge in ``METRIC_SNAPSHOT_NAMES``.
 
@@ -286,22 +304,38 @@ def _collect_metric_snapshot() -> dict[str, int]:
     last_24h = now - timedelta(hours=24)
 
     return {
-        "oms.metric.user.total": User.objects.count(),
-        "oms.metric.user.staff": User.objects.filter(is_staff=True).count(),
-        "oms.metric.membership.active": Membership.objects.filter(
-            status=Membership.STATUS_ACTIVE
-        ).count(),
-        "oms.metric.inventory.item.total": InventoryItem.objects.count(),
-        "oms.metric.inventory.asset.total": Asset.objects.count(),
-        "oms.metric.inventory.location.total": Location.objects.count(),
-        "oms.metric.forgekey.device.total": ESP32Device.objects.count(),
-        "oms.metric.forgekey.device.online": ESP32Device.objects.filter(is_online=True).count(),
-        "oms.metric.checkin.location.last_24h": LocationCheckIn.objects.filter(
-            checked_in_at__gte=last_24h
-        ).count(),
-        "oms.metric.checkin.occupancy_event.last_24h": OccupancyEvent.objects.filter(
-            event_timestamp_utc__gte=last_24h
-        ).count(),
+        "oms.metric.user.total": _safe_count("user.total", User.objects.count),
+        "oms.metric.user.staff": _safe_count(
+            "user.staff", lambda: User.objects.filter(is_staff=True).count()
+        ),
+        "oms.metric.membership.active": _safe_count(
+            "membership.active",
+            lambda: Membership.objects.filter(status=Membership.STATUS_ACTIVE).count(),
+        ),
+        "oms.metric.inventory.item.total": _safe_count(
+            "inventory.item.total", InventoryItem.objects.count
+        ),
+        "oms.metric.inventory.asset.total": _safe_count(
+            "inventory.asset.total", Asset.objects.count
+        ),
+        "oms.metric.inventory.location.total": _safe_count(
+            "inventory.location.total", Location.objects.count
+        ),
+        "oms.metric.forgekey.device.total": _safe_count(
+            "forgekey.device.total", ESP32Device.objects.count
+        ),
+        "oms.metric.forgekey.device.online": _safe_count(
+            "forgekey.device.online",
+            lambda: ESP32Device.objects.filter(is_online=True).count(),
+        ),
+        "oms.metric.checkin.location.last_24h": _safe_count(
+            "checkin.location.last_24h",
+            lambda: LocationCheckIn.objects.filter(checked_in_at__gte=last_24h).count(),
+        ),
+        "oms.metric.checkin.occupancy_event.last_24h": _safe_count(
+            "checkin.occupancy_event.last_24h",
+            lambda: OccupancyEvent.objects.filter(event_timestamp_utc__gte=last_24h).count(),
+        ),
     }
 
 

--- a/backend/analytics/tests/test_metric_snapshot.py
+++ b/backend/analytics/tests/test_metric_snapshot.py
@@ -21,6 +21,7 @@ from analytics.tasks import (
     METRIC_SNAPSHOT_NAMES,
     _collect_metric_snapshot,
     _emit_metric_snapshot_to_sentry,
+    _safe_count,
 )
 from forgekey.tests.factories import ESP32DeviceFactory
 from inventory.models import Asset, InventoryItem, Location
@@ -194,3 +195,38 @@ class TestEmitMetricSnapshotToSentry:
         assert attrs["value"] == 7
         assert attrs["metric.name"] == "oms.metric.user.total"
         assert attrs["metric.kind"] == "gauge"
+
+
+class TestSafeCount:
+    """`_safe_count` swallows database errors so a single absent table
+    doesn't take the whole snapshot down (BACKEND-8). Pin the contract
+    so a future refactor doesn't accidentally re-raise."""
+
+    def test_returns_int_on_success(self):
+        assert _safe_count("ok", lambda: 5) == 5
+
+    def test_returns_zero_on_programming_error(self):
+        from django.db.utils import ProgrammingError
+
+        def raises():
+            raise ProgrammingError('relation "missing" does not exist')
+
+        assert _safe_count("missing", raises) == 0
+
+    def test_returns_zero_on_operational_error(self):
+        from django.db.utils import OperationalError
+
+        def raises():
+            raise OperationalError("connection refused")
+
+        assert _safe_count("conn-down", raises) == 0
+
+    def test_unexpected_exception_propagates(self):
+        # _safe_count only swallows DB-shaped errors. A logic bug in
+        # the snapshot collector should still surface so it's caught
+        # in CI rather than silently zeroing out forever.
+        def raises():
+            raise RuntimeError("not a db error")
+
+        with pytest.raises(RuntimeError):
+            _safe_count("bug", raises)


### PR DESCRIPTION
## Summary

Production hit Sentry **BACKEND-8** the first time
\`analytics.emit_metric_snapshot\` ran: \`ProgrammingError: relation
'inventory_membership' does not exist\`. The \`Membership\` model
declares \`db_table = 'inventory_membership'\` (legacy table name
kept for backwards compat with the old inventory/membership app
split), and on the current production database neither the legacy
nor canonical table is present.

The snapshot task is best-effort observability — a single missing
table shouldn't kill the whole tick and lose the 9 other gauges.

### Fix

Wrap every gauge query in a new \`_safe_count(name, fn)\` helper that
catches DB-shape errors (ProgrammingError / OperationalError /
DataError) and returns 0 with a \`logger.warning\` so the failure
surfaces in Sentry Logs without paging. Non-DB exceptions (logic
bugs in the snapshot collector itself) still propagate so CI
catches them.

\`TestSafeCount\` covers the success path, both DB-error returns-zero
paths, and the assert-still-propagates-other-exceptions path.

## Test plan

- [ ] CI passes (Backend Tests includes the new \`TestSafeCount\`).
- [ ] After deploy, confirm BACKEND-8 stops accumulating and the
      other 9 gauges keep appearing in Sentry Logs every 5 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)