### PR TITLE
feat(lockers): locker setup — CRUD + device binding (web UI)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -1524,6 +1524,18 @@ views:
     - IsAuthenticated
   lockers.views.LockerViewSet:
     actions:
+      add_device:
+        permission_classes:
+        - IsAuthenticated
+      available_certifications:
+        permission_classes:
+        - IsAuthenticated
+      create:
+        permission_classes:
+        - IsAuthenticated
+      destroy:
+        permission_classes:
+        - IsAuthenticated
       issue_otp:
         permission_classes:
         - IsAuthenticated
@@ -1533,6 +1545,12 @@ views:
       otps:
         permission_classes:
         - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsAuthenticated
+      remove_device:
+        permission_classes:
+        - IsAuthenticated
       retrieve:
         permission_classes:
         - IsAuthenticated
@@ -1540,6 +1558,9 @@ views:
         permission_classes:
         - IsAuthenticated
       unlock:
+        permission_classes:
+        - IsAuthenticated
+      update:
         permission_classes:
         - IsAuthenticated
   lockers.views.LockoutEventView:

--- a/backend/lockers/serializers.py
+++ b/backend/lockers/serializers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from django.utils.text import slugify
+
 from rest_framework import serializers
 
 from .models import Locker, LockerDevice, LockerOtp, LockerStatus
@@ -13,6 +15,7 @@ class LockerSerializer(serializers.ModelSerializer):
     current_asset_name = serializers.CharField(
         source="current_asset.name", read_only=True, default=None, allow_null=True
     )
+    required_certification_names = serializers.SerializerMethodField()
 
     class Meta:
         model = Locker
@@ -30,11 +33,16 @@ class LockerSerializer(serializers.ModelSerializer):
             "current_asset_name",
             "is_high_trust",
             "led_count",
+            "required_certifications",
+            "required_certification_names",
             "is_active",
             "created_at",
             "updated_at",
         )
         read_only_fields = ("id", "created_at", "updated_at")
+
+    def get_required_certification_names(self, obj) -> list[str]:
+        return [c.name for c in obj.required_certifications.all()]
 
 
 class LockerOtpSerializer(serializers.ModelSerializer):
@@ -130,6 +138,63 @@ class LockerDetailSerializer(LockerSerializer):
     def get_status(self, obj):
         status = getattr(obj, "status", None)
         return LockerStatusSerializer(status).data if status is not None else None
+
+
+class LockerWriteSerializer(serializers.ModelSerializer):
+    """Create/update payload for the locker setup UI.
+
+    ``slug`` auto-derives from the name when omitted (deduped against
+    existing lockers); the response echoes the full detail representation
+    so the UI gets bound devices + status back without a second fetch.
+    """
+
+    slug = serializers.SlugField(max_length=120, required=False, allow_blank=True)
+
+    class Meta:
+        model = Locker
+        fields = (
+            "id",
+            "name",
+            "slug",
+            "location",
+            "owning_sig",
+            "description",
+            "power_source",
+            "current_asset",
+            "is_high_trust",
+            "led_count",
+            "required_certifications",
+            "is_active",
+        )
+        read_only_fields = ("id",)
+
+    @staticmethod
+    def _unique_slug(name: str, *, exclude_pk=None) -> str:
+        base = slugify(name) or "locker"
+        slug = base
+        n = 2
+        qs = Locker.objects.all()
+        if exclude_pk is not None:
+            qs = qs.exclude(pk=exclude_pk)
+        while qs.filter(slug=slug).exists():
+            slug = f"{base}-{n}"
+            n += 1
+        return slug
+
+    def create(self, validated_data):
+        if not validated_data.get("slug"):
+            validated_data["slug"] = self._unique_slug(validated_data["name"])
+        return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        if "slug" in validated_data and not validated_data["slug"]:
+            validated_data["slug"] = self._unique_slug(
+                validated_data.get("name", instance.name), exclude_pk=instance.pk
+            )
+        return super().update(instance, validated_data)
+
+    def to_representation(self, instance):
+        return LockerDetailSerializer(instance, context=self.context).data
 
 
 # ---------------------------------------------------------------------------

--- a/backend/lockers/services/access.py
+++ b/backend/lockers/services/access.py
@@ -113,11 +113,12 @@ def can_user_access_locker(user, locker: Locker) -> bool:
     return decide_locker_access(user, locker).allowed
 
 
