### PR TITLE
feat(forgekey): ePaper scan page shows a full work order

### DIFF
--- a/backend/forgekey/tests/test_epaper.py
+++ b/backend/forgekey/tests/test_epaper.py
@@ -400,6 +400,57 @@ class TestEPaperServiceInfo:
         assert body["items"] == []
         assert body["primary_item_id"] is None
 
+    def test_info_includes_work_order_detail(self, client):
+        from decimal import Decimal
+
+        from inventory.models import MaintenanceMaterial, MaintenanceTask
+        from loto.models import AssetEnergySource, LOTODevice
+
+        asset = _make_asset("Mill")
+        asset.lockout_instructions = "Verify zero energy at the panel."
+        asset.save(update_fields=["lockout_instructions"])
+
+        item = _make_item(asset, "Lube", interval_days=30, last_done_days=5)
+        item.instructions = "Use way oil only."
+        item.estimated_time_minutes = 20
+        item.save(update_fields=["instructions", "estimated_time_minutes"])
+        MaintenanceTask.objects.create(
+            maintenance_item=item, order=1, title="Wipe ways", is_required=True
+        )
+        MaintenanceTask.objects.create(maintenance_item=item, order=2, title="Apply oil")
+        MaintenanceMaterial.objects.create(
+            maintenance_item=item, name="Way oil", quantity=Decimal("50"), unit="ml"
+        )
+
+        source = AssetEnergySource.objects.create(
+            asset=asset,
+            source_type=AssetEnergySource.SOURCE_ELECTRICAL,
+            magnitude="240V",
+            isolation_point="Panel A breaker 12",
+        )
+        device = LOTODevice.objects.create(
+            device_type=LOTODevice.DEVICE_TYPE_CHOICES[0][0], label="PAD-001"
+        )
+        source.required_devices.add(device)
+
+        display = _bind_display(asset)
+        body = client.get(self._url(display.id)).json()
+
+        # Asset-level lockout/tagout
+        assert body["loto"]["instructions"] == "Verify zero energy at the panel."
+        es = body["loto"]["energy_sources"][0]
+        assert es["magnitude"] == "240V"
+        assert es["isolation_point"] == "Panel A breaker 12"
+        assert es["devices"][0]["label"] == "PAD-001"
+
+        # Per-task work-order detail
+        work_order = body["items"][0]
+        assert work_order["estimated_time_minutes"] == 20
+        assert work_order["instructions"] == "Use way oil only."
+        assert [s["title"] for s in work_order["steps"]] == ["Wipe ways", "Apply oil"]
+        assert work_order["steps"][0]["is_required"] is True
+        assert work_order["materials"][0]["name"] == "Way oil"
+
     def test_info_409_when_unbound(self, client):
         display = _bind_display(asset=None)
         response = client.get(self._url(display.id))

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -1817,6 +1817,31 @@ class EPaperDisplayImageView(APIView):
         return response
 
 
