### PR TITLE
feat(forgekey): device lifecycle controls — retire / delete / lock / reset

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -688,7 +688,13 @@ views:
       partial_update:
         permission_classes:
         - IsAuthenticatedOrReadOnly
+      reactivate:
+        permission_classes:
+        - IsAdminUser
       recent_commands:
+        permission_classes:
+        - IsAdminUser
+      retire:
         permission_classes:
         - IsAdminUser
       retrieve:

--- a/backend/forgekey/tests/test_device_lifecycle.py
+++ b/backend/forgekey/tests/test_device_lifecycle.py
@@ -1,0 +1,81 @@
+"""Tests for ESP32 device lifecycle actions: retire / reactivate + delete gating.
+
+Lock/unlock (enable/disable) and reset (restart) reuse existing, separately
+tested endpoints; this file covers the new retire/reactivate actions and the
+staff-only gate on delete.
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+import pytest
+from rest_framework.test import APIClient
+
+from forgekey.models import ESP32Device
+from forgekey.tests.factories import ESP32DeviceFactory
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def admin_api_client(admin_user):
+    client = APIClient()
+    client.force_authenticate(user=admin_user)
+    return client
+
+
+@pytest.fixture
+def member_api_client():
+    user = User.objects.create_user(username="member", email="m@example.com", password="x" * 20)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _action_url(name, device):
+    return reverse(f"forgekey:esp32-device-{name}", kwargs={"pk": device.id})
+
+
+def _detail_url(device):
+    return reverse("forgekey:esp32-device-detail", kwargs={"pk": device.id})
+
+
+class TestRetireReactivate:
+    def test_staff_retire_deactivates(self, admin_api_client):
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:00:01", is_active=True)
+        resp = admin_api_client.post(_action_url("retire", device))
+        assert resp.status_code == 200, resp.data
+        assert resp.json()["is_active"] is False
+        device.refresh_from_db()
+        assert device.is_active is False
+
+    def test_staff_reactivate_restores(self, admin_api_client):
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:00:02", is_active=False)
+        resp = admin_api_client.post(_action_url("reactivate", device))
+        assert resp.status_code == 200, resp.data
+        device.refresh_from_db()
+        assert device.is_active is True
+
+    def test_member_cannot_retire(self, member_api_client):
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:00:03", is_active=True)
+        resp = member_api_client.post(_action_url("retire", device))
+        assert resp.status_code == 403
+        device.refresh_from_db()
+        assert device.is_active is True
+
+
+class TestDeleteGating:
+    def test_staff_can_delete(self, admin_api_client):
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:00:04")
+        resp = admin_api_client.delete(_detail_url(device))
+        assert resp.status_code == 204
+        assert not ESP32Device.objects.filter(pk=device.id).exists()
+
+    def test_member_cannot_delete(self, member_api_client):
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:00:05")
+        resp = member_api_client.delete(_detail_url(device))
+        assert resp.status_code == 403
+        assert ESP32Device.objects.filter(pk=device.id).exists()

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -777,6 +777,13 @@ class ESP32DeviceViewSet(viewsets.ModelViewSet):
                 qs = qs.filter(id__in=ids)
         return qs
 
+    def get_permissions(self):
+        # Deleting a device is destructive (drops its command history) — keep
+        # it staff-only even though reads/edits are open to authenticated users.
+        if self.action == "destroy":
+            return [IsAdminUser()]
+        return super().get_permissions()
+
     @action(detail=True, methods=["post"])
     def enable(self, request, pk=None):
         """Enable a device (turn on power, etc.)."""
@@ -804,6 +811,26 @@ class ESP32DeviceViewSet(viewsets.ModelViewSet):
         device = self.get_object()
         request_device_status.delay(device.mac_address)
         return Response({"status": "status request sent", "device": device.mac_address})
+
+    @action(detail=True, methods=["post"], permission_classes=[IsAdminUser])
+    def retire(self, request, pk=None):
+        """Take a device out of service (``is_active=False``) — staff only.
+
+        Keeps the row + its history (unlike delete) and is reversible via
+        ``reactivate``.
+        """
+        device = self.get_object()
+        device.is_active = False
+        device.save(update_fields=["is_active", "updated_at"])
+        return Response(self.get_serializer(device).data)
+
+    @action(detail=True, methods=["post"], permission_classes=[IsAdminUser])
+    def reactivate(self, request, pk=None):
+        """Return a retired device to service (``is_active=True``) — staff only."""
+        device = self.get_object()
+        device.is_active = True
+        device.save(update_fields=["is_active", "updated_at"])
+        return Response(self.get_serializer(device).data)
 
     @action(
         detail=True,

--- a/frontend/src/__tests__/components/DeviceLifecycleCard.test.tsx
+++ b/frontend/src/__tests__/components/DeviceLifecycleCard.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Tests for the ForgeKey device lifecycle controls (lock/unlock, reset,
+ * retire/reactivate, delete).
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import DeviceLifecycleCard from '../../components/DeviceLifecycleCard';
+import { forgekeyAPI } from '../../services/api';
+
+vi.mock('../../utils/dialogs', async () => ({
+  showError: jest.fn(),
+  showSuccess: jest.fn(),
+  showInfo: jest.fn(),
+}));
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    forgekeyAPI: {
+      ...(actual as any).forgekeyAPI,
+      disableDevice: jest.fn(),
+      enableDevice: jest.fn(),
+      restart: jest.fn(),
+      retireDevice: jest.fn(),
+      reactivateDevice: jest.fn(),
+      deleteDevice: jest.fn(),
+    },
+  };
+});
+
+const mockApi = forgekeyAPI as jest.Mocked<typeof forgekeyAPI>;
+
+const buildDevice = (overrides: Partial<any> = {}) => ({
+  id: 'd1',
+  mac_address: 'AA:BB:CC:DD:EE:01',
+  device_type: 1,
+  device_type_name: 'indicator',
+  name: 'Shop Indicator',
+  description: '',
+  firmware_version: '1.0',
+  last_seen: null,
+  is_online: true,
+  is_active: true,
+  location: null,
+  ...overrides,
+});
+
+const renderCard = (device: any, onChanged = jest.fn(), onDeleted = jest.fn()) =>
+  render(
+    <MantineProvider>
+      <DeviceLifecycleCard device={device} onChanged={onChanged} onDeleted={onDeleted} />
+    </MantineProvider>,
+  );
+
+describe('DeviceLifecycleCard', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('locks (cuts power) via disableDevice', async () => {
+    mockApi.disableDevice.mockResolvedValue({} as any);
+    renderCard(buildDevice());
+    fireEvent.click(screen.getByTestId('device-lock'));
+    await waitFor(() => expect(mockApi.disableDevice).toHaveBeenCalledWith('d1'));
+  });
+
+  it('retires an active device and reloads', async () => {
+    const onChanged = jest.fn();
+    mockApi.retireDevice.mockResolvedValue({} as any);
+    renderCard(buildDevice(), onChanged);
+    fireEvent.click(screen.getByTestId('device-retire'));
+    await waitFor(() => expect(mockApi.retireDevice).toHaveBeenCalledWith('d1'));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+
+  it('shows reactivate + retired badge for an inactive device', () => {
+    renderCard(buildDevice({ is_active: false }));
+    expect(screen.getByTestId('device-reactivate')).toBeInTheDocument();
+    expect(screen.getByTestId('device-retired-badge')).toBeInTheDocument();
+    expect(screen.queryByTestId('device-retire')).not.toBeInTheDocument();
+  });
+
+  it('deletes after confirmation and navigates away', async () => {
+    const onDeleted = jest.fn();
+    mockApi.deleteDevice.mockResolvedValue({} as any);
+    renderCard(buildDevice(), jest.fn(), onDeleted);
+    fireEvent.click(screen.getByTestId('device-delete'));
+    fireEvent.click(await screen.findByTestId('device-delete-confirm'));
+    await waitFor(() => expect(mockApi.deleteDevice).toHaveBeenCalledWith('d1'));
+    await waitFor(() => expect(onDeleted).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/components/DeviceLifecycleCard.tsx
+++ b/frontend/src/components/DeviceLifecycleCard.tsx
@@ -1,0 +1,179 @@
+/**
+ * DeviceLifecycleCard
+ *
+ * Staff lifecycle controls for a ForgeKey device, on the device detail page:
+ *  - Lock / Unlock  — cut / restore power (disable / enable commands)
+ *  - Reset          — restart the device
+ *  - Retire / Reactivate — take out of service / return to service (is_active)
+ *  - Delete         — remove permanently (with confirmation)
+ *
+ * Lock/unlock/reset are fire-and-forget MQTT commands; retire/reactivate and
+ * delete are gated to staff server-side.
+ */
+import { Badge, Button, Card, Group, Modal, Stack, Text } from '@mantine/core';
+import { useState } from 'react';
+import { ForgeKeyDevice, forgekeyAPI } from '../services/api';
+import { showError, showSuccess } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+interface Props {
+  device: ForgeKeyDevice;
+  /** Reload the device after retire / reactivate. */
+  onChanged: () => void;
+  /** Navigate away after a successful delete. */
+  onDeleted: () => void;
+}
+
+export default function DeviceLifecycleCard({ device, onChanged, onDeleted }: Props) {
+  const [busy, setBusy] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const label = device.name || device.mac_address;
+
+  const run = async (
+    key: string,
+    fn: () => Promise<unknown>,
+    success: string,
+    after?: () => void,
+  ) => {
+    setBusy(key);
+    try {
+      await fn();
+      showSuccess(success);
+      after?.();
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Action failed.'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <Card withBorder radius="md" p="md" data-testid="device-lifecycle">
+      <Group justify="space-between" mb="sm">
+        <Text fw={600}>Device lifecycle</Text>
+        {!device.is_active && (
+          <Badge color="gray" variant="light" data-testid="device-retired-badge">
+            Retired
+          </Badge>
+        )}
+      </Group>
+
+      <Stack gap="sm">
+        <Group gap="xs" wrap="wrap">
+          <Button
+            variant="light"
+            color="orange"
+            loading={busy === 'lock'}
+            onClick={() =>
+              run('lock', () => forgekeyAPI.disableDevice(device.id), `Power-off (lock) sent to ${label}.`)
+            }
+            data-testid="device-lock"
+          >
+            Lock (cut power)
+          </Button>
+          <Button
+            variant="light"
+            color="green"
+            loading={busy === 'unlock'}
+            onClick={() =>
+              run('unlock', () => forgekeyAPI.enableDevice(device.id), `Power-on (unlock) sent to ${label}.`)
+            }
+            data-testid="device-unlock"
+          >
+            Unlock (restore power)
+          </Button>
+          <Button
+            variant="light"
+            loading={busy === 'reset'}
+            onClick={() => run('reset', () => forgekeyAPI.restart(device.id), 'Restart command sent.')}
+            data-testid="device-reset"
+          >
+            Reset (restart)
+          </Button>
+        </Group>
+
+        <Group gap="xs" wrap="wrap">
+          {device.is_active ? (
+            <Button
+              variant="default"
+              loading={busy === 'retire'}
+              onClick={() =>
+                run(
+                  'retire',
+                  () => forgekeyAPI.retireDevice(device.id),
+                  'Device retired (taken out of service).',
+                  onChanged,
+                )
+              }
+              data-testid="device-retire"
+            >
+              Retire
+            </Button>
+          ) : (
+            <Button
+              variant="default"
+              loading={busy === 'reactivate'}
+              onClick={() =>
+                run(
+                  'reactivate',
+                  () => forgekeyAPI.reactivateDevice(device.id),
+                  'Device reactivated.',
+                  onChanged,
+                )
+              }
+              data-testid="device-reactivate"
+            >
+              Reactivate
+            </Button>
+          )}
+          <Button
+            color="red"
+            variant="light"
+            onClick={() => setConfirmDelete(true)}
+            data-testid="device-delete"
+          >
+            Delete…
+          </Button>
+        </Group>
+
+        <Text size="xs" c="dimmed">
+          Lock / Unlock and Reset send live MQTT commands. Retire takes the
+          device out of service but keeps its history; Delete removes it
+          permanently.
+        </Text>
+      </Stack>
+
+      <Modal
+        opened={confirmDelete}
+        onClose={() => setConfirmDelete(false)}
+        title="Delete device?"
+      >
+        <Stack gap="sm">
+          <Text size="sm">
+            Permanently delete <strong>{label}</strong> and its command history?
+            This can&rsquo;t be undone. To temporarily take it out of service,
+            use <strong>Retire</strong> instead.
+          </Text>
+          <Group justify="flex-end">
+            <Button variant="default" onClick={() => setConfirmDelete(false)}>
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              loading={busy === 'delete'}
+              onClick={() =>
+                run('delete', () => forgekeyAPI.deleteDevice(device.id), 'Device deleted.', () => {
+                  setConfirmDelete(false);
+                  onDeleted();
+                })
+              }
+              data-testid="device-delete-confirm"
+            >
+              Delete permanently
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Card>
+  );
+}

--- a/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
+++ b/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
@@ -7,9 +7,10 @@
  */
 import { Paper, Text } from '@mantine/core';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Navigate, useParams } from 'react-router-dom';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import DeviceControlsCard from '../components/DeviceControlsCard';
+import DeviceLifecycleCard from '../components/DeviceLifecycleCard';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import {
   ForgeKeyCommandResponse,
@@ -34,6 +35,7 @@ const initialControl: ControlState = { pending: false, lastResult: null, lastErr
 
 const ForgeKeyDeviceDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
   const isStaff = typeof window !== 'undefined' && localStorage.getItem('is_staff') === 'true';
   const isSuperuser =
     typeof window !== 'undefined' && localStorage.getItem('is_superuser') === 'true';
@@ -266,6 +268,12 @@ const ForgeKeyDeviceDetailPage: React.FC = () => {
           )}
 
           <DeviceControlsCard device={device} />
+
+          <DeviceLifecycleCard
+            device={device}
+            onChanged={loadAll}
+            onDeleted={() => navigate('/facilities/forgekey-devices')}
+          />
 
           <CapabilitiesSection
             device={device}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1911,6 +1911,14 @@ export const forgekeyAPI = {
   getDevice: (id: string) => api.get<ForgeKeyDevice>(`/forgekey/devices/${id}/`),
   updateDevice: (id: string, data: Partial<ForgeKeyDevice>) =>
     api.patch<ForgeKeyDevice>(`/forgekey/devices/${id}/`, data),
+  // Lifecycle: lock/unlock = power off/on, reset = restart (above),
+  // retire/reactivate = is_active toggle (staff), delete = remove (staff).
+  enableDevice: (id: string) => api.post(`/forgekey/devices/${id}/enable/`),
+  disableDevice: (id: string, delaySeconds?: number) =>
+    api.post(`/forgekey/devices/${id}/disable/`, delaySeconds ? { delay_seconds: delaySeconds } : {}),
+  retireDevice: (id: string) => api.post<ForgeKeyDevice>(`/forgekey/devices/${id}/retire/`),
+  reactivateDevice: (id: string) => api.post<ForgeKeyDevice>(`/forgekey/devices/${id}/reactivate/`),
+  deleteDevice: (id: string) => api.delete(`/forgekey/devices/${id}/`),
   getOccupancy: (id: string, since: string = '24h') =>
     api.get<ForgeKeyOccupancyResponse>(`/forgekey/devices/${id}/occupancy/`, {
       params: { since },


### PR DESCRIPTION
Adds the device-lifecycle controls the web console was missing (gap #3 from the parity review) to the **device detail page** (`/facilities/forgekey-devices/:id`).

## New: DeviceLifecycleCard
- **Lock / Unlock** — cut / restore power (the existing `disable` / `enable` commands)
- **Reset** — restart the device
- **Retire / Reactivate** — take out of / return to service (`is_active`), keeping history
- **Delete** — remove permanently, behind a confirmation modal (nudges toward Retire)

## Backend
- New `retire` + `reactivate` actions on `ESP32DeviceViewSet` (**staff-only**), flipping `is_active`.
- `destroy` tightened to **staff-only** via `get_permissions` (was authenticated) — deleting a device drops its command history, so it shouldn't be open to any logged-in user.
- Regenerated the API permission matrix.

Per the agreed scope: manual device *creation* and user-edited *metadata* are intentionally **not** added (provisioning stays automated; metadata comes from the device).

## Testing
- Backend: `test_device_lifecycle.py` — 5 pass (retire/reactivate + staff gate on retire & delete); permission-matrix gate + `spectacular --validate` + black/isort/flake8 green.
- Frontend: `DeviceLifecycleCard` 4 + `ForgeKeyDeviceDetailPage` 7 pass; eslint + `npm run build` ✓.