-def can_user_manage_locker(user, locker: Locker) -> bool:
-    """True if the user is a *manager* of the locker — staff / superuser,
-    a logistics member, or an admin of the owning SIG — as opposed to a
-    member who merely has access. Gates OTP administration (list / revoke)
-    and other operator-only surfaces.
+def can_user_manage_sig(user, sig: Group) -> bool:
+    """True if the user can manage the given SIG (Group) — staff / superuser,
+    a logistics member, or an admin of that SIG.
+
+    Split out from :func:`can_user_manage_locker` so locker *creation* can be
+    gated against the chosen owning SIG before any Locker row exists.
     """
     if not user or not user.is_authenticated:
         return False
@@ -125,7 +126,16 @@ def can_user_manage_locker(user, locker: Locker) -> bool:
         return True
     if is_logistics_member(user):
         return True
-    return _is_sig_admin_for(user, locker.owning_sig)
+    return _is_sig_admin_for(user, sig)
+
+
+def can_user_manage_locker(user, locker: Locker) -> bool:
+    """True if the user is a *manager* of the locker — staff / superuser,
+    a logistics member, or an admin of the owning SIG — as opposed to a
+    member who merely has access. Gates OTP administration (list / revoke),
+    device binding, and other operator-only surfaces.
+    """
+    return can_user_manage_sig(user, locker.owning_sig)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/lockers/tests/test_setup.py
+++ b/backend/lockers/tests/test_setup.py
@@ -1,0 +1,194 @@
+"""Tests for the locker setup API: CRUD + device binding (Phase 4).
+
+Covers manager-gated create / edit / delete, ESP32 device bind + unbind
+(including primary demotion and duplicate-role conflict), and the
+available-certifications picker feed.
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.urls import reverse
+
+import pytest
+from rest_framework.test import APIClient
+
+from forgekey.models import DeviceType, ESP32Device
+from inventory.tests.factories import LocationFactory
+from lockers.models import Locker, LockerDevice
+from membership.models import Certification, SIGAdmin
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def _client(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def sig():
+    return Group.objects.create(name="Wood Shop SIG")
+
+
+@pytest.fixture
+def location():
+    return LocationFactory()
+
+
+@pytest.fixture
+def staff_client():
+    return _client(
+        User.objects.create_user(
+            username="ops", email="o@example.com", password="x" * 24, is_staff=True
+        )
+    )
+
+
+@pytest.fixture
+def member_client():
+    return _client(
+        User.objects.create_user(username="member", email="m@example.com", password="x" * 24)
+    )
+
+
+@pytest.fixture
+def device():
+    dt, _ = DeviceType.objects.get_or_create(
+        code="locker_latch", defaults={"name": "Locker latch controller"}
+    )
+    return ESP32Device.objects.create(mac_address="AA:BB:CC:11:22:33", device_type=dt)
+
+
+def _make_locker(sig, location, **kw):
+    return Locker.objects.create(
+        name=kw.pop("name", "L-1"),
+        slug=kw.pop("slug", "l-1"),
+        location=location,
+        owning_sig=sig,
+        **kw,
+    )
+
+
+class TestLockerCrud:
+    def test_staff_creates_locker_with_autoslug(self, staff_client, sig, location):
+        resp = staff_client.post(
+            reverse("lockers:locker-list"),
+            {"name": "Wood Shop Locker 4", "location": location.pk, "owning_sig": sig.pk},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.content
+        body = resp.json()
+        assert body["slug"] == "wood-shop-locker-4"
+        # The detail representation is echoed back so the UI gets devices+status.
+        assert body["devices"] == []
+        assert body["status"] is None
+
+    def test_member_cannot_create_locker(self, member_client, sig, location):
+        resp = member_client.post(
+            reverse("lockers:locker-list"),
+            {"name": "X", "location": location.pk, "owning_sig": sig.pk},
+            format="json",
+        )
+        assert resp.status_code == 403
+
+    def test_sig_admin_creates_locker_for_their_sig(self, sig, location):
+        admin = User.objects.create_user(username="lead", email="l@example.com", password="x" * 24)
+        SIGAdmin.objects.create(user=admin, group=sig, is_active=True)
+        resp = _client(admin).post(
+            reverse("lockers:locker-list"),
+            {"name": "Lead Locker", "location": location.pk, "owning_sig": sig.pk},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.content
+
+    def test_staff_updates_locker(self, staff_client, sig, location):
+        locker = _make_locker(sig, location)
+        resp = staff_client.patch(
+            reverse("lockers:locker-detail", kwargs={"pk": locker.pk}),
+            {"is_high_trust": True, "led_count": 8},
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+        locker.refresh_from_db()
+        assert locker.is_high_trust is True
+        assert locker.led_count == 8
+
+    def test_member_cannot_update_or_delete(self, member_client, sig, location):
+        locker = _make_locker(sig, location)
+        url = reverse("lockers:locker-detail", kwargs={"pk": locker.pk})
+        assert member_client.patch(url, {"led_count": 3}, format="json").status_code == 403
+        assert member_client.delete(url).status_code == 403
+
+    def test_staff_deletes_locker(self, staff_client, sig, location):
+        locker = _make_locker(sig, location)
+        resp = staff_client.delete(reverse("lockers:locker-detail", kwargs={"pk": locker.pk}))
+        assert resp.status_code == 204
+        assert not Locker.objects.filter(pk=locker.pk).exists()
+
+
+class TestLockerDeviceBinding:
+    def test_add_device_sets_primary_and_demotes_existing(
+        self, staff_client, sig, location, device
+    ):
+        locker = _make_locker(sig, location)
+        first = ESP32Device.objects.create(
+            mac_address="AA:BB:CC:00:00:01", device_type=device.device_type
+        )
+        LockerDevice.objects.create(
+            locker=locker, device=first, role=LockerDevice.ROLE_LATCH, is_primary=True
+        )
+        resp = staff_client.post(
+            reverse("lockers:locker-add-device", kwargs={"pk": locker.pk}),
+            {"device": str(device.pk), "role": "latch", "is_primary": True},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.content
+        assert locker.device_assignments.get(device=device).is_primary is True
+        assert locker.device_assignments.get(device=first).is_primary is False
+
+    def test_add_device_duplicate_role_conflicts(self, staff_client, sig, location, device):
+        locker = _make_locker(sig, location)
+        url = reverse("lockers:locker-add-device", kwargs={"pk": locker.pk})
+        payload = {"device": str(device.pk), "role": "latch"}
+        assert staff_client.post(url, payload, format="json").status_code == 201
+        assert staff_client.post(url, payload, format="json").status_code == 409
+
+    def test_add_device_member_forbidden(self, member_client, sig, location, device):
+        locker = _make_locker(sig, location)
+        resp = member_client.post(
+            reverse("lockers:locker-add-device", kwargs={"pk": locker.pk}),
+            {"device": str(device.pk), "role": "latch"},
+            format="json",
+        )
+        assert resp.status_code == 403
+
+    def test_remove_device(self, staff_client, sig, location, device):
+        locker = _make_locker(sig, location)
+        assignment = LockerDevice.objects.create(
+            locker=locker, device=device, role=LockerDevice.ROLE_LATCH
+        )
+        resp = staff_client.delete(
+            reverse(
+                "lockers:locker-remove-device",
+                kwargs={"pk": locker.pk, "assignment_id": assignment.pk},
+            )
+        )
+        assert resp.status_code == 204
+        assert not LockerDevice.objects.filter(pk=assignment.pk).exists()
+
+
+class TestAvailableCertifications:
+    def test_lists_active_certifications_only(self, staff_client, sig):
+        Certification.objects.create(name="Lathe Cert", slug="lathe-cert", sig=sig)
+        Certification.objects.create(
+            name="Retired Cert", slug="retired-cert", sig=sig, is_active=False
+        )
+        resp = staff_client.get(reverse("lockers:locker-available-certifications"))
+        assert resp.status_code == 200
+        names = [c["name"] for c in resp.json()]
+        assert "Lathe Cert" in names
+        assert "Retired Cert" not in names

--- a/backend/lockers/views.py
+++ b/backend/lockers/views.py
@@ -16,6 +16,7 @@ import logging
 
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -23,11 +24,13 @@ from rest_framework.views import APIView
 from forgekey.models import ESP32Device
 from forgekey.services.device_commands import DeviceCommandError
 
-from .models import Locker, LockerOtp, LockerStatus
+from .models import Locker, LockerDevice, LockerOtp, LockerStatus
 from .serializers import (
     IrBreakEventSerializer,
     LockerDetailSerializer,
+    LockerDeviceSerializer,
     LockerOtpSerializer,
+    LockerWriteSerializer,
     LockoutEventSerializer,
     LockStatusEventSerializer,
     ReedStatusEventSerializer,
@@ -35,6 +38,7 @@ from .serializers import (
 from .services.access import (
     OtpDenied,
     can_user_manage_locker,
+    can_user_manage_sig,
     decide_locker_access,
     generate_otp,
 )
@@ -199,21 +203,120 @@ class RegistrationAckView(APIView):
         )
 
 
-class LockerViewSet(viewsets.ReadOnlyModelViewSet):
-    """Read-only locker list + detail with bound devices and live lock status.
+class LockerViewSet(viewsets.ModelViewSet):
+    """Locker fleet API: list/detail (with bound devices + live lock status),
+    plus setup CRUD and device binding for managers.
 
-    The monitoring surface for the locker fleet — each locker carries its
-    device bindings and its latest ``cabinet_lock/status`` so the UI can show
-    secure / online state and flag possible intrusions.
+    Reading is open to any authenticated user (the monitoring console gates on
+    staff in the UI). Mutating a locker — create, edit, delete, bind/unbind a
+    device — requires *managing* the owning SIG (staff, logistics, or a SIG
+    admin); the unlock/OTP actions keep their own per-call access checks.
     """
 
     queryset = (
         Locker.objects.select_related("location", "owning_sig", "current_asset", "status")
-        .prefetch_related("device_assignments__device")
+        .prefetch_related("device_assignments__device", "required_certifications")
         .all()
     )
     serializer_class = LockerDetailSerializer
     permission_classes = [IsAuthenticated]
+
+    def get_serializer_class(self):
+        if self.action in ("create", "update", "partial_update"):
+            return LockerWriteSerializer
+        return LockerDetailSerializer
+
+    def perform_create(self, serializer):
+        sig = serializer.validated_data.get("owning_sig")
+        if not can_user_manage_sig(self.request.user, sig):
+            raise PermissionDenied("You must manage the owning SIG to create a locker for it.")
+        serializer.save()
+
+    def perform_update(self, serializer):
+        locker = serializer.instance
+        if not can_user_manage_locker(self.request.user, locker):
+            raise PermissionDenied("Only locker managers may edit this locker.")
+        # Reassigning the locker to a SIG you don't manage is also forbidden.
+        new_sig = serializer.validated_data.get("owning_sig")
+        if new_sig is not None and new_sig != locker.owning_sig:
+            if not can_user_manage_sig(self.request.user, new_sig):
+                raise PermissionDenied("You must manage the target SIG to reassign this locker.")
+        serializer.save()
+
+    def perform_destroy(self, instance):
+        if not can_user_manage_locker(self.request.user, instance):
+            raise PermissionDenied("Only locker managers may delete this locker.")
+        instance.delete()
+
+    @action(detail=False, methods=["get"], url_path="available-certifications")
+    def available_certifications(self, request):
+        """Active certifications, for the setup form's required-certs picker."""
+        from membership.models import Certification
+
+        rows = Certification.objects.filter(is_active=True).order_by("name").values("id", "name")
+        return Response(list(rows))
+
+    @action(detail=True, methods=["post"], url_path="devices")
+    def add_device(self, request, pk=None):
+        """Bind an ESP32 device to this locker in a role (managers only).
+
+        Setting ``is_primary`` demotes any existing primary for the same role.
+        """
+        locker = self.get_object()
+        if not can_user_manage_locker(request.user, locker):
+            return Response(
+                {"detail": "Only locker managers may bind devices."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        device_id = request.data.get("device")
+        role = request.data.get("role")
+        if not device_id or not role:
+            return Response(
+                {"detail": "device and role are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if role not in dict(LockerDevice.ROLE_CHOICES):
+            return Response(
+                {"detail": f"Invalid role '{role}'."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        device = ESP32Device.objects.filter(pk=device_id).first()
+        if device is None:
+            return Response({"detail": "Unknown device."}, status=status.HTTP_404_NOT_FOUND)
+        if LockerDevice.objects.filter(locker=locker, device=device, role=role).exists():
+            return Response(
+                {"detail": "That device is already bound to this locker in that role."},
+                status=status.HTTP_409_CONFLICT,
+            )
+        is_primary = bool(request.data.get("is_primary"))
+        if is_primary:
+            locker.device_assignments.filter(role=role, is_primary=True).update(is_primary=False)
+        assignment = LockerDevice.objects.create(
+            locker=locker,
+            device=device,
+            role=role,
+            is_primary=is_primary,
+            notes=(request.data.get("notes") or "").strip(),
+        )
+        return Response(LockerDeviceSerializer(assignment).data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=["delete"], url_path="devices/(?P<assignment_id>[^/.]+)")
+    def remove_device(self, request, pk=None, assignment_id=None):
+        """Unbind a device from this locker (managers only)."""
+        locker = self.get_object()
+        if not can_user_manage_locker(request.user, locker):
+            return Response(
+                {"detail": "Only locker managers may unbind devices."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        assignment = locker.device_assignments.filter(pk=assignment_id).first()
+        if assignment is None:
+            return Response(
+                {"detail": "Device binding not found for this locker."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        assignment.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=True, methods=["post"])
     def unlock(self, request, pk=None):

--- a/frontend/src/__tests__/pages/LockersPage.test.tsx
+++ b/frontend/src/__tests__/pages/LockersPage.test.tsx
@@ -8,7 +8,7 @@ import { MantineProvider } from '@mantine/core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import LockersPage from '../../pages/LockersPage';
-import { lockersAPI } from '../../services/api';
+import { assetsAPI, forgekeyAPI, inventoryAPI, lockersAPI, sigAPI } from '../../services/api';
 import { showSuccess } from '../../utils/dialogs';
 
 vi.mock('../../utils/dialogs', async () => ({
@@ -27,11 +27,34 @@ vi.mock('../../services/api', async () => {
       issueOtp: jest.fn(),
       listOtps: jest.fn(),
       revokeOtp: jest.fn(),
+      getLocker: jest.fn(),
+      createLocker: jest.fn(),
+      updateLocker: jest.fn(),
+      deleteLocker: jest.fn(),
+      addLockerDevice: jest.fn(),
+      removeLockerDevice: jest.fn(),
+      listAvailableCertifications: jest.fn(),
     },
+    inventoryAPI: { ...(actual as any).inventoryAPI, listLocations: jest.fn() },
+    sigAPI: { ...(actual as any).sigAPI, listMySIGs: jest.fn() },
+    assetsAPI: { ...(actual as any).assetsAPI, listAssets: jest.fn() },
+    forgekeyAPI: { ...(actual as any).forgekeyAPI, listDevices: jest.fn() },
   };
 });
 
 const mockApi = lockersAPI as jest.Mocked<typeof lockersAPI>;
+const mockInventory = inventoryAPI as jest.Mocked<typeof inventoryAPI>;
+const mockSig = sigAPI as jest.Mocked<typeof sigAPI>;
+const mockAssets = assetsAPI as jest.Mocked<typeof assetsAPI>;
+const mockForgekey = forgekeyAPI as jest.Mocked<typeof forgekeyAPI>;
+
+const mockOptionLists = () => {
+  mockInventory.listLocations.mockResolvedValue({ data: [{ id: 1, name: 'Wood Shop' }] } as any);
+  mockSig.listMySIGs.mockResolvedValue({ data: { results: [{ id: 2, name: 'Wood SIG' }] } } as any);
+  mockAssets.listAssets.mockResolvedValue({ data: { results: [] } } as any);
+  mockForgekey.listDevices.mockResolvedValue({ data: [] } as any);
+  mockApi.listAvailableCertifications.mockResolvedValue({ data: [] } as any);
+};
 
 const SECURE_STATUS = {
   secure: true,
@@ -156,5 +179,33 @@ describe('LockersPage', () => {
 
     await waitFor(() => expect(mockApi.unlock).toHaveBeenCalledWith('lk1'));
     await waitFor(() => expect(showSuccess).toHaveBeenCalled());
+  });
+
+  test('opens the setup drawer to create a new locker', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockApi.listLockers.mockResolvedValue({ data: [] } as any);
+    mockOptionLists();
+
+    renderPage();
+
+    fireEvent.click(await screen.findByTestId('new-locker'));
+
+    // The create-mode submit button confirms the drawer opened fresh...
+    expect(await screen.findByText('Create locker')).toBeInTheDocument();
+    // ...and the drawer loaded its picker option lists.
+    await waitFor(() => expect(mockInventory.listLocations).toHaveBeenCalled());
+  });
+
+  test('opens the setup drawer to edit an existing locker', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockApi.listLockers.mockResolvedValue({ data: [buildLocker()] } as any);
+    mockOptionLists();
+
+    renderPage();
+
+    fireEvent.click(await screen.findByTestId('setup-lk1'));
+
+    expect(await screen.findByText(/Locker setup/)).toBeInTheDocument();
+    expect(screen.getByText('Save changes')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/LockerSetupDrawer.tsx
+++ b/frontend/src/components/LockerSetupDrawer.tsx
@@ -1,0 +1,434 @@
+/**
+ * LockerSetupDrawer
+ *
+ * Create / edit a locker and bind ESP32 devices to it by role — the web
+ * equivalent of the Django-admin setup that locker provisioning used to
+ * require. Mutations are manager-gated server-side (staff / logistics / SIG
+ * admin); this drawer just surfaces the form + device bindings.
+ *
+ * Create mode flips to edit mode on save so device binding becomes available
+ * immediately against the freshly-created locker.
+ */
+import {
+  Badge,
+  Button,
+  Divider,
+  Drawer,
+  Group,
+  MultiSelect,
+  NumberInput,
+  Select,
+  Stack,
+  Switch,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  assetsAPI,
+  forgekeyAPI,
+  inventoryAPI,
+  lockersAPI,
+  sigAPI,
+  type ForgeKeyLocker,
+  type ForgeKeyLockerDevice,
+} from '../services/api';
+import { showError, showSuccess } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+type Option = { value: string; label: string };
+
+const ROLE_OPTIONS: Option[] = [
+  { value: 'latch', label: 'Latch controller' },
+  { value: 'reed_switch', label: 'Door reed switch' },
+  { value: 'ir_break', label: 'Inventory IR break sensor' },
+  { value: 'keypad', label: 'OTP keypad' },
+  { value: 'led_strip', label: 'WS2818 LED strip controller' },
+  { value: 'mortise_key', label: 'Mortise key (admin override) sensor' },
+];
+
+const POWER_OPTIONS: Option[] = [
+  { value: 'poe', label: 'Power over Ethernet' },
+  { value: 'usb', label: 'USB-C / barrel jack' },
+  { value: 'ac_outlet', label: 'AC mains outlet' },
+  { value: 'battery', label: 'Battery only' },
+  { value: 'unpowered', label: 'Unpowered (mechanical only)' },
+];
+
+const asArray = <T,>(data: { results?: T[] } | T[]): T[] =>
+  Array.isArray(data) ? data : (data.results ?? []);
+
+const toOptions = (rows: Array<{ id: number | string; name: string }>): Option[] =>
+  rows.map((r) => ({ value: String(r.id), label: r.name }));
+
+interface Props {
+  opened: boolean;
+  onClose: () => void;
+  /** The locker to edit, or null to create a new one. */
+  locker: ForgeKeyLocker | null;
+  /** Called after any successful mutation so the parent list can reload. */
+  onSaved: () => void;
+}
+
+export default function LockerSetupDrawer({ opened, onClose, locker, onSaved }: Props) {
+  const [current, setCurrent] = useState<ForgeKeyLocker | null>(locker);
+  const editing = current !== null;
+
+  const [name, setName] = useState('');
+  const [locationId, setLocationId] = useState<string | null>(null);
+  const [sigId, setSigId] = useState<string | null>(null);
+  const [assetId, setAssetId] = useState<string | null>(null);
+  const [powerSource, setPowerSource] = useState('poe');
+  const [ledCount, setLedCount] = useState(0);
+  const [highTrust, setHighTrust] = useState(false);
+  const [isActive, setIsActive] = useState(true);
+  const [certIds, setCertIds] = useState<string[]>([]);
+  const [description, setDescription] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const [locations, setLocations] = useState<Option[]>([]);
+  const [sigs, setSigs] = useState<Option[]>([]);
+  const [assets, setAssets] = useState<Option[]>([]);
+  const [devices, setDevices] = useState<Option[]>([]);
+  const [certs, setCerts] = useState<Option[]>([]);
+
+  const [boundDevices, setBoundDevices] = useState<ForgeKeyLockerDevice[]>([]);
+  const [newDeviceId, setNewDeviceId] = useState<string | null>(null);
+  const [newRole, setNewRole] = useState<string | null>(null);
+  const [newPrimary, setNewPrimary] = useState(false);
+  const [bindingBusy, setBindingBusy] = useState(false);
+
+  // (Re)seed the form whenever the drawer opens for a given locker.
+  useEffect(() => {
+    if (!opened) {
+      return;
+    }
+    setCurrent(locker);
+    if (locker) {
+      setName(locker.name);
+      setLocationId(locker.location != null ? String(locker.location) : null);
+      setSigId(locker.owning_sig != null ? String(locker.owning_sig) : null);
+      setAssetId(locker.current_asset);
+      setPowerSource(locker.power_source || 'poe');
+      setLedCount(locker.led_count);
+      setHighTrust(locker.is_high_trust);
+      setIsActive(locker.is_active);
+      setCertIds((locker.required_certifications || []).map(String));
+      setDescription(locker.description || '');
+      setBoundDevices(locker.devices || []);
+    } else {
+      setName('');
+      setLocationId(null);
+      setSigId(null);
+      setAssetId(null);
+      setPowerSource('poe');
+      setLedCount(0);
+      setHighTrust(false);
+      setIsActive(true);
+      setCertIds([]);
+      setDescription('');
+      setBoundDevices([]);
+    }
+    setNewDeviceId(null);
+    setNewRole(null);
+    setNewPrimary(false);
+  }, [opened, locker]);
+
+  // Load the picker option lists on open.
+  useEffect(() => {
+    if (!opened) {
+      return;
+    }
+    let alive = true;
+    (async () => {
+      try {
+        const [loc, sg, as, dev, ct] = await Promise.all([
+          inventoryAPI.listLocations(),
+          sigAPI.listMySIGs(),
+          assetsAPI.listAssets(),
+          forgekeyAPI.listDevices(),
+          lockersAPI.listAvailableCertifications(),
+        ]);
+        if (!alive) {
+          return;
+        }
+        setLocations(toOptions(asArray(loc.data)));
+        setSigs(toOptions(sg.data.results ?? []));
+        setAssets(toOptions(as.data.results ?? []));
+        setDevices(
+          asArray(dev.data).map((d) => ({
+            value: String(d.id),
+            label: d.name || d.mac_address,
+          })),
+        );
+        setCerts(toOptions(ct.data));
+      } catch (err) {
+        showError(extractErrorMessage(err, 'Failed to load setup options.'));
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [opened]);
+
+  const reloadDevices = useCallback(async (id: string) => {
+    const fresh = await lockersAPI.getLocker(id);
+    setBoundDevices(fresh.data.devices || []);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!name.trim() || !locationId || !sigId) {
+      showError('Name, location, and owning SIG are required.');
+      return;
+    }
+    setSaving(true);
+    const payload = {
+      name: name.trim(),
+      location: Number(locationId),
+      owning_sig: Number(sigId),
+      description,
+      power_source: powerSource,
+      current_asset: assetId,
+      is_high_trust: highTrust,
+      led_count: ledCount,
+      required_certifications: certIds.map(Number),
+      is_active: isActive,
+    };
+    try {
+      if (current) {
+        const res = await lockersAPI.updateLocker(current.id, payload);
+        setCurrent(res.data);
+        setBoundDevices(res.data.devices || []);
+        showSuccess('Locker updated.');
+      } else {
+        const res = await lockersAPI.createLocker(payload);
+        // Flip to edit mode so device binding becomes available.
+        setCurrent(res.data);
+        setBoundDevices(res.data.devices || []);
+        showSuccess('Locker created — you can now bind devices.');
+      }
+      onSaved();
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Failed to save locker.'));
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    name,
+    locationId,
+    sigId,
+    description,
+    powerSource,
+    assetId,
+    highTrust,
+    ledCount,
+    certIds,
+    isActive,
+    current,
+    onSaved,
+  ]);
+
+  const handleAddDevice = useCallback(async () => {
+    if (!current || !newDeviceId || !newRole) {
+      showError('Pick a device and a role.');
+      return;
+    }
+    setBindingBusy(true);
+    try {
+      await lockersAPI.addLockerDevice(current.id, {
+        device: newDeviceId,
+        role: newRole,
+        is_primary: newPrimary,
+      });
+      // Primary demotion happens server-side, so re-read the bindings.
+      await reloadDevices(current.id);
+      setNewDeviceId(null);
+      setNewRole(null);
+      setNewPrimary(false);
+      showSuccess('Device bound.');
+      onSaved();
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Failed to bind device.'));
+    } finally {
+      setBindingBusy(false);
+    }
+  }, [current, newDeviceId, newRole, newPrimary, reloadDevices, onSaved]);
+
+  const handleRemoveDevice = useCallback(
+    async (assignmentId: number) => {
+      if (!current) {
+        return;
+      }
+      setBindingBusy(true);
+      try {
+        await lockersAPI.removeLockerDevice(current.id, assignmentId);
+        setBoundDevices((prev) => prev.filter((d) => d.id !== assignmentId));
+        showSuccess('Device unbound.');
+        onSaved();
+      } catch (err) {
+        showError(extractErrorMessage(err, 'Failed to unbind device.'));
+      } finally {
+        setBindingBusy(false);
+      }
+    },
+    [current, onSaved],
+  );
+
+  return (
+    <Drawer
+      opened={opened}
+      onClose={onClose}
+      position="right"
+      size="lg"
+      title={editing ? `Locker setup — ${current?.name}` : 'New locker'}
+    >
+      <Stack gap="sm">
+        <TextInput
+          label="Name"
+          required
+          value={name}
+          onChange={(e) => setName(e.currentTarget.value)}
+          data-testid="locker-name"
+        />
+        <Select
+          label="Location"
+          required
+          searchable
+          data={locations}
+          value={locationId}
+          onChange={setLocationId}
+        />
+        <Select
+          label="Owning SIG"
+          required
+          searchable
+          data={sigs}
+          value={sigId}
+          onChange={setSigId}
+        />
+        <Select
+          label="Current asset"
+          description="Asset stored inside (optional)"
+          searchable
+          clearable
+          data={assets}
+          value={assetId}
+          onChange={setAssetId}
+        />
+        <Select
+          label="Power source"
+          data={POWER_OPTIONS}
+          value={powerSource}
+          onChange={(v) => setPowerSource(v || 'poe')}
+        />
+        <NumberInput
+          label="LED count"
+          description="WS2818 LEDs inside (0 = none)"
+          min={0}
+          value={ledCount}
+          onChange={(v) => setLedCount(typeof v === 'number' ? v : 0)}
+        />
+        <MultiSelect
+          label="Required certifications"
+          description="Certs a member must hold for self-serve access"
+          searchable
+          clearable
+          data={certs}
+          value={certIds}
+          onChange={setCertIds}
+        />
+        <Group>
+          <Switch
+            label="High trust"
+            checked={highTrust}
+            onChange={(e) => setHighTrust(e.currentTarget.checked)}
+          />
+          <Switch
+            label="Active"
+            checked={isActive}
+            onChange={(e) => setIsActive(e.currentTarget.checked)}
+          />
+        </Group>
+        <Textarea
+          label="Description"
+          autosize
+          minRows={2}
+          value={description}
+          onChange={(e) => setDescription(e.currentTarget.value)}
+        />
+        <Button onClick={handleSave} loading={saving} data-testid="save-locker">
+          {editing ? 'Save changes' : 'Create locker'}
+        </Button>
+
+        {editing && (
+          <>
+            <Divider label="Bound devices" labelPosition="center" />
+            {boundDevices.length === 0 ? (
+              <Text size="sm" c="dimmed">
+                No devices bound yet.
+              </Text>
+            ) : (
+              <Stack gap={6}>
+                {boundDevices.map((d) => (
+                  <Group key={d.id} justify="space-between" wrap="nowrap">
+                    <div>
+                      <Group gap={6}>
+                        <Text size="sm">{d.role_display}</Text>
+                        {d.is_primary && (
+                          <Badge size="xs" color="blue">
+                            primary
+                          </Badge>
+                        )}
+                      </Group>
+                      <Text size="xs" c="dimmed">
+                        {d.device_mac}
+                      </Text>
+                    </div>
+                    <Button
+                      size="compact-xs"
+                      variant="subtle"
+                      color="red"
+                      loading={bindingBusy}
+                      onClick={() => handleRemoveDevice(d.id)}
+                      data-testid={`remove-device-${d.id}`}
+                    >
+                      Remove
+                    </Button>
+                  </Group>
+                ))}
+              </Stack>
+            )}
+            <Group align="flex-end" gap="xs" wrap="nowrap">
+              <Select
+                label="Device"
+                placeholder="ESP32 device"
+                searchable
+                data={devices}
+                value={newDeviceId}
+                onChange={setNewDeviceId}
+                style={{ flex: 1 }}
+              />
+              <Select
+                label="Role"
+                placeholder="Role"
+                data={ROLE_OPTIONS}
+                value={newRole}
+                onChange={setNewRole}
+                style={{ flex: 1 }}
+              />
+              <Switch
+                label="Primary"
+                checked={newPrimary}
+                onChange={(e) => setNewPrimary(e.currentTarget.checked)}
+              />
+              <Button onClick={handleAddDevice} loading={bindingBusy} data-testid="add-device">
+                Bind
+              </Button>
+            </Group>
+          </>
+        )}
+      </Stack>
+    </Drawer>
+  );
+}

--- a/frontend/src/pages/LockersPage.tsx
+++ b/frontend/src/pages/LockersPage.tsx
@@ -24,9 +24,10 @@ import {
   Text,
   Title,
 } from '@mantine/core';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Navigate } from 'react-router-dom';
 import WorkspacePage from '../components/landing/WorkspacePage';
+import LockerSetupDrawer from '../components/LockerSetupDrawer';
 import { ForgeKeyLocker, ForgeKeyLockerOtp, lockersAPI } from '../services/api';
 import { showError, showSuccess } from '../utils/dialogs';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
@@ -90,6 +91,18 @@ const LockersPage: React.FC = () => {
   const [otpsLoading, setOtpsLoading] = useState(false);
   const [issuing, setIssuing] = useState(false);
   const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [setupOpen, setSetupOpen] = useState(false);
+  const [setupLocker, setSetupLocker] = useState<ForgeKeyLocker | null>(null);
+
+  const reload = useCallback(async () => {
+    try {
+      const res = await lockersAPI.listLockers();
+      setLockers(asList(res.data));
+      setError(null);
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to load lockers.'));
+    }
+  }, []);
 
   useEffect(() => {
     if (!isStaff && !isSuperuser) return undefined;
@@ -212,6 +225,19 @@ const LockersPage: React.FC = () => {
             />
           </SimpleGrid>
 
+          <Group justify="space-between">
+            <Title order={4}>Locker fleet</Title>
+            <Button
+              onClick={() => {
+                setSetupLocker(null);
+                setSetupOpen(true);
+              }}
+              data-testid="new-locker"
+            >
+              New locker
+            </Button>
+          </Group>
+
           {lockers.length === 0 ? (
             <Paper p="xl" withBorder>
               <Text c="dimmed" data-testid="lockers-empty">
@@ -220,9 +246,6 @@ const LockersPage: React.FC = () => {
             </Paper>
           ) : (
             <Box>
-              <Group mb="sm" gap="xs">
-                <Title order={4}>Locker fleet</Title>
-              </Group>
               <Paper withBorder>
                 <Table.ScrollContainer minWidth={820}>
                   <Table highlightOnHover>
@@ -301,6 +324,17 @@ const LockersPage: React.FC = () => {
                                   data-testid={`otps-${lk.id}`}
                                 >
                                   Codes
+                                </Button>
+                                <Button
+                                  size="xs"
+                                  variant="default"
+                                  onClick={() => {
+                                    setSetupLocker(lk);
+                                    setSetupOpen(true);
+                                  }}
+                                  data-testid={`setup-${lk.id}`}
+                                >
+                                  Setup
                                 </Button>
                               </Group>
                             </Table.Td>
@@ -382,6 +416,13 @@ const LockersPage: React.FC = () => {
           )}
         </Stack>
       </Modal>
+
+      <LockerSetupDrawer
+        opened={setupOpen}
+        onClose={() => setSetupOpen(false)}
+        locker={setupLocker}
+        onSaved={reload}
+      />
     </WorkspacePage>
   );
 };

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3414,11 +3414,32 @@ export interface ForgeKeyLocker {
   current_asset_name: string | null;
   is_high_trust: boolean;
   led_count: number;
+  required_certifications: number[];
+  required_certification_names: string[];
   is_active: boolean;
   created_at: string;
   updated_at: string;
   devices: ForgeKeyLockerDevice[];
   status: ForgeKeyLockerStatus | null;
+}
+
+export interface ForgeKeyLockerWriteInput {
+  name: string;
+  slug?: string;
+  location: number;
+  owning_sig: number;
+  description?: string;
+  power_source?: string;
+  current_asset?: string | null;
+  is_high_trust?: boolean;
+  led_count?: number;
+  required_certifications?: number[];
+  is_active?: boolean;
+}
+
+export interface ForgeKeyCertificationOption {
+  id: number;
+  name: string;
 }
 
 export interface ForgeKeyLockerOtp {
@@ -3444,6 +3465,19 @@ export const lockersAPI = {
   listOtps: (id: string) => api.get<ForgeKeyLockerOtp[]>(`/lockers/${id}/otps/`),
   revokeOtp: (id: string, otpId: string) =>
     api.post<ForgeKeyLockerOtp>(`/lockers/${id}/revoke-otp/`, { otp_id: otpId }),
+  // Setup / device binding (manager-gated server-side).
+  createLocker: (data: ForgeKeyLockerWriteInput) => api.post<ForgeKeyLocker>('/lockers/', data),
+  updateLocker: (id: string, data: Partial<ForgeKeyLockerWriteInput>) =>
+    api.patch<ForgeKeyLocker>(`/lockers/${id}/`, data),
+  deleteLocker: (id: string) => api.delete(`/lockers/${id}/`),
+  addLockerDevice: (
+    id: string,
+    data: { device: string; role: string; is_primary?: boolean; notes?: string },
+  ) => api.post<ForgeKeyLockerDevice>(`/lockers/${id}/devices/`, data),
+  removeLockerDevice: (id: string, assignmentId: number) =>
+    api.delete(`/lockers/${id}/devices/${assignmentId}/`),
+  listAvailableCertifications: () =>
+    api.get<ForgeKeyCertificationOption[]>('/lockers/available-certifications/'),
 };
 
 export default api;


### PR DESCRIPTION
## Why
Completes the locker console (after #644 monitoring and #645 unlock/OTP). Provisioning a locker — creating it, assigning its SIG/asset/certs, and binding the ESP32 devices by role — used to require **Django admin**. This brings it into the web UI for locker managers.

## Backend
- `LockerViewSet` is now a `ModelViewSet`. Create / edit / delete are gated on **managing the owning SIG** (staff, logistics, or a SIG admin) via a new `can_user_manage_sig()`; the unlock/OTP actions keep their own per-call access checks.
- `LockerWriteSerializer` — slug auto-derives from the name (deduped) when omitted, supports `required_certifications`, and echoes the full detail representation (bound devices + status) on save.
- Device binding actions: `POST /lockers/{id}/devices/` (`add_device` — bind by role; `is_primary` demotes the existing primary; duplicate `(locker, device, role)` → 409) and `DELETE /lockers/{id}/devices/{assignment_id}/` (`remove_device`).
- `GET /lockers/available-certifications/` feeds the setup form's cert picker.
- Read serializer now exposes `required_certifications` + names. Regenerated the API permission matrix.

## Frontend
- A **LockerSetupDrawer** on the monitoring console: a **New locker** button + a per-row **Setup** action.
- Form: name, location, owning SIG, current asset, power source, LED count, high-trust, active, required certifications, description. Create flips to edit mode so device binding is available immediately.
- Device binding section: bound devices (role + primary badge + MAC) with remove, plus an add-device row (ESP32 device + role + primary).

## Testing
- Backend: lockers suite **75 passed** (11 new in `test_setup.py` — CRUD gating, primary demotion, duplicate-role 409, certs feed); permission-matrix gate + `spectacular --validate` + black/isort/flake8 green.
- Frontend: LockersPage suite (create + edit drawer); full suite **700 pass**; eslint + `npm run build` ✓.