### PR TITLE
fix(work-orders): stamp completed_at on digital completion (+ backfill)

### DIFF
--- a/backend/inventory/migrations/0062_backfill_workorder_completed_at.py
+++ b/backend/inventory/migrations/0062_backfill_workorder_completed_at.py
@@ -1,0 +1,35 @@
+"""Backfill WorkOrder.completed_at for already-completed work orders.
+
+Digital completions never stamped ``completed_at`` (it is read-only over the
+API and the viewset did not set it), so completed work orders created that way
+rendered as "Completed N/A" in the asset detail view. Going forward the viewset
+stamps the timestamp; this migration repairs the existing rows using
+``updated_at`` as the best available proxy for when the status last changed.
+"""
+
+from django.db import migrations
+from django.db.models import F
+
+
+def backfill_completed_at(apps, schema_editor):
+    WorkOrder = apps.get_model("inventory", "WorkOrder")
+    WorkOrder.objects.filter(
+        status="completed",
+        completed_at__isnull=True,
+    ).update(completed_at=F("updated_at"))
+
+
+def noop_reverse(apps, schema_editor):
+    # Irreversible data repair; leave the backfilled timestamps in place.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0061_remove_asset_access_code_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_completed_at, noop_reverse),
+    ]

--- a/backend/inventory/tests/test_work_order_parity.py
+++ b/backend/inventory/tests/test_work_order_parity.py
@@ -279,6 +279,88 @@ def test_completion_allowed_after_full_validation(api, staff_user):
     assert wo.status == WorkOrder.STATUS_COMPLETED
 
 
+def test_completion_stamps_completed_at(api):
+    """Digitally completing a work order stamps completed_at.
+
+    The digital path used to leave it null, surfacing as "Completed N/A" in
+    the asset detail view.
+    """
+    wo = _build_wo()
+    assert wo.completed_at is None
+
+    api.post(
+        f"/api/inventory/work-orders/{wo.id}/validate/",
+        {
+            "electrical_acknowledged": True,
+            "loto_acknowledged": True,
+            "required_fields_acknowledged": True,
+        },
+        format="json",
+    )
+    res = api.patch(
+        f"/api/inventory/work-orders/{wo.id}/",
+        {"status": WorkOrder.STATUS_COMPLETED},
+        format="json",
+    )
+
+    assert res.status_code == status.HTTP_200_OK
+    wo.refresh_from_db()
+    assert wo.status == WorkOrder.STATUS_COMPLETED
+    assert wo.completed_at is not None
+
+
+def test_reopening_clears_completed_at(api):
+    """Reopening a completed work order clears its completion timestamp."""
+    wo = _build_wo()
+    api.post(
+        f"/api/inventory/work-orders/{wo.id}/validate/",
+        {
+            "electrical_acknowledged": True,
+            "loto_acknowledged": True,
+            "required_fields_acknowledged": True,
+        },
+        format="json",
+    )
+    api.patch(
+        f"/api/inventory/work-orders/{wo.id}/",
+        {"status": WorkOrder.STATUS_COMPLETED},
+        format="json",
+    )
+    wo.refresh_from_db()
+    assert wo.completed_at is not None
+
+    res = api.patch(
+        f"/api/inventory/work-orders/{wo.id}/",
+        {"status": WorkOrder.STATUS_IN_PROGRESS},
+        format="json",
+    )
+
+    assert res.status_code == status.HTTP_200_OK
+    wo.refresh_from_db()
+    assert wo.status == WorkOrder.STATUS_IN_PROGRESS
+    assert wo.completed_at is None
+
+
+def test_backfill_migration_populates_completed_at():
+    """The 0062 data migration repairs legacy completed work orders that have
+    no completion timestamp, using updated_at as the proxy."""
+    import importlib
+
+    from django.apps import apps as global_apps
+
+    wo = _build_wo()
+    # Simulate a legacy digital completion: completed status, no timestamp.
+    # .update() bypasses auto_now, so updated_at stays at creation time.
+    WorkOrder.objects.filter(pk=wo.pk).update(status=WorkOrder.STATUS_COMPLETED, completed_at=None)
+
+    migration = importlib.import_module("inventory.migrations.0062_backfill_workorder_completed_at")
+    migration.backfill_completed_at(global_apps, None)
+
+    wo.refresh_from_db()
+    assert wo.completed_at is not None
+    assert wo.completed_at == wo.updated_at
+
+
 def test_pdf_allowed_after_full_validation(api):
     wo = _build_wo()
     api.post(

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -3218,8 +3218,27 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
             )
         return None
 
