### PR TITLE
feat(forgekey): device-type catalog management (#7a)

### DIFF
--- a/backend/forgekey/tests/test_device_types.py
+++ b/backend/forgekey/tests/test_device_types.py
@@ -1,0 +1,78 @@
+"""Tests for DeviceType management — reads open, writes staff-only.
+
+The device-type catalog is seeded by migrations, so management is mostly
+editing (rename / describe / activate) existing types; creating only matters
+when a new enum code is added. Both paths are staff-gated.
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+import pytest
+from rest_framework.test import APIClient
+
+from forgekey.models import DeviceType
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def _client(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def admin_api_client(admin_user):
+    return _client(admin_user)
+
+
+@pytest.fixture
+def member_api_client():
+    return _client(User.objects.create_user(username="m", email="m@example.com", password="x" * 20))
+
+
+class TestDeviceTypeManagement:
+    def test_authenticated_member_can_list(self, member_api_client):
+        resp = member_api_client.get(reverse("forgekey:device-type-list"))
+        assert resp.status_code == 200
+
+    def test_staff_can_rename_and_deactivate(self, admin_api_client):
+        dt = DeviceType.objects.first()  # seeded by migration
+        assert dt is not None
+        url = reverse("forgekey:device-type-detail", kwargs={"pk": dt.pk})
+        resp = admin_api_client.patch(
+            url, {"name": "Renamed Type ZZ", "is_active": False}, format="json"
+        )
+        assert resp.status_code == 200, resp.data
+        dt.refresh_from_db()
+        assert dt.name == "Renamed Type ZZ"
+        assert dt.is_active is False
+
+    def test_member_cannot_edit(self, member_api_client):
+        dt = DeviceType.objects.first()
+        url = reverse("forgekey:device-type-detail", kwargs={"pk": dt.pk})
+        resp = member_api_client.patch(url, {"is_active": False}, format="json")
+        assert resp.status_code == 403
+
+    def test_member_cannot_create(self, member_api_client):
+        DeviceType.objects.filter(code="ac_relay").delete()  # free the code; member still blocked
+        resp = member_api_client.post(
+            reverse("forgekey:device-type-list"),
+            {"name": "Member Relay", "code": "ac_relay"},
+            format="json",
+        )
+        assert resp.status_code == 403
+
+    def test_staff_can_create_a_freed_code(self, admin_api_client):
+        DeviceType.objects.filter(code="ac_relay").delete()
+        resp = admin_api_client.post(
+            reverse("forgekey:device-type-list"),
+            {"name": "Bench Relay", "code": "ac_relay", "description": "", "is_active": True},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.data
+        assert DeviceType.objects.filter(code="ac_relay", name="Bench Relay").exists()

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -752,6 +752,13 @@ class DeviceTypeViewSet(viewsets.ModelViewSet):
     serializer_class = DeviceTypeSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
 
+    def get_permissions(self):
+        # Reads stay open to authenticated users (the device + build forms need
+        # the type list); managing the lookup table itself is staff-only.
+        if self.action in ("create", "update", "partial_update", "destroy"):
+            return [IsAdminUser()]
+        return super().get_permissions()
+
 
 class ESP32DeviceViewSet(viewsets.ModelViewSet):
     """API endpoint for ESP32 devices."""

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,6 +43,7 @@ import ForgeKeyCertificatesPage from './pages/ForgeKeyCertificatesPage';
 import ForgeKeyDashboardPage from './pages/ForgeKeyDashboardPage';
 import ForgeKeyDeviceDetailPage from './pages/ForgeKeyDeviceDetailPage';
 import ForgeKeyDevicesPage from './pages/ForgeKeyDevicesPage';
+import ForgeKeyDeviceTypesPage from './pages/ForgeKeyDeviceTypesPage';
 import ForgeKeyEPaperBindPage from './pages/ForgeKeyEPaperBindPage';
 import ForgeKeyEPaperPanelsPage from './pages/ForgeKeyEPaperPanelsPage';
 import ForgeKeyEPaperServicePage from './pages/ForgeKeyEPaperServicePage';
@@ -232,6 +233,7 @@ function AppContent() {
           <Route path="/facilities/forgekey-epaper" element={<WorkspaceLayout><ForgeKeyEPaperPanelsPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-rollouts" element={<WorkspaceLayout><ForgeKeyFirmwareRolloutsPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-certificates" element={<WorkspaceLayout><ForgeKeyCertificatesPage /></WorkspaceLayout>} />
+          <Route path="/facilities/forgekey-device-types" element={<WorkspaceLayout><ForgeKeyDeviceTypesPage /></WorkspaceLayout>} />
           <Route path="/facilities/lockers" element={<WorkspaceLayout><LockersPage /></WorkspaceLayout>} />
           <Route path="/forgekey/epaper" element={<Navigate to="/facilities/forgekey-epaper" replace />} />
           <Route path="/forgekey/epaper/bind" element={<WorkspaceLayout><ForgeKeyEPaperBindPage /></WorkspaceLayout>} />

--- a/frontend/src/__tests__/pages/ForgeKeyDeviceTypesPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyDeviceTypesPage.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Tests for the ForgeKey device-types catalog page.
+ *
+ * Covers: non-staff redirect, the catalog table, the edit→save path, and the
+ * new-type modal opening.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ForgeKeyDeviceTypesPage from '../../pages/ForgeKeyDeviceTypesPage';
+import { forgekeyAPI } from '../../services/api';
+
+vi.mock('../../utils/dialogs', async () => ({
+  showError: jest.fn(),
+  showSuccess: jest.fn(),
+  showInfo: jest.fn(),
+}));
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    forgekeyAPI: {
+      ...(actual as any).forgekeyAPI,
+      listDeviceTypes: jest.fn(),
+      createDeviceType: jest.fn(),
+      updateDeviceType: jest.fn(),
+    },
+  };
+});
+
+const mockApi = forgekeyAPI as jest.Mocked<typeof forgekeyAPI>;
+
+const buildType = (overrides: Partial<any> = {}) => ({
+  id: 1,
+  name: 'Indicator',
+  code: 'indicator',
+  description: 'status light',
+  is_active: true,
+  ...overrides,
+});
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={['/facilities/forgekey-device-types']}>
+        <Routes>
+          <Route
+            path="/facilities/forgekey-device-types"
+            element={<ForgeKeyDeviceTypesPage />}
+          />
+          <Route path="/" element={<div>HOME</div>} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('ForgeKeyDeviceTypesPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockApi.listDeviceTypes.mockResolvedValue({ data: [buildType()] } as any);
+  });
+
+  test('non-staff users are redirected', async () => {
+    localStorage.setItem('is_staff', 'false');
+    localStorage.setItem('is_superuser', 'false');
+
+    renderPage();
+
+    expect(await screen.findByText('HOME')).toBeInTheDocument();
+    expect(mockApi.listDeviceTypes).not.toHaveBeenCalled();
+  });
+
+  test('staff sees the device-type catalog', async () => {
+    localStorage.setItem('is_staff', 'true');
+
+    renderPage();
+
+    expect(await screen.findByText('Indicator')).toBeInTheDocument();
+    expect(screen.getByText('indicator')).toBeInTheDocument();
+    expect(screen.getByTestId('type-1')).toBeInTheDocument();
+  });
+
+  test('editing a type saves via updateDeviceType', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockApi.updateDeviceType.mockResolvedValue({ data: buildType() } as any);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByTestId('edit-1'));
+    fireEvent.click(await screen.findByTestId('save-type'));
+
+    await waitFor(() =>
+      expect(mockApi.updateDeviceType).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ name: 'Indicator' }),
+      ),
+    );
+  });
+
+  test('the New type button opens the create modal', async () => {
+    localStorage.setItem('is_staff', 'true');
+
+    renderPage();
+
+    fireEvent.click(await screen.findByTestId('new-type'));
+
+    expect(await screen.findByText('New device type')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -115,6 +115,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed = false, isMobileOpen = f
         { path: '/facilities/logistics', label: 'Logistics', icon: '🚛' },
         { path: '/facilities/forgekey-dashboard', label: 'ForgeKey Dashboard', icon: '📊', requiresStaff: true },
         { path: '/facilities/forgekey-devices', label: 'ForgeKey Devices', icon: '📡', requiresStaff: true },
+        { path: '/facilities/forgekey-device-types', label: 'Device Types', icon: '🏷️', requiresStaff: true },
         { path: '/facilities/forgekey-epaper', label: 'e-Paper Panels', icon: '🖼️', requiresStaff: true },
         { path: '/facilities/forgekey-rollouts', label: 'Firmware Rollouts', icon: '🚀', requiresStaff: true },
         { path: '/facilities/forgekey-certificates', label: 'Certificates (PKI)', icon: '🔐', requiresStaff: true },

--- a/frontend/src/pages/FacilitiesOverviewPage.tsx
+++ b/frontend/src/pages/FacilitiesOverviewPage.tsx
@@ -88,6 +88,14 @@ const FacilitiesOverviewPage: React.FC = () => (
       testId="facilities-overview-card-/facilities/forgekey-devices"
     />
     <CapabilityCard
+      to="/facilities/forgekey-device-types"
+      title="Device types"
+      description="The ForgeKey device-type catalog — name, code, and active state."
+      icon={<IconKey size={22} stroke={1.8} />}
+      eyebrow="Access"
+      testId="facilities-overview-card-/facilities/forgekey-device-types"
+    />
+    <CapabilityCard
       to="/facilities/forgekey-epaper"
       title="e-Paper panels"
       description="PM status panels glued to machines — binding, battery, and refresh state."

--- a/frontend/src/pages/ForgeKeyDeviceTypesPage.tsx
+++ b/frontend/src/pages/ForgeKeyDeviceTypesPage.tsx
@@ -1,0 +1,278 @@
+/**
+ * ForgeKey Device Types — staff catalog management.
+ *
+ * The device-type lookup table (name, code, description, active). Reads are
+ * open; creating / editing is staff-only. The catalog is seeded, so this is
+ * mostly renaming / describing / (de)activating existing types; create covers
+ * a newly-added code.
+ */
+import {
+  Alert,
+  Badge,
+  Button,
+  Group,
+  Loader,
+  Modal,
+  Paper,
+  Select,
+  Stack,
+  Switch,
+  Table,
+  Text,
+  Textarea,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
+import { ForgeKeyDeviceType, forgekeyAPI } from '../services/api';
+import { showError, showSuccess } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+const asList = <T,>(data: { results?: T[] } | T[]): T[] =>
+  Array.isArray(data) ? data : (data.results ?? []);
+
+// Mirrors forgekey.models.DeviceType.TYPE_CHOICES (the code is a fixed enum).
+const CODE_OPTIONS = [
+  { value: 'indicator', label: 'Indicator/Status Light' },
+  { value: 'badge_reader', label: 'Badge Reader' },
+  { value: 'epaper_screen', label: 'E-Paper Screen' },
+  { value: 'oled_screen', label: 'OLED Screen' },
+  { value: 'temperature_sensor', label: 'Temperature Sensor' },
+  { value: 'generic_input', label: 'Generic Input' },
+  { value: 'generic_output', label: 'Generic Output' },
+  { value: 'ac_relay', label: 'AC Relay' },
+  { value: 'power_measurement', label: 'Power Measurement' },
+  { value: 'people_counter', label: 'People Counter' },
+  { value: 'env_sensor', label: 'Environmental Sensor' },
+  { value: 'door_counter', label: 'Door Counter' },
+  { value: 'locker_latch', label: 'Locker latch controller' },
+  { value: 'door_latch', label: 'Door latch controller' },
+  { value: 'otp_keypad', label: 'OTP keypad' },
+  { value: 'led_strip', label: 'WS2818 LED strip controller' },
+  { value: 'reed_switch', label: 'Door reed switch' },
+  { value: 'ir_break', label: 'Inventory IR-break sensor' },
+  { value: 'mortise_key', label: 'Mortise key (admin override) sensor' },
+];
+
+const ForgeKeyDeviceTypesPage: React.FC = () => {
+  const isStaff = typeof window !== 'undefined' && localStorage.getItem('is_staff') === 'true';
+  const isSuperuser =
+    typeof window !== 'undefined' && localStorage.getItem('is_superuser') === 'true';
+
+  const [types, setTypes] = useState<ForgeKeyDeviceType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [isNew, setIsNew] = useState(false);
+  const [editing, setEditing] = useState<ForgeKeyDeviceType | null>(null);
+  const [formName, setFormName] = useState('');
+  const [formCode, setFormCode] = useState<string | null>(null);
+  const [formDescription, setFormDescription] = useState('');
+  const [formActive, setFormActive] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await forgekeyAPI.listDeviceTypes();
+      setTypes(asList(res.data));
+      setError(null);
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to load device types.'));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isStaff || isSuperuser) load();
+  }, [isStaff, isSuperuser, load]);
+
+  if (!isStaff && !isSuperuser) {
+    return <Navigate to="/" replace />;
+  }
+
+  const openCreate = () => {
+    setIsNew(true);
+    setEditing(null);
+    setFormName('');
+    setFormCode(null);
+    setFormDescription('');
+    setFormActive(true);
+    setModalOpen(true);
+  };
+
+  const openEdit = (t: ForgeKeyDeviceType) => {
+    setIsNew(false);
+    setEditing(t);
+    setFormName(t.name);
+    setFormCode(t.code);
+    setFormDescription(t.description ?? '');
+    setFormActive(t.is_active ?? true);
+    setModalOpen(true);
+  };
+
+  const handleSave = async () => {
+    if (!formName.trim() || (isNew && !formCode)) {
+      showError('Name (and a code for a new type) are required.');
+      return;
+    }
+    setSaving(true);
+    try {
+      if (isNew && formCode) {
+        await forgekeyAPI.createDeviceType({
+          name: formName.trim(),
+          code: formCode,
+          description: formDescription,
+          is_active: formActive,
+        });
+        showSuccess('Device type created.');
+      } else if (editing) {
+        await forgekeyAPI.updateDeviceType(editing.id, {
+          name: formName.trim(),
+          description: formDescription,
+          is_active: formActive,
+        });
+        showSuccess('Device type updated.');
+      }
+      setModalOpen(false);
+      await load();
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Failed to save the device type.'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <WorkspacePage
+      testId="forgekey-device-types-page"
+      hero={{
+        eyebrow: 'Facilities · ForgeKey',
+        title: 'Device types',
+        description: 'The device-type catalog — name, code, and whether a type is in use.',
+      }}
+    >
+      {error && (
+        <Alert color="red" variant="light" data-testid="types-error">
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Group justify="center" p="xl">
+          <Loader />
+        </Group>
+      ) : (
+        <Paper withBorder>
+          <Group p="sm" justify="space-between">
+            <Title order={5}>Device types</Title>
+            <Button onClick={openCreate} data-testid="new-type">
+              New type
+            </Button>
+          </Group>
+          <Table.ScrollContainer minWidth={640}>
+            <Table highlightOnHover>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Name</Table.Th>
+                  <Table.Th>Code</Table.Th>
+                  <Table.Th>Description</Table.Th>
+                  <Table.Th>Status</Table.Th>
+                  <Table.Th />
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {types.map((t) => (
+                  <Table.Tr key={t.id} data-testid={`type-${t.id}`}>
+                    <Table.Td>
+                      <Text fw={500}>{t.name}</Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="sm" ff="monospace">
+                        {t.code}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="sm" c="dimmed" lineClamp={1}>
+                        {t.description || '—'}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge color={t.is_active === false ? 'gray' : 'green'}>
+                        {t.is_active === false ? 'Inactive' : 'Active'}
+                      </Badge>
+                    </Table.Td>
+                    <Table.Td>
+                      <Button
+                        size="xs"
+                        variant="light"
+                        onClick={() => openEdit(t)}
+                        data-testid={`edit-${t.id}`}
+                      >
+                        Edit
+                      </Button>
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          </Table.ScrollContainer>
+        </Paper>
+      )}
+
+      <Modal
+        opened={modalOpen}
+        onClose={() => setModalOpen(false)}
+        title={isNew ? 'New device type' : `Edit ${editing?.name ?? ''}`}
+      >
+        <Stack gap="sm">
+          {isNew ? (
+            <Select
+              label="Code"
+              required
+              searchable
+              data={CODE_OPTIONS}
+              value={formCode}
+              onChange={setFormCode}
+              description="The device-type code (fixed enum)"
+            />
+          ) : (
+            <TextInput label="Code" value={formCode ?? ''} disabled />
+          )}
+          <TextInput
+            label="Name"
+            required
+            value={formName}
+            onChange={(e) => setFormName(e.currentTarget.value)}
+            data-testid="type-name"
+          />
+          <Textarea
+            label="Description"
+            autosize
+            minRows={2}
+            value={formDescription}
+            onChange={(e) => setFormDescription(e.currentTarget.value)}
+          />
+          <Switch
+            label="Active"
+            checked={formActive}
+            onChange={(e) => setFormActive(e.currentTarget.checked)}
+          />
+          <Group justify="flex-end">
+            <Button variant="default" onClick={() => setModalOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} loading={saving} data-testid="save-type">
+              {isNew ? 'Create' : 'Save'}
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </WorkspacePage>
+  );
+};
+
+export default ForgeKeyDeviceTypesPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1885,6 +1885,8 @@ export interface ForgeKeyDeviceType {
   id: number;
   name: string;
   code: string;
+  description?: string;
+  is_active?: boolean;
 }
 
 export type ForgeKeyFirmwareBuildStatus =
@@ -2056,6 +2058,14 @@ export const forgekeyAPI = {
   // Firmware build pipeline (self-hosted build worker).
   listDeviceTypes: () =>
     api.get<{ results?: ForgeKeyDeviceType[] } | ForgeKeyDeviceType[]>('/forgekey/device-types/'),
+  createDeviceType: (data: {
+    name: string;
+    code: string;
+    description?: string;
+    is_active?: boolean;
+  }) => api.post<ForgeKeyDeviceType>('/forgekey/device-types/', data),
+  updateDeviceType: (id: number, data: Partial<ForgeKeyDeviceType>) =>
+    api.patch<ForgeKeyDeviceType>(`/forgekey/device-types/${id}/`, data),
   listFirmwareBuilds: () =>
     api.get<{ results?: ForgeKeyFirmwareBuild[] } | ForgeKeyFirmwareBuild[]>(
       '/forgekey/firmware-builds/',


### PR DESCRIPTION
First slice of parity gap #7 — a staff **Device types** page (Facilities → ForgeKey → Device Types) for the device-type catalog. The catalog is seeded, so management is mostly **rename / describe / (de)activate**; create covers a newly-added enum code.

## Backend
- `DeviceTypeViewSet` writes (create / update / destroy) tightened to **staff** via `get_permissions`; reads stay open to authenticated users (the device + firmware-build forms need the type list).

## Frontend
- A table (name · code · description · status) with an **Edit** modal (name / description / active) and a **New type** modal (code picker from the fixed enum).
- `api.ts`: `createDeviceType` / `updateDeviceType`; `ForgeKeyDeviceType` gains `description` / `is_active`. Sidebar + facilities-overview nav.

## Testing
- Backend: `test_device_types` 5 pass (staff edit/create, member blocked on writes, list open). Permission-matrix gate + lint + OpenAPI green.
- Frontend: device-types page 4; full suite **714 pass**; eslint + build ✓.

Next: #7b — surface `AssetAuthorization` / `DeviceLockout` / `OperationalMode` on the **Asset detail page** (asset-centric, per your scope call).