### PR TITLE
feat(forgekey): PKI visibility (#5) + CA rotation (#6)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -537,6 +537,25 @@ views:
       update:
         permission_classes:
         - IsAuthenticatedOrReadOnly
+  forgekey.views.CertificateAuthorityViewSet:
+    actions:
+      list:
+        permission_classes:
+        - IsAdminUser
+      retrieve:
+        permission_classes:
+        - IsAdminUser
+      rotate:
+        permission_classes:
+        - IsAdminUser
+  forgekey.views.DeviceCertificateViewSet:
+    actions:
+      list:
+        permission_classes:
+        - IsAdminUser
+      retrieve:
+        permission_classes:
+        - IsAdminUser
   forgekey.views.DeviceFirmwareUpdateViewSet:
     actions:
       create:

--- a/backend/forgekey/serializers.py
+++ b/backend/forgekey/serializers.py
@@ -7,6 +7,8 @@ from rest_framework import serializers
 from .models import (
     AssetAuthorization,
     AssetDevice,
+    CertificateAuthority,
+    DeviceCertificate,
     DeviceCommand,
     DeviceFirmwareUpdate,
     DeviceLockout,
@@ -343,3 +345,96 @@ class FirmwareRolloutSerializer(serializers.ModelSerializer):
         from .services.firmware_rollout import rollout_progress
 
         return rollout_progress(obj)
+
+
+class CertificateAuthoritySerializer(serializers.ModelSerializer):
+    """Read-only view of an internal CA, with the CN + fingerprint parsed from
+    the stored certificate. Active-CA rows also carry the device-cert counts."""
+
+    common_name = serializers.SerializerMethodField()
+    fingerprint_sha256 = serializers.SerializerMethodField()
+    active_cert_count = serializers.SerializerMethodField()
+    revoked_cert_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = CertificateAuthority
+        fields = [
+            "id",
+            "name",
+            "common_name",
+            "fingerprint_sha256",
+            "not_before",
+            "not_after",
+            "is_active",
+            "created_at",
+            "active_cert_count",
+            "revoked_cert_count",
+        ]
+
+    @staticmethod
+    def _cert(obj):
+        from cryptography import x509
+
+        try:
+            return x509.load_pem_x509_certificate(obj.cert_pem.encode("utf-8"))
+        except Exception:
+            return None
+
+    def get_common_name(self, obj):
+        cert = self._cert(obj)
+        if cert is None:
+            return None
+        return next(
+            (a.value for a in cert.subject if a.oid.dotted_string == "2.5.4.3"),
+            None,
+        )
+
+    def get_fingerprint_sha256(self, obj):
+        from cryptography.hazmat.primitives import hashes
+
+        cert = self._cert(obj)
+        return cert.fingerprint(hashes.SHA256()).hex() if cert is not None else None
+
+    def get_active_cert_count(self, obj):
+        if not obj.is_active:
+            return None
+        return DeviceCertificate.objects.filter(revoked_at__isnull=True).count()
+
+    def get_revoked_cert_count(self, obj):
+        if not obj.is_active:
+            return None
+        return DeviceCertificate.objects.filter(revoked_at__isnull=False).count()
+
+
+class DeviceCertificateSerializer(serializers.ModelSerializer):
+    """Read-only view of an issued device (mTLS) certificate + its lifecycle
+    status."""
+
+    device_chip_id = serializers.CharField(source="device.device_id", read_only=True, default=None)
+    status = serializers.SerializerMethodField()
+
+    class Meta:
+        model = DeviceCertificate
+        fields = [
+            "id",
+            "device",
+            "device_chip_id",
+            "serial",
+            "subject",
+            "fingerprint_sha256",
+            "not_before",
+            "not_after",
+            "revoked_at",
+            "issued_by",
+            "created_at",
+            "status",
+        ]
+
+    def get_status(self, obj):
+        from django.utils import timezone
+
+        if obj.revoked_at is not None:
+            return "revoked"
+        if obj.not_after is not None and obj.not_after < timezone.now():
+            return "expired"
+        return "active"

--- a/backend/forgekey/services/ca_lifecycle.py
+++ b/backend/forgekey/services/ca_lifecycle.py
@@ -1,0 +1,57 @@
+"""Mint / rotate the internal ForgeKey root CA.
+
+Rotation generates a brand-new self-signed root and deactivates the prior one
+in the same transaction — devices must be re-flashed (or rebuilt via the
+firmware pipeline) to trust the new root. Shared generation logic so the
+staff rotate API and the ``forgekey_ca`` bootstrap command behave identically.
+"""
+
+from __future__ import annotations
+
+from django.db import transaction
+
+from cryptography.hazmat.primitives import serialization
+
+from ..models import CertificateAuthority
+from .ca_key_storage import encrypt_ca_key
+from .csr_signing import generate_ca_keypair
+
+
+def mint_ca(
+    *,
+    name: str = "forgekey-root",
+    cn: str = "ForgeKey Internal Root CA",
+    validity_years: int = 10,
+    replace_active: bool = True,
+) -> CertificateAuthority:
+    """Generate a fresh self-signed root CA and persist it as the active CA.
+
+    If a CA is already active and ``replace_active`` is True, it is deactivated
+    in the same transaction (the partial-unique constraint permits a single
+    active CA). Raises ``RuntimeError`` if an active CA exists and
+    ``replace_active`` is False, and ``ValueError`` for a non-positive validity.
+    """
+    if validity_years <= 0:
+        raise ValueError("validity_years must be positive")
+
+    active = CertificateAuthority.get_active()
+    if active is not None and not replace_active:
+        raise RuntimeError("An active CA already exists; pass replace_active=True to rotate it.")
+
+    private_pem, ca_cert = generate_ca_keypair(cn=cn, validity_days=validity_years * 365)
+    ciphertext, kid = encrypt_ca_key(private_pem)
+
+    with transaction.atomic():
+        if active is not None:
+            # Deactivate first so the single-active partial-unique constraint
+            # doesn't collide with the new row.
+            CertificateAuthority.objects.filter(pk=active.pk).update(is_active=False)
+        return CertificateAuthority.objects.create(
+            name=name,
+            cert_pem=ca_cert.public_bytes(serialization.Encoding.PEM).decode("ascii"),
+            encrypted_private_key=ciphertext,
+            key_kid=kid,
+            not_before=ca_cert.not_valid_before_utc,
+            not_after=ca_cert.not_valid_after_utc,
+            is_active=True,
+        )

--- a/backend/forgekey/tests/test_pki.py
+++ b/backend/forgekey/tests/test_pki.py
@@ -1,0 +1,138 @@
+"""Tests for the read-only PKI surface + CA rotation (parity gaps #5 / #6)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+
+import pytest
+from rest_framework.test import APIClient
+
+from forgekey.models import CertificateAuthority, DeviceCertificate, DeviceIdentity
+from forgekey.services.ca_lifecycle import mint_ca
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def admin_api_client(admin_user):
+    client = APIClient()
+    client.force_authenticate(user=admin_user)
+    return client
+
+
+@pytest.fixture
+def member_api_client():
+    user = User.objects.create_user(username="m", email="m@example.com", password="x" * 20)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def ca_kek(settings):
+    from cryptography.fernet import Fernet
+
+    settings.FORGEKEY_CA_KEY_ENCRYPTION_KEY = Fernet.generate_key().decode("ascii")
+
+
+@pytest.fixture
+def active_ca(ca_kek):
+    return mint_ca(validity_years=5)
+
+
+def _rows(resp):
+    body = resp.json()
+    return body if isinstance(body, list) else body["results"]
+
+
+class TestCertificateAuthorityRead:
+    def test_active_ca_exposes_cn_fingerprint_and_counts(self, admin_api_client, active_ca):
+        resp = admin_api_client.get(reverse("forgekey:certificate-authority-list"))
+        assert resp.status_code == 200
+        ca = next(r for r in _rows(resp) if r["is_active"])
+        assert ca["common_name"] == "ForgeKey Internal Root CA"
+        assert len(ca["fingerprint_sha256"]) == 64
+        assert ca["active_cert_count"] == 0
+        assert ca["revoked_cert_count"] == 0
+
+    def test_non_staff_forbidden(self, member_api_client, active_ca):
+        resp = member_api_client.get(reverse("forgekey:certificate-authority-list"))
+        assert resp.status_code == 403
+
+
+class TestDeviceCertificateRead:
+    def test_lists_certs_with_status(self, admin_api_client):
+        device = DeviceIdentity.objects.create(device_id="chip-aabbcc000009")
+        now = timezone.now()
+        DeviceCertificate.objects.create(
+            device=device,
+            serial="01",
+            subject="CN=dev",
+            fingerprint_sha256="a" * 64,
+            not_before=now - timedelta(days=1),
+            not_after=now + timedelta(days=365),
+            issued_by="test",
+        )
+        DeviceCertificate.objects.create(
+            device=device,
+            serial="02",
+            subject="CN=dev2",
+            fingerprint_sha256="b" * 64,
+            not_before=now - timedelta(days=2),
+            not_after=now - timedelta(days=1),  # expired
+            issued_by="test",
+        )
+        DeviceCertificate.objects.create(
+            device=device,
+            serial="03",
+            subject="CN=dev3",
+            fingerprint_sha256="c" * 64,
+            not_before=now - timedelta(days=1),
+            not_after=now + timedelta(days=365),
+            revoked_at=now,
+            issued_by="test",
+        )
+        resp = admin_api_client.get(reverse("forgekey:device-certificate-list"))
+        assert resp.status_code == 200
+        by_serial = {r["serial"]: r for r in _rows(resp)}
+        assert by_serial["01"]["status"] == "active"
+        assert by_serial["02"]["status"] == "expired"
+        assert by_serial["03"]["status"] == "revoked"
+        assert by_serial["01"]["device_chip_id"] == "chip-aabbcc000009"
+
+
+class TestCaRotation:
+    def test_staff_rotate_mints_new_active_ca(self, admin_api_client, active_ca):
+        old_id = str(active_ca.id)
+        resp = admin_api_client.post(
+            reverse("forgekey:certificate-authority-rotate"),
+            {"validity_years": 3},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.data
+        new = resp.json()
+        assert new["is_active"] is True
+        assert new["id"] != old_id
+        active = CertificateAuthority.objects.filter(is_active=True)
+        assert active.count() == 1
+        assert str(active.first().id) == new["id"]
+        active_ca.refresh_from_db()
+        assert active_ca.is_active is False
+
+    def test_member_cannot_rotate(self, member_api_client):
+        resp = member_api_client.post(reverse("forgekey:certificate-authority-rotate"))
+        assert resp.status_code == 403
+        assert not CertificateAuthority.objects.exists()
+
+    def test_rotate_rejects_non_positive_validity(self, admin_api_client):
+        resp = admin_api_client.post(
+            reverse("forgekey:certificate-authority-rotate"),
+            {"validity_years": 0},
+            format="json",
+        )
+        assert resp.status_code == 400

--- a/backend/forgekey/urls.py
+++ b/backend/forgekey/urls.py
@@ -9,6 +9,8 @@ from rest_framework.routers import DefaultRouter
 from .views import (
     AssetAuthorizationViewSet,
     AssetDeviceViewSet,
+    CertificateAuthorityViewSet,
+    DeviceCertificateViewSet,
     DeviceFirmwareUpdateViewSet,
     DeviceLockoutViewSet,
     DeviceTypeViewSet,
@@ -49,6 +51,10 @@ router.register(r"firmware-versions", FirmwareVersionViewSet, basename="firmware
 router.register(r"firmware-updates", DeviceFirmwareUpdateViewSet, basename="firmware-update")
 router.register(r"firmware-rollouts", FirmwareRolloutViewSet, basename="firmware-rollout")
 router.register(r"firmware-builds", FirmwareBuildViewSet, basename="firmware-build")
+router.register(
+    r"certificate-authorities", CertificateAuthorityViewSet, basename="certificate-authority"
+)
+router.register(r"device-certificates", DeviceCertificateViewSet, basename="device-certificate")
 
 app_name = "forgekey"
 

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -58,6 +58,8 @@ from .models import (
 from .serializers import (
     AssetAuthorizationSerializer,
     AssetDeviceSerializer,
+    CertificateAuthoritySerializer,
+    DeviceCertificateSerializer,
     DeviceCommandSerializer,
     DeviceFirmwareUpdateSerializer,
     DeviceLockoutSerializer,
@@ -1665,6 +1667,57 @@ class DeviceFirmwareUpdateViewSet(viewsets.ModelViewSet):
         serializer.save(requested_by=self.request.user)
         # TODO: Trigger firmware update via MQTT
         # This would send the firmware file and signature to the device
+
+
+class CertificateAuthorityViewSet(viewsets.ReadOnlyModelViewSet):
+    """Read-only view of the internal CA(s) + a staff CA-rotate action.
+
+    Device-cert issuance / revocation stays in the enrollment flow / admin;
+    this surface is for visibility and rotating the root CA. Rotation mints a
+    fresh self-signed root and retires the prior one — devices must be
+    re-flashed (or rebuilt via the firmware pipeline) to trust the new root.
+    """
+
+    queryset = CertificateAuthority.objects.all()
+    serializer_class = CertificateAuthoritySerializer
+    permission_classes = [IsAdminUser]
+
+    @action(detail=False, methods=["post"])
+    def rotate(self, request):
+        from .services.ca_lifecycle import mint_ca
+
+        name = (request.data.get("name") or "forgekey-root").strip() or "forgekey-root"
+        cn = (request.data.get("common_name") or "").strip() or "ForgeKey Internal Root CA"
+        raw_validity = request.data.get("validity_years")
+        try:
+            validity_years = int(raw_validity) if raw_validity is not None else 10
+        except (TypeError, ValueError):
+            return Response(
+                {"detail": "validity_years must be an integer."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if validity_years <= 0:
+            return Response(
+                {"detail": "validity_years must be positive."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            ca = mint_ca(name=name, cn=cn, validity_years=validity_years, replace_active=True)
+        except Exception as exc:  # noqa: BLE001 — surface any CA-gen failure
+            logger.exception("CA rotation failed")
+            return Response(
+                {"detail": f"Failed to rotate the CA: {exc}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        return Response(CertificateAuthoritySerializer(ca).data, status=status.HTTP_201_CREATED)
+
+
+class DeviceCertificateViewSet(viewsets.ReadOnlyModelViewSet):
+    """Read-only list of issued device (mTLS) certificates + their status."""
+
+    queryset = DeviceCertificate.objects.select_related("device").all()
+    serializer_class = DeviceCertificateSerializer
+    permission_classes = [IsAdminUser]
 
 
 class FirmwareBuildViewSet(viewsets.ModelViewSet):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ import PowerPanelPrintPage from './pages/PowerPanelPrintPage';
 import PowerPanelDirectoryPage from './pages/PowerPanelDirectoryPage';
 import PowerPanelFormPage from './pages/PowerPanelFormPage';
 import FixtureScanPage from './pages/FixtureScanPage';
+import ForgeKeyCertificatesPage from './pages/ForgeKeyCertificatesPage';
 import ForgeKeyDashboardPage from './pages/ForgeKeyDashboardPage';
 import ForgeKeyDeviceDetailPage from './pages/ForgeKeyDeviceDetailPage';
 import ForgeKeyDevicesPage from './pages/ForgeKeyDevicesPage';
@@ -230,6 +231,7 @@ function AppContent() {
           <Route path="/facilities/forgekey-devices/:id" element={<WorkspaceLayout><ForgeKeyDeviceDetailPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-epaper" element={<WorkspaceLayout><ForgeKeyEPaperPanelsPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-rollouts" element={<WorkspaceLayout><ForgeKeyFirmwareRolloutsPage /></WorkspaceLayout>} />
+          <Route path="/facilities/forgekey-certificates" element={<WorkspaceLayout><ForgeKeyCertificatesPage /></WorkspaceLayout>} />
           <Route path="/facilities/lockers" element={<WorkspaceLayout><LockersPage /></WorkspaceLayout>} />
           <Route path="/forgekey/epaper" element={<Navigate to="/facilities/forgekey-epaper" replace />} />
           <Route path="/forgekey/epaper/bind" element={<WorkspaceLayout><ForgeKeyEPaperBindPage /></WorkspaceLayout>} />

--- a/frontend/src/__tests__/pages/ForgeKeyCertificatesPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyCertificatesPage.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Tests for the ForgeKey certificates (PKI) page.
+ *
+ * Covers: non-staff redirect, the active-CA + device-cert read views, and the
+ * confirm-then-rotate CA flow.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ForgeKeyCertificatesPage from '../../pages/ForgeKeyCertificatesPage';
+import { forgekeyAPI } from '../../services/api';
+import { showSuccess } from '../../utils/dialogs';
+
+vi.mock('../../utils/dialogs', async () => ({
+  showError: jest.fn(),
+  showSuccess: jest.fn(),
+  showInfo: jest.fn(),
+}));
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    forgekeyAPI: {
+      ...(actual as any).forgekeyAPI,
+      listCertificateAuthorities: jest.fn(),
+      listDeviceCertificates: jest.fn(),
+      rotateCA: jest.fn(),
+    },
+  };
+});
+
+const mockApi = forgekeyAPI as jest.Mocked<typeof forgekeyAPI>;
+
+const buildCA = (overrides: Partial<any> = {}) => ({
+  id: 'ca1',
+  name: 'forgekey-root',
+  common_name: 'ForgeKey Internal Root CA',
+  fingerprint_sha256: 'a'.repeat(64),
+  not_before: '2026-01-01T00:00:00Z',
+  not_after: '2036-01-01T00:00:00Z',
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+  active_cert_count: 2,
+  revoked_cert_count: 1,
+  ...overrides,
+});
+
+const buildCert = (overrides: Partial<any> = {}) => ({
+  id: 'dc1',
+  device: 'di1',
+  device_chip_id: 'chip-aabbcc',
+  serial: '0A',
+  subject: 'CN=device',
+  fingerprint_sha256: 'b'.repeat(64),
+  not_before: '2026-01-01T00:00:00Z',
+  not_after: '2027-01-01T00:00:00Z',
+  revoked_at: null,
+  issued_by: 'enrollment',
+  created_at: '2026-01-01T00:00:00Z',
+  status: 'active',
+  ...overrides,
+});
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={['/facilities/forgekey-certificates']}>
+        <Routes>
+          <Route
+            path="/facilities/forgekey-certificates"
+            element={<ForgeKeyCertificatesPage />}
+          />
+          <Route path="/" element={<div>HOME</div>} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('ForgeKeyCertificatesPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockApi.listCertificateAuthorities.mockResolvedValue({ data: [buildCA()] } as any);
+    mockApi.listDeviceCertificates.mockResolvedValue({ data: [buildCert()] } as any);
+  });
+
+  test('non-staff users are redirected', async () => {
+    localStorage.setItem('is_staff', 'false');
+    localStorage.setItem('is_superuser', 'false');
+
+    renderPage();
+
+    expect(await screen.findByText('HOME')).toBeInTheDocument();
+    expect(mockApi.listCertificateAuthorities).not.toHaveBeenCalled();
+  });
+
+  test('staff sees the active CA + device certificates', async () => {
+    localStorage.setItem('is_staff', 'true');
+
+    renderPage();
+
+    expect(await screen.findByText('ForgeKey Internal Root CA')).toBeInTheDocument();
+    expect(screen.getByText('a'.repeat(64))).toBeInTheDocument();
+    expect(screen.getByTestId('cert-dc1')).toBeInTheDocument();
+    expect(screen.getByText('chip-aabbcc')).toBeInTheDocument();
+  });
+
+  test('rotating the CA confirms then calls rotateCA', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockApi.rotateCA.mockResolvedValue({ data: buildCA({ id: 'ca2' }) } as any);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByTestId('rotate-ca'));
+    fireEvent.click(await screen.findByTestId('rotate-ca-confirm'));
+
+    await waitFor(() => expect(mockApi.rotateCA).toHaveBeenCalled());
+    await waitFor(() => expect(showSuccess).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -117,6 +117,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed = false, isMobileOpen = f
         { path: '/facilities/forgekey-devices', label: 'ForgeKey Devices', icon: '📡', requiresStaff: true },
         { path: '/facilities/forgekey-epaper', label: 'e-Paper Panels', icon: '🖼️', requiresStaff: true },
         { path: '/facilities/forgekey-rollouts', label: 'Firmware Rollouts', icon: '🚀', requiresStaff: true },
+        { path: '/facilities/forgekey-certificates', label: 'Certificates (PKI)', icon: '🔐', requiresStaff: true },
         { path: '/facilities/lockers', label: 'Lockers', icon: '🔒', requiresStaff: true },
         { path: '/facilities/electrical', label: 'Electrical & Network', icon: '⚡', requiresStaff: true },
       ],

--- a/frontend/src/pages/FacilitiesOverviewPage.tsx
+++ b/frontend/src/pages/FacilitiesOverviewPage.tsx
@@ -104,6 +104,14 @@ const FacilitiesOverviewPage: React.FC = () => (
       testId="facilities-overview-card-/facilities/forgekey-rollouts"
     />
     <CapabilityCard
+      to="/facilities/forgekey-certificates"
+      title="Certificates (PKI)"
+      description="The internal CA + issued device certificates — and rotate the root CA."
+      icon={<IconKey size={22} stroke={1.8} />}
+      eyebrow="Access"
+      testId="facilities-overview-card-/facilities/forgekey-certificates"
+    />
+    <CapabilityCard
       to="/facilities/lockers"
       title="Lockers"
       description="ForgeKey-gated lockers — live secure / online status with intrusions flagged."

--- a/frontend/src/pages/ForgeKeyCertificatesPage.tsx
+++ b/frontend/src/pages/ForgeKeyCertificatesPage.tsx
@@ -1,0 +1,249 @@
+/**
+ * ForgeKey Certificates — staff PKI visibility + CA rotation.
+ *
+ * Read-only view of the internal CA(s) and issued device (mTLS) certificates.
+ * Staff can rotate the root CA (mints a fresh self-signed root; devices must be
+ * re-flashed / rebuilt to trust it). Issuance + revocation stay in the
+ * enrollment flow / Django admin.
+ */
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Group,
+  Loader,
+  Modal,
+  Paper,
+  Stack,
+  Table,
+  Text,
+  Title,
+} from '@mantine/core';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
+import {
+  ForgeKeyCertificateAuthority,
+  ForgeKeyDeviceCertificate,
+  forgekeyAPI,
+} from '../services/api';
+import { showError, showSuccess } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+const asList = <T,>(data: { results?: T[] } | T[]): T[] =>
+  Array.isArray(data) ? data : (data.results ?? []);
+
+const CERT_STATUS_COLORS: Record<string, string> = {
+  active: 'green',
+  expired: 'yellow',
+  revoked: 'red',
+};
+
+const fmtDate = (iso: string | null): string => (iso ? new Date(iso).toLocaleDateString() : '—');
+
+const ForgeKeyCertificatesPage: React.FC = () => {
+  const isStaff = typeof window !== 'undefined' && localStorage.getItem('is_staff') === 'true';
+  const isSuperuser =
+    typeof window !== 'undefined' && localStorage.getItem('is_superuser') === 'true';
+
+  const [cas, setCas] = useState<ForgeKeyCertificateAuthority[]>([]);
+  const [certs, setCerts] = useState<ForgeKeyDeviceCertificate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmRotate, setConfirmRotate] = useState(false);
+  const [rotating, setRotating] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const [caRes, certRes] = await Promise.all([
+        forgekeyAPI.listCertificateAuthorities(),
+        forgekeyAPI.listDeviceCertificates(),
+      ]);
+      setCas(asList(caRes.data));
+      setCerts(asList(certRes.data));
+      setError(null);
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to load certificates.'));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isStaff && !isSuperuser) return;
+    load();
+  }, [isStaff, isSuperuser, load]);
+
+  if (!isStaff && !isSuperuser) {
+    return <Navigate to="/" replace />;
+  }
+
+  const handleRotate = async () => {
+    setRotating(true);
+    try {
+      await forgekeyAPI.rotateCA();
+      await load();
+      setConfirmRotate(false);
+      showSuccess('Root CA rotated — re-flash / rebuild firmware to trust the new root.');
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Failed to rotate the CA.'));
+    } finally {
+      setRotating(false);
+    }
+  };
+
+  const activeCa = cas.find((c) => c.is_active) || null;
+  const retired = cas.filter((c) => !c.is_active);
+
+  return (
+    <WorkspacePage
+      testId="forgekey-certificates-page"
+      hero={{
+        eyebrow: 'Facilities · ForgeKey',
+        title: 'Certificates (PKI)',
+        description:
+          'The internal CA + issued device certificates. Read-only; rotate the root CA here.',
+      }}
+    >
+      {error && (
+        <Alert color="red" variant="light" data-testid="certs-error">
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Group justify="center" p="xl">
+          <Loader />
+        </Group>
+      ) : (
+        <Stack gap="lg">
+          <Card withBorder p="md" radius="md" data-testid="active-ca">
+            <Group justify="space-between" mb="xs">
+              <Title order={5}>Root certificate authority</Title>
+              <Button
+                color="red"
+                variant="light"
+                onClick={() => setConfirmRotate(true)}
+                data-testid="rotate-ca"
+              >
+                Rotate CA…
+              </Button>
+            </Group>
+            {activeCa ? (
+              <Stack gap={4}>
+                <Text size="sm">
+                  <Text span fw={600}>
+                    CN:
+                  </Text>{' '}
+                  {activeCa.common_name || activeCa.name}
+                </Text>
+                <Text size="xs" c="dimmed" ff="monospace">
+                  {activeCa.fingerprint_sha256}
+                </Text>
+                <Text size="sm">
+                  Valid {fmtDate(activeCa.not_before)} → {fmtDate(activeCa.not_after)}
+                </Text>
+                <Text size="sm" c="dimmed">
+                  {activeCa.active_cert_count ?? 0} active · {activeCa.revoked_cert_count ?? 0}{' '}
+                  revoked device certs
+                </Text>
+              </Stack>
+            ) : (
+              <Text c="dimmed" data-testid="no-ca">
+                No active CA. Bootstrap one with <code>manage.py forgekey_ca init</code>.
+              </Text>
+            )}
+            {retired.length > 0 && (
+              <Text size="xs" c="dimmed" mt="sm">
+                {retired.length} retired CA(s) in history.
+              </Text>
+            )}
+          </Card>
+
+          <Paper withBorder>
+            <Group p="sm" justify="space-between">
+              <Title order={5}>Device certificates</Title>
+              <Text size="xs" c="dimmed">
+                Issued via enrollment · revoke in admin
+              </Text>
+            </Group>
+            {certs.length === 0 ? (
+              <Text c="dimmed" p="md" data-testid="certs-empty">
+                No device certificates issued yet.
+              </Text>
+            ) : (
+              <Table.ScrollContainer minWidth={720}>
+                <Table highlightOnHover>
+                  <Table.Thead>
+                    <Table.Tr>
+                      <Table.Th>Device</Table.Th>
+                      <Table.Th>Serial</Table.Th>
+                      <Table.Th>Expires</Table.Th>
+                      <Table.Th>Status</Table.Th>
+                    </Table.Tr>
+                  </Table.Thead>
+                  <Table.Tbody>
+                    {certs.map((c) => (
+                      <Table.Tr key={c.id} data-testid={`cert-${c.id}`}>
+                        <Table.Td>
+                          <Text size="sm">{c.device_chip_id || '—'}</Text>
+                          <Text size="xs" c="dimmed" ff="monospace" lineClamp={1}>
+                            {c.fingerprint_sha256}
+                          </Text>
+                        </Table.Td>
+                        <Table.Td>
+                          <Text size="sm" ff="monospace">
+                            {c.serial}
+                          </Text>
+                        </Table.Td>
+                        <Table.Td>
+                          <Text size="sm" c="dimmed">
+                            {fmtDate(c.not_after)}
+                          </Text>
+                        </Table.Td>
+                        <Table.Td>
+                          <Badge color={CERT_STATUS_COLORS[c.status] || 'gray'}>{c.status}</Badge>
+                        </Table.Td>
+                      </Table.Tr>
+                    ))}
+                  </Table.Tbody>
+                </Table>
+              </Table.ScrollContainer>
+            )}
+          </Paper>
+        </Stack>
+      )}
+
+      <Modal
+        opened={confirmRotate}
+        onClose={() => setConfirmRotate(false)}
+        title="Rotate the root CA?"
+      >
+        <Stack gap="sm">
+          <Text size="sm">
+            This mints a <strong>brand-new self-signed root CA</strong> and retires the current one.
+            Devices won&rsquo;t trust the new root until they&rsquo;re <strong>re-flashed</strong>{' '}
+            (or rebuilt via the firmware pipeline with the new CA embedded). This can&rsquo;t be
+            undone.
+          </Text>
+          <Group justify="flex-end">
+            <Button variant="default" onClick={() => setConfirmRotate(false)}>
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              loading={rotating}
+              onClick={handleRotate}
+              data-testid="rotate-ca-confirm"
+            >
+              Rotate root CA
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </WorkspacePage>
+  );
+};
+
+export default ForgeKeyCertificatesPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1916,6 +1916,34 @@ export interface ForgeKeyFirmwareBuild {
   completed_at: string | null;
 }
 
+export interface ForgeKeyCertificateAuthority {
+  id: string;
+  name: string;
+  common_name: string | null;
+  fingerprint_sha256: string | null;
+  not_before: string;
+  not_after: string;
+  is_active: boolean;
+  created_at: string;
+  active_cert_count: number | null;
+  revoked_cert_count: number | null;
+}
+
+export interface ForgeKeyDeviceCertificate {
+  id: string;
+  device: string | null;
+  device_chip_id: string | null;
+  serial: string;
+  subject: string;
+  fingerprint_sha256: string;
+  not_before: string;
+  not_after: string;
+  revoked_at: string | null;
+  issued_by: string;
+  created_at: string;
+  status: 'active' | 'expired' | 'revoked';
+}
+
 export interface ForgeKeyFirmwareRollout {
   id: string;
   firmware_version: string;
@@ -2042,6 +2070,20 @@ export const forgekeyAPI = {
   }) => api.post<ForgeKeyFirmwareBuild>('/forgekey/firmware-builds/', body),
   cancelFirmwareBuild: (id: string) =>
     api.post<ForgeKeyFirmwareBuild>(`/forgekey/firmware-builds/${id}/cancel/`),
+  // PKI: read-only certificate visibility + CA rotation (staff).
+  listCertificateAuthorities: () =>
+    api.get<{ results?: ForgeKeyCertificateAuthority[] } | ForgeKeyCertificateAuthority[]>(
+      '/forgekey/certificate-authorities/',
+    ),
+  listDeviceCertificates: () =>
+    api.get<{ results?: ForgeKeyDeviceCertificate[] } | ForgeKeyDeviceCertificate[]>(
+      '/forgekey/device-certificates/',
+    ),
+  rotateCA: (body?: { name?: string; common_name?: string; validity_years?: number }) =>
+    api.post<ForgeKeyCertificateAuthority>(
+      '/forgekey/certificate-authorities/rotate/',
+      body || {},
+    ),
   // Scan-to-log page: read the panel's recurring maintenance tasks (public)…
   getEPaperServiceInfo: (displayId: string) =>
     api.get<{


### PR DESCRIPTION
Closes parity gaps #5 (read-only certificate lifecycle) and #6 (rotate the CA from the UI). A staff **Certificates (PKI)** page under Facilities → ForgeKey.

## #5 — read-only visibility
- **Active CA** card: CN + SHA-256 fingerprint (parsed from the stored cert), validity window, and active/revoked device-cert counts.
- **Device certificates** table: chip id, serial, expiry, and lifecycle **status** (active / expired / revoked).
- Read-only — issuance stays in the enrollment flow, revocation in Django admin (as you specified).

## #6 — CA rotation
- A **Rotate CA** action (staff) behind a confirmation that spells out the consequence. Per your call, it mints a **brand-new self-signed root** and retires the prior one — devices are re-flashed/rebuilt to trust it anyway.
- Backend: a reusable `mint_ca` service (the `forgekey_ca init --force` logic) + a `rotate` action on `CertificateAuthorityViewSet`. Bootstrap stays CLI-only, as intended.

## API
`CertificateAuthorityViewSet` (read + `rotate`) and `DeviceCertificateViewSet` (read), both **staff-gated**.

## Testing
- Backend: `test_pki` 6 pass (CA read + fingerprint, device-cert status, rotate mints + retires the old, staff gating, validity validation); permission-matrix gate + bandit + black/isort/flake8 + `spectacular --validate` green.
- Frontend: certificates page 3 (read + rotate); full suite **710 pass**; eslint + build ✓.