### PR TITLE
fix(forgekey): run the firmware build worker in prod

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -231,6 +231,55 @@ services:
     networks:
       - app-network
 
+  firmware_builder:
+    # Self-hosted firmware build worker. Unlike celery / mqtt_consumer (which
+    # reuse oms-backend:local), this carries the git + PlatformIO toolchain via
+    # Dockerfile.firmware-builder, and it is the ONLY consumer of the dedicated
+    # `builds` queue that forgekey.tasks.build_firmware is routed to. Without
+    # it, queued firmware builds sit in Redis forever.
+    #
+    # Provide a read-only SSH deploy key with read access to the ForgeKey repo
+    # via FORGEKEY_DEPLOY_KEY in .env; until it's set the container still runs,
+    # but each build fails at `git clone`. See docs/FORGEKEY_FIRMWARE_BUILD.md.
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.firmware-builder
+    image: oms-firmware-builder:local
+    logging: *default-logging
+    # concurrency=1: builds are heavy and serialized. --max-tasks-per-child
+    # recycles the worker so a leaky toolchain run can't accumulate.
+    command: celery -A config worker -Q builds --concurrency=1 -l info --max-tasks-per-child=20
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+        reservations:
+          memory: 512M
+    volumes:
+      - media_volume:/app/media
+      # Read-only SSH deploy key with read access to the ForgeKey repo.
+      - ${FORGEKEY_DEPLOY_KEY:-/dev/null}:/root/.ssh/id_ed25519:ro
+    env_file:
+      - .env
+    environment:
+      - DEBUG=0
+      - GIT_HASH=${GIT_HASH:-}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-makerspace}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-makerspace_inventory}
+      - REDIS_URL=redis://redis:6379/0
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - SKIP_DB_MIGRATIONS=1
+      - FORGEKEY_FIRMWARE_REPO_URL=${FORGEKEY_FIRMWARE_REPO_URL:-git@github.com:uid0/ForgeKey.git}
+    depends_on:
+      backend:
+        condition: service_started
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - app-network
+
   # Long-running MQTT consumer: subscribes to forgekey/+/status,
   # forgekey/+/+/occupancy, forgekey/+/ota/status, etc. and updates the
   # backing ESP32Device rows (last_seen, is_online, occupancy, firmware

--- a/docs/FORGEKEY_FIRMWARE_BUILD.md
+++ b/docs/FORGEKEY_FIRMWARE_BUILD.md
@@ -40,17 +40,27 @@ A failed build is recorded with its log + `error_message` — not retried.
 
 ## Deploying the worker
 
-The worker is an opt-in compose service (profile `firmware-build`):
+**Production (`docker-compose.prod.yml`)** — `firmware_builder` is **always-on**:
+it comes up with the rest of the stack, so a normal
+`docker compose -f docker-compose.prod.yml up -d --build` starts it alongside
+everything else. You only need to give it the deploy key. In your prod `.env`:
 
 ```bash
-# 1. A read-only SSH deploy key with read access to the ForgeKey repo.
-#    (GitHub → repo → Settings → Deploy keys.)
+# A read-only SSH deploy key with read access to the ForgeKey repo
+# (GitHub → repo → Settings → Deploy keys). Host path, mounted read-only.
+FORGEKEY_DEPLOY_KEY=/abs/path/to/forgekey_deploy_key
+# (optional) override the repo if you fork it
+FORGEKEY_FIRMWARE_REPO_URL=git@github.com:uid0/ForgeKey.git
+```
+
+Until `FORGEKEY_DEPLOY_KEY` is set the container still runs, but each build fails
+at `git clone`.
+
+**Development (`docker-compose.yml`)** — the worker is **opt-in** (compose
+profile `firmware-build`) so a routine `docker compose up` stays lightweight:
+
+```bash
 export FORGEKEY_DEPLOY_KEY=/abs/path/to/forgekey_deploy_key
-
-# 2. (optional) override the repo if you fork it
-export FORGEKEY_FIRMWARE_REPO_URL=git@github.com:uid0/ForgeKey.git
-
-# 3. start it
 docker compose --profile firmware-build up -d --build firmware_builder
 ```
 


### PR DESCRIPTION
## Why

A queued firmware build never starts in production because **nothing consumes the `builds` queue there**. PR5 (#652) added the `firmware_builder` service only to the **dev** `docker-compose.yml` (and behind a `firmware-build` profile); it was **never added to `docker-compose.prod.yml`**. The prod `celery` worker runs `celery -A config worker` with no `-Q builds`, and — being the backend image — has no git/PlatformIO toolchain anyway. So `build_firmware` tasks (routed to `builds`) pile up in Redis forever.

## What

Add an **always-on** `firmware_builder` service to `docker-compose.prod.yml`, mirroring the prod `celery` conventions:

- own toolchain image — `build: Dockerfile.firmware-builder` → `image: oms-firmware-builder:local`
- `command: celery -A config worker -Q builds --concurrency=1 -l info --max-tasks-per-child=20`
- read-only deploy-key mount `${FORGEKEY_DEPLOY_KEY:-/dev/null}:/root/.ssh/id_ed25519:ro`
- `env_file: .env` (inherits the CA-key / JWT-signing settings the build needs), `SKIP_DB_MIGRATIONS=1`
- `deploy.resources` 2G limit / 512M reservation, `depends_on` backend+db+redis, `restart: unless-stopped`, `app-network`

It's always-on (no profile) per the operator's preference, so a normal `docker compose -f docker-compose.prod.yml up -d --build` brings it up with the stack. Until `FORGEKEY_DEPLOY_KEY` is set in the prod `.env`, the container runs but each build fails at `git clone`.

## CI safety

The **Prod Stack Smoke** job only brings up `db redis emqx backend` explicitly (`up -d --build db redis emqx backend`) and otherwise runs `docker compose -f docker-compose.prod.yml config -q`. So this change is **parse-validated but the heavy PlatformIO image is never built in CI**. Verified `config` locally with a throwaway `.env` — the service resolves (`oms-firmware-builder:local`, `Dockerfile.firmware-builder`, `-Q builds`, the key mount).

## Docs

`docs/FORGEKEY_FIRMWARE_BUILD.md` now distinguishes **prod (always-on)** from **dev (opt-in `--profile firmware-build`)** and notes the deploy key belongs in the prod `.env`.

> Note: this only fixes the prod **compose definition**. An instance still has to be deployed from current `main` for any of the firmware-build code to be present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)