### PR TITLE
feat(forgekey): e-paper panels management screen

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -632,6 +632,12 @@ views:
   forgekey.views.EPaperDisplayImageView:
     permission_classes:
     - AllowAny
+  forgekey.views.EPaperDisplayListView:
+    permission_classes:
+    - IsAuthenticated
+  forgekey.views.EPaperDisplaySetActiveView:
+    permission_classes:
+    - IsAuthenticated
   forgekey.views.EPaperServiceCompleteView:
     permission_classes:
     - IsAuthenticated

--- a/backend/forgekey/serializers.py
+++ b/backend/forgekey/serializers.py
@@ -12,6 +12,7 @@ from .models import (
     DeviceLockout,
     DeviceType,
     DeviceUsage,
+    EPaperDisplay,
     ESP32Device,
     FirmwareVersion,
     OccupancyEvent,
@@ -203,3 +204,41 @@ class DeviceFirmwareUpdateSerializer(serializers.ModelSerializer):
         model = DeviceFirmwareUpdate
         fields = "__all__"
         read_only_fields = ["id", "requested_at", "updated_at"]
+
+
+class EPaperDisplaySerializer(serializers.ModelSerializer):
+    """Serializer for the e-paper panels management screen."""
+
+    asset_name = serializers.SerializerMethodField()
+    asset_tag = serializers.SerializerMethodField()
+    device_mac_address = serializers.SerializerMethodField()
+    is_low_battery = serializers.BooleanField(read_only=True)
+
+    class Meta:
+        model = EPaperDisplay
+        fields = [
+            "id",
+            "device",
+            "device_mac_address",
+            "asset",
+            "asset_name",
+            "asset_tag",
+            "battery_percent",
+            "is_low_battery",
+            "last_battery_at",
+            "last_image_etag",
+            "last_image_at",
+            "is_active",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = fields
+
+    def get_asset_name(self, obj):
+        return obj.asset.name if obj.asset_id else None
+
+    def get_asset_tag(self, obj):
+        return obj.asset.asset_tag if obj.asset_id else None
+
+    def get_device_mac_address(self, obj):
+        return obj.device.mac_address if obj.device_id else None

--- a/backend/forgekey/tests/test_epaper_panels.py
+++ b/backend/forgekey/tests/test_epaper_panels.py
@@ -1,0 +1,75 @@
+"""Tests for the e-paper panels management endpoints (list + retire/reactivate)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from rest_framework.test import APIClient
+
+from forgekey.models import EPaperDisplay
+from inventory.tests.factories import AssetFactory
+
+pytestmark = pytest.mark.django_db
+
+LIST_URL = "/api/forgekey/epaper/"
+
+
+def _set_active_url(display) -> str:
+    return f"/api/forgekey/epaper/{display.id}/set-active/"
+
+
+@pytest.fixture
+def api_client(admin_user):
+    client = APIClient()
+    client.force_authenticate(user=admin_user)
+    return client
+
+
+def test_list_requires_auth():
+    assert APIClient().get(LIST_URL).status_code in (401, 403)
+
+
+def test_list_returns_panels_with_binding_and_battery(api_client):
+    asset = AssetFactory(name="Lathe")
+    EPaperDisplay.objects.create(asset=asset, battery_percent=8)
+    EPaperDisplay.objects.create(battery_percent=90)  # unbound, healthy
+
+    response = api_client.get(LIST_URL)
+
+    assert response.status_code == 200, response.data
+    body = response.json()
+    assert len(body) == 2
+
+    bound = next(d for d in body if d["asset"] is not None)
+    assert bound["asset_name"] == "Lathe"
+    assert bound["battery_percent"] == 8
+    assert bound["is_low_battery"] is True
+
+    unbound = next(d for d in body if d["asset"] is None)
+    assert unbound["asset_name"] is None
+    assert unbound["is_low_battery"] is False
+
+
+def test_retire_then_reactivate(api_client):
+    display = EPaperDisplay.objects.create(battery_percent=50, is_active=True)
+
+    retire = api_client.post(_set_active_url(display), {"is_active": False}, format="json")
+    assert retire.status_code == 200, retire.data
+    assert retire.json()["is_active"] is False
+    display.refresh_from_db()
+    assert display.is_active is False
+
+    react = api_client.post(_set_active_url(display), {"is_active": True}, format="json")
+    assert react.status_code == 200
+    display.refresh_from_db()
+    assert display.is_active is True
+
+
+def test_set_active_unknown_display_returns_404(api_client):
+    response = api_client.post(
+        f"/api/forgekey/epaper/{uuid.uuid4()}/set-active/",
+        {"is_active": False},
+        format="json",
+    )
+    assert response.status_code == 404

--- a/backend/forgekey/urls.py
+++ b/backend/forgekey/urls.py
@@ -16,6 +16,8 @@ from .views import (
     EPaperDisplayBatteryView,
     EPaperDisplayBindView,
     EPaperDisplayImageView,
+    EPaperDisplayListView,
+    EPaperDisplaySetActiveView,
     EPaperServiceCompleteView,
     EPaperServiceInfoView,
     ESP32DeviceViewSet,
@@ -88,6 +90,11 @@ urlpatterns = [
         name="mqtt-webhook",
     ),
     path(
+        "epaper/",
+        EPaperDisplayListView.as_view(),
+        name="epaper-list",
+    ),
+    path(
         "epaper/<uuid:display_id>/image.png",
         EPaperDisplayImageView.as_view(),
         name="epaper-image",
@@ -101,6 +108,11 @@ urlpatterns = [
         "epaper/<uuid:display_id>/bind/",
         EPaperDisplayBindView.as_view(),
         name="epaper-bind",
+    ),
+    path(
+        "epaper/<uuid:display_id>/set-active/",
+        EPaperDisplaySetActiveView.as_view(),
+        name="epaper-set-active",
     ),
     path(
         "epaper/<uuid:display_id>/service-info/",

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -61,6 +61,7 @@ from .serializers import (
     DeviceLockoutSerializer,
     DeviceTypeSerializer,
     DeviceUsageSerializer,
+    EPaperDisplaySerializer,
     ESP32DeviceSerializer,
     FirmwareVersionSerializer,
     OccupancyEventSerializer,
@@ -2309,3 +2310,45 @@ class EPaperDisplayBindView(APIView):
             },
             status=200,
         )
+
+
+class EPaperDisplayListView(APIView):
+    """List every ePaper panel for the management screen.
+
+    Staff use this to see each panel's asset binding, battery level, last
+    image fetch, and active/retired state at a glance. Rebinding reuses the
+    existing bind endpoint; retiring uses EPaperDisplaySetActiveView below.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        displays = EPaperDisplay.objects.select_related("asset", "device").all()
+        return Response(EPaperDisplaySerializer(displays, many=True).data)
+
+
+class EPaperDisplaySetActiveView(APIView):
+    """Retire or reactivate an ePaper panel.
+
+    ``POST {"is_active": false}`` retires the panel — the firmware's image.png
+    fetch then paints the "retired" card and the panel stops refreshing.
+    ``{"is_active": true}`` brings it back into service.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, display_id):
+        try:
+            display = EPaperDisplay.objects.get(pk=display_id)
+        except EPaperDisplay.DoesNotExist:
+            return Response({"detail": "Display not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        raw = request.data.get("is_active", False)
+        if isinstance(raw, str):
+            is_active = raw.strip().lower() in {"true", "1", "yes"}
+        else:
+            is_active = bool(raw)
+
+        display.is_active = is_active
+        display.save(update_fields=["is_active", "updated_at"])
+        return Response(EPaperDisplaySerializer(display).data)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,6 +43,7 @@ import ForgeKeyDashboardPage from './pages/ForgeKeyDashboardPage';
 import ForgeKeyDeviceDetailPage from './pages/ForgeKeyDeviceDetailPage';
 import ForgeKeyDevicesPage from './pages/ForgeKeyDevicesPage';
 import ForgeKeyEPaperBindPage from './pages/ForgeKeyEPaperBindPage';
+import ForgeKeyEPaperPanelsPage from './pages/ForgeKeyEPaperPanelsPage';
 import ForgeKeyEPaperServicePage from './pages/ForgeKeyEPaperServicePage';
 import HomePage from './pages/HomePage';
 import PurchasingOverviewPage from './pages/PurchasingOverviewPage';
@@ -225,6 +226,7 @@ function AppContent() {
           <Route path="/facilities/forgekey-dashboard" element={<WorkspaceLayout><ForgeKeyDashboardPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-devices" element={<WorkspaceLayout><ForgeKeyDevicesPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-devices/:id" element={<WorkspaceLayout><ForgeKeyDeviceDetailPage /></WorkspaceLayout>} />
+          <Route path="/facilities/forgekey-epaper" element={<WorkspaceLayout><ForgeKeyEPaperPanelsPage /></WorkspaceLayout>} />
           <Route path="/forgekey/epaper/bind" element={<WorkspaceLayout><ForgeKeyEPaperBindPage /></WorkspaceLayout>} />
           <Route path="/forgekey/epaper/service" element={<WorkspaceLayout><ForgeKeyEPaperServicePage /></WorkspaceLayout>} />
           <Route path="/inventory/code-entry" element={<Navigate to="/inventory/scan" replace />} />

--- a/frontend/src/__tests__/pages/ForgeKeyEPaperPanelsPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyEPaperPanelsPage.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Tests for the ForgeKey e-paper panels management page.
+ *
+ * Covers: non-staff redirect, the panel table (binding + battery + status),
+ * and the retire/reactivate toggle.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ForgeKeyEPaperPanelsPage from '../../pages/ForgeKeyEPaperPanelsPage';
+import { forgekeyAPI } from '../../services/api';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    forgekeyAPI: {
+      listEPaperDisplays: jest.fn(),
+      setEPaperActive: jest.fn(),
+    },
+  };
+});
+
+const mockApi = forgekeyAPI as jest.Mocked<typeof forgekeyAPI>;
+
+const buildPanel = (overrides: Partial<any> = {}) => ({
+  id: 'p1',
+  device: null,
+  device_mac_address: null,
+  asset: 'a1',
+  asset_name: 'Lathe',
+  asset_tag: 'TAG-1',
+  battery_percent: 8,
+  is_low_battery: true,
+  last_battery_at: null,
+  last_image_etag: '',
+  last_image_at: null,
+  is_active: true,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  ...overrides,
+});
+
+const renderPage = (initialEntry = '/facilities/forgekey-epaper') =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/facilities/forgekey-epaper" element={<ForgeKeyEPaperPanelsPage />} />
+          <Route path="/" element={<div>HOME</div>} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('ForgeKeyEPaperPanelsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  test('non-staff users are redirected', async () => {
+    localStorage.setItem('is_staff', 'false');
+    localStorage.setItem('is_superuser', 'false');
+
+    renderPage();
+
+    expect(await screen.findByText('HOME')).toBeInTheDocument();
+    expect(mockApi.listEPaperDisplays).not.toHaveBeenCalled();
+  });
+
+  test('staff sees panels with binding, battery, and status', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockApi.listEPaperDisplays.mockResolvedValue({ data: [buildPanel()] } as any);
+
+    renderPage();
+
+    expect(await screen.findByText('Lathe')).toBeInTheDocument();
+    expect(screen.getByText('TAG-1')).toBeInTheDocument();
+    expect(screen.getByText('8%')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  test('retire toggles the panel to retired', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockApi.listEPaperDisplays.mockResolvedValue({ data: [buildPanel()] } as any);
+    mockApi.setEPaperActive.mockResolvedValue({
+      data: buildPanel({ is_active: false }),
+    } as any);
+
+    renderPage();
+
+    const retireBtn = await screen.findByText('Retire');
+    fireEvent.click(retireBtn);
+
+    await waitFor(() => {
+      expect(mockApi.setEPaperActive).toHaveBeenCalledWith('p1', false);
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Retired')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Reactivate')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -115,6 +115,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed = false, isMobileOpen = f
         { path: '/facilities/logistics', label: 'Logistics', icon: '🚛' },
         { path: '/facilities/forgekey-dashboard', label: 'ForgeKey Dashboard', icon: '📊', requiresStaff: true },
         { path: '/facilities/forgekey-devices', label: 'ForgeKey Devices', icon: '📡', requiresStaff: true },
+        { path: '/facilities/forgekey-epaper', label: 'e-Paper Panels', icon: '🖼️', requiresStaff: true },
         { path: '/facilities/electrical', label: 'Electrical & Network', icon: '⚡', requiresStaff: true },
       ],
     },

--- a/frontend/src/navigation/routeMap.ts
+++ b/frontend/src/navigation/routeMap.ts
@@ -70,6 +70,7 @@ const ENTRIES: RouteEntry[] = [
   { path: 'facilities/electrical/network-drops', label: 'Network Drops', clickable: false },
   { path: 'facilities/forgekey-dashboard', label: 'ForgeKey Dashboard' },
   { path: 'facilities/forgekey-devices', label: 'ForgeKey Devices' },
+  { path: 'facilities/forgekey-epaper', label: 'e-Paper Panels' },
   { path: 'admin/audit-feed', label: 'Audit Feed' },
   { path: 'forgekey/epaper/bind', label: 'Bind ePaper Panel' },
   { path: 'forgekey/epaper/service', label: 'Log ePaper Service' },

--- a/frontend/src/pages/FacilitiesOverviewPage.tsx
+++ b/frontend/src/pages/FacilitiesOverviewPage.tsx
@@ -86,6 +86,14 @@ const FacilitiesOverviewPage: React.FC = () => (
       testId="facilities-overview-card-/facilities/forgekey-devices"
     />
     <CapabilityCard
+      to="/facilities/forgekey-epaper"
+      title="e-Paper panels"
+      description="PM status panels glued to machines — binding, battery, and refresh state."
+      icon={<IconDeviceTv size={22} stroke={1.8} />}
+      eyebrow="Access"
+      testId="facilities-overview-card-/facilities/forgekey-epaper"
+    />
+    <CapabilityCard
       to="/facilities/checklist"
       title="Checklists"
       description="Recurring opening, closing, and safety walk-through checklists."

--- a/frontend/src/pages/ForgeKeyEPaperPanelsPage.tsx
+++ b/frontend/src/pages/ForgeKeyEPaperPanelsPage.tsx
@@ -1,0 +1,193 @@
+/**
+ * ForgeKey e-Paper Panels — staff management screen.
+ *
+ * Lists every e-paper PM panel with its asset binding, battery level, last
+ * image fetch, and active/retired state. Staff can rebind a panel to a
+ * different asset (via the existing QR bind flow) or retire / reactivate it.
+ */
+import { Alert, Anchor, Badge, Button, Group, Loader, Paper, Table, Text } from '@mantine/core';
+import React, { useEffect, useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
+import { ForgeKeyEPaperDisplay, forgekeyAPI } from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+const formatRelative = (iso: string | null): string => {
+  if (!iso) return 'never';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '—';
+  const secs = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.round(hrs / 24)}d ago`;
+};
+
+const ForgeKeyEPaperPanelsPage: React.FC = () => {
+  const isStaff = typeof window !== 'undefined' && localStorage.getItem('is_staff') === 'true';
+  const isSuperuser =
+    typeof window !== 'undefined' && localStorage.getItem('is_superuser') === 'true';
+
+  const [panels, setPanels] = useState<ForgeKeyEPaperDisplay[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isStaff && !isSuperuser) return undefined;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await forgekeyAPI.listEPaperDisplays();
+        if (!cancelled) {
+          setPanels(res.data);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(extractErrorMessage(err, 'Failed to load e-paper panels.'));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isStaff, isSuperuser]);
+
+  if (!isStaff && !isSuperuser) {
+    return <Navigate to="/" replace />;
+  }
+
+  const toggleActive = async (panel: ForgeKeyEPaperDisplay) => {
+    setBusyId(panel.id);
+    try {
+      const res = await forgekeyAPI.setEPaperActive(panel.id, !panel.is_active);
+      setPanels((prev) => prev.map((p) => (p.id === panel.id ? { ...p, ...res.data } : p)));
+      setError(null);
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to update the panel.'));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <WorkspacePage
+      testId="forgekey-epaper-panels-page"
+      hero={{
+        eyebrow: 'Facilities · ForgeKey',
+        title: 'e-Paper panels',
+        description:
+          'Every PM e-paper panel — asset binding, battery, last refresh, and status.',
+      }}
+    >
+      {error && (
+        <Alert color="red" variant="light" data-testid="panels-error">
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Group justify="center" p="xl">
+          <Loader />
+        </Group>
+      ) : panels.length === 0 ? (
+        <Paper p="xl" withBorder>
+          <Text c="dimmed" data-testid="panels-empty">
+            No e-paper panels have registered yet.
+          </Text>
+        </Paper>
+      ) : (
+        <Paper withBorder>
+          <Table.ScrollContainer minWidth={760}>
+            <Table highlightOnHover>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Asset</Table.Th>
+                  <Table.Th>Battery</Table.Th>
+                  <Table.Th>Last refresh</Table.Th>
+                  <Table.Th>Device</Table.Th>
+                  <Table.Th>Status</Table.Th>
+                  <Table.Th>Actions</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {panels.map((p) => (
+                  <Table.Tr key={p.id} data-testid={`panel-row-${p.id}`}>
+                    <Table.Td>
+                      {p.asset_name ? (
+                        <>
+                          <Text fw={500}>{p.asset_name}</Text>
+                          {p.asset_tag && (
+                            <Text size="xs" c="dimmed">
+                              {p.asset_tag}
+                            </Text>
+                          )}
+                        </>
+                      ) : (
+                        <Text c="dimmed">Unbound</Text>
+                      )}
+                    </Table.Td>
+                    <Table.Td>
+                      {p.battery_percent == null ? (
+                        <Text size="sm" c="dimmed">
+                          —
+                        </Text>
+                      ) : (
+                        <Badge
+                          color={p.is_low_battery ? 'orange' : 'gray'}
+                          variant={p.is_low_battery ? 'filled' : 'light'}
+                        >
+                          {p.battery_percent}%
+                        </Badge>
+                      )}
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="sm" c="dimmed">
+                        {formatRelative(p.last_image_at)}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="sm" c="dimmed">
+                        {p.device_mac_address || '—'}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge color={p.is_active ? 'green' : 'gray'}>
+                        {p.is_active ? 'Active' : 'Retired'}
+                      </Badge>
+                    </Table.Td>
+                    <Table.Td>
+                      <Group gap="xs">
+                        <Anchor component={Link} to={`/forgekey/epaper/bind?did=${p.id}`} size="sm">
+                          Rebind
+                        </Anchor>
+                        <Button
+                          size="xs"
+                          variant="subtle"
+                          color={p.is_active ? 'red' : 'green'}
+                          loading={busyId === p.id}
+                          onClick={() => toggleActive(p)}
+                        >
+                          {p.is_active ? 'Retire' : 'Reactivate'}
+                        </Button>
+                      </Group>
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          </Table.ScrollContainer>
+        </Paper>
+      )}
+    </WorkspacePage>
+  );
+};
+
+export default ForgeKeyEPaperPanelsPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1844,6 +1844,23 @@ export interface ForgeKeyTemperatureResponse {
   readings: ForgeKeyTemperatureReading[];
 }
 
+export interface ForgeKeyEPaperDisplay {
+  id: string;
+  device: string | null;
+  device_mac_address: string | null;
+  asset: string | null;
+  asset_name: string | null;
+  asset_tag: string | null;
+  battery_percent: number | null;
+  is_low_battery: boolean;
+  last_battery_at: string | null;
+  last_image_etag: string;
+  last_image_at: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 export const forgekeyAPI = {
   listDevices: (opts: { capability?: string } = {}) =>
     api.get<{ results?: ForgeKeyDevice[] } | ForgeKeyDevice[]>('/forgekey/devices/', {
@@ -1898,6 +1915,11 @@ export const forgekeyAPI = {
       `/forgekey/epaper/${displayId}/bind/`,
       { asset_id: assetId },
     ),
+  listEPaperDisplays: () => api.get<ForgeKeyEPaperDisplay[]>('/forgekey/epaper/'),
+  setEPaperActive: (displayId: string, isActive: boolean) =>
+    api.post<ForgeKeyEPaperDisplay>(`/forgekey/epaper/${displayId}/set-active/`, {
+      is_active: isActive,
+    }),
   // Scan-to-log page: read the panel's recurring maintenance tasks (public)…
   getEPaperServiceInfo: (displayId: string) =>
     api.get<{


### PR DESCRIPTION
## What & why

`EPaperDisplay` rows (battery telemetry, asset binding, image-fetch state) were only reachable by scanning each panel's QR — there was no fleet view. This adds a staff management screen.

**PR 3 of 5** in the ForgeKey enablement series (dashboard → temperature → **e-paper panels** → firmware rollout → build pipeline).

## Backend

- **`EPaperDisplaySerializer`** — null-safe asset/device method fields + `is_low_battery`.
- **`GET /forgekey/epaper/`** — list every panel (authenticated).
- **`POST /forgekey/epaper/<id>/set-active/`** `{is_active}` — retire (the firmware's `image.png` fetch then paints the "retired" card and the panel stops refreshing) or reactivate.
- Permission matrix regenerated. **No model change / no migration.**

## Frontend

- `api.ts` `listEPaperDisplays` + `setEPaperActive` + types.
- **`ForgeKeyEPaperPanelsPage`**: a table of panels — asset binding, battery (with low-battery highlight), last refresh, device MAC, active/retired — with a **Rebind** link (reuses the existing QR bind flow) and a **Retire / Reactivate** toggle. Wired into routing, sidebar, route map, and a Facilities overview card.

## Testing

- **Backend** (4): auth gate, list (binding + battery + low-battery flag), retire→reactivate round-trip, unknown-display 404.
- **Frontend** (3): non-staff redirect, table render, retire toggle.
- Full frontend suite **686 passed**; `config/tests/test_permission_matrix.py` + existing `test_epaper.py` green; lint (black/isort/flake8 + eslint) + `vite build`; `makemigrations --check` clean.