### PR TITLE
feat(inventory): infinite-scroll the items list with server-side filtering

### DIFF
--- a/backend/inventory/tests/test_api.py
+++ b/backend/inventory/tests/test_api.py
@@ -93,6 +93,55 @@ class TestInventoryItemAPI:
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data["results"]) == 3
 
+    def test_list_items_filter_low_stock_true(self, api_client):
+        """low_stock=true returns only items at or under their minimum."""
+        low = InventoryItemFactory(current_stock=5, minimum_stock=10)
+        InventoryItemFactory(current_stock=50, minimum_stock=10)
+
+        url = reverse("inventoryitem-list")
+        response = api_client.get(url, {"low_stock": "true"})
+
+        assert response.status_code == status.HTTP_200_OK
+        ids = [r["id"] for r in response.data["results"]]
+        assert ids == [str(low.id)]
+
+    def test_list_items_filter_low_stock_false(self, api_client):
+        """low_stock=false returns only items above their minimum."""
+        InventoryItemFactory(current_stock=5, minimum_stock=10)
+        in_stock = InventoryItemFactory(current_stock=50, minimum_stock=10)
+
+        url = reverse("inventoryitem-list")
+        response = api_client.get(url, {"low_stock": "false"})
+
+        assert response.status_code == status.HTTP_200_OK
+        ids = [r["id"] for r in response.data["results"]]
+        assert ids == [str(in_stock.id)]
+
+    def test_list_items_ordering(self, api_client):
+        """The ordering param sorts by the requested allow-listed field."""
+        InventoryItemFactory(name="Banana")
+        InventoryItemFactory(name="Apple")
+        InventoryItemFactory(name="Cherry")
+
+        url = reverse("inventoryitem-list")
+
+        asc = api_client.get(url, {"ordering": "name"})
+        assert [r["name"] for r in asc.data["results"]] == ["Apple", "Banana", "Cherry"]
+
+        desc = api_client.get(url, {"ordering": "-name"})
+        assert [r["name"] for r in desc.data["results"]] == ["Cherry", "Banana", "Apple"]
+
+    def test_list_items_invalid_ordering_falls_back_to_name(self, api_client):
+        """An ordering value outside the allow-list is ignored (defaults to name)."""
+        InventoryItemFactory(name="Banana")
+        InventoryItemFactory(name="Apple")
+
+        url = reverse("inventoryitem-list")
+        response = api_client.get(url, {"ordering": "current_stock); DROP TABLE"})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert [r["name"] for r in response.data["results"]] == ["Apple", "Banana"]
+
     def test_retrieve_item(self, api_client):
         """Test retrieving a single item with details."""
         item = InventoryItemFactory()

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -545,12 +545,37 @@ class InventoryItemViewSet(viewsets.ModelViewSet):
         low_stock = self.request.query_params.get("low_stock", "").lower()
         if low_stock == "true":
             queryset = queryset.filter(current_stock__lte=F("minimum_stock"))
+        elif low_stock == "false":
+            queryset = queryset.filter(current_stock__gt=F("minimum_stock"))
 
         # Filter by active status if specified
         is_active = self.request.query_params.get("is_active")
         if is_active is not None:
             queryset = queryset.filter(is_active=is_active.lower() == "true")
 
+        # Ordering support (validated against an allow-list to keep the
+        # client-driven `ordering` param from reaching arbitrary fields).
+        ordering = self.request.query_params.get("ordering", "name")
+        valid_ordering_fields = {
+            "name",
+            "-name",
+            "sku",
+            "-sku",
+            "current_stock",
+            "-current_stock",
+            "minimum_stock",
+            "-minimum_stock",
+            "category__name",
+            "-category__name",
+            "location__name",
+            "-location__name",
+            "created_at",
+            "-created_at",
+            "updated_at",
+            "-updated_at",
+        }
+        if ordering in valid_ordering_fields:
+            return queryset.order_by(ordering)
         return queryset.order_by("name")
 
     def create(self, request, *args, **kwargs):

--- a/frontend/src/__tests__/pages/InventoryListPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryListPage.test.tsx
@@ -2,7 +2,7 @@
  * Tests for InventoryListPage component
  */
 import { MantineProvider } from '@mantine/core';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import InventoryListPage from '../../pages/InventoryListPage';
 import * as api from '../../services/api';
