### PR TITLE
feat(forgekey): asset access controls on the asset detail page (#7b)

### DIFF
--- a/backend/forgekey/tests/test_asset_access_filtering.py
+++ b/backend/forgekey/tests/test_asset_access_filtering.py
@@ -1,0 +1,85 @@
+"""Asset-scoped filtering for the ForgeKey access viewsets (operational mode,
+authorizations, lockouts).
+
+Added for #7b so the asset detail page can fetch just the records for the
+asset it's showing via ``?asset=<id>`` (plus ``?is_active=`` for the
+authorization/lockout lists).
+"""
+
+import pytest
+from rest_framework.test import APIClient
+
+from forgekey.tests.factories import (
+    AssetAuthorizationFactory,
+    DeviceLockoutFactory,
+    OperationalModeFactory,
+)
+from inventory.tests.factories import AssetFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def client(admin_user):
+    api = APIClient()
+    api.force_authenticate(user=admin_user)
+    return api
+
+
+def _results(response):
+    body = response.json()
+    return body["results"] if isinstance(body, dict) and "results" in body else body
+
+
+class TestOperationalModeAssetFilter:
+    def test_filters_to_single_asset(self, client):
+        asset = AssetFactory()
+        OperationalModeFactory(asset=asset)
+        OperationalModeFactory(asset=AssetFactory())  # unrelated asset
+
+        resp = client.get(f"/api/forgekey/operational-modes/?asset={asset.id}")
+        assert resp.status_code == 200, resp.data
+        results = _results(resp)
+        assert len(results) == 1
+        assert str(results[0]["asset"]) == str(asset.id)
+
+    def test_no_filter_returns_all(self, client):
+        OperationalModeFactory()
+        OperationalModeFactory()
+        resp = client.get("/api/forgekey/operational-modes/")
+        assert resp.status_code == 200
+        assert len(_results(resp)) == 2
+
+
+class TestAuthorizationAssetFilter:
+    def test_filters_by_asset_and_is_active(self, client):
+        asset = AssetFactory()
+        AssetAuthorizationFactory(asset=asset, is_active=True)
+        AssetAuthorizationFactory(asset=asset, is_active=False)
+        AssetAuthorizationFactory(asset=AssetFactory(), is_active=True)  # unrelated
+
+        resp = client.get(f"/api/forgekey/authorizations/?asset={asset.id}")
+        assert resp.status_code == 200
+        assert len(_results(resp)) == 2  # both of this asset's, regardless of active
+
+        active = client.get(f"/api/forgekey/authorizations/?asset={asset.id}&is_active=true")
+        results = _results(active)
+        assert len(results) == 1
+        assert results[0]["is_active"] is True
+
+
+class TestLockoutAssetFilter:
+    def test_filters_by_asset_and_is_active(self, client):
+        asset = AssetFactory()
+        DeviceLockoutFactory(asset=asset, is_active=True)
+        DeviceLockoutFactory(asset=asset, is_active=False)
+        DeviceLockoutFactory(asset=AssetFactory(), is_active=True)  # unrelated
+
+        resp = client.get(f"/api/forgekey/lockouts/?asset={asset.id}")
+        assert resp.status_code == 200
+        assert len(_results(resp)) == 2
+
+        active = client.get(f"/api/forgekey/lockouts/?asset={asset.id}&is_active=1")
+        results = _results(active)
+        assert len(results) == 1
+        assert results[0]["is_active"] is True

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -1342,6 +1342,15 @@ class OperationalModeViewSet(viewsets.ModelViewSet):
     serializer_class = OperationalModeSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
 
+    def get_queryset(self):
+        """Allow ``?asset=<id>`` so the asset detail page can fetch just the
+        single OperationalMode (if any) for the asset it's showing."""
+        qs = super().get_queryset()
+        asset_id = self.request.query_params.get("asset")
+        if asset_id:
+            qs = qs.filter(asset_id=asset_id)
+        return qs
+
     @action(detail=True, methods=["post"])
     def enable_classroom_mode(self, request, pk=None):
         """Enable classroom mode for an asset."""
@@ -1392,6 +1401,19 @@ class AssetAuthorizationViewSet(viewsets.ModelViewSet):
     queryset = AssetAuthorization.objects.select_related("asset", "user", "authorized_by").all()
     serializer_class = AssetAuthorizationSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
+
+    def get_queryset(self):
+        """Support ``?asset=<id>`` and ``?is_active=<bool>`` so the asset
+        detail page can list just that asset's authorizations (typically the
+        active ones)."""
+        qs = super().get_queryset()
+        asset_id = self.request.query_params.get("asset")
+        if asset_id:
+            qs = qs.filter(asset_id=asset_id)
+        is_active = self.request.query_params.get("is_active")
+        if is_active is not None:
+            qs = qs.filter(is_active=is_active.lower() in ("1", "true", "yes"))
+        return qs
 
     def perform_create(self, serializer):
         """Set authorized_by to current user when creating authorization."""
@@ -1499,6 +1521,19 @@ class DeviceLockoutViewSet(viewsets.ModelViewSet):
     queryset = DeviceLockout.objects.select_related("asset", "locked_by", "unlocked_by").all()
     serializer_class = DeviceLockoutSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
+
+    def get_queryset(self):
+        """Support ``?asset=<id>`` and ``?is_active=<bool>`` so the asset
+        detail page can list just that asset's lockouts (typically the active
+        ones)."""
+        qs = super().get_queryset()
+        asset_id = self.request.query_params.get("asset")
+        if asset_id:
+            qs = qs.filter(asset_id=asset_id)
+        is_active = self.request.query_params.get("is_active")
+        if is_active is not None:
+            qs = qs.filter(is_active=is_active.lower() in ("1", "true", "yes"))
+        return qs
 
     def perform_create(self, serializer):
         """Create a lockout and determine the lockout level."""

--- a/frontend/src/__tests__/components/AssetForgeKeyAccessCard.test.tsx
+++ b/frontend/src/__tests__/components/AssetForgeKeyAccessCard.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Tests for the ForgeKey access controls surfaced on the asset detail page
+ * (#7b): operational mode + classroom toggle, authorizations (revoke), and
+ * lockouts (unlock).
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import AssetForgeKeyAccessCard from '../../components/AssetForgeKeyAccessCard';
+import { forgekeyAPI } from '../../services/api';
+
+vi.mock('../../utils/dialogs', async () => ({
+  showError: jest.fn(),
+  showSuccess: jest.fn(),
+  // Auto-confirm so the revoke/unlock action paths run in tests.
+  confirmAction: (_t: string, _m: string, onConfirm: () => void) => onConfirm(),
+}));
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    forgekeyAPI: {
+      ...(actual as any).forgekeyAPI,
+      listOperationalModes: jest.fn(),
+      listAuthorizations: jest.fn(),
+      listLockouts: jest.fn(),
+      enableClassroomMode: jest.fn(),
+      disableClassroomMode: jest.fn(),
+      revokeAuthorization: jest.fn(),
+      unlockLockout: jest.fn(),
+    },
+  };
+});
+
+const mockApi = forgekeyAPI as jest.Mocked<typeof forgekeyAPI>;
+
+const buildMode = (overrides: Partial<any> = {}) => ({
+  id: 1,
+  asset: 'a1',
+  asset_name: 'Table Saw',
+  mode: 'classroom',
+  classroom_mode_enabled: false,
+  classroom_mode_enabled_by: null,
+  classroom_mode_enabled_by_username: null,
+  classroom_mode_enabled_at: null,
+  updated_at: '2026-06-01T00:00:00Z',
+  ...overrides,
+});
+
+const buildAuth = (overrides: Partial<any> = {}) => ({
+  id: 10,
+  asset: 'a1',
+  asset_name: 'Table Saw',
+  user: 5,
+  username: 'alice',
+  authorized_by: 2,
+  authorized_by_username: 'bob',
+  authorized_at: '2026-06-01T00:00:00Z',
+  is_active: true,
+  notes: '',
+  ...overrides,
+});
+
+const buildLockout = (overrides: Partial<any> = {}) => ({
+  id: 'l1',
+  asset: 'a1',
+  asset_name: 'Table Saw',
+  locked_by: 3,
+  locked_by_username: 'carol',
+  lockout_level: 'user',
+  reason: 'Blade guard missing',
+  locked_at: '2026-06-01T00:00:00Z',
+  unlocked_at: null,
+  unlocked_by: null,
+  unlocked_by_username: null,
+  is_active: true,
+  ...overrides,
+});
+
+const renderCard = (assetId = 'a1') =>
+  render(
+    <MantineProvider>
+      <AssetForgeKeyAccessCard assetId={assetId} />
+    </MantineProvider>,
+  );
+
+describe('AssetForgeKeyAccessCard', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders nothing for an asset with no ForgeKey data', async () => {
+    mockApi.listOperationalModes.mockResolvedValue({ data: [] } as any);
+    mockApi.listAuthorizations.mockResolvedValue({ data: [] } as any);
+    mockApi.listLockouts.mockResolvedValue({ data: [] } as any);
+
+    renderCard();
+    await waitFor(() => expect(mockApi.listOperationalModes).toHaveBeenCalledWith('a1'));
+    expect(screen.queryByTestId('asset-forgekey-access')).not.toBeInTheDocument();
+  });
+
+  it('renders mode, authorizations, and lockouts', async () => {
+    mockApi.listOperationalModes.mockResolvedValue({ data: [buildMode()] } as any);
+    mockApi.listAuthorizations.mockResolvedValue({ data: [buildAuth()] } as any);
+    mockApi.listLockouts.mockResolvedValue({ data: [buildLockout()] } as any);
+
+    renderCard();
+    await screen.findByTestId('asset-forgekey-access');
+    expect(screen.getByTestId('operational-mode-badge')).toHaveTextContent('classroom');
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('carol · user')).toBeInTheDocument();
+    expect(screen.getByText('Enable classroom mode')).toBeInTheDocument();
+    expect(screen.getByText('Revoke')).toBeInTheDocument();
+    expect(screen.getByText('Unlock')).toBeInTheDocument();
+  });
+
+  it('enables classroom mode', async () => {
+    mockApi.listOperationalModes.mockResolvedValue({ data: [buildMode()] } as any);
+    mockApi.listAuthorizations.mockResolvedValue({ data: [] } as any);
+    mockApi.listLockouts.mockResolvedValue({ data: [] } as any);
+    mockApi.enableClassroomMode.mockResolvedValue({} as any);
+
+    renderCard();
+    fireEvent.click(await screen.findByText('Enable classroom mode'));
+    await waitFor(() => expect(mockApi.enableClassroomMode).toHaveBeenCalledWith(1));
+  });
+
+  it('revokes an authorization (after confirm)', async () => {
+    mockApi.listOperationalModes.mockResolvedValue({ data: [] } as any);
+    mockApi.listAuthorizations.mockResolvedValue({ data: [buildAuth()] } as any);
+    mockApi.listLockouts.mockResolvedValue({ data: [] } as any);
+    mockApi.revokeAuthorization.mockResolvedValue({} as any);
+
+    renderCard();
+    fireEvent.click(await screen.findByText('Revoke'));
+    await waitFor(() => expect(mockApi.revokeAuthorization).toHaveBeenCalledWith(10));
+  });
+});

