### PR TITLE
feat(lockers): operator unlock + OTP management (+ run locker tests in CI)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -1524,10 +1524,22 @@ views:
     - IsAuthenticated
   lockers.views.LockerViewSet:
     actions:
+      issue_otp:
+        permission_classes:
+        - IsAuthenticated
       list:
         permission_classes:
         - IsAuthenticated
+      otps:
+        permission_classes:
+        - IsAuthenticated
       retrieve:
+        permission_classes:
+        - IsAuthenticated
+      revoke_otp:
+        permission_classes:
+        - IsAuthenticated
+      unlock:
         permission_classes:
         - IsAuthenticated
   lockers.views.LockoutEventView:

--- a/backend/lockers/services/access.py
+++ b/backend/lockers/services/access.py
@@ -113,6 +113,21 @@ def can_user_access_locker(user, locker: Locker) -> bool:
     return decide_locker_access(user, locker).allowed
 
 
+def can_user_manage_locker(user, locker: Locker) -> bool:
+    """True if the user is a *manager* of the locker — staff / superuser,
+    a logistics member, or an admin of the owning SIG — as opposed to a
+    member who merely has access. Gates OTP administration (list / revoke)
+    and other operator-only surfaces.
+    """
+    if not user or not user.is_authenticated:
+        return False
+    if _is_staff_or_super(user):
+        return True
+    if is_logistics_member(user):
+        return True
+    return _is_sig_admin_for(user, locker.owning_sig)
+
+
 # ---------------------------------------------------------------------------
 # OTP lifecycle
 # ---------------------------------------------------------------------------

--- a/backend/lockers/tests/test_commands.py
+++ b/backend/lockers/tests/test_commands.py
@@ -103,7 +103,9 @@ class TestPublishUnlock:
         client = MagicMock()
         client.publish.return_value = MagicMock(rc=0)
         topic = publish_unlock(locker=locker, actor=staff, client=client)
-        assert device.mac_address.replace(":", "-") in topic
+        # The command topic uses the firmware-contract MAC encoding
+        # (lowercase hex, no separators) — see forgekey.utils.get_mqtt_topic.
+        assert device.mac_address.replace(":", "").lower() in topic
         body = _published_payload(client)
         assert body["cmd"] == "unlock"
         # JWT verifies + carries (mac, cmd).