@@ -25,6 +25,10 @@ vi.mock('react-router-dom', async () => ({
   ...(await vi.importActual('react-router-dom')),
   useNavigate: () => mockNavigate,
 }));
+
+// Capture the IntersectionObserver callback so tests can simulate the
+// infinite-scroll sentinel coming into view.
+let intersectionCallback: IntersectionObserverCallback | null = null;
 
 describe('InventoryListPage', () => {
   const mockItems = [
@@ -133,11 +137,26 @@ describe('InventoryListPage', () => {
     { id: 2, name: 'Shelf B', description: 'Shelf B location', is_active: true },
   ];
 
+  // A full page of results: no further pages to fetch.
+  const fullPage = (results: typeof mockItems) => ({
+    data: { count: results.length, next: null, previous: null, results },
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
-    (api.inventoryAPI.listItems as jest.Mock).mockResolvedValue({
-      data: { results: mockItems },
-    });
+
+    intersectionCallback = null;
+    (globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver = class {
+      constructor(cb: IntersectionObserverCallback) {
+        intersectionCallback = cb;
+      }
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+      takeRecords = () => [];
+    };
+
+    (api.inventoryAPI.listItems as jest.Mock).mockResolvedValue(fullPage(mockItems));
     (api.inventoryAPI.listCategories as jest.Mock).mockResolvedValue({
       data: { results: mockCategories },
     });
@@ -172,66 +191,125 @@ describe('InventoryListPage', () => {
     });
   });
 
-  it('filters items by search term', async () => {
+  it('requests page 1 with default ordering on first load', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(api.inventoryAPI.listItems).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1, ordering: 'name' })
+      );
+    });
+  });
+
+  it('requests server-side search filtering (debounced)', async () => {
     renderPage();
 
     await waitFor(() => {
       expect(screen.getByText('Test Item 1')).toBeInTheDocument();
     });
+    (api.inventoryAPI.listItems as jest.Mock).mockClear();
 
     const searchInput = screen.getByPlaceholderText(/Search by name/);
     fireEvent.change(searchInput, { target: { value: 'Low' } });
 
-    expect(screen.queryByText('Test Item 1')).not.toBeInTheDocument();
-    expect(screen.getByText('Low Stock Item')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(api.inventoryAPI.listItems).toHaveBeenCalledWith(
+        expect.objectContaining({ search: 'Low', page: 1 })
+      );
+    });
   });
 
