### PR TITLE
feat(forgekey): redesign ePaper PM panel, read MaintenanceItem

### DIFF
--- a/backend/forgekey/admin.py
+++ b/backend/forgekey/admin.py
@@ -7,6 +7,8 @@ import logging
 from django import forms
 from django.contrib import admin, messages
 from django.db import transaction
+from django.http import Http404, HttpResponse
+from django.urls import path, reverse
 from django.utils import timezone
 from django.utils.html import format_html
 
@@ -670,6 +672,7 @@ class EPaperDisplayAdmin(admin.ModelAdmin):
         "last_battery_at",
         "last_image_at",
         "is_active",
+        "preview_link",
     ]
     list_filter = ["is_active"]
     search_fields = [
@@ -679,6 +682,7 @@ class EPaperDisplayAdmin(admin.ModelAdmin):
     ]
     readonly_fields = [
         "id",
+        "panel_preview",
         "battery_percent",
         "last_battery_at",
         "last_image_etag",
@@ -686,3 +690,54 @@ class EPaperDisplayAdmin(admin.ModelAdmin):
         "created_at",
         "updated_at",
     ]
+
+    # --- Live panel preview -------------------------------------------------
+    # Renders the exact PNG a panel would flash, so the layout can be
+    # iterated on from the admin without a device in hand.
+
+    def get_urls(self):
+        custom = [
+            path(
+                "<uuid:pk>/preview.png",
+                self.admin_site.admin_view(self.preview_png),
+                name="forgekey_epaperdisplay_preview",
+            ),
+        ]
+        return custom + super().get_urls()
+
+    def preview_png(self, request, pk):
+        from .services.epaper_render import render_pm_image
+        from .views import epaper_service_url
+
+        display = self.get_object(request, pk)
+        if display is None:
+            raise Http404("No such ePaper display.")
+        if display.asset_id is None:
+            return HttpResponse(
+                "Display is unbound — bind it to an asset to preview the panel.",
+                content_type="text/plain",
+                status=409,
+            )
+        png = render_pm_image(display.asset, service_url=epaper_service_url(request, display.pk))
+        return HttpResponse(png, content_type="image/png")
+
+    @admin.display(description="Preview")
+    def preview_link(self, obj):
+        if obj.asset_id is None:
+            return "—"
+        url = reverse("admin:forgekey_epaperdisplay_preview", args=[obj.pk])
+        return format_html('<a href="{}" target="_blank">Preview Image</a>', url)
+
+    @admin.display(description="Panel preview")
+    def panel_preview(self, obj):
+        if obj is None or obj.pk is None:
+            return "(save the display first)"
+        if obj.asset_id is None:
+            return "Bind an asset to preview the panel."
+        url = reverse("admin:forgekey_epaperdisplay_preview", args=[obj.pk])
+        return format_html(
+            '<div><a href="{0}" target="_blank">Open full size (800×480)</a></div>'
+            '<img src="{0}" alt="panel preview" style="margin-top:8px;width:480px;'
+            'max-width:100%;border:1px solid #ccc;image-rendering:pixelated"/>',
+            url,
+        )

