### PR TITLE
feat(forgekey): generate root CA from the Django admin

### DIFF
--- a/backend/forgekey/admin.py
+++ b/backend/forgekey/admin.py
@@ -12,6 +12,8 @@ from django.urls import path, reverse
 from django.utils import timezone
 from django.utils.html import format_html
 
+from cryptography.hazmat.primitives import serialization
+
 from .models import (
     AssetAuthorization,
     AssetDevice,
@@ -32,6 +34,8 @@ from .models import (
     OperationalMode,
     PowerMeterReading,
 )
+from .services.ca_key_storage import CaKeyStorageError, encrypt_ca_key
+from .services.csr_signing import generate_ca_keypair
 from .services.firmware_signing import (
     FirmwareSigningError,
     derive_public_pem,
@@ -645,16 +649,72 @@ class DeviceEnrollmentAdmin(admin.ModelAdmin):
         return False
 
 
+class CertificateAuthorityForm(forms.ModelForm):
+    """Add-form for a CA: collects metadata, mints the keypair on save.
+
+    Only ``name`` is a real model field on this form. ``cn`` and
+    ``validity_years`` parameterize ``generate_ca_keypair`` at save time;
+    ``force_replace`` gates rotation when an active CA already exists.
+    The private key is generated server-side and never enters the form.
+    """
+
+    cn = forms.CharField(
+        label="Common name",
+        max_length=200,
+        initial="ForgeKey Internal Root CA",
+        help_text="CN baked into the CA certificate's subject. Cosmetic; "
+        "devices identify the CA by full subject + fingerprint.",
+    )
+    validity_years = forms.IntegerField(
+        min_value=1,
+        max_value=20,
+        initial=10,
+        help_text="Years until the CA expires. Rotate before expiry — every "
+        "device certificate it signed stops verifying when it lapses.",
+    )
+    force_replace = forms.BooleanField(
+        required=False,
+        label="Replace the active CA",
+        help_text="Required when an active CA already exists. The prior CA is "
+        "deactivated atomically; device certs it issued only continue to "
+        "verify as long as relying parties still trust the old CA cert.",
+    )
+
+    class Meta:
+        model = CertificateAuthority
+        fields = ["name"]
+
+    def clean(self):
+        cleaned = super().clean()
+        # `self.instance.pk` is unreliable here — the model's UUID pk default
+        # fires on construction so a fresh instance still has a non-None pk.
+        # `_state.adding` flips to False once the row hits the DB.
+        if not self.instance._state.adding:
+            return cleaned
+        active = CertificateAuthority.get_active()
+        if active is not None and not cleaned.get("force_replace"):
+            raise forms.ValidationError(
+                f"An active CA already exists (name={active.name!r}). Tick "
+                "'Replace the active CA' to deactivate it and bootstrap a "
+                "replacement."
+            )
+        return cleaned
+
+
 @admin.register(CertificateAuthority)
 class CertificateAuthorityAdmin(admin.ModelAdmin):
-    """Read-only view of the internal CA. Bootstrap via ``manage.py forgekey_ca``."""
+    """Internal CA admin. Add generates a fresh CA server-side; change view is read-only.
 
+    The CLI command ``manage.py forgekey_ca init`` remains for scripted /
+    headless bootstrap; this admin is the operator-facing equivalent.
+    """
+
+    form = CertificateAuthorityForm
     list_display = ["name", "is_active", "not_before", "not_after", "created_at"]
     list_filter = ["is_active"]
     search_fields = ["name", "key_kid"]
     readonly_fields = [
         "id",
-        "name",
         "cert_pem",
         "key_kid",
         "not_before",
@@ -663,14 +723,79 @@ class CertificateAuthorityAdmin(admin.ModelAdmin):
         "created_at",
         "updated_at",
     ]
-    fields = readonly_fields
     # The encrypted private-key blob never appears in the admin.
 
     def has_add_permission(self, request):
-        return False
+        # Generating a CA mints the root private key for every device cert in
+        # the system — superuser-only on purpose.
+        return request.user.is_active and request.user.is_superuser
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+    def get_fields(self, request, obj=None):
+        if obj is None:
+            # Add form: name + generation parameters.
+            return ["name", "cn", "validity_years", "force_replace"]
+        # Change form: existing readonly view (plus the name field).
+        return ["id", "name"] + self.readonly_fields[1:]
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj is None:
+            return []
+        return ["name"] + list(self.readonly_fields)
+
+    def save_model(self, request, obj, form, change):
+        if change:
+            super().save_model(request, obj, form, change)
+            return
+
+        cn = form.cleaned_data["cn"]
+        validity_years = form.cleaned_data["validity_years"]
+        try:
+            private_pem, ca_cert = generate_ca_keypair(cn=cn, validity_days=validity_years * 365)
+            ciphertext, kid = encrypt_ca_key(private_pem)
+        except CaKeyStorageError as exc:
+            # Most common cause: FORGEKEY_CA_KEY_ENCRYPTION_KEY unset. Surface
+            # the configuration problem to the operator instead of 500ing.
+            messages.error(request, f"Cannot encrypt CA private key: {exc}")
+            raise
+
+        with transaction.atomic():
+            prior = CertificateAuthority.get_active()
+            if prior is not None:
+                CertificateAuthority.objects.filter(pk=prior.pk).update(is_active=False)
+                audit_logger.info(
+                    "forgekey.certificate_authority.rotated retired_id=%s "
+                    "retired_name=%s actor_id=%s actor_username=%s",
+                    prior.pk,
+                    prior.name,
+                    getattr(request.user, "id", None),
+                    getattr(request.user, "username", None),
+                )
+            obj.cert_pem = ca_cert.public_bytes(serialization.Encoding.PEM).decode("ascii")
+            obj.encrypted_private_key = ciphertext
+            obj.key_kid = kid
+            obj.not_before = ca_cert.not_valid_before_utc
+            obj.not_after = ca_cert.not_valid_after_utc
+            obj.is_active = True
+            obj.save()
+            audit_logger.info(
+                "forgekey.certificate_authority.created id=%s name=%s "
+                "validity_years=%d actor_id=%s actor_username=%s",
+                obj.pk,
+                obj.name,
+                validity_years,
+                getattr(request.user, "id", None),
+                getattr(request.user, "username", None),
+            )
+
+        if prior is not None:
+            messages.warning(request, f"Deactivated prior active CA: {prior.name!r}")
+        messages.success(
+            request,
+            f"Generated CA {obj.name!r} (valid until {obj.not_after.isoformat()}).",
+        )
 
 
 @admin.register(EPaperDisplay)

--- a/backend/forgekey/tests/test_admin_add_blocked.py
+++ b/backend/forgekey/tests/test_admin_add_blocked.py
@@ -16,17 +16,19 @@ from django.test import Client
 
 import pytest
 
-from forgekey.admin import CertificateAuthorityAdmin, DeviceCertificateAdmin, DeviceEnrollmentAdmin
-from forgekey.models import CertificateAuthority, DeviceCertificate, DeviceEnrollment
+from forgekey.admin import DeviceCertificateAdmin, DeviceEnrollmentAdmin
+from forgekey.models import DeviceCertificate, DeviceEnrollment
 from forgekey.tests.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
 
 
+# CertificateAuthorityAdmin had this same guard in the original BACKEND-D
+# fix, but now exposes an Add path that generates the CA server-side. See
+# test_admin_ca_generate.py for the generation flow's coverage.
 VIEW_ONLY_ADMINS = [
     (DeviceCertificateAdmin, DeviceCertificate, "devicecertificate"),
     (DeviceEnrollmentAdmin, DeviceEnrollment, "deviceenrollment"),
-    (CertificateAuthorityAdmin, CertificateAuthority, "certificateauthority"),
 ]
 
 

--- a/backend/forgekey/tests/test_admin_ca_generate.py
+++ b/backend/forgekey/tests/test_admin_ca_generate.py
@@ -1,0 +1,189 @@
+"""
+Admin-side CA generation: clicking "Add Certificate Authority" in
+/admin/forgekey/certificateauthority/ mints a fresh CA server-side
+instead of presenting a no-op form (the old behavior — see PR #662 for
+context on the readonly-form trap).
+
+Mirrors the test surface around `manage.py forgekey_ca init` but exercises
+the admin form + save_model path.
+"""
+
+from __future__ import annotations
+
+from django.contrib import admin
+from django.test import RequestFactory
+
+import pytest
+from cryptography import x509
+from cryptography.fernet import Fernet
+
+from forgekey.admin import CertificateAuthorityAdmin, CertificateAuthorityForm
+from forgekey.models import CertificateAuthority
+from forgekey.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def kek(settings):
+    settings.FORGEKEY_CA_KEY_ENCRYPTION_KEY = Fernet.generate_key().decode("ascii")
+
+
+def _admin() -> CertificateAuthorityAdmin:
+    return CertificateAuthorityAdmin(CertificateAuthority, admin.site)
+
+
+def _add_request(user):
+    request = RequestFactory().post("/admin/forgekey/certificateauthority/add/")
+    request.user = user
+    # Required by Django's MessageMiddleware path that save_model invokes via
+    # `messages.success`. We never read these back, but the storage has to
+    # exist or `add_message` raises.
+    from django.contrib.messages.storage.fallback import FallbackStorage
+
+    setattr(request, "session", {})
+    request._messages = FallbackStorage(request)
+    return request
+
+
+# ----- permission gating -----------------------------------------------------
+
+
+def test_only_superuser_can_add():
+    superuser = UserFactory(is_staff=True, is_superuser=True)
+    staff = UserFactory(is_staff=True, is_superuser=False)
+
+    admin_cls = _admin()
+    su_req = RequestFactory().get("/")
+    su_req.user = superuser
+    staff_req = RequestFactory().get("/")
+    staff_req.user = staff
+
+    assert admin_cls.has_add_permission(su_req) is True
+    assert admin_cls.has_add_permission(staff_req) is False
+
+
+def test_delete_is_blocked_for_superuser():
+    admin_cls = _admin()
+    request = RequestFactory().get("/")
+    request.user = UserFactory(is_staff=True, is_superuser=True)
+
+    assert admin_cls.has_delete_permission(request) is False
+
+
+# ----- form validation -------------------------------------------------------
+
+
+def test_form_accepts_first_ca_without_force(kek):
+    form = CertificateAuthorityForm(
+        data={"name": "forgekey-root", "cn": "ForgeKey", "validity_years": "1"}
+    )
+    assert form.is_valid(), form.errors
+
+
+def test_form_requires_force_replace_when_active_ca_exists(kek):
+    _generate_active_ca(name="existing")
+    form = CertificateAuthorityForm(
+        data={"name": "forgekey-root-2", "cn": "ForgeKey", "validity_years": "1"}
+    )
+    assert not form.is_valid()
+    assert any("active CA already exists" in e for e in form.non_field_errors())
+
+
+def test_form_accepts_replacement_with_force(kek):
+    _generate_active_ca(name="existing")
+    form = CertificateAuthorityForm(
+        data={
+            "name": "forgekey-root-2",
+            "cn": "ForgeKey",
+            "validity_years": "1",
+            "force_replace": "on",
+        }
+    )
+    assert form.is_valid(), form.errors
+
+
+# ----- save_model mints + persists ------------------------------------------
+
+
+def test_save_model_generates_and_persists_active_ca(kek):
+    user = UserFactory(is_staff=True, is_superuser=True)
+    request = _add_request(user)
+    form = CertificateAuthorityForm(
+        data={"name": "forgekey-root", "cn": "ForgeKey", "validity_years": "1"}
+    )
+    assert form.is_valid(), form.errors
+    obj = form.save(commit=False)
+
+    _admin().save_model(request, obj, form, change=False)
+
+    assert CertificateAuthority.objects.filter(is_active=True).count() == 1
+    active = CertificateAuthority.get_active()
+    assert active.name == "forgekey-root"
+    # The cert is a parseable x509 with the requested CN.
+    cert = x509.load_pem_x509_certificate(active.cert_pem.encode("utf-8"))
+    cn_attr = next(a.value for a in cert.subject if a.oid.dotted_string == "2.5.4.3")
+    assert cn_attr == "ForgeKey"
+    # not_before/not_after came from the cert itself, not blank.
+    assert active.not_before == cert.not_valid_before_utc
+    assert active.not_after == cert.not_valid_after_utc
+    assert active.key_kid.startswith("forgekey-ca-kek-")
+    assert active.encrypted_private_key  # non-empty
+
+
+def test_save_model_deactivates_prior_active(kek):
+    prior = _generate_active_ca(name="prior")
+    user = UserFactory(is_staff=True, is_superuser=True)
+    request = _add_request(user)
+    form = CertificateAuthorityForm(
+        data={
+            "name": "successor",
+            "cn": "ForgeKey",
+            "validity_years": "1",
+            "force_replace": "on",
+        }
+    )
+    assert form.is_valid(), form.errors
+    obj = form.save(commit=False)
+
+    _admin().save_model(request, obj, form, change=False)
+
+    prior.refresh_from_db()
+    assert prior.is_active is False
+    active = CertificateAuthority.get_active()
+    assert active.name == "successor"
+
+
+def test_save_model_surfaces_missing_kek_via_messages(settings):
+    """No KEK ⇒ CaKeyStorageError ⇒ admin message + raise (no IntegrityError 500)."""
+    from forgekey.services.ca_key_storage import CaKeyStorageError
+
+    settings.FORGEKEY_CA_KEY_ENCRYPTION_KEY = ""  # explicitly cleared
+    user = UserFactory(is_staff=True, is_superuser=True)
+    request = _add_request(user)
+    form = CertificateAuthorityForm(
+        data={"name": "forgekey-root", "cn": "ForgeKey", "validity_years": "1"}
+    )
+    assert form.is_valid(), form.errors
+    obj = form.save(commit=False)
+
+    with pytest.raises(CaKeyStorageError):
+        _admin().save_model(request, obj, form, change=False)
+
+    assert CertificateAuthority.objects.count() == 0
+    msgs = [str(m) for m in request._messages]
+    assert any("Cannot encrypt CA private key" in m for m in msgs)
+
+
+# ----- helpers ---------------------------------------------------------------
+
+
+def _generate_active_ca(*, name: str) -> CertificateAuthority:
+    """Use the form+admin path itself so the test fixture matches production."""
+    user = UserFactory(is_staff=True, is_superuser=True)
+    request = _add_request(user)
+    form = CertificateAuthorityForm(data={"name": name, "cn": name, "validity_years": "1"})
+    assert form.is_valid(), form.errors
+    obj = form.save(commit=False)
+    _admin().save_model(request, obj, form, change=False)
+    return CertificateAuthority.get_active()


### PR DESCRIPTION
## Why

Follow-up to #662, which blocked the broken \`Add Certificate Authority\` form. The right answer to *why don't we just generate one when the operator clicks Add?* is — yes, do that. Issuing a CA is a thing operators should be able to bootstrap from the admin; they just can't paste the private key in by hand.

Partly addresses #663 too: operators no longer have to drop into a shell and run \`manage.py forgekey_ca init\` for the very first CA. The CLI command stays for headless / scripted use.

## What

\`CertificateAuthorityForm\` mirrors the existing \`FirmwareSigningKeyForm\` pattern: model-backed \`name\`, plus form-only \`cn\` / \`validity_years\` / \`force_replace\` that parameterize \`generate_ca_keypair\`. \`save_model\` runs the same sequence as the CLI's \`init\`:

1. \`generate_ca_keypair(cn=..., validity_days=validity_years*365)\`
2. \`encrypt_ca_key(private_pem)\` with the Fernet KEK
3. Deactivate the prior active row in the same transaction
4. Persist the new row with cert PEM, encrypted key, kid, validity window, \`is_active=True\`

Both rotation and activation are audit-logged with the actor.

## Guard rails

- **Superuser-only** (\`has_add_permission\`). A root CA mints the trust anchor for every device cert in the fleet — not regular-staff territory.
- **Delete still blocked.** CAs go away via \`is_active=False\`, never via row delete; the audit chain stays intact.
- **\`force_replace\` required when an active CA exists** — matches the CLI's \`--force\` semantics so admin + CLI converge on the same UX.
- **Missing \`FORGEKEY_CA_KEY_ENCRYPTION_KEY\`** surfaces as a clear admin message + re-raised exception (no 500 IntegrityError on the encrypted_private_key column).

## Test plan

- [x] Pre-commit (\`black\`, \`isort\`, \`ruff\`, \`bandit\`, \`django-upgrade\`) green on changed files.
- [x] \`pytest forgekey/tests/test_admin_ca_generate.py\` → 8 passed (perm gate × 2, form validation × 3, save_model × 3 including the missing-KEK path).
- [x] \`pytest forgekey/tests/test_admin_add_blocked.py forgekey/tests/test_admin_delete.py forgekey/tests/test_forgekey_ca_command.py forgekey/tests/test_csr_signing.py forgekey/tests/test_enrollment.py\` → 44 passed (no regressions).
- [ ] CI green.
- [ ] Spot-check in dev: \`/admin/forgekey/certificateauthority/add/\` with no active CA → mints one. Again with an active CA + \`force_replace\` → rotates. Without \`force_replace\` → form error. With \`FORGEKEY_CA_KEY_ENCRYPTION_KEY\` unset → admin error message, no DB row written.

Note: \`test_admin_add_blocked.py\` no longer asserts CertificateAuthorityAdmin is view-only — that case is now covered in the new test file.

Refs #662 #663