### PR TITLE
refactor(scan): resolve inventory scans via the unified dispatcher

### DIFF
--- a/frontend/src/components/RecentPages.tsx
+++ b/frontend/src/components/RecentPages.tsx
@@ -47,7 +47,6 @@ const RecentPages: React.FC<{ isCollapsed?: boolean }> = ({ isCollapsed = false 
       '/inventory': 'Inventory Dashboard',
       '/inventory/assets': 'Assets',
       '/inventory/admin': 'Admin Dashboard',
-      '/inventory/code-entry': 'Code Entry',
       '/inventory/transparency': 'Transparency',
       '/inventory/scan': 'Scan Items',
       '/purchasing/orders': 'Purchase Orders',

--- a/frontend/src/navigation/routeMap.ts
+++ b/frontend/src/navigation/routeMap.ts
@@ -33,7 +33,6 @@ const ENTRIES: RouteEntry[] = [
   { path: 'inventory', label: 'Inventory' },
   { path: 'inventory/assets', label: 'Assets' },
   { path: 'inventory/admin', label: 'Admin Dashboard' },
-  { path: 'inventory/code-entry', label: 'Code Entry' },
   { path: 'inventory/transparency', label: 'Transparency' },
   { path: 'inventory/scan', label: 'Scan Items' },
   { path: 'inventory/items', label: 'Items' },

--- a/frontend/src/pages/ChecklistCompletionPage.tsx
+++ b/frontend/src/pages/ChecklistCompletionPage.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import QRScanner, { QRScannerError } from '../components/QRScanner';
 import { useNotifications } from '../hooks/useNotifications';
-import { checklistsAPI, inventoryAPI } from '../services/api';
+import { checklistsAPI, scannerAPI } from '../services/api';
 import '../styles/ScanPage.css';
 import { Checklist, ChecklistCompletion, ChecklistStep } from '../types';
 import { confirmAction } from '../utils/dialogs';
@@ -63,17 +63,18 @@ const ChecklistCompletionPage: React.FC = () => {
 
     try {
       setScanning(true);
-      // Extract code from URL if it's a full URL
-      let codeToUse = code;
-      if (code.includes('/')) {
-        // Extract the last part of the URL path
-        const urlParts = code.split('/');
-        codeToUse = urlParts[urlParts.length - 1];
-      }
+      // Resolve the scan through the unified scanner dispatcher, which handles
+      // our QR URLs, UPC barcodes, and location codes.
+      const lookupResponse = await scannerAPI.dispatch(code.trim());
+      const { target_type: type, target_id: id } = lookupResponse.data;
 
-      // Look up the code
-      const lookupResponse = await inventoryAPI.lookupByCode(codeToUse.toUpperCase());
-      const { type, id } = lookupResponse.data;
+      if (!id) {
+        notifications.showWarning(
+          'Code not recognized',
+          lookupResponse.data.message || "Couldn't identify this scan.",
+        );
+        return;
+      }
 
       // Find the current step that needs to be scanned
       const completedStepIds = new Set(completion.step_completions.map(sc => sc.step));
@@ -96,7 +97,7 @@ const ChecklistCompletionPage: React.FC = () => {
       } else if (type === 'location' && nextStep.location === parseInt(id)) {
         matches = true;
         scannedItem = { location_id: parseInt(id) };
-      } else if (type === 'item' && nextStep.inventory_item === id) {
+      } else if (type === 'inventory_item' && nextStep.inventory_item === id) {
         matches = true;
         scannedItem = { item_id: id };
       }

--- a/frontend/src/pages/CodeEntryPage.tsx
+++ b/frontend/src/pages/CodeEntryPage.tsx
@@ -1,84 +1,45 @@
 /**
- * Code Entry Page
- * Allows users who are phobic of scanning QR codes to enter a 6-character code
- * to navigate to the appropriate asset, inventory item, or location page.
+ * Inventory Scan Page (`/inventory/scan`)
+ *
+ * Camera-based QR scanner for inventory. A scanned payload is resolved through
+ * the unified scanner dispatcher (`/scanner/dispatch/`), which understands our
+ * QR URLs, UPC/EAN barcodes, and location codes, then navigates to the target.
+ *
+ * The legacy 6-character manual access-code entry was removed once the org
+ * standardized on QR/UPC scanning. Inventory items and assets no longer carry
+ * an `access_code`; the dispatcher resolves them by QR URL or UPC instead.
  */
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import QRScanner, { QRScannerError } from '../components/QRScanner';
-import { inventoryAPI } from '../services/api';
+import { scannerAPI } from '../services/api';
 import '../styles/ScanPage.css';
 
 const CodeEntryPage: React.FC = () => {
   const navigate = useNavigate();
-  const [code, setCode] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showScanner, setShowScanner] = useState(false);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    
-    if (!code || code.length !== 6) {
-      setError('Please enter a 6-character code');
-      return;
-    }
-
-    setLoading(true);
-    setError(null);
-
-    try {
-      const response = await inventoryAPI.lookupByCode(code.toUpperCase());
-      const { url } = response.data;
-      
-      // Navigate to the URL
-      if (url) {
-        // Extract path from full URL if needed
-        const urlObj = new URL(url);
-        navigate(urlObj.pathname);
-      } else {
-        setError('Invalid response from server');
-      }
-    } catch (err: any) {
-      const errorMessage = err.response?.data?.error || 'Code not found. Please check and try again.';
-      setError(errorMessage);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    // Convert to uppercase and filter out invalid characters
-    const value = e.target.value.toUpperCase().replace(/[^A-HJ-NP-Z2-9]/g, '');
-    // Limit to 6 characters
-    const limitedValue = value.slice(0, 6);
-    setCode(limitedValue);
-    setError(null);
-  };
 
   const processScannedCode = async (scannedText: string) => {
     setLoading(true);
     setError(null);
 
     try {
-      // Extract code from URL if it's a full URL
-      let codeToUse = scannedText;
-      if (scannedText.includes('/')) {
-        const urlParts = scannedText.split('/');
-        codeToUse = urlParts[urlParts.length - 1];
-      }
+      const { data } = await scannerAPI.dispatch(scannedText.trim());
 
-      const response = await inventoryAPI.lookupByCode(codeToUse.toUpperCase());
-      const { url } = response.data;
-      
-      if (url) {
-        const urlObj = new URL(url);
-        navigate(urlObj.pathname);
+      // A resolved scan always carries a target_url (a frontend route path);
+      // a miss comes back as action `unknown` with no target.
+      if (data.target_url) {
+        navigate(data.target_url);
       } else {
-        setError('Invalid response from server');
+        setError(data.message || 'Code not found. Please check and try again.');
       }
     } catch (err: any) {
-      const errorMessage = err.response?.data?.error || 'Code not found. Please check and try again.';
+      const errorMessage =
+        err.response?.data?.detail ||
+        err.response?.data?.error ||
+        'Could not reach the scanner. Please try again.';
       setError(errorMessage);
     } finally {
       setLoading(false);
@@ -116,81 +77,39 @@ const CodeEntryPage: React.FC = () => {
       )}
       <div className="scan-page">
         <div className="scan-container">
-          <h1>Enter Access Code</h1>
+          <h1>Scan QR Code</h1>
           <p className="scan-description">
-            Scan a QR code or enter the 6-character code manually to access the item.
+            Scan an item, asset, or location QR code to open it.
           </p>
 
           <div style={{ marginBottom: '1.5rem', textAlign: 'center' }}>
             <button
               onClick={handleOpenScanner}
+              disabled={loading}
               className="submit-button"
               style={{
                 padding: '1rem 2rem',
                 fontSize: '1.2rem',
                 backgroundColor: '#28a745',
-                marginBottom: '1rem',
               }}
             >
               📱 Scan QR Code
             </button>
-            <p style={{ color: '#666', fontSize: '0.9rem' }}>or</p>
           </div>
 
-        <form onSubmit={handleSubmit} className="code-entry-form">
-          <div className="code-input-group">
-            <label htmlFor="code">Access Code</label>
-            <input
-              id="code"
-              type="text"
-              value={code}
-              onChange={handleCodeChange}
-              placeholder="Enter 6-character code"
-              maxLength={6}
-              autoFocus
-              className="code-input"
-              style={{
-                fontSize: '2rem',
-                letterSpacing: '0.5rem',
-                textAlign: 'center',
-                textTransform: 'uppercase',
-                fontFamily: 'monospace',
-                padding: '1rem',
-                border: '2px solid #ccc',
-                borderRadius: '8px',
-                width: '100%',
-                maxWidth: '300px',
-              }}
-            />
-            <p className="code-hint">
-              Enter the 6-character code (letters and numbers, excluding I, O, 0, 1, L)
-            </p>
-          </div>
+          {loading && (
+            <p style={{ textAlign: 'center', color: '#666' }}>Looking up…</p>
+          )}
 
           {error && (
             <div className="error-message" style={{ marginTop: '1rem' }}>
               {error}
             </div>
           )}
-
-          <button
-            type="submit"
-            disabled={loading || code.length !== 6}
-            className="submit-button"
-            style={{
-              marginTop: '1.5rem',
-              padding: '1rem 2rem',
-              fontSize: '1.2rem',
-            }}
-          >
-            {loading ? 'Looking up...' : 'Go to Item'}
-          </button>
-        </form>
-      </div>
+        </div>
       </div>
     </>
   );
 };
 
 export default CodeEntryPage;
-

--- a/frontend/src/pages/InventoryReconciliationPage.tsx
+++ b/frontend/src/pages/InventoryReconciliationPage.tsx
@@ -28,6 +28,7 @@ import QRScanner from '../components/QRScanner';
 import { useNotifications } from '../hooks/useNotifications';
 import {
   inventoryAPI,
+  scannerAPI,
   ReconciliationGridItem,
   ReconciliationRow,
   ReconciliationUploadResponse,
@@ -208,8 +209,8 @@ const InventoryReconciliationPage: React.FC = () => {
   const handleScanSuccess = async (decodedText: string) => {
     setScannerOpen(false);
     try {
-      const response = await inventoryAPI.lookupByCode(decodedText);
-      const scannedId = (response.data as { id?: string })?.id;
+      const response = await scannerAPI.dispatch(decodedText.trim());
+      const scannedId = response.data.target_id;
       if (!scannedId) {
         notifications.showWarning('Unknown code', 'Could not resolve scanned code.');
         return;

--- a/frontend/src/pages/PurchaseOrderFormPage.tsx
+++ b/frontend/src/pages/PurchaseOrderFormPage.tsx
@@ -13,6 +13,7 @@ import {
   ReorderDataAsset,
   ReorderDataItem,
   ReorderDataSupplier,
+  scannerAPI,
 } from '../services/api';
 import '../styles/PurchaseOrderFormPage.css';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
@@ -263,9 +264,9 @@ const PurchaseOrderFormPage: React.FC = () => {
       // Try barcode lookup first if barcode is provided
       if (barcodeToSearch.trim()) {
         try {
-          const lookupResponse = await inventoryAPI.lookupByCode(barcodeToSearch.trim().toUpperCase());
-          if (lookupResponse.data.type === 'item') {
-            itemId = lookupResponse.data.id;
+          const lookupResponse = await scannerAPI.dispatch(barcodeToSearch.trim());
+          if (lookupResponse.data.target_type === 'inventory_item' && lookupResponse.data.target_id) {
+            itemId = lookupResponse.data.target_id;
           } else {
             setError('Barcode does not match an inventory item');
             setSearchingProduct(false);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -233,8 +233,6 @@ export const inventoryAPI = {
 
   generateQR: (id: string) =>
     api.post(`/inventory/items/${id}/generate_qr/`),
-  lookupByCode: (code: string) =>
-    api.get(`/inventory/lookup-code/`, { params: { code } }),
 
   logUsage: (id: string, quantity: number, notes?: string) =>
     api.post(`/inventory/items/${id}/log_usage/`, {


### PR DESCRIPTION
## Part 1 of 2 — frontend

Routes the four inventory scan-resolution callers off the legacy 6-character `lookupByCode` endpoint and onto the **unified scanner dispatcher** (`scannerAPI.dispatch` → `POST /scanner/dispatch/`), which already powers `UniversalScannerPage` and resolves QR URLs, UPC/EAN barcodes, and location codes — a strict superset of the old access-code lookup.

### Changes
- **CodeEntryPage** (`/inventory/scan`): removed the 6-char manual-entry form. The page is now a camera QR scanner that dispatches the scanned payload and navigates to the resolved `target_url`.
- **ChecklistCompletionPage / InventoryReconciliationPage / PurchaseOrderFormPage**: resolve scans via `dispatch`; map the `{target_type, target_id, target_url}` response (and the `inventory_item` type) instead of the old `{type, id}`.
- Removed the unused `inventoryAPI.lookupByCode` and the "Code Entry" nav label (routeMap + RecentPages).

A miss now returns `200 { action: "unknown" }` (vs the old `404`), so each caller checks for a resolved `target_id`.

### Why split
Part 2 (follow-up) drops the `Asset`/`InventoryItem.access_code` columns + the now-dead `lookup-code/` endpoint. Landing the frontend first means there's no window where the UI calls a removed endpoint. **Location codes are retained** — the scanner dispatcher and the people-counter webhook depend on `Location.access_code`.

### Testing
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run build` (vite) — clean
- `npm run test:ci` (affected): ChecklistCompletion, InventoryReconciliation, PurchaseOrderForm, Sidebar, RecentPages — **37 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)