### PR TITLE
fix(forgekey): classify ePaper endpoints in api_permission_matrix

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -623,6 +623,21 @@ views:
       update:
         permission_classes:
         - IsAuthenticatedOrReadOnly
+  forgekey.views.EPaperDisplayBatteryView:
+    permission_classes:
+    - AllowAny
+  forgekey.views.EPaperDisplayBindView:
+    permission_classes:
+    - IsAuthenticated
+  forgekey.views.EPaperDisplayImageView:
+    permission_classes:
+    - AllowAny
+  forgekey.views.EPaperServiceCompleteView:
+    permission_classes:
+    - IsAuthenticated
+  forgekey.views.EPaperServiceInfoView:
+    permission_classes:
+    - AllowAny
   forgekey.views.ESP32DeviceViewSet:
     actions:
       command_blink:
@@ -706,12 +721,6 @@ views:
     permission_classes:
     - AllowAny
   forgekey.views.ForgeKeyFirmwareDownloadView:
-    permission_classes:
-    - AllowAny
-  forgekey.views.EPaperDisplayBatteryView:
-    permission_classes:
-    - AllowAny
-  forgekey.views.EPaperDisplayImageView:
     permission_classes:
     - AllowAny
   forgekey.views.ForgeKeyFirmwarePublicKeyView:


### PR DESCRIPTION
## Why

`main` is red: `config/tests/test_permission_matrix.py::test_permission_matrix_in_sync` requires every URL-routed DRF view to be classified in `config/api_permission_matrix.yaml`. Three ePaper endpoints were unclassified:

- `EPaperServiceInfoView` (AllowAny) and `EPaperServiceCompleteView` (IsAuthenticated) — added in #629
- `EPaperDisplayBindView` (IsAuthenticated) — pre-existing gap from #619

(#629 merged via Mergify even though Backend Tests failed, so this lands the missing matrix entries as a fast follow-up.)

## Change

Regenerated the YAML with `python manage.py check_permission_matrix --write` — adds the three entries and sorts the existing Battery/Image entries into place. YAML-only, no code change.

## Test plan

`pytest backend/config/tests/test_permission_matrix.py` → 2 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)