-  it('filters items by category', async () => {
+  it('requests server-side category filtering', async () => {
     renderPage();
 
     await waitFor(() => {
       expect(screen.getByText('Test Item 1')).toBeInTheDocument();
     });
+    (api.inventoryAPI.listItems as jest.Mock).mockClear();
 
     const categorySelect = screen.getByPlaceholderText('All Categories');
-    fireEvent.change(categorySelect, { target: { value: '1' } });
+    fireEvent.click(categorySelect);
+    const option = await screen.findByRole('option', { name: 'Tools' });
+    fireEvent.click(option);
 
-    // Items should still be visible as they both have category 1
-    expect(screen.getByText('Test Item 1')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(api.inventoryAPI.listItems).toHaveBeenCalledWith(
+        expect.objectContaining({ category: 1, page: 1 })
+      );
+    });
   });
 
-  it('filters items by low stock status', async () => {
+  it('requests server-side low-stock filtering', async () => {
     renderPage();
 
     await waitFor(() => {
       expect(screen.getByText('Test Item 1')).toBeInTheDocument();
     });
+    (api.inventoryAPI.listItems as jest.Mock).mockClear();
 
-    // Find the select input and interact with it
     const stockSelect = screen.getByPlaceholderText('Stock Status');
-    
-    // Click to open dropdown
     fireEvent.click(stockSelect);
-    
-    // Wait for dropdown and select "Low Stock" option (not the badge)
+    const option = await screen.findByRole('option', { name: 'Low Stock' });
+    fireEvent.click(option);
+
     await waitFor(() => {
-      const lowStockOptions = screen.getAllByText('Low Stock');
-      // Find the one that's in the dropdown (not the badge in the table)
-      const dropdownOption = lowStockOptions.find(opt => {
-        const parent = opt.closest('[role="option"]') || opt.closest('div[data-combobox-option]');
-        return parent !== null;
-      });
-      if (dropdownOption) {
-        fireEvent.click(dropdownOption);
-      }
+      expect(api.inventoryAPI.listItems).toHaveBeenCalledWith(
+        expect.objectContaining({ low_stock: true, page: 1 })
+      );
     });
-    
-    // Wait for filter to apply
+  });
+
+  it('requests server-side sorting when a column header is clicked', async () => {
+    renderPage();
+
     await waitFor(() => {
-      expect(screen.queryByText('Test Item 1')).not.toBeInTheDocument();
-    }, { timeout: 3000 });
-    
-    expect(screen.getByText('Low Stock Item')).toBeInTheDocument();
+      expect(screen.getByText('Test Item 1')).toBeInTheDocument();
+    });
+    (api.inventoryAPI.listItems as jest.Mock).mockClear();
+
+    fireEvent.click(screen.getByText('SKU'));
+
+    await waitFor(() => {
+      expect(api.inventoryAPI.listItems).toHaveBeenCalledWith(
+        expect.objectContaining({ ordering: 'sku', page: 1 })
+      );
+    });
+  });
+
+  it('loads the next page when the scroll sentinel intersects', async () => {
+    (api.inventoryAPI.listItems as jest.Mock)
+      .mockResolvedValueOnce({
+        data: {
+          count: 2,
+          next: 'http://test/api/inventory/items/?page=2',
+          previous: null,
+          results: [mockItems[0]],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: { count: 2, next: null, previous: null, results: [mockItems[1]] },
+      });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item 1')).toBeInTheDocument();
+    });
+    // Second page not loaded yet.
+    expect(screen.queryByText('Low Stock Item')).not.toBeInTheDocument();
+
+    // Simulate the sentinel scrolling into view.
+    await act(async () => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        null as unknown as IntersectionObserver
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Low Stock Item')).toBeInTheDocument();
+    });
+    expect(api.inventoryAPI.listItems).toHaveBeenCalledWith(expect.objectContaining({ page: 2 }));
   });
 
   it('handles item selection', async () => {
@@ -302,11 +380,8 @@ describe('InventoryListPage', () => {
       expect(screen.getByText('Test Item 1')).toBeInTheDocument();
     });
 
-    // Bulk QR button is only visible when items are selected, so this exercise
-    // is best achieved by directly invoking through the selection flow:
-    // Select an item, click Generate QR, then deselect — but simplest path:
-    // call setSelectedItems via toggling. We instead verify via a select-and-act
-    // that *with* selections, success notification fires below.
+    // Bulk QR button is only visible when items are selected, so with no
+    // selection there is nothing to fire an info notification yet.
     expect(showInfo).not.toHaveBeenCalled();
   });
 
@@ -330,12 +405,9 @@ describe('InventoryListPage', () => {
     });
   });
 
