### PR TITLE
feat(forgekey): notify the build requester when a firmware build finishes

### DIFF
--- a/backend/forgekey/services/firmware_build.py
+++ b/backend/forgekey/services/firmware_build.py
@@ -75,6 +75,46 @@ def _truncate(text: str) -> str:
     return text if len(text) <= _LOG_TAIL_LIMIT else text[-_LOG_TAIL_LIMIT:]
 
 
+def _notify_requester(build, *, succeeded: bool) -> None:
+    """Notify the user who queued a build that it finished.
+
+    Best-effort and in-app (the notifications surface the frontend already
+    polls): a notification failure must never mask the recorded build outcome.
+    """
+    requester = build.requested_by
+    if requester is None:
+        return
+    try:
+        from notifications.services import create_notification
+
+        if succeeded:
+            create_notification(
+                user=requester,
+                type="success",
+                title="Firmware build succeeded",
+                message=(
+                    f"{build.pio_env} {build.version} built successfully and is "
+                    "ready to roll out."
+                ),
+                action_url="/facilities/forgekey-rollouts",
+                metadata={"build_id": str(build.pk), "kind": "firmware_build_succeeded"},
+            )
+        else:
+            create_notification(
+                user=requester,
+                type="error",
+                title="Firmware build failed",
+                message=(
+                    f"{build.pio_env} {build.version} failed to build: "
+                    f"{build.error_message or 'see the build log'}"
+                ),
+                action_url="/facilities/forgekey-rollouts",
+                metadata={"build_id": str(build.pk), "kind": "firmware_build_failed"},
+            )
+    except Exception:  # noqa: BLE001 — notification delivery must not break build recording
+        logger.exception("Failed to notify %s about firmware build %s", requester, build.pk)
+
+
 def run_firmware_build(build_id: str) -> dict:
     """Execute a :class:`~forgekey.models.FirmwareBuild` end to end.
 
@@ -140,6 +180,7 @@ def run_firmware_build(build_id: str) -> dict:
         build.completed_at = timezone.now()
         build.log = _truncate("\n".join(log_lines))
         build.save()
+        _notify_requester(build, succeeded=True)
         return {
             "status": "succeeded",
             "build_id": str(build.pk),
@@ -152,4 +193,5 @@ def run_firmware_build(build_id: str) -> dict:
         build.completed_at = timezone.now()
         build.log = _truncate("\n".join(log_lines))
         build.save()
+        _notify_requester(build, succeeded=False)
         return {"status": "failed", "build_id": str(build.pk), "error": str(exc)}

--- a/backend/forgekey/tests/test_firmware_build.py
+++ b/backend/forgekey/tests/test_firmware_build.py
@@ -19,6 +19,7 @@ from rest_framework.test import APIClient
 
 from forgekey.models import DeviceType, FirmwareBuild
 from forgekey.services import firmware_build as fb
+from notifications.models import Notification
 
 User = get_user_model()
 pytestmark = pytest.mark.django_db
@@ -131,6 +132,58 @@ class TestRunFirmwareBuild:
         assert result["status"] == "failed"
         build.refresh_from_db()
         assert "CertificateAuthority" in build.error_message
+
+
+class TestBuildCompletionNotifications:
+    """The requester gets an in-app notification when their build finishes."""
+
+    def test_success_notifies_requester(self, device_type, admin_user):
+        build = FirmwareBuild.objects.create(
+            device_type=device_type,
+            pio_env="seeed_xiao_epaper",
+            source_ref="main",
+            version="9.9.9",
+            requested_by=admin_user,
+        )
+        with (
+            patch("forgekey.models.CertificateAuthority.get_active", return_value=_FAKE_CA),
+            patch(
+                "forgekey.services.jwt_signing.get_jwt_public_key_pem",
+                return_value=_FAKE_PUBKEY,
+            ),
+            patch("forgekey.services.firmware_build.subprocess.run", side_effect=_fake_run),
+        ):
+            fb.run_firmware_build(str(build.id))
+
+        note = Notification.objects.filter(user=admin_user, type="success").first()
+        assert note is not None
+        assert "succeeded" in note.title.lower()
+        assert note.metadata.get("build_id") == str(build.id)
+        assert note.action_url == "/facilities/forgekey-rollouts"
+
+    def test_failure_notifies_requester(self, device_type, admin_user):
+        # The "no active CA" path fails fast without needing the subprocess mock.
+        build = FirmwareBuild.objects.create(
+            device_type=device_type,
+            pio_env="x",
+            source_ref="main",
+            version="8.8.8",
+            requested_by=admin_user,
+        )
+        with patch("forgekey.models.CertificateAuthority.get_active", return_value=None):
+            fb.run_firmware_build(str(build.id))
+
+        note = Notification.objects.filter(user=admin_user, type="error").first()
+        assert note is not None
+        assert "failed" in note.title.lower()
+
+    def test_no_requester_means_no_notification(self, device_type):
+        build = FirmwareBuild.objects.create(
+            device_type=device_type, pio_env="x", source_ref="main", version="6.6.6"
+        )
+        with patch("forgekey.models.CertificateAuthority.get_active", return_value=None):
+            fb.run_firmware_build(str(build.id))
+        assert not Notification.objects.exists()
 
 
 class TestFirmwareBuildViewSet:


### PR DESCRIPTION
## What

Closes the loop the operator asked for during the firmware-build UX work — *"will I get notified if it succeeds or fails?"*. When a `FirmwareBuild` reaches **succeeded** or **failed**, the user who queued it (`requested_by`) now gets an **in-app notification** with the outcome, so they don't have to watch the 30s rollouts poll.

## How

`run_firmware_build` calls a small best-effort helper at both completion points:

- **Succeeded** → a `success` notification ("Firmware build succeeded", "<env> <version> built successfully and is ready to roll out.")
- **Failed** → an `error` notification with the failure reason.

Both carry `action_url=/facilities/forgekey-rollouts` and `metadata={build_id, kind}`.

It reuses the existing **notifications** app (`notifications.services.create_notification`) — the same surface the work-order/maintenance flows use. The frontend `NotificationContext` already polls `GET /notifications/`, so the result lands in the bell/inbox automatically: **no frontend change required, no new push infrastructure.**

Guardrails:
- **Best-effort** — wrapped in try/except; a notification failure is logged and never masks the recorded build result.
- Builds with **no requester** (e.g. system-triggered) are skipped.

## Tests

`TestBuildCompletionNotifications` — success notifies (type `success`, `build_id` metadata, action_url), failure notifies (type `error`), and a build with no `requested_by` creates no notification. The existing build-pipeline tests (which create builds without a requester) are unaffected. black / isort / flake8 / bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)