--- a/backend/forgekey/management/commands/epaper_preview.py
+++ b/backend/forgekey/management/commands/epaper_preview.py
@@ -1,0 +1,140 @@
+"""Render an ePaper PM-display PNG to a file for design previewing.
+
+The XIAO 7.5" panel image is rendered server-side
+(``forgekey.services.epaper_render.render_pm_image``). This command
+exercises that renderer so the exact image a panel will show can be
+inspected without a device in hand.
+
+Run it inside the backend container, e.g.::
+
+    # Synthetic asset (no DB rows persisted) — quickest design loop:
+    python manage.py epaper_preview
+
+    # A real asset / bound display:
+    python manage.py epaper_preview --asset-id 5
+    python manage.py epaper_preview --display-id <uuid>
+
+    # Pick the sample status so you can eyeball each state:
+    python manage.py epaper_preview --state overdue
+    python manage.py epaper_preview --state never
+
+    # Choose where the PNG lands (default /tmp/epaper_preview.png):
+    python manage.py epaper_preview --out /tmp/foo.png
+
+Copy it to the host with::
+
+    docker cp oms-backend-1:/tmp/epaper_preview.png /tmp/epaper_preview.png
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from uuid import uuid4
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.utils import timezone
+
+
+class Command(BaseCommand):
+    help = "Render an ePaper PM-display PNG to a file for previewing the layout."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--asset-id", type=int, default=None)
+        parser.add_argument("--display-id", type=str, default=None)
+        parser.add_argument(
+            "--state",
+            choices=["ok", "warning", "overdue", "never", "none"],
+            default="ok",
+            help="Sample PM state to render (only used when no asset/display given).",
+        )
+        # Dev preview tool; /tmp is the documented drop point (docker cp).
+        parser.add_argument("--out", type=str, default="/tmp/epaper_preview.png")  # nosec B108
+        parser.add_argument(
+            "--base-url",
+            type=str,
+            default="https://dms.openmakersuite.net",
+            help="Public base URL used to build the scan-to-log QR target.",
+        )
+
+    def _service_url(self, base: str, display_id: str) -> str:
+        return f"{base.rstrip('/')}/forgekey/epaper/{display_id}/service"
+
+    def handle(self, *args, **opts):
+        from forgekey.services.epaper_render import render_pm_image
+        from inventory.models import Asset
+
+        out = opts["out"]
+        base = opts["base_url"]
+
+        if opts["asset_id"] is not None:
+            asset = Asset.objects.filter(pk=opts["asset_id"]).first()
+            if asset is None:
+                raise CommandError(f"No asset with id {opts['asset_id']}")
+            display = asset.epaper_displays.first()
+            did = str(display.pk) if display else f"sample-asset-{asset.pk}"
+            self._write(
+                out, render_pm_image(asset, service_url=self._service_url(base, did)), asset
+            )
+            return
+
+        if opts["display_id"]:
+            from forgekey.models import EPaperDisplay
+
+            display = EPaperDisplay.objects.filter(pk=opts["display_id"]).first()
+            if display is None:
+                raise CommandError(f"No EPaperDisplay with id {opts['display_id']}")
+            if display.asset_id is None:
+                raise CommandError("Display is unbound (no asset); nothing to render.")
+            url = self._service_url(base, str(display.pk))
+            self._write(out, render_pm_image(display.asset, service_url=url), display.asset)
+            return
+
+        self._render_sample(out, opts["state"], base)
+
+    def _render_sample(self, out: str, state: str, base: str) -> None:
+        """Build a throwaway asset + maintenance item, render, roll the DB back."""
+        from forgekey.services.epaper_render import render_pm_image
+        from inventory.models import Asset, Location, MaintenanceItem
+
+        interval = 30
+        # Map the requested state to a "days since last completion" so the
+        # renderer's own status logic produces it (no faking strings).
+        last_done_days = {
+            "ok": 5,  # well within interval → "X DAYS REMAINING"
+            "warning": 26,  # inside the final 20% → "due soon"
+            "overdue": 41,  # past the interval → "OVERDUE BY N DAYS"
+            "never": None,  # recurring but never completed → "DUE NOW"
+            "none": "no-item",  # no maintenance item at all
+        }[state]
+
+        with transaction.atomic():
+            sfx = uuid4().hex[:6].upper()
+            location = Location.objects.create(name=f"Preview Loc {sfx}")
+            asset = Asset.objects.create(
+                name='Bandsaw 14"',
+                location=location,
+                asset_tag=f"PREVIEW-{sfx}",
+            )
+            if last_done_days != "no-item":
+                last_completed = (
+                    timezone.now() - timedelta(days=last_done_days)
+                    if last_done_days is not None
+                    else None
+                )
+                MaintenanceItem.objects.create(
+                    asset=asset,
+                    title="Blade tension & alignment",
+                    interval_days=interval,
+                    last_completed_at=last_completed,
+                )
+            url = self._service_url(base, "00000000-0000-0000-0000-0000000000ab")
+            self._write(out, render_pm_image(asset, service_url=url), asset)
+            transaction.set_rollback(True)
+
+    def _write(self, out: str, png: bytes, asset) -> None:
+        with open(out, "wb") as fh:
+            fh.write(png)
+        self.stdout.write(
+            self.style.SUCCESS(f"Wrote {len(png)} bytes to {out}  (asset: {asset.name})")
+        )

--- a/backend/forgekey/services/epaper_render.py
+++ b/backend/forgekey/services/epaper_render.py
@@ -7,13 +7,16 @@ Server-side render means the panel itself stays simple, fonts come
 from one place, and ops can preview the exact image a given asset
 will display without firmware in hand.
 
-Image content per panel (top-to-bottom):
+Layout (800x480, top-to-bottom):
 
-    [eyebrow]  ASSET NAME              ← serif display, large
-    [task]     PM task                 ← sans, medium
-    [status]   X days remaining        ← mono, large, status-coloured
-                                         (or "OVERDUE" / "NEVER")
-    [footer]   Last serviced: DATE     ← sans, small
+    PREVENTIVE MAINTENANCE          ← eyebrow, small bold, under a rule
+    ASSET NAME                      ← bold, auto-fit, wraps to 2 lines
+    PM task name                    ← regular, medium
+    ┌──────────────────┐  ┌──────┐
+    │  12 DAYS         │  │  QR  │  ← status headline (inverted when
+    │  REMAINING       │  │      │     overdue/never) + scan-to-log QR
+    └──────────────────┘  └──────┘
+    Last serviced: DATE · TAG       ← footer rule + meta
 
 The render is deterministic for a given snapshot of an asset's PM
 state, so we expose ``compute_snapshot_etag`` for the HTTP layer to
@@ -22,163 +25,296 @@ short-circuit unchanged requests with 304 Not Modified.
 
 from __future__ import annotations
 
+import functools
 import hashlib
 import io
+import os
 from typing import Iterable
 
 from django.utils import timezone
 
 from PIL import Image, ImageDraw, ImageFont
 
-from inventory.models import Asset
-from preventive_maintenance.models import PMSchedule
-
-# Stick to PIL's default font so the render never depends on a font
-# file that might be absent from the worker container. The default is
-# fixed-width and renders crisply on a 1-bpp panel, which is what we
-# want anyway.
-_FONT = ImageFont.load_default()
+from inventory.models import Asset, MaintenanceItem
 
 EPAPER_WIDTH = 800
 EPAPER_HEIGHT = 480
 _BG = 255  # white
 _FG = 0  # black
 
+_MARGIN = 34
 
-def _next_due_schedule(asset: Asset) -> PMSchedule | None:
-    """Pick the schedule that should drive the panel display.
+# DejaVu ships in the slim Debian base the worker container builds on.
+# If a future base image drops it, ``_font`` falls back to Pillow's
+# scalable built-in so the panel degrades to plain-but-legible rather
+# than crashing the device's wake cycle.
+_FONT_DIR = "/usr/share/fonts/truetype/dejavu"
+_FONT_FILES = {
+    "sans": "DejaVuSans.ttf",
+    "sans_bold": "DejaVuSans-Bold.ttf",
+    "mono_bold": "DejaVuSansMono-Bold.ttf",
+}
 
-    Priority order:
-      1. Any OVERDUE schedule (most urgent first by negative
-         days_until_due).
-      2. The WARNING schedule with the fewest days remaining.
-      3. The OK schedule with the fewest days remaining.
-      4. A NEVER-serviced schedule if no service log exists.
 
-    Returns ``None`` when the asset has no active schedules.
+@functools.lru_cache(maxsize=64)
+def _font(kind: str, size: int) -> ImageFont.ImageFont:
+    path = os.path.join(_FONT_DIR, _FONT_FILES.get(kind, "DejaVuSans.ttf"))
+    try:
+        return ImageFont.truetype(path, size)
+    except OSError:
+        try:
+            return ImageFont.load_default(size=size)
+        except TypeError:  # Pillow < 10.1 has no size kwarg
+            return ImageFont.load_default()
+
+
+# ---------------------------------------------------------------------------
+# PM-state selection + ETag (unchanged contract)
+# ---------------------------------------------------------------------------
+
+
+# A maintenance task counts as "preventive" (panel-eligible) when it
+# recurs — i.e. it has an interval. One-off / as-needed items
+# (interval_days is None) are left off the panel.
+_WARNING_FRACTION = 0.2  # final 20% of the interval reads as "due soon"
+
+# Panel status buckets, most urgent first.
+_OVERDUE, _NEVER, _WARNING, _OK = "overdue", "never", "warning", "ok"
+
+
+def _recurring_items(asset: Asset) -> list[MaintenanceItem]:
+    """Active maintenance items that recur (= preventive)."""
+    return [item for item in asset.maintenance_items.filter(is_active=True) if item.interval_days]
+
+
+def _days_until_due(item: MaintenanceItem) -> int | None:
+    """Whole days until the item is next due; None if never completed."""
+    due = item.next_due_at
+    if due is None:
+        return None
+    return (due.date() - timezone.now().date()).days
+
+
+def _item_status(item: MaintenanceItem) -> str:
+    if item.last_completed_at is None:
+        return _NEVER
+    days = _days_until_due(item)
+    if days is None:
+        return _NEVER
+    if days < 0:
+        return _OVERDUE
+    if item.interval_days and days <= max(1, int(item.interval_days * _WARNING_FRACTION)):
+        return _WARNING
+    return _OK
+
+
+def _next_due_item(asset: Asset) -> MaintenanceItem | None:
+    """Pick the recurring task that should drive the panel display.
+
+    Priority: overdue (most overdue first) → never completed → due soon →
+    ok (fewest days remaining). Returns ``None`` when the asset has no
+    active recurring maintenance items.
     """
