### PR TITLE
feat(membership): public account-activation page for registration tokens

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,6 +56,7 @@ import InventoryListPage from './pages/InventoryListPage';
 import InventoryOverviewPage from './pages/InventoryOverviewPage';
 import InviteCodeAdminPage from './pages/InviteCodeAdminPage';
 import InviteRedeemPage from './pages/InviteRedeemPage';
+import RegisterWithTokenPage from './pages/RegisterWithTokenPage';
 import InventoryReportPage from './pages/InventoryReportPage';
 import InventoryReconciliationPage from './pages/InventoryReconciliationPage';
 import LocationDetailPage from './pages/LocationDetailPage';
@@ -192,6 +193,7 @@ function AppContent() {
 
           {/* Anonymous invite redemption: outside person creates their own account */}
           <Route path="/invite/:code" element={<InviteRedeemPage />} />
+          <Route path="/register/:token" element={<RegisterWithTokenPage />} />
 
           {/* Staff: mint + revoke invite codes */}
           <Route path="/admin/invite-codes" element={<WorkspaceLayout><InviteCodeAdminPage /></WorkspaceLayout>} />

--- a/frontend/src/pages/RegisterWithTokenPage.tsx
+++ b/frontend/src/pages/RegisterWithTokenPage.tsx
@@ -1,0 +1,233 @@
+/**
+ * Public account activation (`/register/:token`).
+ *
+ * An admin pre-creates the user in OMS, which mints a one-time
+ * UserRegistrationToken and a QR encoding `/register/<token>`. The new
+ * member scans it, lands here, we validate the token + show who the
+ * account is for, and they set their password to activate it. Single
+ * use; the backend rejects an expired or already-used token.
+ */
+import {
+  Anchor,
+  Box,
+  Button,
+  Card,
+  Center,
+  Container,
+  Group,
+  Loader,
+  PasswordInput,
+  Stack,
+  Text,
+  ThemeIcon,
+  Title,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { IconAlertTriangle, IconCheck, IconKey } from '@tabler/icons-react';
+import dayjs from 'dayjs';
+import React, { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import '../styles/landing.css';
+import { registrationPublicAPI, RegistrationTokenUser } from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+const fullName = (user: RegistrationTokenUser): string =>
+  [user.first_name, user.last_name].filter(Boolean).join(' ').trim() || user.username;
+
+const RegisterWithTokenPage: React.FC = () => {
+  const { token = '' } = useParams<{ token: string }>();
+  const navigate = useNavigate();
+
+  const [user, setUser] = useState<RegistrationTokenUser | null>(null);
+  const [expiresAt, setExpiresAt] = useState<string | null>(null);
+  const [validateError, setValidateError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [completed, setCompleted] = useState(false);
+
+  const form = useForm({
+    initialValues: { password: '', password2: '' },
+    validate: {
+      password: (v) => (v.length < 8 ? 'Password must be at least 8 characters' : null),
+      password2: (v, values) => (v === values.password ? null : 'Passwords do not match'),
+    },
+  });
+
+  useEffect(() => {
+    if (!token) {
+      setValidateError('Missing registration token in URL.');
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    registrationPublicAPI
+      .validate(token)
+      .then((res) => {
+        if (!cancelled) {
+          setUser(res.data.user);
+          setExpiresAt(res.data.expires_at);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled)
+          setValidateError(
+            extractErrorMessage(err, 'This registration link is not valid or has expired.'),
+          );
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const handleSubmit = form.onSubmit(async (values) => {
+    setSubmitting(true);
+    try {
+      await registrationPublicAPI.complete({
+        token,
+        password: values.password,
+        password2: values.password2,
+      });
+      setCompleted(true);
+    } catch (err) {
+      const raw = (err as { response?: { data?: unknown } })?.response?.data ?? {};
+      const details =
+        (raw as { error?: { details?: Record<string, string[]> } })?.error?.details ??
+        (raw as Record<string, string[] | string>);
+      let mapped = false;
+      for (const field of ['password', 'password2', 'token'] as const) {
+        const value = (details as Record<string, unknown>)[field];
+        if (value) {
+          const target = field === 'token' ? 'password' : field;
+          form.setFieldError(target, Array.isArray(value) ? value[0] : String(value));
+          mapped = true;
+        }
+      }
+      if (!mapped) {
+        form.setFieldError(
+          'password',
+          extractErrorMessage(err, 'Could not activate the account. Try again.'),
+        );
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  });
+
+  if (loading) {
+    return (
+      <Box className="landing-surface">
+        <Container size="sm" py="xl">
+          <Center mih={240}>
+            <Loader />
+          </Center>
+        </Container>
+      </Box>
+    );
+  }
+
+  if (validateError || !user) {
+    return (
+      <Box className="landing-surface">
+        <Container size="sm" py="xl">
+          <Stack gap="lg" align="center">
+            <ThemeIcon size={72} radius="xl" color="red" variant="light">
+              <IconAlertTriangle size={36} />
+            </ThemeIcon>
+            <Title order={2} ta="center">
+              Registration link not valid
+            </Title>
+            <Text c="dimmed" ta="center" maw={420}>
+              {validateError ??
+                'This registration link has expired, already been used, or never existed. Ask an OMS admin for a fresh one.'}
+            </Text>
+            <Button variant="default" onClick={() => navigate('/')}>
+              Back to homepage
+            </Button>
+          </Stack>
+        </Container>
+      </Box>
+    );
+  }
+
+  if (completed) {
+    return (
+      <Box className="landing-surface">
+        <Container size="sm" py="xl">
+          <Stack gap="lg" align="center">
+            <ThemeIcon size={72} radius="xl" color="green" variant="light">
+              <IconCheck size={36} />
+            </ThemeIcon>
+            <Title order={2} ta="center">
+              Account activated
+            </Title>
+            <Text c="dimmed" ta="center" maw={460}>
+              You can sign in now as{' '}
+              <Text component="span" fw={600}>
+                {user.username}
+              </Text>{' '}
+              with the password you just set.
+            </Text>
+            <Button component={Link} to="/login">
+              Sign in
+            </Button>
+          </Stack>
+        </Container>
+      </Box>
+    );
+  }
+
+  return (
+    <Box className="landing-surface">
+      <Container size="sm" py="xl">
+        <Card withBorder padding="lg" radius="md" data-testid="register-token-page">
+          <Stack gap="md">
+            <Group gap="xs">
+              <IconKey size={20} />
+              <Text className="landing-eyebrow">Activate your account</Text>
+            </Group>
+            <Title order={2}>{fullName(user)}</Title>
+            <Text size="sm" c="dimmed">
+              Setting up the OMS account for <strong>{user.username}</strong>
+              {user.email ? ` (${user.email})` : ''}. Choose a password to finish.
+              {expiresAt
+                ? ` This link works once and expires ${dayjs(expiresAt).format('MMM D, YYYY')}.`
+                : ' This link works once.'}
+            </Text>
+
+            <form onSubmit={handleSubmit}>
+              <Stack gap="sm">
+                <PasswordInput
+                  label="Password"
+                  required
+                  description="8+ characters. Pick something a password manager generates."
+                  autoComplete="new-password"
+                  {...form.getInputProps('password')}
+                />
+                <PasswordInput
+                  label="Confirm password"
+                  required
+                  autoComplete="new-password"
+                  {...form.getInputProps('password2')}
+                />
+                <Group justify="space-between" mt="sm">
+                  <Anchor component={Link} to="/" size="sm" c="dimmed">
+                    Cancel
+                  </Anchor>
+                  <Button type="submit" loading={submitting}>
+                    Activate account
+                  </Button>
+                </Group>
+              </Stack>
+            </form>
+          </Stack>
+        </Card>
+      </Container>
+    </Box>
+  );
+};
+
+export default RegisterWithTokenPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3068,4 +3068,25 @@ export const invitePublicAPI = {
     api.post<InviteRedeemResponse>('/membership/invite/redeem/', data),
 };
 
+// Anonymous endpoints for the public `/register/<token>` page. An admin
+// pre-creates the user + one-time token (Django admin); this page only
+// validates the token and lets the new member set their password.
+export interface RegistrationTokenUser {
+  username: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+}
+
+export const registrationPublicAPI = {
+  validate: (token: string) =>
+    api.post<{ valid: boolean; user: RegistrationTokenUser; expires_at: string }>(
+      '/membership/register/validate-token/',
+      { token },
+    ),
+
+  complete: (data: { token: string; password: string; password2: string }) =>
+    api.post<RegistrationTokenUser>('/membership/register/complete/', data),
+};
+
 export default api;


### PR DESCRIPTION
## Why ("where did my registration tokens land / nothing on the front end")

An admin creates a user in Django admin → OMS mints a one-time `UserRegistrationToken` + a QR encoding `{FRONTEND_URL}/register/<token>`. **That route never existed**, so every registration QR 404'd and the tokens couldn't be redeemed. The tokens themselves are fine — they live in `membership_user_registration_token` — there was just no page to use them.

## Change (frontend only)

Adds the public `/register/:token` page, mirroring the existing `/invite/:code` redeem page:
- Validates the token (`register/validate-token/`) and shows who the account is for + expiry.
- Lets the new member set a password (8+, confirmed) and activates the account (`register/complete/`).
- Friendly invalid/expired/used and success states; backend field errors mapped onto the form.

`registrationPublicAPI` wraps the two existing membership endpoints. **No backend change.**

## Notes / test plan

- `npm run build` clean; page + api typecheck and eslint clean.
- Worth a quick manual run end-to-end (create a user in admin → scan/open the QR → set password → sign in), since this is a public auth surface — I built it from the backend contract but couldn't exercise the live QR.
- Separately: **BACKEND-8** (the 500 you saw) is unrelated to these tokens — it's an analytics task hitting a missing `inventory_membership` table in prod; the code already handles it gracefully (`_safe_count`). Diagnosis posted on the Sentry issue. It needs a prod migrate, not a code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)