+    @staticmethod
+    def _sync_completion_timestamp(work_order, *, was_completed: bool) -> None:
+        """Keep completed_at in step with the completed status.
+
+        completed_at is read-only over the API, so the server owns it: stamp it
+        when a work order becomes completed (the digital-completion path used to
+        leave it null, surfacing as "Completed N/A" in the asset view) and clear
+        it if a completed work order is reopened. An already-set timestamp (e.g.
+        from the paper-form ingest) is left untouched.
+        """
+        if work_order.status == WorkOrder.STATUS_COMPLETED:
+            if work_order.completed_at is None:
+                work_order.completed_at = timezone.now()
+                work_order.save(update_fields=["completed_at"])
+        elif was_completed and work_order.completed_at is not None:
+            work_order.completed_at = None
+            work_order.save(update_fields=["completed_at"])
+
     def perform_create(self, serializer):
         work_order = serializer.save()
+        self._sync_completion_timestamp(work_order, was_completed=False)
         record_maintenance_audit_event(
             action="wo_create",
             actor=self.request.user,
@@ -3233,6 +3252,9 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
     def perform_update(self, serializer):
         old_status = serializer.instance.status
         work_order = serializer.save()
+        self._sync_completion_timestamp(
+            work_order, was_completed=(old_status == WorkOrder.STATUS_COMPLETED)
+        )
         if (
             work_order.status == WorkOrder.STATUS_COMPLETED
             and old_status != WorkOrder.STATUS_COMPLETED


### PR DESCRIPTION
## Problem

In **Asset Detail → Recent Work Orders**, completed work orders show **"Completed N/A"** for a lot of records.

Root cause: completing a work order through the API never set `completed_at`. The field is `read_only` on the serializer, and `WorkOrderViewSet.perform_update` only recorded an audit event on the completed-transition — it never stamped the timestamp. So every *digitally*-completed work order kept `completed_at = null` (only the paper-form ingest path stamped a date). The UI renders `Completed ${formatDate(wo.completed_at)}`, and a null date becomes "N/A".

## Fix

- **`WorkOrderViewSet`** now stamps `completed_at = now()` when a work order transitions **into** the completed status, and **clears** it when a completed work order is reopened — handled in a shared helper used by both `perform_create` and `perform_update` (so create-as-completed is covered too). An already-set timestamp (paper ingest) is left untouched. The stamp happens before the audit event, so the audit metadata now captures the real `completed_at`.
- **Migration `0062`** backfills existing completed work orders with a null `completed_at`, using `updated_at` as the best available proxy for when the status last changed. (`.update()` + `F("updated_at")`, so it doesn't bump `updated_at` itself.)

**Side benefit:** these work orders rejoin the in-house **cost report**, which filters on `completed_at__isnull=False` and was silently dropping them.

No model/serializer/endpoint/permission changes — `completed_at` was already serialized; only the write path and a data migration change.

## Testing

`inventory/tests/test_work_order_parity.py` — **18 passed** (3 new):
- completing a WO via the API stamps `completed_at`;
- reopening a completed WO clears it;
- the `0062` backfill repairs a legacy completed row (`completed_at == updated_at`).

`makemigrations --check` reports no pending model changes; black/isort/flake8 clean (CI versions).