### PR TITLE
feat(forgekey): fleet dashboard with aggregate health summary

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -670,6 +670,9 @@ views:
       enable:
         permission_classes:
         - IsAuthenticatedOrReadOnly
+      fleet_summary:
+        permission_classes:
+        - IsAuthenticated
       list:
         permission_classes:
         - IsAuthenticatedOrReadOnly

--- a/backend/forgekey/tests/test_fleet_summary.py
+++ b/backend/forgekey/tests/test_fleet_summary.py
@@ -1,0 +1,84 @@
+"""Tests for the ForgeKey fleet-summary dashboard endpoint."""
+
+from __future__ import annotations
+
+from django.utils import timezone
+
+import pytest
+from rest_framework.test import APIClient
+
+from forgekey.models import EPaperDisplay
+from forgekey.tests.factories import DeviceTypeFactory, ESP32DeviceFactory
+
+pytestmark = pytest.mark.django_db
+
+FLEET_SUMMARY_URL = "/api/forgekey/devices/fleet-summary/"
+
+
+@pytest.fixture
+def api_client(admin_user):
+    client = APIClient()
+    client.force_authenticate(user=admin_user)
+    return client
+
+
+def test_fleet_summary_requires_authentication():
+    response = APIClient().get(FLEET_SUMMARY_URL)
+    assert response.status_code in (401, 403)
+
+
+def test_fleet_summary_counts_online_offline_and_aggregates(api_client):
+    dt = DeviceTypeFactory()
+    ESP32DeviceFactory(
+        device_type=dt,
+        is_online=True,
+        is_active=True,
+        firmware_version="1.0.0",
+        capabilities=["status_led", "people_counter"],
+        last_seen=timezone.now(),
+    )
+    ESP32DeviceFactory(
+        device_type=dt,
+        is_online=False,
+        is_active=True,
+        firmware_version="1.0.0",
+        capabilities=["status_led"],
+        last_seen=timezone.now(),
+    )
+    # An inactive device must not count toward the active online/offline tallies.
+    ESP32DeviceFactory(device_type=dt, is_online=False, is_active=False, firmware_version="0.9.0")
+
+    response = api_client.get(FLEET_SUMMARY_URL)
+    assert response.status_code == 200, response.data
+    body = response.json()
+
+    assert body["devices"]["total"] == 3
+    assert body["devices"]["active"] == 2
+    assert body["devices"]["online"] == 1
+    assert body["devices"]["offline"] == 1
+
+    caps = {c["capability"]: c["count"] for c in body["devices"]["by_capability"]}
+    assert caps["status_led"] == 2
+    assert caps["people_counter"] == 1
+
+    fw = {f["version"]: f["count"] for f in body["devices"]["by_firmware"]}
+    assert fw["1.0.0"] == 2
+    assert fw["0.9.0"] == 1
+
+    # The offline (active) device surfaces in the attention feed.
+    assert len(body["attention"]["offline"]) == 1
+
+
+def test_fleet_summary_flags_low_battery_epaper(api_client):
+    EPaperDisplay.objects.create(battery_percent=80, is_active=True)
+    EPaperDisplay.objects.create(battery_percent=5, is_active=True)
+
+    response = api_client.get(FLEET_SUMMARY_URL)
+    assert response.status_code == 200, response.data
+    body = response.json()
+
+    assert body["epaper"]["total"] == 2
+    assert body["epaper"]["low_battery"] == 1
+    low = body["attention"]["low_battery"]
+    assert len(low) == 1
+    assert low[0]["battery_percent"] == 5

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -1005,6 +1005,180 @@ class ESP32DeviceViewSet(viewsets.ModelViewSet):
             }
         )
 
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="fleet-summary",
+        permission_classes=[IsAuthenticated],
+    )
+    def fleet_summary(self, request):
+        """Aggregate fleet health for the ForgeKey dashboard.
+
+        One round-trip: device counts (online/offline, by type, by capability,
+        by firmware), an e-paper battery summary, firmware-update activity, a
+        prioritised "needs attention" feed, and recent commands/updates — so the
+        dashboard never has to fan out per device.
+        """
+        from collections import Counter
+
+        devices = list(ESP32Device.objects.select_related("device_type").all())
+        active = [d for d in devices if d.is_active]
+        online = [d for d in active if d.is_online]
+        offline = [d for d in active if not d.is_online]
+        never_seen = [d for d in devices if d.last_seen is None]
+
+        type_buckets: dict = {}
+        for d in devices:
+            code = d.device_type.code if d.device_type else "unknown"
+            name = d.device_type.name if d.device_type else "Unknown"
+            bucket = type_buckets.setdefault(
+                code, {"code": code, "name": name, "count": 0, "online": 0}
+            )
+            bucket["count"] += 1
+            if d.is_online:
+                bucket["online"] += 1
+        by_type = sorted(type_buckets.values(), key=lambda b: (-b["count"], b["name"]))
+
+        cap_counter: Counter = Counter()
+        for d in devices:
+            for cap in d.capabilities or []:
+                cap_counter[cap] += 1
+        by_capability = [
+            {"capability": cap, "count": n}
+            for cap, n in sorted(cap_counter.items(), key=lambda kv: (-kv[1], kv[0]))
+        ]
+
+        fw_counter = Counter(d.firmware_version or "unknown" for d in devices)
+        by_firmware = [
+            {"version": v, "count": n}
+            for v, n in sorted(fw_counter.items(), key=lambda kv: (-kv[1], kv[0]))
+        ]
+
+        low_battery_threshold = int(getattr(settings, "FORGEKEY_EPAPER_LOW_BATTERY_PERCENT", 20))
+        epaper_qs = EPaperDisplay.objects.filter(is_active=True)
+        epaper_total = epaper_qs.count()
+        epaper_unbound = epaper_qs.filter(asset__isnull=True).count()
+        low_battery_panels = list(
+            epaper_qs.filter(
+                battery_percent__isnull=False,
+                battery_percent__lt=low_battery_threshold,
+            )
+            .select_related("asset")
+            .order_by("battery_percent")[:20]
+        )
+
+        updates_in_flight = DeviceFirmwareUpdate.objects.filter(
+            status__in=[
+                DeviceFirmwareUpdate.STATUS_PENDING,
+                DeviceFirmwareUpdate.STATUS_IN_PROGRESS,
+            ]
+        ).count()
+        recent_failed = list(
+            DeviceFirmwareUpdate.objects.filter(status=DeviceFirmwareUpdate.STATUS_FAILED)
+            .select_related("device", "firmware_version")
+            .order_by("-requested_at")[:10]
+        )
+
+        # Needs-attention feed. Offline devices are ordered never-seen first,
+        # then longest-offline (oldest last_seen) first.
+        offline_sorted = sorted(
+            offline,
+            key=lambda d: (d.last_seen is not None, d.last_seen or timezone.now()),
+        )
+        attention_offline = [
+            {
+                "kind": "offline",
+                "device_id": str(d.id),
+                "name": d.name or d.mac_address,
+                "mac_address": d.mac_address,
+                "last_seen": d.last_seen.isoformat() if d.last_seen else None,
+            }
+            for d in offline_sorted[:15]
+        ]
+        attention_low_battery = [
+            {
+                "kind": "low_battery",
+                "display_id": str(p.id),
+                "asset_name": p.asset.name if p.asset else None,
+                "battery_percent": p.battery_percent,
+                "last_battery_at": p.last_battery_at.isoformat() if p.last_battery_at else None,
+            }
+            for p in low_battery_panels
+        ]
+        attention_ota = [
+            {
+                "kind": "ota_failed",
+                "device_id": str(u.device_id),
+                "name": u.device.name or u.device.mac_address,
+                "version": u.firmware_version.version if u.firmware_version else None,
+                "error": u.error_message or "",
+                "requested_at": u.requested_at.isoformat(),
+            }
+            for u in recent_failed
+        ]
+
+        recent_commands = [
+            {
+                "id": str(c.id),
+                "device_id": str(c.device_id),
+                "device_name": c.device.name or c.device.mac_address,
+                "command": c.command,
+                "ack_status": c.effective_ack_status,
+                "sent_at": c.sent_at.isoformat(),
+                "sent_by": c.sent_by.username if c.sent_by else None,
+            }
+            for c in DeviceCommand.objects.select_related("device", "sent_by").order_by("-sent_at")[
+                :10
+            ]
+        ]
+        recent_updates = [
+            {
+                "id": str(u.id),
+                "device_id": str(u.device_id),
+                "device_name": u.device.name or u.device.mac_address,
+                "version": u.firmware_version.version if u.firmware_version else None,
+                "status": u.status,
+                "requested_at": u.requested_at.isoformat(),
+                "requested_by": u.requested_by.username if u.requested_by else None,
+            }
+            for u in DeviceFirmwareUpdate.objects.select_related(
+                "device", "firmware_version", "requested_by"
+            ).order_by("-requested_at")[:10]
+        ]
+
+        return Response(
+            {
+                "generated_at": timezone.now().isoformat(),
+                "devices": {
+                    "total": len(devices),
+                    "active": len(active),
+                    "online": len(online),
+                    "offline": len(offline),
+                    "never_seen": len(never_seen),
+                    "by_type": by_type,
+                    "by_capability": by_capability,
+                    "by_firmware": by_firmware,
+                },
+                "epaper": {
+                    "total": epaper_total,
+                    "bound": epaper_total - epaper_unbound,
+                    "unbound": epaper_unbound,
+                    "low_battery": len(attention_low_battery),
+                },
+                "firmware": {
+                    "updates_in_flight": updates_in_flight,
+                    "recent_failures": len(attention_ota),
+                },
+                "attention": {
+                    "offline": attention_offline,
+                    "low_battery": attention_low_battery,
+                    "ota_failed": attention_ota,
+                },
+                "recent_commands": recent_commands,
+                "recent_updates": recent_updates,
+            }
+        )
+
     def _dispatch_command(self, device, actor, payload, audit_action):
         # Persist an audit row first so the firmware can echo its UUID back
         # on the status topic and the UI can render live ack feedback. The

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ import PowerPanelPrintPage from './pages/PowerPanelPrintPage';
 import PowerPanelDirectoryPage from './pages/PowerPanelDirectoryPage';
 import PowerPanelFormPage from './pages/PowerPanelFormPage';
 import FixtureScanPage from './pages/FixtureScanPage';