-  it('updates stock inline', async () => {
+  it('updates stock inline and patches the row in place', async () => {
     (api.inventoryAPI.updateStock as jest.Mock).mockResolvedValue({
       data: { ...mockItems[0], current_stock: 15 },
-    });
-    (api.inventoryAPI.listItems as jest.Mock).mockResolvedValue({
-      data: { results: [{ ...mockItems[0], current_stock: 15 }] },
     });
 
     renderPage();
@@ -344,37 +416,21 @@ describe('InventoryListPage', () => {
       expect(screen.getByText('Test Item 1')).toBeInTheDocument();
     });
 
-    // Find the stock cell in the table - look for the table cell containing stock value
-    const tableRows = screen.getAllByRole('row');
-    const itemRow = tableRows.find(row => row.textContent?.includes('Test Item 1'));
-    
-    if (itemRow) {
-      // Find the stock cell (should be in a td)
-      const stockCell = itemRow.querySelector('td:nth-child(6)') || itemRow.querySelector('td');
-      
-      if (stockCell && stockCell.textContent?.includes('10')) {
-        fireEvent.click(stockCell);
+    // Click the first item's stock value to open the inline editor.
+    fireEvent.click(screen.getByText('10'));
 
-        await waitFor(() => {
-          expect(screen.getByRole('spinbutton')).toBeInTheDocument();
-        });
+    // Editor reveals Save/Cancel and a number input pre-filled with the value.
+    await screen.findByText('Save');
+    const numberInput = screen.getByDisplayValue('10');
+    fireEvent.change(numberInput, { target: { value: '15' } });
+    fireEvent.click(screen.getByText('Save'));
 
-        const numberInput = screen.getByRole('spinbutton');
-        fireEvent.change(numberInput, { target: { value: '15' } });
-
-        const saveButton = screen.getByText('Save');
-        fireEvent.click(saveButton);
-
-        await waitFor(() => {
-          expect(api.inventoryAPI.updateStock).toHaveBeenCalledWith('1', 15);
-        });
-      } else {
-        // Fallback: just verify the component renders correctly
-        expect(screen.getByText('Test Item 1')).toBeInTheDocument();
-      }
-    } else {
-      // Fallback: just verify the component renders correctly
-      expect(screen.getByText('Test Item 1')).toBeInTheDocument();
-    }
+    await waitFor(() => {
+      expect(api.inventoryAPI.updateStock).toHaveBeenCalledWith('1', 15);
+    });
+    // Row reflects the new value without a full reload.
+    await waitFor(() => {
+      expect(screen.getByText('15')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/pages/InventoryListPage.tsx
+++ b/frontend/src/pages/InventoryListPage.tsx
@@ -1,6 +1,8 @@
 /**
  * Inventory List Page
- * Advanced data table with filtering, sorting, search, bulk actions, and inline stock adjustment
+ * Advanced data table with server-side filtering, sorting, and search.
+ * Items are loaded lazily (infinite scroll) so the list is no longer
+ * capped at the first page of results.
  */
 import {
     ActionIcon,
@@ -8,6 +10,7 @@ import {
     Button,
     Checkbox,
     Group,
+    Loader,
     NumberInput,
     Paper,
     Select,
@@ -18,7 +21,7 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { IconDownload, IconQrcode, IconSearch, IconSortAscending, IconSortDescending } from '@tabler/icons-react';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import { indexCardsAPI, inventoryAPI } from '../services/api';
@@ -26,8 +29,20 @@ import { Category, InventoryItem, Location } from '../types';
 import { exportInventoryItemsToCSV } from '../utils/csvExport';
 import { showError, showInfo, showSuccess } from '../utils/dialogs';
 
-type SortField = 'name' | 'sku' | 'current_stock' | 'category_name' | 'location' | 'unit_cost';
+type SortField = 'name' | 'sku' | 'current_stock' | 'category_name' | 'location';
 type SortDirection = 'asc' | 'desc';
+
+// Map the table's sortable columns onto the backend's allow-listed
+// `ordering` fields (see InventoryItemViewSet.get_queryset).
+const SORT_FIELD_TO_BACKEND: Record<SortField, string> = {
+  name: 'name',
+  sku: 'sku',
+  current_stock: 'current_stock',
+  category_name: 'category__name',
+  location: 'location__name',
+};
+
+const SEARCH_DEBOUNCE_MS = 300;
 
 const InventoryListPage: React.FC = () => {
   const navigate = useNavigate();
@@ -35,7 +50,9 @@ const InventoryListPage: React.FC = () => {
   const [categories, setCategories] = useState<Category[]>([]);
   const [locations, setLocations] = useState<Location[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [selectedLocation, setSelectedLocation] = useState<string | null>(null);
   const [lowStockFilter, setLowStockFilter] = useState<string | null>(null);
@@ -46,27 +63,122 @@ const InventoryListPage: React.FC = () => {
   const [generatingQR, setGeneratingQR] = useState(false);
   const [generatingTestSheet, setGeneratingTestSheet] = useState(false);
 
+  // Pagination / infinite-scroll state.
+  const [page, setPage] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+
+  // Load the filter dropdown data once.
   useEffect(() => {
-    loadData();
+    const loadFilters = async () => {
+      try {
+        const [categoriesRes, locationsRes] = await Promise.all([
+          inventoryAPI.listCategories(),
+          inventoryAPI.listLocations(),
+        ]);
+        setCategories(categoriesRes.data.results);
+        setLocations(locationsRes.data.results);
+      } catch (err) {
+        console.error('Error loading filters:', err);
+      }
+    };
+    loadFilters();
   }, []);
 
-  const loadData = async () => {
+  // Debounce the free-text search so each keystroke doesn't hit the API.
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(searchTerm), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [searchTerm]);
+
+  const buildListParams = (targetPage: number) => {
+    const params: Parameters<typeof inventoryAPI.listItems>[0] = {
+      page: targetPage,
+      ordering: `${sortDirection === 'desc' ? '-' : ''}${SORT_FIELD_TO_BACKEND[sortField]}`,
+    };
+    const trimmedSearch = debouncedSearch.trim();
+    if (trimmedSearch) {
+      params.search = trimmedSearch;
+    }
+    if (selectedCategory) {
+      params.category = Number(selectedCategory);
+    }
+    if (selectedLocation) {
+      params.location = Number(selectedLocation);
+    }
+    if (lowStockFilter === 'true') {
+      params.low_stock = true;
+    } else if (lowStockFilter === 'false') {
+      params.low_stock = false;
+    }
+    return params;
+  };
+
+  // (Re)load the first page whenever the filters, search, or sort change.
+  useEffect(() => {
+    const loadFirstPage = async () => {
+      try {
+        setLoading(true);
+        const res = await inventoryAPI.listItems(buildListParams(1));
+        setItems(res.data.results);
+        setTotalCount(res.data.count ?? res.data.results.length);
+        setHasMore(Boolean(res.data.next));
+        setPage(1);
+      } catch (err) {
+        console.error('Error loading data:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadFirstPage();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch, selectedCategory, selectedLocation, lowStockFilter, sortField, sortDirection]);
+
+  const loadMore = async () => {
+    if (loadingMore || loading || !hasMore) {
+      return;
+    }
     try {
-      setLoading(true);
-      const [itemsRes, categoriesRes, locationsRes] = await Promise.all([
-        inventoryAPI.listItems(),
-        inventoryAPI.listCategories(),
-        inventoryAPI.listLocations(),
-      ]);
-      setItems(itemsRes.data.results);
-      setCategories(categoriesRes.data.results);
-      setLocations(locationsRes.data.results);
+      setLoadingMore(true);
+      const nextPage = page + 1;
+      const res = await inventoryAPI.listItems(buildListParams(nextPage));
+      setItems((prev) => [...prev, ...res.data.results]);
+      setTotalCount(res.data.count ?? totalCount);
+      setHasMore(Boolean(res.data.next));
+      setPage(nextPage);
     } catch (err) {
-      console.error('Error loading data:', err);
+      console.error('Error loading more items:', err);
     } finally {
-      setLoading(false);
+      setLoadingMore(false);
     }
   };
+
+  // Keep the latest loadMore reachable from the (stable) observer callback,
+  // so the observer never has to be torn down just to capture fresh state.
+  const loadMoreRef = useRef(loadMore);
+  loadMoreRef.current = loadMore;
+
+  // Callback ref: attach an IntersectionObserver as soon as the sentinel
+  // mounts (it isn't present during the initial loading screen) and tear it
+  // down when the sentinel unmounts.
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const sentinelRef = useCallback((node: HTMLDivElement | null) => {
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+      observerRef.current = null;
+    }
+    if (node && typeof IntersectionObserver !== 'undefined') {
+      observerRef.current = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting) {
+            loadMoreRef.current();
+          }
+        },
+        { rootMargin: '200px' }
+      );
+      observerRef.current.observe(node);
+    }
+  }, []);
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
@@ -77,87 +189,27 @@ const InventoryListPage: React.FC = () => {
     }
   };
 
-  const sortedAndFilteredItems = useMemo(() => {
-    let filtered = [...items];
-
-    // Search filter
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase();
-      filtered = filtered.filter(
-        (item) =>
-          item.name.toLowerCase().includes(term) ||
-          item.sku.toLowerCase().includes(term) ||
-          (item.description && item.description.toLowerCase().includes(term))
-      );
-    }
-
-    // Category filter
-    if (selectedCategory) {
-      filtered = filtered.filter((item) => item.category === Number(selectedCategory));
-    }
-
-    // Location filter
-    if (selectedLocation) {
-      filtered = filtered.filter((item) => {
-        const location = locations.find((l) => l.id === Number(selectedLocation));
-        return location && item.location === location.name;
-      });
-    }
-
-    // Low stock filter
-    if (lowStockFilter === 'true') {
-      filtered = filtered.filter((item) => item.needs_reorder);
-    } else if (lowStockFilter === 'false') {
-      filtered = filtered.filter((item) => !item.needs_reorder);
-    }
-
-    // Sort
-    filtered.sort((a, b) => {
-      let aVal: any;
-      let bVal: any;
-
-      switch (sortField) {
-        case 'name':
-          aVal = a.name.toLowerCase();
-          bVal = b.name.toLowerCase();
-          break;
-        case 'sku':
-          aVal = a.sku.toLowerCase();
-          bVal = b.sku.toLowerCase();
-          break;
-        case 'current_stock':
-          aVal = a.current_stock;
-          bVal = b.current_stock;
-          break;
-        case 'category_name':
-          aVal = a.category_name || '';
-          bVal = b.category_name || '';
-          break;
-        case 'location':
-          aVal = a.location || '';
-          bVal = b.location || '';
-          break;
-        case 'unit_cost':
-          aVal = a.unit_cost ? parseFloat(a.unit_cost) : 0;
-          bVal = b.unit_cost ? parseFloat(b.unit_cost) : 0;
-          break;
-        default:
-          return 0;
+  // Fetch every item matching the current filters (used by the export
+  // actions when nothing is explicitly selected).
+  const fetchAllMatchingItems = async (): Promise<InventoryItem[]> => {
+    const all: InventoryItem[] = [];
+    let targetPage = 1;
+    for (;;) {
+      const res = await inventoryAPI.listItems(buildListParams(targetPage));
+      all.push(...res.data.results);
+      if (!res.data.next) {
+        break;
       }
-
-      if (aVal < bVal) return sortDirection === 'asc' ? -1 : 1;
-      if (aVal > bVal) return sortDirection === 'asc' ? 1 : -1;
-      return 0;
-    });
-
-    return filtered;
-  }, [items, searchTerm, selectedCategory, selectedLocation, lowStockFilter, sortField, sortDirection, locations]);
+      targetPage += 1;
+    }
+    return all;
+  };
 
   const handleSelectAll = () => {
-    if (selectedItems.size === sortedAndFilteredItems.length) {
+    if (selectedItems.size === items.length) {
       setSelectedItems(new Set());
     } else {
-      setSelectedItems(new Set(sortedAndFilteredItems.map((item) => item.id)));
+      setSelectedItems(new Set(items.map((item) => item.id)));
     }
   };
 
@@ -177,8 +229,10 @@ const InventoryListPage: React.FC = () => {
 
   const handleStockSave = async (id: string, newValue: number) => {
     try {
-      await inventoryAPI.updateStock(id, newValue);
-      await loadData();
+      const res = await inventoryAPI.updateStock(id, newValue);
+      // Patch the row in place so we don't disturb scroll position or
+      // the already-loaded pages.
+      setItems((prev) => prev.map((item) => (item.id === id ? { ...item, ...res.data } : item)));
       setEditingStock(null);
     } catch (err) {
       console.error('Error updating stock:', err);
@@ -198,7 +252,6 @@ const InventoryListPage: React.FC = () => {
       await Promise.all(promises);
       showSuccess(`Successfully generated QR codes for ${selectedItems.size} items.`);
       setSelectedItems(new Set());
-      await loadData();
     } catch (err) {
       console.error('Error generating QR codes:', err);
       showError('Failed to generate QR codes. Please try again.');
@@ -207,22 +260,29 @@ const InventoryListPage: React.FC = () => {
     }
   };
 
-  const handleExportCSV = () => {
-    const itemsToExport = sortedAndFilteredItems.filter((item) => selectedItems.has(item.id));
-    exportInventoryItemsToCSV(itemsToExport.length > 0 ? itemsToExport : sortedAndFilteredItems);
+  const handleExportCSV = async () => {
+    try {
+      const selected = items.filter((item) => selectedItems.has(item.id));
+      const itemsToExport = selected.length > 0 ? selected : await fetchAllMatchingItems();
+      exportInventoryItemsToCSV(itemsToExport);
+    } catch (err) {
+      console.error('Error exporting items:', err);
+      showError('Failed to export items. Please try again.');
+    }
   };
 
   const handleGenerateTestSheet = async () => {
-    const itemsToExport = sortedAndFilteredItems.filter((item) => selectedItems.has(item.id));
-    const itemIds = itemsToExport.length > 0 ? itemsToExport.map((i) => i.id) : sortedAndFilteredItems.map((i) => i.id);
-
-    if (itemIds.length === 0) {
-      showInfo('No items to generate test sheet for.');
-      return;
-    }
-
     try {
       setGeneratingTestSheet(true);
+      const selected = items.filter((item) => selectedItems.has(item.id));
+      const itemsToExport = selected.length > 0 ? selected : await fetchAllMatchingItems();
+      const itemIds = itemsToExport.map((i) => i.id);
+
+      if (itemIds.length === 0) {
+        showInfo('No items to generate test sheet for.');
+        return;
+      }
+
       const response = await indexCardsAPI.generateTestSheet(itemIds);
       const blob = new Blob([response.data], { type: 'application/pdf' });
       const url = window.URL.createObjectURL(blob);
@@ -246,7 +306,7 @@ const InventoryListPage: React.FC = () => {
     return sortDirection === 'asc' ? <IconSortAscending size={16} /> : <IconSortDescending size={16} />;
   };
 
-  if (loading) {
+  if (loading && items.length === 0) {
     return (
       <WorkspacePage
         hero={{ eyebrow: 'Inventory', title: 'Items', description: 'Loading…' }}
@@ -265,7 +325,7 @@ const InventoryListPage: React.FC = () => {
       hero={{
         eyebrow: 'Inventory',
         title: 'Items',
-        description: `${sortedAndFilteredItems.length} of ${items.length} items in stock.`,
+        description: `Showing ${items.length} of ${totalCount} item${totalCount === 1 ? '' : 's'}.`,
         action: (
           <Button onClick={() => navigate('/inventory/items/new')}>Add new item</Button>
         ),
@@ -350,8 +410,8 @@ const InventoryListPage: React.FC = () => {
               <Table.Tr>
                 <Table.Th style={{ width: 40 }}>
                   <Checkbox
-                    checked={selectedItems.size === sortedAndFilteredItems.length && sortedAndFilteredItems.length > 0}
-                    indeterminate={selectedItems.size > 0 && selectedItems.size < sortedAndFilteredItems.length}
+                    checked={selectedItems.size === items.length && items.length > 0}
+                    indeterminate={selectedItems.size > 0 && selectedItems.size < items.length}
                     onChange={handleSelectAll}
                   />
                 </Table.Th>
@@ -385,18 +445,13 @@ const InventoryListPage: React.FC = () => {
                     <SortIcon field="current_stock" />
                   </Group>
                 </Table.Th>
-                <Table.Th>
-                  <Group gap="xs" style={{ cursor: 'pointer' }} onClick={() => handleSort('unit_cost')}>
-                    Unit Cost
-                    <SortIcon field="unit_cost" />
-                  </Group>
-                </Table.Th>
+                <Table.Th>Unit Cost</Table.Th>
                 <Table.Th>Status</Table.Th>
                 <Table.Th>Actions</Table.Th>
               </Table.Tr>
             </Table.Thead>
             <Table.Tbody>
-              {sortedAndFilteredItems.map((item) => (
+              {items.map((item) => (
                 <Table.Tr
                   key={item.id}
                   style={{
@@ -488,10 +543,27 @@ const InventoryListPage: React.FC = () => {
             </Table.Tbody>
           </Table>
         </Table.ScrollContainer>
-        {sortedAndFilteredItems.length === 0 && (
+        {items.length === 0 ? (
           <Paper p="xl" ta="center">
             <Text c="dimmed">No items found matching your filters.</Text>
           </Paper>
+        ) : (
+          // Infinite-scroll sentinel: observed to fetch the next page.
+          <div ref={sentinelRef} data-testid="inventory-scroll-sentinel">
+            {loadingMore && (
+              <Group justify="center" p="md">
+                <Loader size="sm" />
+                <Text size="sm" c="dimmed">
+                  Loading more…
+                </Text>
+              </Group>
+            )}
+            {!hasMore && (
+              <Text ta="center" c="dimmed" size="sm" p="md">
+                All {totalCount} item{totalCount === 1 ? '' : 's'} loaded.
+              </Text>
+            )}
+          </div>
         )}
       </Paper>
     </WorkspacePage>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -214,8 +214,21 @@ export const inventoryAPI = {
   markItemSupplierDiscontinued: (itemSupplierId: string) =>
     api.post(`/inventory/item-suppliers/${itemSupplierId}/mark_discontinued/`),
 
-  listItems: (params?: { category?: number; location?: number; search?: string; low_stock?: boolean; owning_group?: number }) =>
-    api.get<{ results: InventoryItem[] }>('/inventory/items/', { params }),
+  listItems: (params?: {
+    category?: number;
+    location?: number;
+    search?: string;
+    low_stock?: boolean;
+    owning_group?: number;
+    is_active?: boolean;
+    ordering?: string;
+    page?: number;
+    page_size?: number;
+  }) =>
+    api.get<{ count: number; next: string | null; previous: string | null; results: InventoryItem[] }>(
+      '/inventory/items/',
+      { params }
+    ),
 
   getMySIGInventory: () =>
     api.get<InventoryItem[]>('/inventory/items/my_sig_inventory/'),

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -75,4 +75,22 @@ if (typeof window !== 'undefined') {
   (window as unknown as { ResizeObserver: typeof ResizeObserverMock }).ResizeObserver = ResizeObserverMock;
 }
 
+// jsdom has no IntersectionObserver; provide an inert default so components
+// using it for infinite scroll render without throwing. Individual tests may
+// override this to capture the callback and simulate intersections.
+class IntersectionObserverMock {
+  constructor(_callback: IntersectionObserverCallback) {}
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+  takeRecords = vi.fn(() => []);
+}
+
+(globalThis as unknown as { IntersectionObserver: typeof IntersectionObserverMock }).IntersectionObserver =
+  IntersectionObserverMock;
+if (typeof window !== 'undefined') {
+  (window as unknown as { IntersectionObserver: typeof IntersectionObserverMock }).IntersectionObserver =
+    IntersectionObserverMock;
+}
+
 Element.prototype.scrollIntoView = vi.fn();


### PR DESCRIPTION
## Problem

The **Items** page (`InventoryListPage`) only ever loaded the first page of results (50 items) and then filtered/sorted them **in the browser**. Any item past the first 50 was invisible — you couldn't see it, search it, or sort to it. Search/category/stock filters only ever applied to that first page.

## What changed

Lazy-load the list (infinite scroll) and push filtering + sorting to the server so the whole catalog is reachable.

**Backend** — `InventoryItemViewSet.get_queryset`:
- Added an **allow-listed `ordering` param** (same pattern as `AssetViewSet`) — `name`, `sku`, `current_stock`, `minimum_stock`, `category__name`, `location__name`, `created_at`, `updated_at` (± desc). Anything off-list falls back to `name`.
- Added **`low_stock=false`** (stock above minimum) alongside the existing `low_stock=true`, so the "In Stock" filter runs server-side too.

**Frontend**:
- `api.ts` `listItems` now accepts `page` / `ordering` / `is_active` and returns the full paginated envelope (`{count, next, previous, results}`). The change is **additive** — existing `.results` callers are unaffected.
- `InventoryListPage` does server-side **debounced search**, category/location/stock filtering, and column sorting, with an **`IntersectionObserver` sentinel** that fetches the next page as you scroll. CSV export and index-card printing page through *all* matching items when nothing is selected; inline stock edits patch the row in place (no full reload / scroll jump).
- `setupTests`: inert `IntersectionObserver` mock (jsdom doesn't provide one), mirroring the existing `ResizeObserver` shim.

**Note:** *Unit Cost* stays a display-only column — it's a computed min-across-suppliers property, not a DB field, so it can't be ordered server-side.

## Testing

- **Backend:** `TestInventoryItemAPI` — 14 passed (4 new: ordering asc/desc, `low_stock` true/false, invalid-ordering fallback).
- **Frontend:** full suite green under CI's `TZ=America/Chicago` (679+ passing); `InventoryListPage` tests rewritten to assert the server-side params and cover the infinite-scroll sentinel. `npm run lint` 0 errors, `vite build` clean.

## Scope

This is the items list, which was the broken case (hard truncation at 50). **Assets** lazy-loading is a focused follow-up: `AssetList` already server-paginates (page controls at 250+), so converting it to the same infinite-scroll UX is a separate PR against a more complex component.