--- a/frontend/src/components/AssetForgeKeyAccessCard.tsx
+++ b/frontend/src/components/AssetForgeKeyAccessCard.tsx
@@ -1,0 +1,245 @@
+/**
+ * AssetForgeKeyAccessCard
+ *
+ * Surfaces the ForgeKey access controls for a single inventory Asset on the
+ * asset detail page (#7b):
+ *  - Operational mode + classroom-mode toggle (enable / disable)
+ *  - Authorized users, each revocable
+ *  - Active device lockouts, each unlockable (server enforces the unlock
+ *    permission hierarchy; a 403 surfaces as an error toast)
+ *
+ * The card renders nothing for assets that have no ForgeKey relationship (no
+ * operational mode, no active authorizations, no active lockouts), so it's a
+ * no-op on ordinary inventory assets.
+ */
+import { Badge, Button, Card, Group, Stack, Text } from '@mantine/core';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  ForgeKeyAssetAuthorization,
+  ForgeKeyDeviceLockout,
+  ForgeKeyOperationalMode,
+  forgekeyAPI,
+} from '../services/api';
+import { confirmAction, showError, showSuccess } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+interface Props {
+  assetId: string;
+}
+
+function unwrap<T>(data: { results?: T[] } | T[]): T[] {
+  if (Array.isArray(data)) return data;
+  return data.results ?? [];
+}
+
+const MODE_COLORS: Record<string, string> = {
+  available: 'green',
+  classroom: 'blue',
+  maintenance: 'yellow',
+  locked_out: 'red',
+};
+
+export default function AssetForgeKeyAccessCard({ assetId }: Props) {
+  const [mode, setMode] = useState<ForgeKeyOperationalMode | null>(null);
+  const [auths, setAuths] = useState<ForgeKeyAssetAuthorization[]>([]);
+  const [lockouts, setLockouts] = useState<ForgeKeyDeviceLockout[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const [modeRes, authRes, lockRes] = await Promise.all([
+        forgekeyAPI.listOperationalModes(assetId),
+        forgekeyAPI.listAuthorizations(assetId, { activeOnly: true }),
+        forgekeyAPI.listLockouts(assetId, { activeOnly: true }),
+      ]);
+      const modes = unwrap<ForgeKeyOperationalMode>(modeRes.data);
+      setMode(modes.length > 0 ? modes[0] : null);
+      setAuths(unwrap<ForgeKeyAssetAuthorization>(authRes.data));
+      setLockouts(unwrap<ForgeKeyDeviceLockout>(lockRes.data));
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Failed to load device access controls.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [assetId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const run = async (key: string, fn: () => Promise<unknown>, success: string) => {
+    setBusy(key);
+    try {
+      await fn();
+      showSuccess(success);
+      await load();
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Action failed.'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (loading) return null;
+  if (!mode && auths.length === 0 && lockouts.length === 0) return null;
+
+  return (
+    <Card withBorder radius="md" p="md" data-testid="asset-forgekey-access">
+      <Text fw={600}>Device access and modes</Text>
+      <Text size="xs" c="dimmed" mb="md">
+        ForgeKey access controls for this asset.
+      </Text>
+
+      <Stack gap="lg">
+        {mode && (
+          <div>
+            <Group gap="xs" mb="xs">
+              <Text size="sm" fw={500}>
+                Operational mode
+              </Text>
+              <Badge
+                color={MODE_COLORS[mode.mode] ?? 'gray'}
+                data-testid="operational-mode-badge"
+              >
+                {mode.mode.replace('_', ' ')}
+              </Badge>
+            </Group>
+            {mode.classroom_mode_enabled ? (
+              <>
+                <Button
+                  size="xs"
+                  variant="light"
+                  loading={busy === 'classroom'}
+                  onClick={() =>
+                    run(
+                      'classroom',
+                      () => forgekeyAPI.disableClassroomMode(mode.id),
+                      'Classroom mode disabled.',
+                    )
+                  }
+                >
+                  Disable classroom mode
+                </Button>
+                {mode.classroom_mode_enabled_by_username && (
+                  <Text size="xs" c="dimmed" mt={4}>
+                    Enabled by {mode.classroom_mode_enabled_by_username}
+                  </Text>
+                )}
+              </>
+            ) : (
+              <Button
+                size="xs"
+                variant="light"
+                loading={busy === 'classroom'}
+                onClick={() =>
+                  run(
+                    'classroom',
+                    () => forgekeyAPI.enableClassroomMode(mode.id),
+                    'Classroom mode enabled.',
+                  )
+                }
+              >
+                Enable classroom mode
+              </Button>
+            )}
+          </div>
+        )}
+
+        <div>
+          <Text size="sm" fw={500} mb="xs">
+            Authorized users ({auths.length})
+          </Text>
+          {auths.length === 0 ? (
+            <Text size="xs" c="dimmed">
+              No active authorizations.
+            </Text>
+          ) : (
+            <Stack gap="xs">
+              {auths.map((a) => (
+                <Group key={a.id} justify="space-between" wrap="nowrap">
+                  <div>
+                    <Text size="sm">{a.username}</Text>
+                    {a.authorized_by_username && (
+                      <Text size="xs" c="dimmed">
+                        by {a.authorized_by_username}
+                      </Text>
+                    )}
+                  </div>
+                  <Button
+                    size="xs"
+                    variant="light"
+                    color="red"
+                    loading={busy === `revoke-${a.id}`}
+                    onClick={() =>
+                      confirmAction(
+                        'Revoke authorization',
+                        `Revoke ${a.username}'s access to this asset?`,
+                        () =>
+                          run(
+                            `revoke-${a.id}`,
+                            () => forgekeyAPI.revokeAuthorization(a.id),
+                            'Authorization revoked.',
+                          ),
+                        { color: 'red' },
+                      )
+                    }
+                  >
+                    Revoke
+                  </Button>
+                </Group>
+              ))}
+            </Stack>
+          )}
+        </div>
+
+        <div>
+          <Text size="sm" fw={500} mb="xs">
+            Active lockouts ({lockouts.length})
+          </Text>
+          {lockouts.length === 0 ? (
+            <Text size="xs" c="dimmed">
+              No active lockouts.
+            </Text>
+          ) : (
+            <Stack gap="xs">
+              {lockouts.map((l) => (
+                <Group key={l.id} justify="space-between" wrap="nowrap">
+                  <div>
+                    <Text size="sm">
+                      {l.locked_by_username ?? 'unknown'} · {l.lockout_level}
+                    </Text>
+                    {l.reason && (
+                      <Text size="xs" c="dimmed">
+                        {l.reason}
+                      </Text>
+                    )}
+                  </div>
+                  <Button
+                    size="xs"
+                    variant="light"
+                    loading={busy === `unlock-${l.id}`}
+                    onClick={() =>
+                      confirmAction(
+                        'Unlock device',
+                        'Clear this lockout? You must have sufficient permissions.',
+                        () =>
+                          run(
+                            `unlock-${l.id}`,
+                            () => forgekeyAPI.unlockLockout(l.id),
+                            'Lockout cleared.',
+                          ),
+                      )
+                    }
+                  >
+                    Unlock
+                  </Button>
+                </Group>
+              ))}
+            </Stack>
+          )}
+        </div>
+      </Stack>
+    </Card>
+  );
+}

--- a/frontend/src/pages/AssetDetailPage.tsx
+++ b/frontend/src/pages/AssetDetailPage.tsx
@@ -5,6 +5,7 @@
 import { Badge, Button, Group, Paper, Text } from '@mantine/core';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import AssetForgeKeyAccessCard from '../components/AssetForgeKeyAccessCard';
 import MaintenanceHistorySection from '../components/assets/MaintenanceHistorySection';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import {
@@ -1001,6 +1002,12 @@ const AssetDetailPage: React.FC = () => {
             canManage={isLoggedIn && localStorage.getItem('is_staff') === 'true'}
           />
         )}
+
+        {id &&
+          (localStorage.getItem('is_staff') === 'true' ||
+            localStorage.getItem('is_superuser') === 'true') && (
+            <AssetForgeKeyAccessCard assetId={id} />
+          )}
 
         {id &&
           (localStorage.getItem('is_staff') === 'true' ||

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1966,6 +1966,46 @@ export interface ForgeKeyFirmwareRollout {
   dispatched?: number;
 }
 
+export interface ForgeKeyOperationalMode {
+  id: number;
+  asset: string;
+  asset_name: string;
+  mode: 'available' | 'classroom' | 'maintenance' | 'locked_out';
+  classroom_mode_enabled: boolean;
+  classroom_mode_enabled_by: number | null;
+  classroom_mode_enabled_by_username: string | null;
+  classroom_mode_enabled_at: string | null;
+  updated_at: string;
+}
+
+export interface ForgeKeyAssetAuthorization {
+  id: number;
+  asset: string;
+  asset_name: string;
+  user: number;
+  username: string;
+  authorized_by: number | null;
+  authorized_by_username: string | null;
+  authorized_at: string;
+  is_active: boolean;
+  notes: string;
+}
+
+export interface ForgeKeyDeviceLockout {
+  id: string;
+  asset: string;
+  asset_name: string;
+  locked_by: number | null;
+  locked_by_username: string | null;
+  lockout_level: string;
+  reason: string;
+  locked_at: string;
+  unlocked_at: string | null;
+  unlocked_by: number | null;
+  unlocked_by_username: string | null;
+  is_active: boolean;
+}
+
 export const forgekeyAPI = {
   listDevices: (opts: { capability?: string } = {}) =>
     api.get<{ results?: ForgeKeyDevice[] } | ForgeKeyDevice[]>('/forgekey/devices/', {
@@ -1984,6 +2024,38 @@ export const forgekeyAPI = {
   retireDevice: (id: string) => api.post<ForgeKeyDevice>(`/forgekey/devices/${id}/retire/`),
   reactivateDevice: (id: string) => api.post<ForgeKeyDevice>(`/forgekey/devices/${id}/reactivate/`),
   deleteDevice: (id: string) => api.delete(`/forgekey/devices/${id}/`),
+  // Asset access controls (#7b): operational mode + authorizations + lockouts,
+  // surfaced on the asset detail page. All keyed to an inventory Asset id.
+  listOperationalModes: (assetId: string) =>
+    api.get<{ results?: ForgeKeyOperationalMode[] } | ForgeKeyOperationalMode[]>(
+      '/forgekey/operational-modes/',
+      { params: { asset: assetId } },
+    ),
+  enableClassroomMode: (id: number) =>
+    api.post<ForgeKeyOperationalMode>(
+      `/forgekey/operational-modes/${id}/enable_classroom_mode/`,
+    ),
+  disableClassroomMode: (id: number) =>
+    api.post<ForgeKeyOperationalMode>(
+      `/forgekey/operational-modes/${id}/disable_classroom_mode/`,
+    ),
+  listAuthorizations: (assetId: string, opts: { activeOnly?: boolean } = {}) =>
+    api.get<{ results?: ForgeKeyAssetAuthorization[] } | ForgeKeyAssetAuthorization[]>(
+      '/forgekey/authorizations/',
+      { params: { asset: assetId, ...(opts.activeOnly ? { is_active: 'true' } : {}) } },
+    ),
+  revokeAuthorization: (id: number, notes?: string) =>
+    api.post<ForgeKeyAssetAuthorization>(
+      `/forgekey/authorizations/${id}/revoke/`,
+      notes ? { notes } : {},
+    ),
+  listLockouts: (assetId: string, opts: { activeOnly?: boolean } = {}) =>
+    api.get<{ results?: ForgeKeyDeviceLockout[] } | ForgeKeyDeviceLockout[]>(
+      '/forgekey/lockouts/',
+      { params: { asset: assetId, ...(opts.activeOnly ? { is_active: 'true' } : {}) } },
+    ),
+  unlockLockout: (id: string) =>
+    api.post<ForgeKeyDeviceLockout>(`/forgekey/lockouts/${id}/unlock/`),
   getOccupancy: (id: string, since: string = '24h') =>
     api.get<ForgeKeyOccupancyResponse>(`/forgekey/devices/${id}/occupancy/`, {
       params: { since },


### PR DESCRIPTION
## What

Completes #7 (after #654's DeviceType page): surfaces the ForgeKey **access controls** for an inventory Asset directly on its **detail page** (staff-gated), so an operator can see and manage them without leaving the asset.

| Control | Action |
|---|---|
| **Operational mode** | shows current mode; toggle **classroom mode** on/off |
| **Authorized users** | lists active authorizations; **revoke** each (confirmed) |
| **Active lockouts** | lists active device lockouts; **unlock** each — server enforces the unlock permission hierarchy (a 403 surfaces as a toast) |

The reused backend actions (`revoke`, `enable_classroom_mode` / `disable_classroom_mode`, `unlock`) already existed; this PR makes them reachable from the asset page.

## Backend

The `OperationalMode` / `AssetAuthorization` / `DeviceLockout` viewsets gain **`?asset=<id>`** filtering (plus **`?is_active=`** on the authorization/lockout lists) so the page fetches just one asset's records. Backward-compatible — no query param returns the full list exactly as before, so existing consumers and tests are unchanged.

## Frontend

- **`AssetForgeKeyAccessCard`** — fetches the three lists for the asset and **renders nothing** when the asset has no ForgeKey relationship (no operational mode, no active authorizations, no active lockouts), so it's a no-op on ordinary inventory assets. Mirrors `DeviceLifecycleCard` (Mantine `Card` + action buttons + `confirmAction` + success/error toasts).
- **`api.ts`** — 3 types (`ForgeKeyOperationalMode` / `ForgeKeyAssetAuthorization` / `ForgeKeyDeviceLockout`) + 7 `forgekeyAPI` methods (list/enable/disable classroom, list/revoke authorizations, list/unlock lockouts).
- Wired into `AssetDetailPage` after the Maintenance section, gated to staff/superuser (same gate as the Power section).

## Tests / verification

- **Backend:** new `test_asset_access_filtering.py` — `?asset=` and `?is_active=` filtering across all three viewsets; the audit-events suite still passes. black / isort / flake8 clean.
- **Frontend:** new `AssetForgeKeyAccessCard.test.tsx` — empty-asset → no card; full render (mode badge + users + lockouts); enable-classroom and revoke (auto-confirmed) action paths. `npm run build` ✓, eslint ✓, existing `AssetDetailPage` suite (17 tests) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)