+import ForgeKeyDashboardPage from './pages/ForgeKeyDashboardPage';
 import ForgeKeyDeviceDetailPage from './pages/ForgeKeyDeviceDetailPage';
 import ForgeKeyDevicesPage from './pages/ForgeKeyDevicesPage';
 import ForgeKeyEPaperBindPage from './pages/ForgeKeyEPaperBindPage';
@@ -221,6 +222,7 @@ function AppContent() {
           <Route path="/inventory/suppliers/:id/edit" element={<WorkspaceLayout><SupplierFormPage /></WorkspaceLayout>} />
           <Route path="/inventory/assets" element={<WorkspaceLayout><AssetsPage /></WorkspaceLayout>} />
           <Route path="/inventory/admin" element={<WorkspaceLayout><AdminDashboard /></WorkspaceLayout>} />
+          <Route path="/facilities/forgekey-dashboard" element={<WorkspaceLayout><ForgeKeyDashboardPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-devices" element={<WorkspaceLayout><ForgeKeyDevicesPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-devices/:id" element={<WorkspaceLayout><ForgeKeyDeviceDetailPage /></WorkspaceLayout>} />
           <Route path="/forgekey/epaper/bind" element={<WorkspaceLayout><ForgeKeyEPaperBindPage /></WorkspaceLayout>} />

--- a/frontend/src/__tests__/pages/ForgeKeyDashboardPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyDashboardPage.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Tests for the ForgeKey fleet dashboard page.
+ *
+ * Covers: non-staff redirect, the headline stat cards, the needs-attention
+ * feed (offline devices + low-battery panels), breakdowns, and the all-clear
+ * empty state.
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ForgeKeyDashboardPage from '../../pages/ForgeKeyDashboardPage';
+import { forgekeyAPI } from '../../services/api';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    forgekeyAPI: {
+      getFleetSummary: jest.fn(),
+    },
+  };
+});
+
+const mockForgekey = forgekeyAPI as jest.Mocked<typeof forgekeyAPI>;
+
+const buildSummary = (overrides: Partial<any> = {}) => ({
+  generated_at: '2026-05-31T00:00:00Z',
+  devices: {
+    total: 5,
+    active: 4,
+    online: 3,
+    offline: 1,
+    never_seen: 0,
+    by_type: [{ code: 'ac_relay', name: 'AC Relay', count: 3, online: 2 }],
+    by_capability: [{ capability: 'status_led', count: 4 }],
+    by_firmware: [{ version: '1.0.0', count: 5 }],
+  },
+  epaper: { total: 2, bound: 1, unbound: 1, low_battery: 1 },
+  firmware: { updates_in_flight: 1, recent_failures: 0 },
+  attention: {
+    offline: [
+      { kind: 'offline', device_id: 'd9', name: 'Back door', mac_address: 'AA:BB', last_seen: null },
+    ],
+    low_battery: [
+      {
+        kind: 'low_battery',
+        display_id: 'e1',
+        asset_name: 'Lathe panel',
+        battery_percent: 7,
+        last_battery_at: null,
+      },
+    ],
+    ota_failed: [],
+  },
+  recent_commands: [
+    {
+      id: 'c1',
+      device_id: 'd1',
+      device_name: 'Front door',
+      command: 'restart',
+      ack_status: 'acked',
+      sent_at: '2026-05-31T00:00:00Z',
+      sent_by: 'admin',
+    },
+  ],
+  recent_updates: [],
+  ...overrides,
+});
+
+const renderPage = (initialEntry = '/facilities/forgekey-dashboard') =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/facilities/forgekey-dashboard" element={<ForgeKeyDashboardPage />} />
+          <Route path="/" element={<div>HOME</div>} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('ForgeKeyDashboardPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  test('non-staff users are redirected away', async () => {
+    localStorage.setItem('is_staff', 'false');
+    localStorage.setItem('is_superuser', 'false');
+
+    renderPage();
+
+    expect(await screen.findByText('HOME')).toBeInTheDocument();
+    expect(mockForgekey.getFleetSummary).not.toHaveBeenCalled();
+  });
+
+  test('staff sees fleet stats and the needs-attention feed', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockForgekey.getFleetSummary.mockResolvedValue({ data: buildSummary() } as any);
+
+    renderPage();
+
+    expect(await screen.findByTestId('stat-total')).toHaveTextContent('5');
+    expect(screen.getByTestId('stat-online')).toHaveTextContent('3');
+    expect(screen.getByTestId('stat-offline')).toHaveTextContent('1');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('attention-offline')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Back door')).toBeInTheDocument();
+    expect(screen.getByTestId('attention-lowbatt')).toBeInTheDocument();
+    expect(screen.getByText('Lathe panel')).toBeInTheDocument();
+    expect(screen.getByText('7%')).toBeInTheDocument();
+
+    expect(screen.getByTestId('breakdown-firmware')).toHaveTextContent('1.0.0');
+    expect(screen.getByText('Front door')).toBeInTheDocument();
+  });
+
+  test('shows an all-clear state when nothing needs attention', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockForgekey.getFleetSummary.mockResolvedValue({
+      data: buildSummary({
+        devices: {
+          total: 1,
+          active: 1,
+          online: 1,
+          offline: 0,
+          never_seen: 0,
+          by_type: [],
+          by_capability: [],
+          by_firmware: [],
+        },
+        epaper: { total: 0, bound: 0, unbound: 0, low_battery: 0 },
+        firmware: { updates_in_flight: 0, recent_failures: 0 },
+        attention: { offline: [], low_battery: [], ota_failed: [] },
+        recent_commands: [],
+        recent_updates: [],
+      }),
+    } as any);
+
+    renderPage();
+
+    expect(await screen.findByTestId('all-clear')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -113,6 +113,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed = false, isMobileOpen = f
       items: [
         { path: '/facilities/tv-dashboard', label: 'TV Dashboard', icon: '📺' },
         { path: '/facilities/logistics', label: 'Logistics', icon: '🚛' },
+        { path: '/facilities/forgekey-dashboard', label: 'ForgeKey Dashboard', icon: '📊', requiresStaff: true },
         { path: '/facilities/forgekey-devices', label: 'ForgeKey Devices', icon: '📡', requiresStaff: true },
         { path: '/facilities/electrical', label: 'Electrical & Network', icon: '⚡', requiresStaff: true },
       ],

--- a/frontend/src/navigation/routeMap.ts
+++ b/frontend/src/navigation/routeMap.ts
@@ -68,6 +68,7 @@ const ENTRIES: RouteEntry[] = [
   { path: 'facilities/electrical/outlets', label: 'Outlets', clickable: false },
   { path: 'facilities/electrical/light-switches', label: 'Light Switches', clickable: false },
   { path: 'facilities/electrical/network-drops', label: 'Network Drops', clickable: false },
+  { path: 'facilities/forgekey-dashboard', label: 'ForgeKey Dashboard' },
   { path: 'facilities/forgekey-devices', label: 'ForgeKey Devices' },
   { path: 'admin/audit-feed', label: 'Audit Feed' },
   { path: 'forgekey/epaper/bind', label: 'Bind ePaper Panel' },

--- a/frontend/src/pages/FacilitiesOverviewPage.tsx
+++ b/frontend/src/pages/FacilitiesOverviewPage.tsx
@@ -8,6 +8,7 @@ import {
   IconBox,
   IconChecklist,
   IconDeviceTv,
+  IconGauge,
   IconKey,
   IconPackage,
   IconScreenshot,
@@ -67,6 +68,14 @@ const FacilitiesOverviewPage: React.FC = () => (
       icon={<IconBolt size={22} stroke={1.8} />}
       eyebrow="Plant"
       testId="facilities-overview-card-/facilities/electrical"
+    />
+    <CapabilityCard
+      to="/facilities/forgekey-dashboard"
+      title="ForgeKey dashboard"
+      description="Fleet health at a glance — online/offline, firmware, e-paper panels, and alerts."
+      icon={<IconGauge size={22} stroke={1.8} />}
+      eyebrow="Access"
+      testId="facilities-overview-card-/facilities/forgekey-dashboard"
     />
     <CapabilityCard
       to="/facilities/forgekey-devices"

--- a/frontend/src/pages/ForgeKeyDashboardPage.tsx
+++ b/frontend/src/pages/ForgeKeyDashboardPage.tsx
@@ -1,0 +1,394 @@
+/**
+ * ForgeKey Fleet Dashboard
+ *
+ * Staff-only, at-a-glance health across the whole ForgeKey device fleet:
+ * online/offline counts, breakdowns by type / capability / firmware, a
+ * "needs attention" feed (offline devices, low-battery e-paper panels, failed
+ * OTA), and recent command / firmware activity. Backed by a single
+ * /forgekey/devices/fleet-summary/ aggregate, so the page never fans out per
+ * device. Refreshes every 30s.
+ */
+import {
+  Alert,
+  Anchor,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Group,
+  Loader,
+  SimpleGrid,
+  Stack,
+  Table,
+  Text,
+  Title,
+} from '@mantine/core';
+import React, { useEffect, useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
+import { ForgeKeyFleetSummary, forgekeyAPI } from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+const POLL_INTERVAL_MS = 30_000;
+
+const formatRelative = (iso: string | null): string => {
+  if (!iso) return 'never';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '—';
+  const secs = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.round(hrs / 24)}d ago`;
+};
+
+const ACK_COLORS: Record<string, string> = {
+  pending: 'gray',
+  acked: 'green',
+  error: 'red',
+  timeout: 'orange',
+};
+
+const OTA_COLORS: Record<string, string> = {
+  pending: 'gray',
+  in_progress: 'blue',
+  completed: 'green',
+  failed: 'red',
+  cancelled: 'gray',
+};
+
+const StatCard: React.FC<{
+  label: string;
+  value: React.ReactNode;
+  color?: string;
+  testId?: string;
+}> = ({ label, value, color, testId }) => (
+  <Card withBorder p="md" radius="md" data-testid={testId}>
+    <Text size="sm" c="dimmed" fw={500}>
+      {label}
+    </Text>
+    <Text size="xl" fw={700} c={color}>
+      {value}
+    </Text>
+  </Card>
+);
+
+const BreakdownCard: React.FC<{
+  title: string;
+  rows: Array<{ label: string; count: number; extra?: React.ReactNode }>;
+  testId?: string;
+}> = ({ title, rows, testId }) => (
+  <Card withBorder p="md" radius="sm" data-testid={testId}>
+    <Text fw={600} size="sm" mb="xs">
+      {title}
+    </Text>
+    {rows.length === 0 ? (
+      <Text size="sm" c="dimmed">
+        No data yet.
+      </Text>
+    ) : (
+      <Stack gap={4}>
+        {rows.map((r) => (
+          <Group key={r.label} justify="space-between" gap="xs">
+            <Text size="sm">{r.label}</Text>
+            <Group gap="xs">
+              {r.extra}
+              <Badge variant="light">{r.count}</Badge>
+            </Group>
+          </Group>
+        ))}
+      </Stack>
+    )}
+  </Card>
+);
+
+const ForgeKeyDashboardPage: React.FC = () => {
+  const isStaff = typeof window !== 'undefined' && localStorage.getItem('is_staff') === 'true';
+  const isSuperuser =
+    typeof window !== 'undefined' && localStorage.getItem('is_superuser') === 'true';
+
+  const [summary, setSummary] = useState<ForgeKeyFleetSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isStaff && !isSuperuser) return undefined;
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const res = await forgekeyAPI.getFleetSummary();
+        if (!cancelled) {
+          setSummary(res.data);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(extractErrorMessage(err, 'Failed to load the ForgeKey fleet summary.'));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+    load();
+    const handle = window.setInterval(load, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(handle);
+    };
+  }, [isStaff, isSuperuser]);
+
+  if (!isStaff && !isSuperuser) {
+    return <Navigate to="/" replace />;
+  }
+
+  const attentionCount = summary
+    ? summary.attention.offline.length +
+      summary.attention.low_battery.length +
+      summary.attention.ota_failed.length
+    : 0;
+
+  return (
+    <WorkspacePage
+      testId="forgekey-dashboard-page"
+      hero={{
+        eyebrow: 'Facilities · ForgeKey',
+        title: 'Fleet dashboard',
+        description:
+          'Health across every ForgeKey device — connectivity, firmware, e-paper panels, and recent activity.',
+        action: (
+          <Button component={Link} to="/facilities/forgekey-devices" variant="default">
+            Manage devices
+          </Button>
+        ),
+      }}
+    >
+      {error && (
+        <Alert color="red" variant="light" data-testid="dashboard-error">
+          {error}
+        </Alert>
+      )}
+
+      {loading && !summary ? (
+        <Group justify="center" p="xl">
+          <Loader />
+        </Group>
+      ) : summary ? (
+        <Stack gap="lg">
+          {/* Headline stats */}
+          <SimpleGrid cols={{ base: 2, sm: 3, lg: 6 }} data-testid="fleet-stat-cards">
+            <StatCard label="Devices" value={summary.devices.total} testId="stat-total" />
+            <StatCard label="Online" value={summary.devices.online} color="green" testId="stat-online" />
+            <StatCard
+              label="Offline"
+              value={summary.devices.offline}
+              color={summary.devices.offline > 0 ? 'red' : undefined}
+              testId="stat-offline"
+            />
+            <StatCard label="e-Paper panels" value={summary.epaper.total} testId="stat-epaper" />
+            <StatCard
+              label="Low battery"
+              value={summary.epaper.low_battery}
+              color={summary.epaper.low_battery > 0 ? 'orange' : undefined}
+              testId="stat-lowbatt"
+            />
+            <StatCard
+              label="OTA in flight"
+              value={summary.firmware.updates_in_flight}
+              testId="stat-ota"
+            />
+          </SimpleGrid>
+
+          {/* Needs attention */}
+          <Box data-testid="needs-attention">
+            <Group mb="sm" gap="xs">
+              <Title order={4}>Needs attention</Title>
+              <Badge color={attentionCount > 0 ? 'red' : 'gray'}>{attentionCount}</Badge>
+            </Group>
+            {attentionCount === 0 ? (
+              <Card withBorder p="md" radius="sm">
+                <Text size="sm" c="dimmed" data-testid="all-clear">
+                  All clear — every device is online and healthy.
+                </Text>
+              </Card>
+            ) : (
+              <Stack gap="sm">
+                {summary.attention.offline.length > 0 && (
+                  <Card withBorder p="md" radius="sm" data-testid="attention-offline">
+                    <Text fw={600} size="sm" mb="xs">
+                      Offline ({summary.attention.offline.length})
+                    </Text>
+                    <Stack gap={4}>
+                      {summary.attention.offline.map((d) => (
+                        <Group key={d.device_id} justify="space-between" gap="xs">
+                          <Anchor component={Link} to={`/facilities/forgekey-devices/${d.device_id}`}>
+                            {d.name}
+                          </Anchor>
+                          <Text size="sm" c="dimmed">
+                            last seen {formatRelative(d.last_seen)}
+                          </Text>
+                        </Group>
+                      ))}
+                    </Stack>
+                  </Card>
+                )}
+                {summary.attention.low_battery.length > 0 && (
+                  <Card withBorder p="md" radius="sm" data-testid="attention-lowbatt">
+                    <Text fw={600} size="sm" mb="xs">
+                      Low-battery e-paper panels ({summary.attention.low_battery.length})
+                    </Text>
+                    <Stack gap={4}>
+                      {summary.attention.low_battery.map((p) => (
+                        <Group key={p.display_id} justify="space-between" gap="xs">
+                          <Text size="sm">{p.asset_name || 'Unbound panel'}</Text>
+                          <Badge color="orange" variant="light">
+                            {p.battery_percent}%
+                          </Badge>
+                        </Group>
+                      ))}
+                    </Stack>
+                  </Card>
+                )}
+                {summary.attention.ota_failed.length > 0 && (
+                  <Card withBorder p="md" radius="sm" data-testid="attention-ota">
+                    <Text fw={600} size="sm" mb="xs">
+                      Failed firmware updates ({summary.attention.ota_failed.length})
+                    </Text>
+                    <Stack gap={4}>
+                      {summary.attention.ota_failed.map((u) => (
+                        <Group key={u.device_id + u.requested_at} justify="space-between" gap="xs">
+                          <Anchor component={Link} to={`/facilities/forgekey-devices/${u.device_id}`}>
+                            {u.name}
+                          </Anchor>
+                          <Text size="sm" c="dimmed">
+                            {u.version || '—'} · {formatRelative(u.requested_at)}
+                          </Text>
+                        </Group>
+                      ))}
+                    </Stack>
+                  </Card>
+                )}
+              </Stack>
+            )}
+          </Box>
+
+          {/* Breakdowns */}
+          <SimpleGrid cols={{ base: 1, md: 3 }}>
+            <BreakdownCard
+              title="By type"
+              testId="breakdown-type"
+              rows={summary.devices.by_type.map((t) => ({
+                label: t.name,
+                count: t.count,
+                extra: (
+                  <Text size="xs" c="dimmed">
+                    {t.online} online
+                  </Text>
+                ),
+              }))}
+            />
+            <BreakdownCard
+              title="By capability"
+              testId="breakdown-capability"
+              rows={summary.devices.by_capability.map((c) => ({
+                label: c.capability,
+                count: c.count,
+              }))}
+            />
+            <BreakdownCard
+              title="By firmware"
+              testId="breakdown-firmware"
+              rows={summary.devices.by_firmware.map((f) => ({
+                label: f.version,
+                count: f.count,
+              }))}
+            />
+          </SimpleGrid>
+
+          {/* Recent activity */}
+          <SimpleGrid cols={{ base: 1, md: 2 }}>
+            <Card withBorder p="md" radius="sm" data-testid="recent-commands">
+              <Text fw={600} size="sm" mb="xs">
+                Recent commands
+              </Text>
+              {summary.recent_commands.length === 0 ? (
+                <Text size="sm" c="dimmed">
+                  No commands sent yet.
+                </Text>
+              ) : (
+                <Table>
+                  <Table.Tbody>
+                    {summary.recent_commands.map((c) => (
+                      <Table.Tr key={c.id}>
+                        <Table.Td>
+                          <Anchor component={Link} to={`/facilities/forgekey-devices/${c.device_id}`}>
+                            {c.device_name}
+                          </Anchor>
+                        </Table.Td>
+                        <Table.Td>
+                          <Text size="sm">{c.command}</Text>
+                        </Table.Td>
+                        <Table.Td>
+                          <Badge size="sm" color={ACK_COLORS[c.ack_status] || 'gray'}>
+                            {c.ack_status}
+                          </Badge>
+                        </Table.Td>
+                        <Table.Td>
+                          <Text size="xs" c="dimmed">
+                            {formatRelative(c.sent_at)}
+                          </Text>
+                        </Table.Td>
+                      </Table.Tr>
+                    ))}
+                  </Table.Tbody>
+                </Table>
+              )}
+            </Card>
+            <Card withBorder p="md" radius="sm" data-testid="recent-updates">
+              <Text fw={600} size="sm" mb="xs">
+                Recent firmware updates
+              </Text>
+              {summary.recent_updates.length === 0 ? (
+                <Text size="sm" c="dimmed">
+                  No firmware updates yet.
+                </Text>
+              ) : (
+                <Table>
+                  <Table.Tbody>
+                    {summary.recent_updates.map((u) => (
+                      <Table.Tr key={u.id}>
+                        <Table.Td>
+                          <Anchor component={Link} to={`/facilities/forgekey-devices/${u.device_id}`}>
+                            {u.device_name}
+                          </Anchor>
+                        </Table.Td>
+                        <Table.Td>
+                          <Text size="sm">{u.version || '—'}</Text>
+                        </Table.Td>
+                        <Table.Td>
+                          <Badge size="sm" color={OTA_COLORS[u.status] || 'gray'}>
+                            {u.status}
+                          </Badge>
+                        </Table.Td>
+                        <Table.Td>
+                          <Text size="xs" c="dimmed">
+                            {formatRelative(u.requested_at)}
+                          </Text>
+                        </Table.Td>
+                      </Table.Tr>
+                    ))}
+                  </Table.Tbody>
+                </Table>
+              )}
+            </Card>
+          </SimpleGrid>
+        </Stack>
+      ) : null}
+    </WorkspacePage>
+  );
+};
+
+export default ForgeKeyDashboardPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1768,11 +1768,71 @@ export interface ForgeKeyRecentCommandsResponse {
   results: ForgeKeyDeviceCommand[];
 }
 
+export interface ForgeKeyFleetSummary {
+  generated_at: string;
+  devices: {
+    total: number;
+    active: number;
+    online: number;
+    offline: number;
+    never_seen: number;
+    by_type: Array<{ code: string; name: string; count: number; online: number }>;
+    by_capability: Array<{ capability: string; count: number }>;
+    by_firmware: Array<{ version: string; count: number }>;
+  };
+  epaper: { total: number; bound: number; unbound: number; low_battery: number };
+  firmware: { updates_in_flight: number; recent_failures: number };
+  attention: {
+    offline: Array<{
+      kind: 'offline';
+      device_id: string;
+      name: string;
+      mac_address: string;
+      last_seen: string | null;
+    }>;
+    low_battery: Array<{
+      kind: 'low_battery';
+      display_id: string;
+      asset_name: string | null;
+      battery_percent: number;
+      last_battery_at: string | null;
+    }>;
+    ota_failed: Array<{
+      kind: 'ota_failed';
+      device_id: string;
+      name: string;
+      version: string | null;
+      error: string;
+      requested_at: string;
+    }>;
+  };
+  recent_commands: Array<{
+    id: string;
+    device_id: string;
+    device_name: string;
+    command: string;
+    ack_status: ForgeKeyAckStatus;
+    sent_at: string;
+    sent_by: string | null;
+  }>;
+  recent_updates: Array<{
+    id: string;
+    device_id: string;
+    device_name: string;
+    version: string | null;
+    status: string;
+    requested_at: string;
+    requested_by: string | null;
+  }>;
+}
+
 export const forgekeyAPI = {
   listDevices: (opts: { capability?: string } = {}) =>
     api.get<{ results?: ForgeKeyDevice[] } | ForgeKeyDevice[]>('/forgekey/devices/', {
       params: opts.capability ? { capability: opts.capability } : undefined,
     }),
+  getFleetSummary: () =>
+    api.get<ForgeKeyFleetSummary>('/forgekey/devices/fleet-summary/'),
   getDevice: (id: string) => api.get<ForgeKeyDevice>(`/forgekey/devices/${id}/`),
   updateDevice: (id: string, data: Partial<ForgeKeyDevice>) =>
     api.patch<ForgeKeyDevice>(`/forgekey/devices/${id}/`, data),


### PR DESCRIPTION
## What & why

ForgeKey already has a mature backend and per-device list/detail UI, but **no fleet-level view**. This adds a staff-only **fleet dashboard** at `/facilities/forgekey-dashboard` that shows device health at a glance.

This is **PR 1 of 5** in the ForgeKey enablement series (dashboard → temperature telemetry → e-paper panels → firmware rollout → build pipeline).

## Backend

New aggregate endpoint **`GET /forgekey/devices/fleet-summary/`** (authenticated) — one round-trip, no per-device fan-out:
- **Device counts**: total / active / online / offline / never-seen, plus breakdowns by **type**, **capability**, and **firmware version** (a free rollout snapshot).
- **E-paper**: total / bound / unbound / low-battery (reuses `FORGEKEY_EPAPER_LOW_BATTERY_PERCENT`).
- **Firmware**: updates in flight + recent failures.
- **Needs-attention feed**: offline devices (never-seen first, then longest-offline), low-battery panels, and recently-failed OTA.
- **Recent activity**: last 10 commands (with ack status) and firmware updates, each self-contained (device name + version inline).

Relies on the existing, beat-maintained `is_online` flag. Permission matrix regenerated for the new route.

## Frontend

`ForgeKeyDashboardPage` (WorkspacePage shell, Mantine): headline stat cards, the needs-attention feed, the three breakdowns, and recent-activity tables — **polling every 30s**. Wired into routing, the sidebar, the route map, and a new Facilities overview card.

## Testing

- **Backend** (3): auth gate (401/403 unauth), online/offline + capability/firmware aggregation (inactive devices excluded), low-battery e-paper flag.
- **Frontend** (3): non-staff redirect, stats + attention feed render, all-clear empty state.
- Full frontend suite (**682 passed**), `config/tests/test_permission_matrix.py`, device-viewset tests, lint (eslint + black/isort/flake8 at CI versions), and `vite build` all green.