+def _serialize_loto(asset) -> dict:
+    """Lockout/tagout payload for the work-order page: free-form
+    instructions plus each energy source to isolate and the lock devices
+    it needs. Stale (de-derived) sources are omitted.
+    """
+    sources = asset.energy_sources.filter(is_stale=False).prefetch_related("required_devices")
+    return {
+        "instructions": getattr(asset, "lockout_instructions", "") or "",
+        "energy_sources": [
+            {
+                "source_type": source.source_type,
+                "source_type_display": source.get_source_type_display(),
+                "magnitude": source.magnitude or "",
+                "isolation_point": source.isolation_point or "",
+                "notes": source.notes or "",
+                "devices": [
+                    {"device_type": device.get_device_type_display(), "label": device.label}
+                    for device in source.required_devices.all()
+                ],
+            }
+            for source in sources
+        ],
+    }
+
+
 class EPaperServiceInfoView(APIView):
     """What-needs-doing payload for the scan-to-log front-end page.
 
@@ -1866,6 +1891,28 @@ class EPaperServiceInfoView(APIView):
                     item.last_completed_at.date().isoformat() if item.last_completed_at else None
                 ),
                 "instructions": item.instructions or "",
+                "estimated_time_minutes": item.estimated_time_minutes,
+                # Ordered checklist of what to actually do (printed-work-order parity).
+                "steps": [
+                    {
+                        "order": task.order,
+                        "title": task.title,
+                        "description": task.description or "",
+                        "is_required": task.is_required,
+                    }
+                    for task in item.tasks.order_by("order", "title")
+                ],
+                # Tools / parts / supplies needed for the job.
+                "materials": [
+                    {
+                        "name": material.name,
+                        "quantity": (
+                            str(material.quantity) if material.quantity is not None else None
+                        ),
+                        "unit": material.unit or "",
+                    }
+                    for material in item.materials.all()
+                ],
             }
 
         return Response(
@@ -1878,6 +1925,9 @@ class EPaperServiceInfoView(APIView):
                     "asset_tag": getattr(asset, "asset_tag", "") or "",
                     "location": asset.location.name if asset.location_id else None,
                 },
+                # Asset-level lockout/tagout: free-form instructions plus the
+                # energy sources to isolate and the lock devices needed.
+                "loto": _serialize_loto(asset),
                 "items": [serialize(i) for i in items],
                 "primary_item_id": str(primary.pk) if primary else None,
             }

--- a/frontend/src/pages/ForgeKeyEPaperServicePage.tsx
+++ b/frontend/src/pages/ForgeKeyEPaperServicePage.tsx
@@ -1,22 +1,62 @@
 /**
- * ForgeKey ePaper "Log Service" Page
+ * ForgeKey ePaper "Work Order" Page
  *
  * Mobile-first page a maintainer lands on after scanning the QR on a
- * mounted ePaper panel (`?did=<uuid>`). It shows the asset's recurring
- * maintenance task(s) — readable by anyone, like the panel face itself —
- * and lets a logged-in member check the work off. Logging a completion
- * records an attributable MaintenanceLog; the panel repaints the reset
- * countdown on its next wake.
+ * mounted ePaper panel (`?did=<uuid>`). It presents the asset's recurring
+ * maintenance as a work order — lockout/tagout to perform first, tools &
+ * materials to gather, the ordered steps to follow — and lets a logged-in
+ * member check the work off. Logging a completion records an attributable
+ * MaintenanceLog; the panel repaints the reset countdown on its next wake.
  *
  * Mirrors ForgeKeyEPaperBindPage's shape (route param, api service,
  * Mantine UI). Viewing is public; the "Mark complete" action requires a
  * login (`token` in localStorage) and the backend re-checks auth.
  */
-import { Alert, Badge, Button, Loader, Paper, Stack, Text, Title } from '@mantine/core';
+import {
+  Alert,
+  Badge,
+  Button,
+  Divider,
+  Group,
+  List,
+  Loader,
+  Paper,
+  Stack,
+  Text,
+  ThemeIcon,
+  Title,
+} from '@mantine/core';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { forgekeyAPI } from '../services/api';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+interface Step {
+  order: number;
+  title: string;
+  description: string;
+  is_required: boolean;
+}
+
+interface Material {
+  name: string;
+  quantity: string | null;
+  unit: string;
+}
+
+interface EnergySource {
+  source_type: string;
+  source_type_display: string;
+  magnitude: string;
+  isolation_point: string;
+  notes: string;
+  devices: Array<{ device_type: string; label: string }>;
+}
+
+interface Loto {
+  instructions: string;
+  energy_sources: EnergySource[];
+}
 
 interface ItemRow {
   id: string;
@@ -27,12 +67,16 @@ interface ItemRow {
   status_line: string;
   last_completed: string | null;
   instructions: string;
+  estimated_time_minutes: number | null;
+  steps: Step[];
+  materials: Material[];
 }
 
 interface ServiceInfo {
   display_id: string;
   bound: boolean;
   asset: { id: string; name: string; asset_tag: string; location: string | null };
+  loto: Loto;
   items: ItemRow[];
   primary_item_id: string | null;
 }
@@ -48,6 +92,52 @@ const statusColor = (status: string): string => {
     default:
       return 'green';
   }
+};
+
+const formatMaterial = (material: Material): string => {
+  const qty = [material.quantity, material.unit].filter(Boolean).join(' ').trim();
+  return qty ? `${material.name} — ${qty}` : material.name;
+};
+
+const LotoSection: React.FC<{ loto: Loto }> = ({ loto }) => {
+  const hasContent = loto.instructions || loto.energy_sources.length > 0;
+  if (!hasContent) {
+    return null;
+  }
+  return (
+    <Alert color="red" variant="light" title="Lockout / Tagout — isolate before servicing">
+      <Stack gap="xs">
+        {loto.instructions && (
+          <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
+            {loto.instructions}
+          </Text>
+        )}
+        {loto.energy_sources.map((source, idx) => (
+          <Stack key={idx} gap={2}>
+            <Text size="sm" fw={600}>
+              {source.source_type_display}
+              {source.magnitude ? ` · ${source.magnitude}` : ''}
+            </Text>
+            {source.isolation_point && (
+              <Text size="xs" c="dimmed">
+                Isolate at: {source.isolation_point}
+              </Text>
+            )}
+            {source.devices.length > 0 && (
+              <Text size="xs" c="dimmed">
+                Locks: {source.devices.map((d) => `${d.label} (${d.device_type})`).join(', ')}
+              </Text>
+            )}
+            {source.notes && (
+              <Text size="xs" c="dimmed">
+                {source.notes}
+              </Text>
+            )}
+          </Stack>
+        ))}
+      </Stack>
+    </Alert>
+  );
 };
 
 const ForgeKeyEPaperServicePage: React.FC = () => {
@@ -134,7 +224,7 @@ const ForgeKeyEPaperServicePage: React.FC = () => {
       <Stack align="center" gap="xs" py="xl">
         <Loader />
         <Text size="sm" c="dimmed">
-          Loading panel…
+          Loading work order…
         </Text>
       </Stack>
     );
@@ -162,7 +252,7 @@ const ForgeKeyEPaperServicePage: React.FC = () => {
       <Stack gap="md">
         <Stack gap={2}>
           <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
-            Preventive maintenance
+            Maintenance work order
           </Text>
           <Title order={2}>{info.asset.name}</Title>
           <Text size="sm" c="dimmed">
@@ -170,6 +260,8 @@ const ForgeKeyEPaperServicePage: React.FC = () => {
             {info.asset.asset_tag ? ` · ${info.asset.asset_tag}` : ''}
           </Text>
         </Stack>
+
+        <LotoSection loto={info.loto} />
 
         {!loggedIn && (
           <Alert color="blue" variant="light">
@@ -187,7 +279,7 @@ const ForgeKeyEPaperServicePage: React.FC = () => {
             No recurring maintenance tasks are scheduled for this asset.
           </Text>
         ) : (
-          <Stack gap="sm">
+          <Stack gap="md">
             {info.items.map((item) => {
               const done = justCompleted[item.id];
               return (
@@ -198,24 +290,75 @@ const ForgeKeyEPaperServicePage: React.FC = () => {
                   radius="md"
                   data-testid={`item-row-${item.id}`}
                 >
-                  <Stack gap="xs">
-                    <Stack gap={2}>
+                  <Stack gap="sm">
+                    <Group justify="space-between" wrap="nowrap" align="flex-start">
                       <Text fw={600}>{item.title}</Text>
                       <Badge color={statusColor(done ? 'ok' : item.status)} variant="light">
                         {done || item.status_line}
                       </Badge>
-                      <Text size="xs" c="dimmed">
-                        {item.last_completed
-                          ? `Last serviced: ${item.last_completed}`
-                          : 'Last serviced: never'}
-                        {item.interval_days ? ` · every ${item.interval_days} days` : ''}
+                    </Group>
+
+                    <Text size="xs" c="dimmed">
+                      {item.last_completed
+                        ? `Last serviced: ${item.last_completed}`
+                        : 'Last serviced: never'}
+                      {item.interval_days ? ` · every ${item.interval_days} days` : ''}
+                      {item.estimated_time_minutes ? ` · ~${item.estimated_time_minutes} min` : ''}
+                    </Text>
+
+                    {item.instructions && (
+                      <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
+                        {item.instructions}
                       </Text>
-                      {item.instructions && (
-                        <Text size="sm" mt={4} style={{ whiteSpace: 'pre-wrap' }}>
-                          {item.instructions}
+                    )}
+
+                    {item.materials.length > 0 && (
+                      <Stack gap={4}>
+                        <Text size="sm" fw={600}>
+                          Tools &amp; materials
                         </Text>
-                      )}
-                    </Stack>
+                        <List size="sm" spacing={2}>
+                          {item.materials.map((material, idx) => (
+                            <List.Item key={idx}>{formatMaterial(material)}</List.Item>
+                          ))}
+                        </List>
+                      </Stack>
+                    )}
+
+                    {item.steps.length > 0 && (
+                      <Stack gap={4}>
+                        <Text size="sm" fw={600}>
+                          Steps
+                        </Text>
+                        <List type="ordered" size="sm" spacing={4}>
+                          {item.steps.map((step) => (
+                            <List.Item
+                              key={step.order}
+                              icon={
+                                step.is_required ? (
+                                  <ThemeIcon color="red" size={16} radius="xl">
+                                    <Text size="9px" fw={700}>
+                                      !
+                                    </Text>
+                                  </ThemeIcon>
+                                ) : undefined
+                              }
+                            >
+                              <Text size="sm" fw={500} span>
+                                {step.title}
+                              </Text>
+                              {step.description && (
+                                <Text size="xs" c="dimmed" style={{ whiteSpace: 'pre-wrap' }}>
+                                  {step.description}
+                                </Text>
+                              )}
+                            </List.Item>
+                          ))}
+                        </List>
+                      </Stack>
+                    )}
+
+                    <Divider />
                     <Button
                       onClick={() => handleComplete(item.id)}
                       loading={submittingId === item.id}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1784,6 +1784,17 @@ export const forgekeyAPI = {
       display_id: string;
       bound: boolean;
       asset: { id: string; name: string; asset_tag: string; location: string | null };
+      loto: {
+        instructions: string;
+        energy_sources: Array<{
+          source_type: string;
+          source_type_display: string;
+          magnitude: string;
+          isolation_point: string;
+          notes: string;
+          devices: Array<{ device_type: string; label: string }>;
+        }>;
+      };
       items: Array<{
         id: string;
         title: string;
@@ -1793,6 +1804,14 @@ export const forgekeyAPI = {
         status_line: string;
         last_completed: string | null;
         instructions: string;
+        estimated_time_minutes: number | null;
+        steps: Array<{
+          order: number;
+          title: string;
+          description: string;
+          is_required: boolean;
+        }>;
+        materials: Array<{ name: string; quantity: string | null; unit: string }>;
       }>;
       primary_item_id: string | null;
     }>(`/forgekey/epaper/${displayId}/service-info/`),


### PR DESCRIPTION
## Why

Scanning a panel's QR only showed the task name + a "mark complete" button. It should be a **work order**: where the lockout/tagout is, what tools are needed, and the steps to follow.

## Changes

- **LOTO (safety-first, top of page):** `asset.lockout_instructions` + each `AssetEnergySource` to isolate (type, magnitude, isolation point) and the required lock `LOTODevice`s.
- **Tools & materials** per task (`MaintenanceMaterial`).
- **Ordered steps** with required-step markers (`MaintenanceTask`).
- **Estimated time**, then the existing attributable "mark complete".

`service-info` now returns `loto` and per-item `steps` / `materials` / `estimated_time_minutes`. `ForgeKeyEPaperServicePage` renders the work order. The panel PNG itself is unchanged.

## Test plan

- `pytest backend/forgekey/tests/test_epaper.py` → 36 passing (new `test_info_includes_work_order_detail` covers steps, materials, LOTO).
- `npm run build` clean; page + api typecheck and eslint clean.

## ⚠️ Merge order
Branched off `main`, which is currently red pending **#630** (classifies the e-paper endpoints in the permission matrix). The only failing check here will be `test_permission_matrix_in_sync` until #630 lands — merge #630 first, then this re-runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)