-    schedules = list(asset.pm_schedules.filter(is_active=True))
-    if not schedules:
+    items = _recurring_items(asset)
+    if not items:
         return None
 
-    def sort_key(schedule: PMSchedule) -> tuple[int, int]:
-        # Status priority: overdue=0, warning=1, ok=2, never=3.
-        status_priority = {
-            PMSchedule.STATUS_OVERDUE: 0,
-            PMSchedule.STATUS_WARNING: 1,
-            PMSchedule.STATUS_OK: 2,
-            PMSchedule.STATUS_NEVER: 3,
-        }
-        days_remaining = schedule.days_until_due()
-        # For OVERDUE rows, days_until_due is negative — the *more*
-        # negative, the more overdue. For OK/WARNING, the *fewer*
-        # remaining days, the higher priority. NEVER → None, push to
-        # the end with a large sentinel.
-        sort_remaining = days_remaining if days_remaining is not None else 10_000
-        return (status_priority[schedule.status()], sort_remaining)
+    order = {_OVERDUE: 0, _NEVER: 1, _WARNING: 2, _OK: 3}
 
-    return sorted(schedules, key=sort_key)[0]
+    def sort_key(item: MaintenanceItem) -> tuple[int, int]:
+        days = _days_until_due(item)
+        # Never-completed sorts to the front of its bucket; within overdue
+        # the most-negative (most overdue) day count comes first.
+        return (order[_item_status(item)], days if days is not None else -10_000)
+
+    return sorted(items, key=sort_key)[0]
 
 
-def _snapshot_fingerprint(asset: Asset, schedules: Iterable[PMSchedule]) -> str:
-    """Return a stable hex fingerprint of the inputs to the rendered image.
-
-    The HTTP layer uses this as the response ETag; an unchanged
-    fingerprint means the panel can keep displaying its cached PNG.
-    """
+def _snapshot_fingerprint(asset: Asset, items: Iterable[MaintenanceItem]) -> str:
+    """Return a stable hex fingerprint of the inputs to the rendered image."""
     parts: list[str] = [str(asset.pk), asset.name]
-    for schedule in schedules:
-        last = schedule.last_log()
-        last_at = last.performed_at.isoformat() if last else "never"
-        parts.append(
-            "|".join(
-                [
-                    str(schedule.pk),
-                    schedule.task_name,
-                    str(schedule.interval_days),
-                    schedule.status(),
-                    last_at,
-                ]
-            )
-        )
+    for item in items:
+        last = item.last_completed_at.isoformat() if item.last_completed_at else "never"
+        parts.append("|".join([str(item.pk), item.title, str(item.interval_days), last]))
     digest = hashlib.sha256("\n".join(parts).encode("utf-8")).hexdigest()
     return digest[:32]
 
 
 def compute_snapshot_etag(asset: Asset) -> str:
     """Public helper for the view layer: stable ETag for an asset's PM state."""
-    schedules = list(asset.pm_schedules.filter(is_active=True).order_by("pk"))
-    return _snapshot_fingerprint(asset, schedules)
+    items = sorted(_recurring_items(asset), key=lambda item: str(item.pk))
+    return _snapshot_fingerprint(asset, items)
 
 
-def _draw_centered(
-    draw: ImageDraw.ImageDraw,
-    text: str,
-    y: int,
-    font: ImageFont.ImageFont,
-    fill: int = _FG,
-) -> None:
-    bbox = draw.textbbox((0, 0), text, font=font)
-    text_w = bbox[2] - bbox[0]
-    x = (EPAPER_WIDTH - text_w) // 2
-    draw.text((x, y), text, font=font, fill=fill)
-
-
-def _status_line(schedule: PMSchedule | None) -> str:
-    if schedule is None:
-        return "NO PM SCHEDULE"
-    status = schedule.status()
-    if status == PMSchedule.STATUS_NEVER:
-        return "NEVER SERVICED"
-    days = schedule.days_until_due() or 0
-    if status == PMSchedule.STATUS_OVERDUE:
-        # days is negative when overdue; show the absolute lateness.
+def _status_line(item: MaintenanceItem | None) -> str:
+    if item is None:
+        return "NO PM TASKS"
+    if item.last_completed_at is None:
+        return "DUE NOW"
+    days = _days_until_due(item)
+    if days is None:
+        return "DUE NOW"
+    if days < 0:
         return f"OVERDUE BY {abs(days)} DAYS"
     return f"{days} DAYS REMAINING"
 
 
-def render_pm_image(asset: Asset) -> bytes:
-    """Render the full panel image for ``asset`` and return PNG bytes."""
+# ---------------------------------------------------------------------------
+# Drawing helpers
+# ---------------------------------------------------------------------------
+
+
+def _text_size(draw: ImageDraw.ImageDraw, text: str, font) -> tuple[int, int]:
+    bbox = draw.textbbox((0, 0), text, font=font)
+    return bbox[2] - bbox[0], bbox[3] - bbox[1]
+
+
+def _wrap(draw, text: str, font, max_width: int, max_lines: int) -> list[str]:
+    """Greedy word-wrap; the final line is ellipsised if it overflows."""
+    words = text.split()
+    lines: list[str] = []
+    cur = ""
+    for word in words:
+        trial = f"{cur} {word}".strip()
+        if _text_size(draw, trial, font)[0] <= max_width or not cur:
+            cur = trial
+        else:
+            lines.append(cur)
+            cur = word
+            if len(lines) == max_lines:
+                break
+    if cur and len(lines) < max_lines:
+        lines.append(cur)
+    if len(lines) == max_lines and words:
+        # Make sure the last kept line plus any dropped words is marked.
+        joined = " ".join(lines)
+        if _text_size(draw, joined, font)[0] < _text_size(draw, text, font)[0]:
+            while lines[-1] and _text_size(draw, lines[-1] + "…", font)[0] > max_width:
+                lines[-1] = lines[-1][:-1]
+            lines[-1] = lines[-1].rstrip() + "…"
+    return lines or [""]
+
+
+def _fit_font(draw, text: str, kind: str, max_size: int, min_size: int, max_width: int):
+    """Largest font of ``kind`` at which ``text`` fits on one line."""
+    size = max_size
+    while size > min_size:
+        font = _font(kind, size)
+        if _text_size(draw, text, font)[0] <= max_width:
+            return font
+        size -= 2
+    return _font(kind, min_size)
+
+
+def _qr_image(data: str, target_px: int) -> Image.Image:
+    """Render ``data`` to a crisp monochrome QR of ~``target_px`` square."""
+    import qrcode
+
+    qr = qrcode.QRCode(
+        version=None,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=10,
+        border=2,
+    )
+    qr.add_data(data)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white").convert("L")
+    # NEAREST keeps the module edges hard so the panel threshold is clean.
+    return img.resize((target_px, target_px), Image.NEAREST)
+
+
+# ---------------------------------------------------------------------------
+# Main render
+# ---------------------------------------------------------------------------
+
+
+def render_pm_image(asset: Asset, *, service_url: str | None = None) -> bytes:
+    """Render the full panel image for ``asset`` and return PNG bytes.
+
+    ``service_url`` (when given) is encoded into a QR in the lower-right
+    so a maintainer can scan the panel, see the task, and log the work.
+    """
     img = Image.new("L", (EPAPER_WIDTH, EPAPER_HEIGHT), color=_BG)
     draw = ImageDraw.Draw(img)