--- a/backend/lockers/tests/test_unlock_otp.py
+++ b/backend/lockers/tests/test_unlock_otp.py
@@ -1,0 +1,141 @@
+"""Tests for the locker unlock + OTP management API actions."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.test import override_settings
+from django.urls import reverse
+
+import pytest
+from rest_framework.test import APIClient
+
+from forgekey.models import DeviceType, ESP32Device
+from forgekey.services.jwt_signing import generate_jwt_signing_keypair
+from inventory.tests.factories import LocationFactory
+from lockers.models import Locker, LockerDevice
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def signed_settings():
+    private_pem, _ = generate_jwt_signing_keypair()
+    with override_settings(FORGEKEY_JWT_SIGNING_KEY=private_pem, FORGEKEY_JWT_KEY_ID="test-kid"):
+        yield
+
+
+@pytest.fixture
+def mqtt_ok():
+    client = MagicMock()
+    client.publish.return_value = MagicMock(rc=0)
+    # publish_command imports get_mqtt_client at module load, so patch the
+    # name where it is looked up (device_commands), not where it is defined.
+    with patch("forgekey.services.device_commands.get_mqtt_client", return_value=client):
+        yield client
+
+
+@pytest.fixture
+def locker_with_latch():
+    sig = Group.objects.create(name="Wood Shop SIG")
+    locker = Locker.objects.create(
+        name="L-1", slug="l-1", location=LocationFactory(), owning_sig=sig
+    )
+    latch_type, _ = DeviceType.objects.get_or_create(
+        code="locker_latch", defaults={"name": "Locker latch controller"}
+    )
+    device = ESP32Device.objects.create(mac_address="AA:BB:CC:11:22:33", device_type=latch_type)
+    LockerDevice.objects.create(
+        locker=locker, device=device, role=LockerDevice.ROLE_LATCH, is_primary=True
+    )
+    return locker
+
+
+@pytest.fixture
+def staff_client():
+    user = User.objects.create_user(
+        username="ops", email="o@example.com", password="x" * 24, is_staff=True
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def member_client():
+    user = User.objects.create_user(username="member", email="m@example.com", password="x" * 24)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+class TestUnlock:
+    def test_staff_unlock_publishes(
+        self, staff_client, locker_with_latch, signed_settings, mqtt_ok
+    ):
+        url = reverse("lockers:locker-unlock", kwargs={"pk": locker_with_latch.pk})
+        resp = staff_client.post(url)
+        assert resp.status_code == 200, resp.data
+        assert resp.json()["status"] == "unlock_sent"
+        assert mqtt_ok.publish.called
+
+    def test_member_without_access_denied(
+        self, member_client, locker_with_latch, signed_settings, mqtt_ok
+    ):
+        url = reverse("lockers:locker-unlock", kwargs={"pk": locker_with_latch.pk})
+        resp = member_client.post(url)
+        assert resp.status_code == 403
+        assert "reason" in resp.json()
+        assert not mqtt_ok.publish.called
+
+    def test_unlock_without_latch_returns_409(self, staff_client, signed_settings, mqtt_ok):
+        sig = Group.objects.create(name="Empty SIG")
+        locker = Locker.objects.create(
+            name="E-1", slug="e-1", location=LocationFactory(), owning_sig=sig
+        )
+        url = reverse("lockers:locker-unlock", kwargs={"pk": locker.pk})
+        resp = staff_client.post(url)
+        assert resp.status_code == 409
+
+
+class TestOtp:
+    def test_staff_issues_otp(self, staff_client, locker_with_latch):
+        url = reverse("lockers:locker-issue-otp", kwargs={"pk": locker_with_latch.pk})
+        resp = staff_client.post(url)
+        assert resp.status_code == 201, resp.data
+        body = resp.json()
+        assert len(body["code"]) >= 6
+        assert body["state"] == "active"
+
+    def test_member_without_access_cannot_issue(self, member_client, locker_with_latch):
+        url = reverse("lockers:locker-issue-otp", kwargs={"pk": locker_with_latch.pk})
+        assert member_client.post(url).status_code == 403
+
+    def test_manager_lists_and_revokes(self, staff_client, locker_with_latch):
+        issue = staff_client.post(
+            reverse("lockers:locker-issue-otp", kwargs={"pk": locker_with_latch.pk})
+        )
+        otp_id = issue.json()["id"]
+
+        listing = staff_client.get(
+            reverse("lockers:locker-otps", kwargs={"pk": locker_with_latch.pk})
+        )
+        assert listing.status_code == 200
+        assert any(o["id"] == otp_id for o in listing.json())
+
+        revoke = staff_client.post(
+            reverse("lockers:locker-revoke-otp", kwargs={"pk": locker_with_latch.pk}),
+            {"otp_id": otp_id},
+            format="json",
+        )
+        assert revoke.status_code == 200
+        assert revoke.json()["state"] == "revoked"
+
+    def test_member_cannot_list_otps(self, member_client, locker_with_latch):
+        resp = member_client.get(
+            reverse("lockers:locker-otps", kwargs={"pk": locker_with_latch.pk})
+        )
+        assert resp.status_code == 403

--- a/backend/lockers/views.py
+++ b/backend/lockers/views.py
@@ -15,20 +15,30 @@ from __future__ import annotations
 import logging
 
 from rest_framework import status, viewsets
+from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from forgekey.models import ESP32Device
+from forgekey.services.device_commands import DeviceCommandError
 
-from .models import Locker, LockerStatus
+from .models import Locker, LockerOtp, LockerStatus
 from .serializers import (
     IrBreakEventSerializer,
     LockerDetailSerializer,
+    LockerOtpSerializer,
     LockoutEventSerializer,
     LockStatusEventSerializer,
     ReedStatusEventSerializer,
 )
+from .services.access import (
+    OtpDenied,
+    can_user_manage_locker,
+    decide_locker_access,
+    generate_otp,
+)
+from .services.commands import NoSuchLockerDevice, publish_unlock
 
 logger = logging.getLogger(__name__)
 
@@ -204,3 +214,80 @@ class LockerViewSet(viewsets.ReadOnlyModelViewSet):
     )
     serializer_class = LockerDetailSerializer
     permission_classes = [IsAuthenticated]
+
+    @action(detail=True, methods=["post"])
+    def unlock(self, request, pk=None):
+        """Sign + publish the ES256 unlock command to the latch device, gated
+        by the locker access decision and audited via ``publish_unlock``."""
+        locker = self.get_object()
+        decision = decide_locker_access(request.user, locker)
+        if not decision.allowed:
+            return Response(
+                {
+                    "detail": f"Access denied ({decision.reason}).",
+                    "reason": decision.reason,
+                    "missing_certifications": list(decision.missing_certifications),
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        try:
+            topic = publish_unlock(locker=locker, actor=request.user)
+        except NoSuchLockerDevice as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_409_CONFLICT)
+        except DeviceCommandError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_502_BAD_GATEWAY)
+        return Response({"status": "unlock_sent", "topic": topic, "reason": decision.reason})
+
+    @action(detail=True, methods=["post"], url_path="issue-otp")
+    def issue_otp(self, request, pk=None):
+        """Mint a one-time access code, gated by the same access decision as a
+        direct unlock. Returns the code (the bearer credential)."""
+        locker = self.get_object()
+        try:
+            otp = generate_otp(user=request.user, locker=locker)
+        except OtpDenied as exc:
+            return Response(
+                {
+                    "detail": f"Access denied ({exc.decision.reason}).",
+                    "reason": exc.decision.reason,
+                    "missing_certifications": list(exc.decision.missing_certifications),
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        return Response(LockerOtpSerializer(otp).data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=["get"])
+    def otps(self, request, pk=None):
+        """List recent OTPs for the locker (managers only)."""
+        locker = self.get_object()
+        if not can_user_manage_locker(request.user, locker):
+            return Response(
+                {"detail": "Only locker managers may view OTPs."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        rows = locker.otps.select_related("requesting_user", "revoked_by").order_by("-created_at")[
+            :50
+        ]
+        return Response(LockerOtpSerializer(rows, many=True).data)
+
+    @action(detail=True, methods=["post"], url_path="revoke-otp")
+    def revoke_otp(self, request, pk=None):
+        """Revoke an outstanding OTP (managers only)."""
+        locker = self.get_object()
+        if not can_user_manage_locker(request.user, locker):
+            return Response(
+                {"detail": "Only locker managers may revoke OTPs."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        otp_id = request.data.get("otp_id")
+        if not otp_id:
+            return Response({"detail": "otp_id is required."}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            otp = locker.otps.get(id=otp_id)
+        except LockerOtp.DoesNotExist:
+            return Response(
+                {"detail": "OTP not found for this locker."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        otp.revoke(by=request.user)
+        return Response(LockerOtpSerializer(otp).data)

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -45,6 +45,7 @@ testpaths =
     index_cards/tests
     inventory/tests
     location_checkins/tests
+    lockers/tests
     loto/tests
     maintenance_orders/tests
     maker_boxes/tests

--- a/frontend/src/__tests__/pages/LockersPage.test.tsx
+++ b/frontend/src/__tests__/pages/LockersPage.test.tsx
@@ -5,10 +5,17 @@
  * intrusion (ALARM / not-secure) highlight.
  */
 import { MantineProvider } from '@mantine/core';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import LockersPage from '../../pages/LockersPage';
 import { lockersAPI } from '../../services/api';
+import { showSuccess } from '../../utils/dialogs';
+
+vi.mock('../../utils/dialogs', async () => ({
+  showError: jest.fn(),
+  showSuccess: jest.fn(),
+  showInfo: jest.fn(),
+}));
 
 vi.mock('../../services/api', async () => {
   const actual = await vi.importActual('../../services/api');
@@ -16,6 +23,10 @@ vi.mock('../../services/api', async () => {
     ...actual,
     lockersAPI: {
       listLockers: jest.fn(),
+      unlock: jest.fn(),
+      issueOtp: jest.fn(),
+      listOtps: jest.fn(),
+      revokeOtp: jest.fn(),
     },
   };
 });
@@ -129,5 +140,21 @@ describe('LockersPage', () => {
     expect(await screen.findByText('ALARM')).toBeInTheDocument();
     expect(screen.getByText('Alarm')).toBeInTheDocument(); // the attention badge
     expect(screen.getByTestId('stat-attention')).toHaveTextContent('1');
+  });
+
+  test('staff can send an unlock command', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockApi.listLockers.mockResolvedValue({ data: [buildLocker()] } as any);
+    mockApi.unlock.mockResolvedValue({
+      data: { status: 'unlock_sent', topic: 'forgekey/x/command', reason: 'staff_bypass' },
+    } as any);
+
+    renderPage();
+
+    const unlockBtn = await screen.findByTestId('unlock-lk1');
+    fireEvent.click(unlockBtn);
+
+    await waitFor(() => expect(mockApi.unlock).toHaveBeenCalledWith('lk1'));
+    await waitFor(() => expect(showSuccess).toHaveBeenCalled());
   });
 });

--- a/frontend/src/pages/LockersPage.tsx
+++ b/frontend/src/pages/LockersPage.tsx
@@ -4,15 +4,19 @@
  * Live status of the locker fleet from the firmware's cabinet_lock/status
  * heartbeat: secure / online / state per locker, with possible intrusions
  * (ALARM or a sustained not-secure reading) flagged. Refreshes every 30s.
- * Setup, OTP issuance, and operator unlock land in follow-up PRs.
+ * Staff can also unlock a locker (signs + publishes the ES256 command) and
+ * issue / revoke one-time access codes.
  */
 import {
   Alert,
   Badge,
   Box,
+  Button,
   Card,
+  CopyButton,
   Group,
   Loader,
+  Modal,
   Paper,
   SimpleGrid,
   Stack,
@@ -23,7 +27,8 @@ import {
 import React, { useEffect, useMemo, useState } from 'react';
 import { Navigate } from 'react-router-dom';
 import WorkspacePage from '../components/landing/WorkspacePage';
-import { ForgeKeyLocker, lockersAPI } from '../services/api';
+import { ForgeKeyLocker, ForgeKeyLockerOtp, lockersAPI } from '../services/api';
+import { showError, showSuccess } from '../utils/dialogs';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const POLL_INTERVAL_MS = 30_000;
@@ -79,6 +84,12 @@ const LockersPage: React.FC = () => {
   const [lockers, setLockers] = useState<ForgeKeyLocker[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [unlockingId, setUnlockingId] = useState<string | null>(null);
+  const [otpLocker, setOtpLocker] = useState<ForgeKeyLocker | null>(null);
+  const [otps, setOtps] = useState<ForgeKeyLockerOtp[]>([]);
+  const [otpsLoading, setOtpsLoading] = useState(false);
+  const [issuing, setIssuing] = useState(false);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isStaff && !isSuperuser) return undefined;
@@ -110,6 +121,59 @@ const LockersPage: React.FC = () => {
     const attention = lockers.filter(needsAttention).length;
     return { total, secure, attention };
   }, [lockers]);
+
+  const handleUnlock = async (lk: ForgeKeyLocker) => {
+    setUnlockingId(lk.id);
+    try {
+      await lockersAPI.unlock(lk.id);
+      showSuccess(`Unlock command sent to ${lk.name}.`);
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Unlock failed.'));
+    } finally {
+      setUnlockingId(null);
+    }
+  };
+
+  const openOtps = async (lk: ForgeKeyLocker) => {
+    setOtpLocker(lk);
+    setOtps([]);
+    setOtpsLoading(true);
+    try {
+      const res = await lockersAPI.listOtps(lk.id);
+      setOtps(res.data);
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Failed to load access codes.'));
+    } finally {
+      setOtpsLoading(false);
+    }
+  };
+
+  const handleIssueOtp = async () => {
+    if (!otpLocker) return;
+    setIssuing(true);
+    try {
+      const res = await lockersAPI.issueOtp(otpLocker.id);
+      setOtps((prev) => [res.data, ...prev]);
+      showSuccess(`New access code: ${res.data.code}`);
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Could not issue an access code.'));
+    } finally {
+      setIssuing(false);
+    }
+  };
+
+  const handleRevokeOtp = async (otpId: string) => {
+    if (!otpLocker) return;
+    setRevokingId(otpId);
+    try {
+      const res = await lockersAPI.revokeOtp(otpLocker.id, otpId);
+      setOtps((prev) => prev.map((o) => (o.id === otpId ? res.data : o)));
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Revoke failed.'));
+    } finally {
+      setRevokingId(null);
+    }
+  };
 
   if (!isStaff && !isSuperuser) {
     return <Navigate to="/" replace />;
@@ -171,6 +235,7 @@ const LockersPage: React.FC = () => {
                         <Table.Th>Lock state</Table.Th>
                         <Table.Th>Online</Table.Th>
                         <Table.Th>Updated</Table.Th>
+                        <Table.Th>Actions</Table.Th>
                       </Table.Tr>
                     </Table.Thead>
                     <Table.Tbody>
@@ -219,6 +284,26 @@ const LockersPage: React.FC = () => {
                                 {formatRelative(lk.status?.last_status_at ?? null)}
                               </Text>
                             </Table.Td>
+                            <Table.Td onClick={(e) => e.stopPropagation()}>
+                              <Group gap="xs">
+                                <Button
+                                  size="xs"
+                                  loading={unlockingId === lk.id}
+                                  onClick={() => handleUnlock(lk)}
+                                  data-testid={`unlock-${lk.id}`}
+                                >
+                                  Unlock
+                                </Button>
+                                <Button
+                                  size="xs"
+                                  variant="light"
+                                  onClick={() => openOtps(lk)}
+                                  data-testid={`otps-${lk.id}`}
+                                >
+                                  Codes
+                                </Button>
+                              </Group>
+                            </Table.Td>
                           </Table.Tr>
                         );
                       })}
@@ -230,6 +315,73 @@ const LockersPage: React.FC = () => {
           )}
         </Stack>
       )}
+
+      <Modal
+        opened={otpLocker !== null}
+        onClose={() => setOtpLocker(null)}
+        title={otpLocker ? `Access codes — ${otpLocker.name}` : 'Access codes'}
+      >
+        <Stack gap="sm" data-testid="otp-modal">
+          <Button onClick={handleIssueOtp} loading={issuing} data-testid="issue-otp">
+            Issue new code
+          </Button>
+          {otpsLoading ? (
+            <Group justify="center" p="md">
+              <Loader size="sm" />
+            </Group>
+          ) : otps.length === 0 ? (
+            <Text size="sm" c="dimmed">
+              No access codes yet.
+            </Text>
+          ) : (
+            <Table>
+              <Table.Tbody>
+                {otps.map((otp) => (
+                  <Table.Tr key={otp.id}>
+                    <Table.Td>
+                      <Group gap="xs">
+                        <Text fw={600} ff="monospace">
+                          {otp.code}
+                        </Text>
+                        <CopyButton value={otp.code}>
+                          {({ copied, copy }) => (
+                            <Button size="compact-xs" variant="subtle" onClick={copy}>
+                              {copied ? 'Copied' : 'Copy'}
+                            </Button>
+                          )}
+                        </CopyButton>
+                      </Group>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge
+                        size="sm"
+                        color={
+                          otp.state === 'active' ? 'green' : otp.state === 'used' ? 'blue' : 'gray'
+                        }
+                      >
+                        {otp.state}
+                      </Badge>
+                    </Table.Td>
+                    <Table.Td>
+                      {otp.state === 'active' && (
+                        <Button
+                          size="compact-xs"
+                          variant="subtle"
+                          color="red"
+                          loading={revokingId === otp.id}
+                          onClick={() => handleRevokeOtp(otp.id)}
+                        >
+                          Revoke
+                        </Button>
+                      )}
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          )}
+        </Stack>
+      </Modal>
     </WorkspacePage>
   );
 };

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3362,9 +3362,29 @@ export interface ForgeKeyLocker {
   status: ForgeKeyLockerStatus | null;
 }
 
+export interface ForgeKeyLockerOtp {
+  id: string;
+  locker: string;
+  locker_name: string;
+  requesting_user: number | null;
+  code: string;
+  expires_at: string;
+  used_at: string | null;
+  revoked_at: string | null;
+  revoked_by: number | null;
+  created_at: string;
+  state: string;
+}
+
 export const lockersAPI = {
   listLockers: () => api.get<{ results?: ForgeKeyLocker[] } | ForgeKeyLocker[]>('/lockers/'),
   getLocker: (id: string) => api.get<ForgeKeyLocker>(`/lockers/${id}/`),
+  unlock: (id: string) =>
+    api.post<{ status: string; topic: string; reason: string }>(`/lockers/${id}/unlock/`),
+  issueOtp: (id: string) => api.post<ForgeKeyLockerOtp>(`/lockers/${id}/issue-otp/`),
+  listOtps: (id: string) => api.get<ForgeKeyLockerOtp[]>(`/lockers/${id}/otps/`),
+  revokeOtp: (id: string, otpId: string) =>
+    api.post<ForgeKeyLockerOtp>(`/lockers/${id}/revoke-otp/`, { otp_id: otpId }),
 };
 
 export default api;


### PR DESCRIPTION
## What & why

Builds on the monitoring console (#644): staff / SIG-admins can **unlock a locker** and **issue / revoke one-time access codes**.

**PR 2 of the locker console** (monitoring → **unlock + OTP** → setup).

## Backend — `LockerViewSet` actions

- **`POST /api/lockers/<id>/unlock/`** — runs `decide_locker_access`, then signs + publishes the ES256 unlock command via the existing `publish_unlock` (audited as `locker_unlock`). 403 + reason if denied, 409 if the locker has no latch device, 502 on broker failure.
- **`POST /api/lockers/<id>/issue-otp/`** — mints a one-time code (same access gate; returns the bearer code).
- **`GET /api/lockers/<id>/otps/`** + **`POST .../revoke-otp/`** — list / revoke, gated to locker **managers** (new `access.can_user_manage_locker` = staff / logistics / owning-SIG admin).
- Permission matrix regenerated.

## ⚠️ CI fix (important)

`lockers/tests` was **never in `pytest.ini` `testpaths`**, so the entire app's tests have never run in CI. That's how a stale assertion in `test_commands` — still expecting the **pre-#400** `UPPER-WITH-HYPHENS` command topic — sat broken unnoticed. This PR adds `lockers/tests` to `testpaths` and corrects that assertion to the firmware-contract MAC encoding (lowercase hex, no separators). **The 64-test locker suite now runs in CI and is green.**

## Frontend

`LockersPage`: a per-row **Unlock** button + an **access-codes modal** (issue / copy / revoke, with state badges). `api.ts` unlock + OTP methods + types.

## Testing

- **Backend** (8): unlock allow / deny-with-reason / no-latch-409; OTP issue / member-denied; manager list + revoke; member-cannot-list.
- **Frontend** (1): unlock dispatches + confirms.
- Full **lockers suite (64)** now runs in CI; frontend suite **693**; lint (black/isort/flake8 + eslint) + `vite build` + permission-matrix all green.