### PR TITLE
fix(forgekey): block hand-creating certificates / enrollments in admin (Sentry BACKEND-D)

### DIFF
--- a/backend/forgekey/admin.py
+++ b/backend/forgekey/admin.py
@@ -585,6 +585,13 @@ class DeviceCertificateAdmin(admin.ModelAdmin):
     ]
     fields = readonly_fields + ["revoked_at"]
 
+    def has_add_permission(self, request):
+        # Certificates are issued by the CSR / enrollment flow, never created
+        # by hand. Without this guard the admin renders an Add form whose
+        # fields are all read-only, so POST submits null/empty values and
+        # 500s on NOT NULL constraints (e.g. not_before).
+        return False
+
     @admin.display(description="fingerprint")
     def fingerprint_sha256_short(self, obj):
         return (obj.fingerprint_sha256 or "")[:16]
@@ -631,6 +638,11 @@ class DeviceEnrollmentAdmin(admin.ModelAdmin):
         "enrollment_photo",
     ]
     fields = readonly_fields + ["status"]
+
+    def has_add_permission(self, request):
+        # Enrollments come from devices POSTing CSRs to /enroll/, never from
+        # the admin. Same read-only-form NOT-NULL trap as DeviceCertificate.
+        return False
 
 
 @admin.register(CertificateAuthority)

--- a/backend/forgekey/tests/test_admin_add_blocked.py
+++ b/backend/forgekey/tests/test_admin_add_blocked.py
@@ -1,0 +1,52 @@
+"""
+View-only admins for CSR-issued artifacts must refuse hand-creation.
+
+Without `has_add_permission = False`, Django still renders an Add form even
+when every model field is in `readonly_fields` — submitting the form POSTs
+empty values and 500s on NOT NULL columns. Sentry BACKEND-D was exactly
+that: clicking "Add Device Certificate" produced an IntegrityError on
+`not_before`. These admins exist purely for revoke / approve actions on
+rows that the enrollment pipeline already created.
+"""
+
+from __future__ import annotations
+
+from django.contrib import admin
+from django.test import Client
+
+import pytest
+
+from forgekey.admin import CertificateAuthorityAdmin, DeviceCertificateAdmin, DeviceEnrollmentAdmin
+from forgekey.models import CertificateAuthority, DeviceCertificate, DeviceEnrollment
+from forgekey.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+VIEW_ONLY_ADMINS = [
+    (DeviceCertificateAdmin, DeviceCertificate, "devicecertificate"),
+    (DeviceEnrollmentAdmin, DeviceEnrollment, "deviceenrollment"),
+    (CertificateAuthorityAdmin, CertificateAuthority, "certificateauthority"),
+]
+
+
+@pytest.mark.parametrize("admin_cls,model,_url", VIEW_ONLY_ADMINS)
+def test_has_add_permission_is_false(admin_cls, model, _url):
+    assert admin_cls(model, admin.site).has_add_permission(None) is False
+
+
+@pytest.mark.parametrize("_admin_cls,_model,url_segment", VIEW_ONLY_ADMINS)
+def test_admin_add_url_is_forbidden_for_superuser(_admin_cls, _model, url_segment):
+    """Even a superuser navigating to /admin/.../add/ must not be able to create.
+
+    Pre-fix behavior: the GET rendered an Add form (200), then POST 500'd on
+    NOT NULL constraints. With `has_add_permission=False`, Django raises
+    PermissionDenied → 403.
+    """
+    superuser = UserFactory(is_staff=True, is_superuser=True)
+    client = Client()
+    client.force_login(superuser)
+
+    response = client.get(f"/admin/forgekey/{url_segment}/add/")
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Why

Sentry **BACKEND-D**: clicking *Add Device Certificate* in the Django admin produces a 500 in production.

```
IntegrityError: null value in column "not_before" of relation
"forgekey_devicecertificate" violates not-null constraint
```

`DeviceCertificateAdmin` (and `DeviceEnrollmentAdmin`) are intentionally view-only — every field is in `readonly_fields`, with only `revoked_at` / `status` editable for revoke / approve. But Django still renders the Add form; the readonly form submits empty values and trips NOT NULL on the first column that has the constraint. Today that was `not_before`; on `DeviceEnrollment` it would have been `csr_pem`.

Certificates are issued by the CSR / enrollment pipeline. Enrollments come from devices POSTing to `/enroll/`. Neither has a meaningful hand-creation path. The sibling `CertificateAuthorityAdmin` already had this guard (the docstring says *"Bootstrap via `manage.py forgekey_ca`"*) — applying the same pattern to the two siblings.

## What

- `DeviceCertificateAdmin.has_add_permission → False`
- `DeviceEnrollmentAdmin.has_add_permission → False`
- New parametrized regression test (`backend/forgekey/tests/test_admin_add_blocked.py`) covering both the method-level guard and the URL-level `/admin/forgekey/<model>/add/ → 403` behavior across all three view-only admins (cert / enrollment / CA).

## Test plan

- [x] Pre-commit (`pre-commit run --files backend/forgekey/admin.py backend/forgekey/tests/test_admin_add_blocked.py`) green.
- [x] `pytest forgekey/tests/test_admin_add_blocked.py forgekey/tests/test_admin_delete.py` → 10 passed (6 new + 4 existing).
- [ ] CI green.
- [ ] Spot-check in prod after deploy that `/admin/forgekey/devicecertificate/add/` now returns 403 instead of 500.

Fixes Sentry: https://highlighter.openmakersuite.net/organizations/sentry/issues/20/