+    right = EPAPER_WIDTH - _MARGIN
 
-    # Outer rule — thin border so the panel feels intentional, not
-    # like the firmware forgot to paint corners.
-    draw.rectangle([(8, 8), (EPAPER_WIDTH - 8, EPAPER_HEIGHT - 8)], outline=_FG, width=2)
+    # Frame.
+    draw.rectangle([(5, 5), (EPAPER_WIDTH - 6, EPAPER_HEIGHT - 6)], outline=_FG, width=4)
 
-    # Eyebrow.
-    _draw_centered(draw, "PREVENTIVE MAINTENANCE", 36, _FONT)
+    item = _next_due_item(asset)
+    status = _item_status(item) if item else None
+    urgent = status in (_OVERDUE, _NEVER)
 
-    # Asset name — large, centred.
-    _draw_centered(draw, asset.name.upper(), 90, _FONT)
+    # QR block (lower-right) — reserve its column so text wraps clear of it.
+    qr_px = 188
+    qr_x = right - qr_px
+    qr_y = EPAPER_HEIGHT - _MARGIN - 26 - qr_px
+    has_qr = bool(service_url)
+    text_right = (qr_x - 24) if has_qr else right
 
-    schedule = _next_due_schedule(asset)
-    task_line = schedule.task_name if schedule else "—"
-    _draw_centered(draw, task_line, 180, _FONT)
+    # Eyebrow + rule.
+    eyebrow = _font("mono_bold", 24)
+    draw.text((_MARGIN, _MARGIN - 8), "PREVENTIVE MAINTENANCE", font=eyebrow, fill=_FG)
+    rule_y = _MARGIN + 26
+    draw.line([(_MARGIN, rule_y), (right, rule_y)], fill=_FG, width=2)
 
