### PR TITLE
fix(forgekey): /forgekey/epaper blank screen + inline e-paper asset rebind

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -231,6 +231,7 @@ function AppContent() {
           <Route path="/facilities/forgekey-epaper" element={<WorkspaceLayout><ForgeKeyEPaperPanelsPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-rollouts" element={<WorkspaceLayout><ForgeKeyFirmwareRolloutsPage /></WorkspaceLayout>} />
           <Route path="/facilities/lockers" element={<WorkspaceLayout><LockersPage /></WorkspaceLayout>} />
+          <Route path="/forgekey/epaper" element={<Navigate to="/facilities/forgekey-epaper" replace />} />
           <Route path="/forgekey/epaper/bind" element={<WorkspaceLayout><ForgeKeyEPaperBindPage /></WorkspaceLayout>} />
           <Route path="/forgekey/epaper/service" element={<WorkspaceLayout><ForgeKeyEPaperServicePage /></WorkspaceLayout>} />
           <Route path="/inventory/code-entry" element={<Navigate to="/inventory/scan" replace />} />

--- a/frontend/src/__tests__/pages/ForgeKeyEPaperPanelsPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyEPaperPanelsPage.test.tsx
@@ -8,7 +8,7 @@ import { MantineProvider } from '@mantine/core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import ForgeKeyEPaperPanelsPage from '../../pages/ForgeKeyEPaperPanelsPage';
-import { forgekeyAPI } from '../../services/api';
+import { assetsAPI, forgekeyAPI } from '../../services/api';
 
 vi.mock('../../services/api', async () => {
   const actual = await vi.importActual('../../services/api');
@@ -17,11 +17,14 @@ vi.mock('../../services/api', async () => {
     forgekeyAPI: {
       listEPaperDisplays: jest.fn(),
       setEPaperActive: jest.fn(),
+      bindEPaper: jest.fn(),
     },
+    assetsAPI: { ...(actual as any).assetsAPI, listAssets: jest.fn() },
   };
 });
 
 const mockApi = forgekeyAPI as jest.Mocked<typeof forgekeyAPI>;
+const mockAssets = assetsAPI as jest.Mocked<typeof assetsAPI>;
 
 const buildPanel = (overrides: Partial<any> = {}) => ({
   id: 'p1',
@@ -57,6 +60,9 @@ describe('ForgeKeyEPaperPanelsPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+    mockAssets.listAssets.mockResolvedValue({
+      data: { results: [{ id: 'a9', name: 'Drill' }] },
+    } as any);
   });
 
   test('non-staff users are redirected', async () => {
@@ -100,5 +106,16 @@ describe('ForgeKeyEPaperPanelsPage', () => {
       expect(screen.getByText('Retired')).toBeInTheDocument();
     });
     expect(screen.getByText('Reactivate')).toBeInTheDocument();
+  });
+
+  test('renders an inline asset rebind picker per panel', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockApi.listEPaperDisplays.mockResolvedValue({ data: [buildPanel()] } as any);
+
+    renderPage();
+
+    // The inline picker means rebinding happens from this page (not a bounce
+    // to the QR flow). Asset options come from the assets feed.
+    expect(await screen.findByTestId('bind-select-p1')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ForgeKeyEPaperPanelsPage.tsx
+++ b/frontend/src/pages/ForgeKeyEPaperPanelsPage.tsx
@@ -5,11 +5,11 @@
  * image fetch, and active/retired state. Staff can rebind a panel to a
  * different asset (via the existing QR bind flow) or retire / reactivate it.
  */
-import { Alert, Anchor, Badge, Button, Group, Loader, Paper, Table, Text } from '@mantine/core';
-import React, { useEffect, useState } from 'react';
+import { Alert, Anchor, Badge, Button, Group, Loader, Paper, Select, Table, Text } from '@mantine/core';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Link, Navigate } from 'react-router-dom';
 import WorkspacePage from '../components/landing/WorkspacePage';
-import { ForgeKeyEPaperDisplay, forgekeyAPI } from '../services/api';
+import { assetsAPI, ForgeKeyEPaperDisplay, forgekeyAPI } from '../services/api';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const formatRelative = (iso: string | null): string => {
@@ -31,32 +31,44 @@ const ForgeKeyEPaperPanelsPage: React.FC = () => {
     typeof window !== 'undefined' && localStorage.getItem('is_superuser') === 'true';
 
   const [panels, setPanels] = useState<ForgeKeyEPaperDisplay[]>([]);
+  const [assets, setAssets] = useState<{ value: string; label: string }[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
 
+  const load = useCallback(async () => {
+    try {
+      const res = await forgekeyAPI.listEPaperDisplays();
+      setPanels(res.data);
+      setError(null);
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to load e-paper panels.'));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
-    if (!isStaff && !isSuperuser) return undefined;
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await forgekeyAPI.listEPaperDisplays();
-        if (!cancelled) {
-          setPanels(res.data);
-          setError(null);
+    if (!isStaff && !isSuperuser) return;
+    load();
+  }, [isStaff, isSuperuser, load]);
+
+  // Assets for the inline "bind to asset" picker.
+  useEffect(() => {
+    if (!isStaff && !isSuperuser) return;
+    let alive = true;
+    assetsAPI
+      .listAssets()
+      .then((res) => {
+        if (alive) {
+          setAssets(res.data.results.map((a) => ({ value: String(a.id), label: a.name })));
         }
-      } catch (err) {
-        if (!cancelled) {
-          setError(extractErrorMessage(err, 'Failed to load e-paper panels.'));
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    })();
+      })
+      .catch(() => {
+        /* the asset picker is optional */
+      });
     return () => {
-      cancelled = true;
+      alive = false;
     };
   }, [isStaff, isSuperuser]);
 
@@ -72,6 +84,21 @@ const ForgeKeyEPaperPanelsPage: React.FC = () => {
       setError(null);
     } catch (err) {
       setError(extractErrorMessage(err, 'Failed to update the panel.'));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleBind = async (panel: ForgeKeyEPaperDisplay, assetId: string | null) => {
+    if (!assetId || assetId === panel.asset) {
+      return;
+    }
+    setBusyId(panel.id);
+    try {
+      await forgekeyAPI.bindEPaper(panel.id, assetId);
+      await load();
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to bind the panel.'));
     } finally {
       setBusyId(null);
     }
@@ -164,10 +191,19 @@ const ForgeKeyEPaperPanelsPage: React.FC = () => {
                       </Badge>
                     </Table.Td>
                     <Table.Td>
-                      <Group gap="xs">
-                        <Anchor component={Link} to={`/forgekey/epaper/bind?did=${p.id}`} size="sm">
-                          Rebind
-                        </Anchor>
+                      <Group gap="xs" wrap="nowrap" align="center">
+                        <Select
+                          size="xs"
+                          placeholder="Bind asset…"
+                          data={assets}
+                          value={p.asset}
+                          onChange={(v) => handleBind(p, v)}
+                          searchable
+                          disabled={busyId === p.id}
+                          comboboxProps={{ withinPortal: true }}
+                          style={{ minWidth: 170 }}
+                          data-testid={`bind-select-${p.id}`}
+                        />
                         <Button
                           size="xs"
                           variant="subtle"
@@ -177,6 +213,15 @@ const ForgeKeyEPaperPanelsPage: React.FC = () => {
                         >
                           {p.is_active ? 'Retire' : 'Reactivate'}
                         </Button>
+                        <Anchor
+                          component={Link}
+                          to={`/forgekey/epaper/bind?did=${p.id}`}
+                          size="xs"
+                          c="dimmed"
+                          title="Bind by scanning the panel QR instead"
+                        >
+                          QR
+                        </Anchor>
                       </Group>
                     </Table.Td>
                   </Table.Tr>


### PR DESCRIPTION
## The blank screen
`/forgekey/epaper` rendered blank because it was **never a route** — only `/forgekey/epaper/bind` and `/forgekey/epaper/service` exist, and the panels page lives at `/facilities/forgekey-epaper` (linked from the sidebar). Typing the intuitive URL matched nothing. Fix: redirect `/forgekey/epaper` → `/facilities/forgekey-epaper`.

## E-paper device management from this page
The panels page already lists each e-paper device (asset binding, battery, device MAC, last refresh, status) with inline **Retire / Reactivate**. Added the missing piece — **inline asset (re)binding** via a searchable picker, so you can modify a panel's binding *from this page* instead of bouncing to the QR-scan flow (the QR link is kept as a secondary option).

## Testing
- Panels page suite (4) + App (1); full frontend suite **701 pass**; eslint + `npm run build` ✓.

Frontend-only (the bind / set-active / list endpoints already exist).