-    # Status block — the headline number. Drawn into an inverted bar
-    # so the panel still reads clearly on a quick glance.
-    status_y = 250
-    status_text = _status_line(schedule)
-    inverted = schedule is not None and schedule.status() in (
-        PMSchedule.STATUS_OVERDUE,
-        PMSchedule.STATUS_NEVER,
-    )
-    if inverted:
-        draw.rectangle([(40, status_y - 20), (EPAPER_WIDTH - 40, status_y + 60)], fill=_FG)
-        _draw_centered(draw, status_text, status_y, _FONT, fill=_BG)
+    # Asset name — the "what is this" line. Auto-fit, wrap to 2 lines.
+    name = (asset.name or "UNNAMED ASSET").upper()
+    name_font = _fit_font(draw, name, "sans_bold", 52, 30, EPAPER_WIDTH - 2 * _MARGIN)
+    name_lines = _wrap(draw, name, name_font, EPAPER_WIDTH - 2 * _MARGIN, max_lines=2)
+    y = rule_y + 18
+    for line in name_lines:
+        draw.text((_MARGIN, y), line, font=name_font, fill=_FG)
+        y += _text_size(draw, line, name_font)[1] + 8
+
+    # PM task.
+    task_font = _font("sans", 30)
+    task_line = item.title if item else "No preventive tasks"
+    for line in _wrap(draw, task_line, task_font, text_right - _MARGIN, max_lines=2):
+        draw.text((_MARGIN, y), line, font=task_font, fill=_FG)
+        y += _text_size(draw, line, task_font)[1] + 6
+
+    # Status headline — the glanceable number, in a box. Inverted for
+    # overdue/never so a problem panel reads across the room.
+    status_text = _status_line(item)
+    box_top = max(y + 14, qr_y)
+    box_bottom = qr_y + qr_px
+    box_left = _MARGIN
+    box_right = text_right
+    status_font = _fit_font(draw, status_text, "sans_bold", 60, 26, (box_right - box_left) - 36)
+    sw, sh = _text_size(draw, status_text, status_font)
+    cx = box_left + (box_right - box_left) // 2
+    cy = box_top + (box_bottom - box_top) // 2
+    if urgent:
+        draw.rectangle([(box_left, box_top), (box_right, box_bottom)], fill=_FG)
+        draw.text((cx - sw // 2, cy - sh // 2 - 6), status_text, font=status_font, fill=_BG)
     else:
-        _draw_centered(draw, status_text, status_y, _FONT)
+        draw.rectangle([(box_left, box_top), (box_right, box_bottom)], outline=_FG, width=3)
+        draw.text((cx - sw // 2, cy - sh // 2 - 6), status_text, font=status_font, fill=_FG)
+
+    # QR + caption.
+    if has_qr:
+        img.paste(_qr_image(service_url, qr_px), (qr_x, qr_y))
+        cap = _font("mono_bold", 19)
+        for i, line in enumerate(("SCAN TO", "LOG SERVICE")):
+            cw = _text_size(draw, line, cap)[0]
+            draw.text(
+                (qr_x + (qr_px - cw) // 2, qr_y + qr_px + 2 + i * 22),
+                line,
+                font=cap,
+                fill=_FG,
+            )
 
     # Footer.
+    foot_y = EPAPER_HEIGHT - _MARGIN - 18
+    draw.line([(_MARGIN, foot_y - 8), (right, foot_y - 8)], fill=_FG, width=1)
     last_line = "Last serviced: never"
-    if schedule:
-        log = schedule.last_log()
-        if log is not None:
-            last_line = f"Last serviced: {log.performed_at.date().isoformat()}"
-    rendered_line = f"Rendered: {timezone.now().date().isoformat()}"
-    _draw_centered(draw, last_line, 380, _FONT)
-    _draw_centered(draw, rendered_line, 410, _FONT)
+    if item and item.last_completed_at:
+        last_line = f"Last serviced: {item.last_completed_at.date().isoformat()}"
+    tag = getattr(asset, "asset_tag", "") or ""
+    if tag:
+        last_line = f"{last_line}   ·   {tag}"
+    draw.text((_MARGIN, foot_y), last_line, font=_font("sans", 19), fill=_FG)
 
     buffer = io.BytesIO()
     img.save(buffer, format="PNG", optimize=True)

--- a/backend/forgekey/tests/test_epaper.py
+++ b/backend/forgekey/tests/test_epaper.py
@@ -3,7 +3,7 @@
 Covers:
   - Model: low-battery threshold, default ordering, asset binding.
   - Render service: deterministic ETag, image bytes are valid PNG,
-    status-line content reflects PMSchedule state.
+    status-line content reflects MaintenanceItem state.
   - Image endpoint: 200 on first fetch with ETag header, 304 on
     matching If-None-Match, auto-creates an unbound row on first
     contact (409), 404 for a retired display, 409 for an unbound
@@ -29,10 +29,24 @@ import pytest
 from forgekey.models import EPaperDisplay
 from forgekey.services.epaper_render import compute_snapshot_etag, render_pm_image
 from forgekey.tests.factories import ESP32DeviceFactory
-from inventory.models import Asset, Location
-from preventive_maintenance.models import PMSchedule, PMServiceLog
+from inventory.models import Asset, Location, MaintenanceItem
 
 pytestmark = pytest.mark.django_db
+
+
+def _make_item(
+    asset: Asset,
+    title: str = "Blade tension",
+    interval_days: int = 30,
+    last_done_days: int | None = None,
+) -> MaintenanceItem:
+    """A recurring (= preventive) maintenance item, optionally last completed
+    ``last_done_days`` ago. ``last_done_days=None`` leaves it never-completed."""
+    item = MaintenanceItem.objects.create(asset=asset, title=title, interval_days=interval_days)
+    if last_done_days is not None:
+        item.last_completed_at = timezone.now() - timedelta(days=last_done_days)
+        item.save(update_fields=["last_completed_at"])
+    return item
 
 
 def _make_asset(name: str = "ePaper Asset") -> Asset:
@@ -88,30 +102,29 @@ class TestEPaperDisplayModel:
 class TestEPaperRender:
     def test_etag_is_stable_for_same_state(self):
         asset = _make_asset("Bandsaw")
-        PMSchedule.objects.create(asset=asset, task_name="Blade tension", interval_days=30)
+        _make_item(asset, "Blade tension", interval_days=30)
         first = compute_snapshot_etag(asset)
         second = compute_snapshot_etag(asset)
         assert first == second
 
     def test_etag_changes_when_service_logged(self):
         asset = _make_asset("Bandsaw")
-        schedule = PMSchedule.objects.create(
-            asset=asset, task_name="Blade tension", interval_days=30
-        )
+        item = _make_item(asset, "Blade tension", interval_days=30)
         before = compute_snapshot_etag(asset)
-        PMServiceLog.objects.create(schedule=schedule, performed_at=timezone.now())
+        item.last_completed_at = timezone.now()
+        item.save(update_fields=["last_completed_at"])
         after = compute_snapshot_etag(asset)
         assert before != after
 
     def test_render_returns_png_bytes(self):
         asset = _make_asset()
-        PMSchedule.objects.create(asset=asset, task_name="Filter swap", interval_days=90)
+        _make_item(asset, "Filter swap", interval_days=90)
         png = render_pm_image(asset)
         # PNG magic: 89 50 4E 47 0D 0A 1A 0A.
         assert png[:8] == b"\x89PNG\r\n\x1a\n"
         assert len(png) > 100  # not an empty buffer
 
-    def test_render_handles_asset_without_schedules(self):
+    def test_render_handles_asset_without_items(self):
         asset = _make_asset("Idle")
         png = render_pm_image(asset)
         assert png[:8] == b"\x89PNG\r\n\x1a\n"
@@ -125,7 +138,7 @@ class TestEPaperRender:
 class TestEPaperImageEndpoint:
     def test_image_endpoint_returns_png_with_etag(self, client):
         asset = _make_asset()
-        PMSchedule.objects.create(asset=asset, task_name="Lube", interval_days=90)
+        _make_item(asset, "Lube", interval_days=90)
         display = _bind_display(asset)
         url = reverse("forgekey:epaper-image", args=[display.id])
         response = client.get(url)
@@ -354,3 +367,104 @@ class TestEPaperBatteryEndpoint:
         client.post(self._url(display), data={"percent": 40}, content_type="application/json")
         display.refresh_from_db()
         assert display.battery_percent == 40
+
+
+# ---------------------------------------------------------------------------
+# Scan-to-log service endpoints (front-end "complete this PM" page)
+# ---------------------------------------------------------------------------
+
+
+class TestEPaperServiceInfo:
+    def _url(self, display_id) -> str:
+        return reverse("forgekey:epaper-service-info", args=[display_id])
+
+    def test_info_is_public_and_lists_due_task(self, client):
+        asset = _make_asset("Bandsaw")
+        item = _make_item(asset, "Blade tension", interval_days=30, last_done_days=41)
+        display = _bind_display(asset)
+        response = client.get(self._url(display.id))
+        assert response.status_code == 200
+        body = response.json()
+        assert body["bound"] is True
+        assert body["asset"]["name"] == "Bandsaw"
+        assert body["primary_item_id"] == str(item.pk)
+        assert body["items"][0]["title"] == "Blade tension"
+        assert body["items"][0]["status"] == "overdue"
+
+    def test_info_excludes_non_recurring_items(self, client):
+        # One-off items (no interval) are not "preventive" → off the panel.
+        asset = _make_asset("Bandsaw")
+        MaintenanceItem.objects.create(asset=asset, title="One-off fix", interval_days=None)
+        display = _bind_display(asset)
+        body = client.get(self._url(display.id)).json()
+        assert body["items"] == []
+        assert body["primary_item_id"] is None
+
+    def test_info_409_when_unbound(self, client):
+        display = _bind_display(asset=None)
+        response = client.get(self._url(display.id))
+        assert response.status_code == 409
+        assert response.json()["bound"] is False
+
+    def test_info_404_when_retired(self, client):
+        display = _bind_display(_make_asset())
+        display.is_active = False
+        display.save(update_fields=["is_active"])
+        response = client.get(self._url(display.id))
+        assert response.status_code == 404
+
+
+class TestEPaperServiceComplete:
+    def _url(self, display_id) -> str:
+        return reverse("forgekey:epaper-complete", args=[display_id])
+
+    def test_complete_requires_authentication(self, client):
+        display = _bind_display(_make_asset())
+        _make_item(display.asset, "Lube", interval_days=30)
+        response = client.post(self._url(display.id), data={}, content_type="application/json")
+        assert response.status_code in (401, 403)
+
+    def test_complete_logs_attributable_service_and_resets_status(self, authenticated_client):
+        client, user = authenticated_client
+        asset = _make_asset("Bandsaw")
+        item = _make_item(asset, "Blade tension", interval_days=30, last_done_days=41)
+        assert item.is_overdue is True
+        display = _bind_display(asset)
+
+        response = client.post(
+            self._url(display.id), data={"notes": "swapped blade"}, format="json"
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["ok"] is True
+        assert body["status"] == "ok"
+
+        latest = item.logs.order_by("-completed_at").first()
+        assert latest.completed_by_id == user.pk
+        assert latest.notes == "swapped blade"
+        item.refresh_from_db()
+        assert item.is_overdue is False
+
+    def test_complete_honours_explicit_item_id(self, authenticated_client):
+        client, _user = authenticated_client
+        asset = _make_asset("Mill")
+        lube = _make_item(asset, "Lube", interval_days=30)
+        belt = _make_item(asset, "Belt", interval_days=60)
+        display = _bind_display(asset)
+
+        response = client.post(self._url(display.id), data={"item_id": str(belt.pk)}, format="json")
+        assert response.status_code == 201
+        assert belt.logs.exists() is True
+        assert lube.logs.exists() is False
+
+    def test_complete_400_when_asset_has_no_schedule(self, authenticated_client):
+        client, _user = authenticated_client
+        display = _bind_display(_make_asset("Idle"))
+        response = client.post(self._url(display.id), data={}, format="json")
+        assert response.status_code == 400
+
+    def test_complete_409_when_unbound(self, authenticated_client):
+        client, _user = authenticated_client
+        display = _bind_display(asset=None)
+        response = client.post(self._url(display.id), data={}, format="json")
+        assert response.status_code == 409

--- a/backend/forgekey/urls.py
+++ b/backend/forgekey/urls.py
@@ -16,6 +16,8 @@ from .views import (
     EPaperDisplayBatteryView,
     EPaperDisplayBindView,
     EPaperDisplayImageView,
+    EPaperServiceCompleteView,
+    EPaperServiceInfoView,
     ESP32DeviceViewSet,
     FirmwareVersionViewSet,
     ForgeKeyCertificateRevocationListView,
@@ -99,6 +101,16 @@ urlpatterns = [
         "epaper/<uuid:display_id>/bind/",
         EPaperDisplayBindView.as_view(),
         name="epaper-bind",
+    ),
+    path(
+        "epaper/<uuid:display_id>/service-info/",
+        EPaperServiceInfoView.as_view(),
+        name="epaper-service-info",
+    ),
+    path(
+        "epaper/<uuid:display_id>/complete/",
+        EPaperServiceCompleteView.as_view(),
+        name="epaper-complete",
     ),
     path("", include(router.urls)),
 ]

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -1747,6 +1747,18 @@ class ForgeKeyCertificateRevocationListView(APIView):
         return response
 
 
+def epaper_service_url(request, display_pk) -> str:
+    """Front-end "log service" page a maintainer lands on from a panel QR.
+
+    This is a React-Router route (mirrors the bind page's
+    ``/forgekey/epaper/...`` path), not a Django view, so it is built as a
+    plain path rather than reversed. Front-end and API share the origin
+    behind nginx in prod, so deriving it from the request host keeps the
+    QR correct across dev/staging/prod without a hardcoded domain.
+    """
+    return request.build_absolute_uri(f"/forgekey/epaper/service?did={display_pk}")
+
+
 class EPaperDisplayImageView(APIView):
     """Return the latest PM-status PNG for a XIAO 7.5" ePaper panel.
 
@@ -1786,7 +1798,13 @@ class EPaperDisplayImageView(APIView):
         if if_none_match and if_none_match == etag:
             return HttpResponse(status=304)
 
-        png_bytes = render_pm_image(display.asset)
+        # The QR encodes the front-end "log service" page for this panel
+        # (mirrors the bind page's /forgekey/epaper/... route). Built from
+        # the host the firmware reached us on so it stays correct across
+        # dev/staging/prod without a hardcoded domain — front-end and API
+        # share the origin behind nginx in prod.
+        service_url = epaper_service_url(request, display.pk)
+        png_bytes = render_pm_image(display.asset, service_url=service_url)
         # Record what version the panel just flashed; the operator
         # dashboard reads `last_image_at` to spot stale panels.
         EPaperDisplay.objects.filter(pk=display.pk).update(
@@ -1797,6 +1815,134 @@ class EPaperDisplayImageView(APIView):
         response["ETag"] = f'"{etag}"'
         response["Cache-Control"] = "no-cache, must-revalidate"
         return response
+
+
+class EPaperServiceInfoView(APIView):
+    """What-needs-doing payload for the scan-to-log front-end page.
+
+    AllowAny: reading the task is as public as the panel face mounted on
+    the asset. Logging the work (``/complete/``) requires auth so the
+    MaintenanceLog is attributable.
+    """
+
+    permission_classes = [AllowAny]
+
+    def get(self, request, display_id):
+        try:
+            display = EPaperDisplay.objects.select_related("asset", "asset__location").get(
+                pk=display_id
+            )
+        except EPaperDisplay.DoesNotExist:
+            return Response({"detail": "Unknown display."}, status=status.HTTP_404_NOT_FOUND)
+        if not display.is_active:
+            return Response({"detail": "Display retired."}, status=status.HTTP_404_NOT_FOUND)
+        if display.asset_id is None:
+            return Response(
+                {"detail": "Display is not bound to an asset.", "bound": False},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        from .services.epaper_render import (
+            _days_until_due,
+            _item_status,
+            _next_due_item,
+            _recurring_items,
+            _status_line,
+        )
+
+        asset = display.asset
+        items = _recurring_items(asset)
+        primary = _next_due_item(asset)
+
+        def serialize(item):
+            return {
+                "id": str(item.pk),
+                "title": item.title,
+                "interval_days": item.interval_days,
+                "status": _item_status(item),
+                "days_until_due": _days_until_due(item),
+                "status_line": _status_line(item),
+                "last_completed": (
+                    item.last_completed_at.date().isoformat() if item.last_completed_at else None
+                ),
+                "instructions": item.instructions or "",
+            }
+
+        return Response(
+            {
+                "display_id": str(display.pk),
+                "bound": True,
+                "asset": {
+                    "id": str(asset.pk),
+                    "name": asset.name,
+                    "asset_tag": getattr(asset, "asset_tag", "") or "",
+                    "location": asset.location.name if asset.location_id else None,
+                },
+                "items": [serialize(i) for i in items],
+                "primary_item_id": str(primary.pk) if primary else None,
+            }
+        )
+
+
+class EPaperServiceCompleteView(APIView):
+    """Log a PM service from the scanned panel page.
+
+    Login required (any member) so ``MaintenanceLog.completed_by`` records
+    who did the work. Logging a service shifts the asset's ETag, so the
+    panel paints the reset countdown on its next wake.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, display_id):
+        try:
+            display = EPaperDisplay.objects.select_related("asset").get(pk=display_id)
+        except EPaperDisplay.DoesNotExist:
+            return Response({"detail": "Unknown display."}, status=status.HTTP_404_NOT_FOUND)
+        if not display.is_active or display.asset_id is None:
+            return Response(
+                {"detail": "Display is not bound to an active asset."},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        from inventory.models import MaintenanceLog
+
+        from .services.epaper_render import _item_status, _next_due_item, _status_line
+
+        active = display.asset.maintenance_items.filter(is_active=True)
+        item_id = request.data.get("item_id")
+        if item_id:
+            item = active.filter(pk=item_id).first()
+        else:
+            item = _next_due_item(display.asset)
+        if item is None:
+            return Response(
+                {"detail": "No matching active maintenance task for this asset."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Mirror inventory's MaintenanceItem.complete action: log the
+        # completion (attributed) and roll the item's due date forward.
+        notes = (request.data.get("notes") or "").strip()
+        log = MaintenanceLog.objects.create(
+            maintenance_item=item,
+            completed_by=request.user,
+            notes=notes,
+        )
+        item.last_completed_at = log.completed_at
+        item.save(update_fields=["last_completed_at"])
+        return Response(
+            {
+                "ok": True,
+                "item_id": str(item.pk),
+                "title": item.title,
+                "status": _item_status(item),
+                "status_line": _status_line(item),
+                "completed_at": log.completed_at.isoformat(),
+                "completed_by": getattr(request.user, "username", None),
+            },
+            status=status.HTTP_201_CREATED,
+        )
 
 
 class EPaperDisplayBatteryView(APIView):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ import FixtureScanPage from './pages/FixtureScanPage';
 import ForgeKeyDeviceDetailPage from './pages/ForgeKeyDeviceDetailPage';
 import ForgeKeyDevicesPage from './pages/ForgeKeyDevicesPage';
 import ForgeKeyEPaperBindPage from './pages/ForgeKeyEPaperBindPage';
+import ForgeKeyEPaperServicePage from './pages/ForgeKeyEPaperServicePage';
 import HomePage from './pages/HomePage';
 import PurchasingOverviewPage from './pages/PurchasingOverviewPage';
 import ReportsOverviewPage from './pages/ReportsOverviewPage';
@@ -219,6 +220,7 @@ function AppContent() {
           <Route path="/facilities/forgekey-devices" element={<WorkspaceLayout><ForgeKeyDevicesPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-devices/:id" element={<WorkspaceLayout><ForgeKeyDeviceDetailPage /></WorkspaceLayout>} />
           <Route path="/forgekey/epaper/bind" element={<WorkspaceLayout><ForgeKeyEPaperBindPage /></WorkspaceLayout>} />
+          <Route path="/forgekey/epaper/service" element={<WorkspaceLayout><ForgeKeyEPaperServicePage /></WorkspaceLayout>} />
           <Route path="/inventory/code-entry" element={<Navigate to="/inventory/scan" replace />} />
           <Route path="/inventory/transparency" element={<WorkspaceLayout><TransparencyPage /></WorkspaceLayout>} />
           <Route path="/inventory/scan" element={<WorkspaceLayout><CodeEntryPage /></WorkspaceLayout>} />

--- a/frontend/src/navigation/routeMap.ts
+++ b/frontend/src/navigation/routeMap.ts
@@ -71,6 +71,7 @@ const ENTRIES: RouteEntry[] = [
   { path: 'facilities/electrical/network-drops', label: 'Network Drops', clickable: false },
   { path: 'facilities/forgekey-devices', label: 'ForgeKey Devices' },
   { path: 'forgekey/epaper/bind', label: 'Bind ePaper Panel' },
+  { path: 'forgekey/epaper/service', label: 'Log ePaper Service' },
 
   { path: 'maintenance', label: 'Maintenance' },
   { path: 'maintenance/dashboard', label: 'PM Dashboard' },

--- a/frontend/src/pages/ForgeKeyEPaperServicePage.tsx
+++ b/frontend/src/pages/ForgeKeyEPaperServicePage.tsx
@@ -1,0 +1,248 @@
+/**
+ * ForgeKey ePaper "Log Service" Page
+ *
+ * Mobile-first page a maintainer lands on after scanning the QR on a
+ * mounted ePaper panel (`?did=<uuid>`). It shows the asset's recurring
+ * maintenance task(s) — readable by anyone, like the panel face itself —
+ * and lets a logged-in member check the work off. Logging a completion
+ * records an attributable MaintenanceLog; the panel repaints the reset
+ * countdown on its next wake.
+ *
+ * Mirrors ForgeKeyEPaperBindPage's shape (route param, api service,
+ * Mantine UI). Viewing is public; the "Mark complete" action requires a
+ * login (`token` in localStorage) and the backend re-checks auth.
+ */
+import { Alert, Badge, Button, Loader, Paper, Stack, Text, Title } from '@mantine/core';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { forgekeyAPI } from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+interface ItemRow {
+  id: string;
+  title: string;
+  interval_days: number | null;
+  status: string;
+  days_until_due: number | null;
+  status_line: string;
+  last_completed: string | null;
+  instructions: string;
+}
+
+interface ServiceInfo {
+  display_id: string;
+  bound: boolean;
+  asset: { id: string; name: string; asset_tag: string; location: string | null };
+  items: ItemRow[];
+  primary_item_id: string | null;
+}
+
+const statusColor = (status: string): string => {
+  switch (status) {
+    case 'overdue':
+      return 'red';
+    case 'warning':
+      return 'yellow';
+    case 'never':
+      return 'gray';
+    default:
+      return 'green';
+  }
+};
+
+const ForgeKeyEPaperServicePage: React.FC = () => {
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const did = params.get('did') ?? '';
+  const loggedIn =
+    typeof window !== 'undefined' && Boolean(localStorage.getItem('token'));
+
+  const [info, setInfo] = useState<ServiceInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [submittingId, setSubmittingId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [justCompleted, setJustCompleted] = useState<Record<string, string>>({});
+
+  const load = useCallback(async () => {
+    if (!did) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const response = await forgekeyAPI.getEPaperServiceInfo(did);
+      setInfo(response.data);
+    } catch (err) {
+      const code = (err as { response?: { status?: number } })?.response?.status;
+      if (code === 409) {
+        setLoadError("This panel isn't bound to an asset yet. Scan the bind QR first.");
+      } else if (code === 404) {
+        setLoadError('This panel has been retired in OMS.');
+      } else {
+        setLoadError(extractErrorMessage(err, 'Failed to load panel info.'));
+      }
+      setInfo(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [did]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleComplete = useCallback(
+    async (itemId: string) => {
+      if (!loggedIn) {
+        // Punt to the login surface; SessionExpiredBanner restores the URL.
+        navigate('/');
+        return;
+      }
+      setSubmittingId(itemId);
+      setActionError(null);
+      try {
+        const response = await forgekeyAPI.completeEPaperService(did, {
+          item_id: itemId,
+        });
+        setJustCompleted((prev) => ({ ...prev, [itemId]: response.data.status_line }));
+        await load();
+      } catch (err) {
+        setActionError(extractErrorMessage(err, 'Failed to record completion.'));
+      } finally {
+        setSubmittingId(null);
+      }
+    },
+    [did, loggedIn, navigate, load],
+  );
+
+  if (!did) {
+    return (
+      <Paper p="lg" m="md" withBorder>
+        <Title order={3}>No display_id</Title>
+        <Text mt="sm">
+          This page expects a <code>?did=</code> query parameter from the
+          panel's QR. Scan the QR on the panel face instead.
+        </Text>
+      </Paper>
+    );
+  }
+
+  if (loading) {
+    return (
+      <Stack align="center" gap="xs" py="xl">
+        <Loader />
+        <Text size="sm" c="dimmed">
+          Loading panel…
+        </Text>
+      </Stack>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <Paper p="lg" m="md" withBorder>
+        <Stack gap="sm">
+          <Title order={3}>Preventive maintenance</Title>
+          <Alert color="red" variant="light">
+            {loadError}
+          </Alert>
+        </Stack>
+      </Paper>
+    );
+  }
+
+  if (!info) {
+    return null;
+  }
+
+  return (
+    <Paper p="lg" m="md" withBorder>
+      <Stack gap="md">
+        <Stack gap={2}>
+          <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+            Preventive maintenance
+          </Text>
+          <Title order={2}>{info.asset.name}</Title>
+          <Text size="sm" c="dimmed">
+            {info.asset.location || 'No location'}
+            {info.asset.asset_tag ? ` · ${info.asset.asset_tag}` : ''}
+          </Text>
+        </Stack>
+
+        {!loggedIn && (
+          <Alert color="blue" variant="light">
+            You can mark a task complete once you’re logged in to OMS.
+          </Alert>
+        )}
+        {actionError && (
+          <Alert color="red" variant="light">
+            {actionError}
+          </Alert>
+        )}
+
+        {info.items.length === 0 ? (
+          <Text size="sm" c="dimmed">
+            No recurring maintenance tasks are scheduled for this asset.
+          </Text>
+        ) : (
+          <Stack gap="sm">
+            {info.items.map((item) => {
+              const done = justCompleted[item.id];
+              return (
+                <Paper
+                  key={item.id}
+                  p="md"
+                  withBorder
+                  radius="md"
+                  data-testid={`item-row-${item.id}`}
+                >
+                  <Stack gap="xs">
+                    <Stack gap={2}>
+                      <Text fw={600}>{item.title}</Text>
+                      <Badge color={statusColor(done ? 'ok' : item.status)} variant="light">
+                        {done || item.status_line}
+                      </Badge>
+                      <Text size="xs" c="dimmed">
+                        {item.last_completed
+                          ? `Last serviced: ${item.last_completed}`
+                          : 'Last serviced: never'}
+                        {item.interval_days ? ` · every ${item.interval_days} days` : ''}
+                      </Text>
+                      {item.instructions && (
+                        <Text size="sm" mt={4} style={{ whiteSpace: 'pre-wrap' }}>
+                          {item.instructions}
+                        </Text>
+                      )}
+                    </Stack>
+                    <Button
+                      onClick={() => handleComplete(item.id)}
+                      loading={submittingId === item.id}
+                      disabled={Boolean(done)}
+                      variant={done ? 'light' : 'filled'}
+                      fullWidth
+                    >
+                      {done
+                        ? 'Completed — thank you'
+                        : loggedIn
+                          ? 'Mark complete'
+                          : 'Log in to mark complete'}
+                    </Button>
+                  </Stack>
+                </Paper>
+              );
+            })}
+          </Stack>
+        )}
+
+        <Text size="xs" c="dimmed">
+          The panel updates on its next wake (within the configured wake
+          interval). display_id: <code>{did}</code>
+        </Text>
+      </Stack>
+    </Paper>
+  );
+};
+
+export default ForgeKeyEPaperServicePage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1778,6 +1778,38 @@ export const forgekeyAPI = {
       `/forgekey/epaper/${displayId}/bind/`,
       { asset_id: assetId },
     ),
+  // Scan-to-log page: read the panel's recurring maintenance tasks (public)…
+  getEPaperServiceInfo: (displayId: string) =>
+    api.get<{
+      display_id: string;
+      bound: boolean;
+      asset: { id: string; name: string; asset_tag: string; location: string | null };
+      items: Array<{
+        id: string;
+        title: string;
+        interval_days: number | null;
+        status: string;
+        days_until_due: number | null;
+        status_line: string;
+        last_completed: string | null;
+        instructions: string;
+      }>;
+      primary_item_id: string | null;
+    }>(`/forgekey/epaper/${displayId}/service-info/`),
+  // …and log a completed maintenance task (auth required, attributed to the user).
+  completeEPaperService: (
+    displayId: string,
+    payload: { item_id?: string; notes?: string },
+  ) =>
+    api.post<{
+      ok: boolean;
+      item_id: string;
+      title: string;
+      status: string;
+      status_line: string;
+      completed_at: string;
+      completed_by: string | null;
+    }>(`/forgekey/epaper/${displayId}/complete/`, payload),
 };
 
 export const makerBoxesAPI = {


### PR DESCRIPTION
## What & why

The XIAO 7.5" ePaper PM panel showed only a border / "NO PM SCHEDULE": the renderer used PIL's ~10px default font on an 800×480 panel **and** read the empty `PMSchedule` table instead of the `inventory.MaintenanceItem` tasks the Maintenance UI actually uses.

## Changes

- **Render redesign** — DejaVu fonts at panel scale, clear hierarchy (asset name → boxed status headline, inverted for overdue/never), plus an asset **QR**.
- **Re-pointed to `inventory.MaintenanceItem`** (a recurring item = preventive). The separate `preventive_maintenance` app is left untouched.
- **Scan-to-log flow** — QR → `/forgekey/epaper/service?did=` front-end page (mirrors the bind page). `GET …/service-info/` (public) lists due tasks; `POST …/complete/` (login required) writes an attributable `MaintenanceLog` and resets the countdown, which the panel repaints on its next wake.
- **Tooling** — `manage.py epaper_preview` renders a sample PNG; `EPaperDisplayAdmin` gains a "Preview Image" link.

## Test plan

- `pytest backend/forgekey/tests/test_epaper.py` → **35 passing** (render states, ETag, image/battery/bind endpoints, new service-info + complete).
- `npm run build` clean; new TS files typecheck clean; eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)