### PR TITLE
feat(forgekey): sign device certificates from the Django admin (closes #663)

### DIFF
--- a/backend/forgekey/admin.py
+++ b/backend/forgekey/admin.py
@@ -35,7 +35,13 @@ from .models import (
     PowerMeterReading,
 )
 from .services.ca_key_storage import CaKeyStorageError, encrypt_ca_key
-from .services.csr_signing import generate_ca_keypair
+from .services.csr_signing import (
+    CsrSigningError,
+    CsrValidationError,
+    generate_ca_keypair,
+    sign_csr,
+    validate_csr,
+)
 from .services.firmware_signing import (
     FirmwareSigningError,
     derive_public_pem,
@@ -562,10 +568,79 @@ class DeviceIdentityAdmin(admin.ModelAdmin):
     fields = ["id", "device_id", "status", "notes", "created_at", "updated_at"]
 
 
+class DeviceCertificateForm(forms.ModelForm):
+    """Add-form for a device certificate: paste a CSR, server signs it.
+
+    The full enrollment flow normally runs over `/api/forgekey/devices/enroll/`
+    — the device generates its own keypair, POSTs the CSR with the
+    provisioning token, gets a signed cert in the response. This admin form
+    is the manual escape-hatch for the cases that flow doesn't cover:
+    factory pre-provisioning, devices on flaky networks, support-driven
+    re-cert, etc. The operator obtains a CSR from the device out-of-band
+    and pastes it here.
+
+    Form-only fields:
+      * ``csr_pem`` — PEM-encoded CSR (parsed + validated on clean()).
+      * ``validity_days`` — optional cert lifetime (defaults to the
+        ``FORGEKEY_CLIENT_CERT_VALIDITY_DAYS`` setting).
+    """
+
+    csr_pem = forms.CharField(
+        label="CSR (PEM)",
+        widget=forms.Textarea(attrs={"rows": 10, "cols": 80, "style": "font-family: monospace;"}),
+        help_text=(
+            "Paste the device's PEM-encoded certificate signing request. "
+            "Must be EC P-256 with SHA-256, matching the /enroll/ contract."
+        ),
+    )
+    validity_days = forms.IntegerField(
+        required=False,
+        min_value=1,
+        max_value=825,  # CA/Browser Forum cap; keeps us off the rails.
+        help_text=(
+            "Days before the cert expires. Leave blank to use the server "
+            "default (FORGEKEY_CLIENT_CERT_VALIDITY_DAYS)."
+        ),
+    )
+
+    class Meta:
+        model = DeviceCertificate
+        fields = ["device"]
+
+    def clean(self):
+        cleaned = super().clean()
+        if not self.instance._state.adding:
+            # Edit path — only `revoked_at` is editable; nothing to validate.
+            return cleaned
+
+        csr_pem = (cleaned.get("csr_pem") or "").strip()
+        if csr_pem:
+            try:
+                validate_csr(csr_pem)
+            except CsrValidationError as exc:
+                raise forms.ValidationError(f"Invalid CSR: {exc}") from exc
+
+        device = cleaned.get("device")
+        if device is not None and device.status == DeviceIdentity.STATUS_DECOMMISSIONED:
+            raise forms.ValidationError(
+                f"Device {device.device_id!r} is decommissioned; cannot issue."
+            )
+        return cleaned
+
+
 @admin.register(DeviceCertificate)
 class DeviceCertificateAdmin(admin.ModelAdmin):
-    """mTLS client certificates issued by the internal CA."""
+    """mTLS client certificates issued by the internal CA.
 
+    Add: paste a CSR for a known DeviceIdentity, server signs it via the
+    same `sign_csr` path the /enroll/ endpoint uses, prior active cert for
+    the same device is revoked atomically, the resulting PEM is returned to
+    the browser as a `cert-<serial>.pem` download (the server doesn't keep
+    the PEM long-term — mirrors the /enroll/ HTTP-only delivery model).
+    Change: revoke only.
+    """
+
+    form = DeviceCertificateForm
     list_display = [
         "serial",
         "device",
@@ -578,7 +653,6 @@ class DeviceCertificateAdmin(admin.ModelAdmin):
     search_fields = ["serial", "fingerprint_sha256", "device__device_id", "subject"]
     readonly_fields = [
         "id",
-        "device",
         "serial",
         "subject",
         "fingerprint_sha256",
@@ -587,14 +661,108 @@ class DeviceCertificateAdmin(admin.ModelAdmin):
         "issued_by",
         "created_at",
     ]
-    fields = readonly_fields + ["revoked_at"]
 
     def has_add_permission(self, request):
-        # Certificates are issued by the CSR / enrollment flow, never created
-        # by hand. Without this guard the admin renders an Add form whose
-        # fields are all read-only, so POST submits null/empty values and
-        # 500s on NOT NULL constraints (e.g. not_before).
-        return False
+        # Signing a device cert mints something the device authenticates
+        # with on every mTLS handshake; superuser-only on purpose.
+        return request.user.is_active and request.user.is_superuser
+
+    def get_fields(self, request, obj=None):
+        if obj is None:
+            return ["device", "csr_pem", "validity_days"]
+        return [
+            "id",
+            "device",
+            "serial",
+            "subject",
+            "fingerprint_sha256",
+            "not_before",
+            "not_after",
+            "issued_by",
+            "created_at",
+            "revoked_at",
+        ]
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj is None:
+            return []
+        # `device` is editable only at signing time — never change which
+        # device a cert is bound to.
+        return ["device"] + list(self.readonly_fields)
+
+    def save_model(self, request, obj, form, change):
+        if change:
+            super().save_model(request, obj, form, change)
+            return
+
+        device = form.cleaned_data["device"]
+        csr_pem = form.cleaned_data["csr_pem"].strip()
+        validity_days = form.cleaned_data.get("validity_days")
+
+        try:
+            signed = sign_csr(
+                csr_pem,
+                device_id=device.device_id,
+                validity_days=validity_days,
+            )
+        except CsrSigningError as exc:
+            # Most common: no active CA configured. Surface clearly.
+            messages.error(request, f"CA unavailable: {exc}")
+            raise
+        except CsrValidationError as exc:
+            # clean() should have caught this, but signers re-validate.
+            messages.error(request, f"Invalid CSR: {exc}")
+            raise
+
+        now = timezone.now()
+        active_ca = CertificateAuthority.get_active()
+        ca_name = active_ca.name if active_ca else ""
+
+        with transaction.atomic():
+            revoked_count = DeviceCertificate.objects.filter(
+                device=device, revoked_at__isnull=True
+            ).update(revoked_at=now)
+
+            obj.device = device
+            obj.serial = signed.serial
+            obj.subject = signed.subject
+            obj.fingerprint_sha256 = signed.fingerprint_sha256
+            obj.not_before = signed.not_before
+            obj.not_after = signed.not_after
+            obj.issued_by = ca_name
+            obj.save()
+
+            audit_logger.info(
+                "forgekey.device_certificate.issued_via_admin id=%s device_id=%s "
+                "serial=%s revoked_prior=%d actor_id=%s actor_username=%s",
+                obj.pk,
+                device.device_id,
+                obj.serial,
+                revoked_count,
+                getattr(request.user, "id", None),
+                getattr(request.user, "username", None),
+            )
+
+        if revoked_count:
+            messages.warning(
+                request,
+                f"Revoked {revoked_count} prior active cert(s) for {device.device_id}.",
+            )
+        # Stash the PEM for response_add to serve as a download. We don't
+        # persist the PEM — the /enroll/ contract is also delivery-only,
+        # and storing it would mean an extra ~1.5 KB per cert with no
+        # current consumer.
+        request._signed_cert_pem = signed.cert_pem
+        request._signed_cert_serial = signed.serial
+
+    def response_add(self, request, obj, post_url_continue=None):
+        pem = getattr(request, "_signed_cert_pem", None)
+        serial = getattr(request, "_signed_cert_serial", None)
+        if pem and serial:
+            response = HttpResponse(pem, content_type="application/x-pem-file")
+            response["Content-Disposition"] = f'attachment; filename="cert-{serial}.pem"'
+            return response
+        return super().response_add(request, obj, post_url_continue)
 
     @admin.display(description="fingerprint")
     def fingerprint_sha256_short(self, obj):

--- a/backend/forgekey/tests/test_admin_add_blocked.py
+++ b/backend/forgekey/tests/test_admin_add_blocked.py
@@ -16,18 +16,20 @@ from django.test import Client
 
 import pytest
 
-from forgekey.admin import DeviceCertificateAdmin, DeviceEnrollmentAdmin
-from forgekey.models import DeviceCertificate, DeviceEnrollment
+from forgekey.admin import DeviceEnrollmentAdmin
+from forgekey.models import DeviceEnrollment
 from forgekey.tests.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
 
 
-# CertificateAuthorityAdmin had this same guard in the original BACKEND-D
-# fix, but now exposes an Add path that generates the CA server-side. See
-# test_admin_ca_generate.py for the generation flow's coverage.
+# CertificateAuthorityAdmin and DeviceCertificateAdmin both had this guard
+# in the original BACKEND-D fix; both now expose Add paths that mint server-
+# side (CA via generate_ca_keypair, device cert via sign_csr). Their flows
+# are covered by test_admin_ca_generate.py and test_admin_csr_sign.py
+# respectively. DeviceEnrollment stays view-only — enrollment rows are an
+# audit trail of /enroll/ POSTs and have no useful admin-creation path.
 VIEW_ONLY_ADMINS = [
-    (DeviceCertificateAdmin, DeviceCertificate, "devicecertificate"),
     (DeviceEnrollmentAdmin, DeviceEnrollment, "deviceenrollment"),
 ]
 

--- a/backend/forgekey/tests/test_admin_csr_sign.py
+++ b/backend/forgekey/tests/test_admin_csr_sign.py
@@ -1,0 +1,200 @@
+"""
+Admin-side device certificate signing: paste a CSR for a known
+DeviceIdentity, server signs via the same `sign_csr` path the
+/enroll/ endpoint uses, prior active cert for that device is
+revoked atomically, the PEM is returned as a download.
+"""
+
+from __future__ import annotations
+
+from django.contrib import admin
+from django.test import RequestFactory
+
+import pytest
+from cryptography import x509
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from forgekey.admin import DeviceCertificateAdmin, DeviceCertificateForm
+from forgekey.models import CertificateAuthority, DeviceCertificate, DeviceIdentity
+from forgekey.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+# ----- fixtures --------------------------------------------------------------
+
+
+@pytest.fixture
+def kek(settings):
+    settings.FORGEKEY_CA_KEY_ENCRYPTION_KEY = Fernet.generate_key().decode("ascii")
+
+
+@pytest.fixture
+def active_ca(kek):
+    from django.core.management import call_command
+
+    call_command("forgekey_ca", "init", "--validity-years", "1")
+    return CertificateAuthority.get_active()
+
+
+@pytest.fixture
+def device():
+    return DeviceIdentity.objects.create(device_id="chip-aabbccddeeff")
+
+
+def _build_csr(mac: str = "aabbccddeeff") -> str:
+    """Build a valid CSR matching the firmware contract: EC P-256 / SHA-256 /
+    CommonName = ``forgekey-<12-hex-mac>``. (``validate_csr`` rejects anything
+    else, same gate the /enroll/ endpoint runs.)"""
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, f"forgekey-{mac}")])
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(subject)
+        .sign(private_key=private_key, algorithm=hashes.SHA256())
+    )
+    return csr.public_bytes(serialization.Encoding.PEM).decode("ascii")
+
+
+def _admin() -> DeviceCertificateAdmin:
+    return DeviceCertificateAdmin(DeviceCertificate, admin.site)
+
+
+def _add_request(user):
+    request = RequestFactory().post("/admin/forgekey/devicecertificate/add/")
+    request.user = user
+    from django.contrib.messages.storage.fallback import FallbackStorage
+
+    request.session = {}
+    request._messages = FallbackStorage(request)
+    return request
+
+
+# ----- permission gating -----------------------------------------------------
+
+
+def test_only_superuser_can_sign_via_admin():
+    request_su = RequestFactory().get("/")
+    request_su.user = UserFactory(is_staff=True, is_superuser=True)
+    request_staff = RequestFactory().get("/")
+    request_staff.user = UserFactory(is_staff=True, is_superuser=False)
+
+    assert _admin().has_add_permission(request_su) is True
+    assert _admin().has_add_permission(request_staff) is False
+
+
+# ----- form validation -------------------------------------------------------
+
+
+def test_form_rejects_garbage_csr(device):
+    form = DeviceCertificateForm(data={"device": device.pk, "csr_pem": "not a CSR"})
+    assert not form.is_valid()
+    assert any("Invalid CSR" in e for e in form.non_field_errors())
+
+
+def test_form_rejects_decommissioned_device():
+    decom = DeviceIdentity.objects.create(
+        device_id="chip-dead", status=DeviceIdentity.STATUS_DECOMMISSIONED
+    )
+    form = DeviceCertificateForm(data={"device": decom.pk, "csr_pem": _build_csr()})
+    assert not form.is_valid()
+    assert any("decommissioned" in e for e in form.non_field_errors())
+
+
+def test_form_accepts_well_formed_csr(device):
+    form = DeviceCertificateForm(data={"device": device.pk, "csr_pem": _build_csr()})
+    assert form.is_valid(), form.errors
+
+
+# ----- save_model signs + persists + revokes --------------------------------
+
+
+def test_save_model_signs_and_persists(active_ca, device):
+    user = UserFactory(is_staff=True, is_superuser=True)
+    request = _add_request(user)
+    form = DeviceCertificateForm(data={"device": device.pk, "csr_pem": _build_csr()})
+    assert form.is_valid(), form.errors
+    obj = form.save(commit=False)
+
+    _admin().save_model(request, obj, form, change=False)
+
+    assert DeviceCertificate.objects.filter(device=device).count() == 1
+    cert = DeviceCertificate.objects.get(device=device)
+    assert cert.serial
+    assert cert.fingerprint_sha256
+    assert cert.issued_by == active_ca.name
+    assert cert.revoked_at is None
+    # PEM is stashed on the request for response_add to deliver.
+    assert request._signed_cert_pem.startswith("-----BEGIN CERTIFICATE-----")
+    assert request._signed_cert_serial == cert.serial
+
+
+def test_save_model_revokes_prior_active_cert(active_ca, device):
+    """Re-signing replaces the device's previous active cert."""
+    user = UserFactory(is_staff=True, is_superuser=True)
+
+    # First signing
+    request = _add_request(user)
+    form = DeviceCertificateForm(data={"device": device.pk, "csr_pem": _build_csr()})
+    assert form.is_valid(), form.errors
+    _admin().save_model(request, form.save(commit=False), form, change=False)
+    first = DeviceCertificate.objects.get(device=device, revoked_at__isnull=True)
+
+    # Second signing — first should now be revoked.
+    request2 = _add_request(user)
+    form2 = DeviceCertificateForm(data={"device": device.pk, "csr_pem": _build_csr()})
+    assert form2.is_valid(), form2.errors
+    _admin().save_model(request2, form2.save(commit=False), form2, change=False)
+
+    first.refresh_from_db()
+    assert first.revoked_at is not None
+    active_now = DeviceCertificate.objects.filter(device=device, revoked_at__isnull=True)
+    assert active_now.count() == 1
+    assert active_now.first().pk != first.pk
+
+
+def test_save_model_surfaces_no_active_ca(device):
+    """No active CA ⇒ CsrSigningError ⇒ admin message + raise (no 500)."""
+    from forgekey.services.csr_signing import CsrSigningError
+
+    user = UserFactory(is_staff=True, is_superuser=True)
+    request = _add_request(user)
+    form = DeviceCertificateForm(data={"device": device.pk, "csr_pem": _build_csr()})
+    assert form.is_valid(), form.errors
+    obj = form.save(commit=False)
+
+    with pytest.raises(CsrSigningError):
+        _admin().save_model(request, obj, form, change=False)
+
+    assert DeviceCertificate.objects.count() == 0
+    msgs = [str(m) for m in request._messages]
+    assert any("CA unavailable" in m for m in msgs)
+
+
+# ----- response_add delivers the PEM as a download --------------------------
+
+
+def test_response_add_returns_pem_as_attachment(active_ca, device):
+    user = UserFactory(is_staff=True, is_superuser=True)
+    request = _add_request(user)
+    form = DeviceCertificateForm(data={"device": device.pk, "csr_pem": _build_csr()})
+    assert form.is_valid(), form.errors
+    obj = form.save(commit=False)
+    _admin().save_model(request, obj, form, change=False)
+
+    response = _admin().response_add(request, obj)
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "application/x-pem-file"
+    assert "attachment" in response["Content-Disposition"]
+    assert f"cert-{obj.serial}.pem" in response["Content-Disposition"]
+    body = response.content.decode("ascii")
+    assert body.startswith("-----BEGIN CERTIFICATE-----")
+    # PEM body is a valid x509 cert with the right device_id in the SAN URI.
+    cert = x509.load_pem_x509_certificate(body.encode("ascii"))
+    san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+    uris = [u.value for u in san.value if isinstance(u, x509.UniformResourceIdentifier)]
+    assert any(device.device_id in u for u in uris)


### PR DESCRIPTION
## Why

Followup to #664 (admin CA generation), continuing the #663 thread. The \`/enroll/\` HTTP endpoint covers the normal device flow; this is the manual escape-hatch — factory pre-provisioning, support-driven re-cert, devices that can't reach the network.

Replaces the BACKEND-D guard (#662) on \`DeviceCertificateAdmin\` with a real Add path.

## What

Superuser picks a \`DeviceIdentity\`, pastes a PEM CSR (obtained from the device out-of-band), optionally overrides \`validity_days\`, submits.

- \`clean()\` runs \`validate_csr\` (the same gate \`/enroll/\` uses — EC P-256 / SHA-256 / CN = \`forgekey-<12-hex-mac>\`). Bad CSRs become form errors, not 500s.
- \`save_model\` calls \`sign_csr\` (the same path the API view uses), atomically revokes any prior active cert for that device, persists the new metadata row, audit-logs the issuance with the actor.
- \`response_add\` returns the signed PEM as a \`cert-<serial>.pem\` download. The server doesn't keep the PEM long-term — mirrors the \`/enroll/\` HTTP-only delivery model.

## Guard rails

- **Superuser-only** (\`has_add_permission\`) — mints a credential the device authenticates with on every mTLS handshake.
- **Decommissioned DeviceIdentity is refused** at \`clean()\`, matching \`/enroll/\` semantics (forgekey/views.py:309).
- **Missing active CA** surfaces as a clear admin error message + raise — no NOT-NULL 500 on the persistence write.
- **Delete still blocked** at the admin level — certs go away via \`revoked_at\`, never row-delete.

## Test plan

- [x] Pre-commit green on changed files.
- [x] \`pytest forgekey/tests/test_admin_csr_sign.py\` → 8 passed (perm gate, form validation × 3, save_model × 3, response_add download).
- [x] \`pytest forgekey/tests/test_admin_ca_generate.py test_admin_add_blocked.py test_admin_delete.py\` → 14 passed (no regressions; \`test_admin_add_blocked.py\` drops DeviceCertificateAdmin from VIEW_ONLY_ADMINS since both formerly-blocked admins now have proper Add paths).
- [ ] CI green.
- [ ] Spot-check in dev:
  - Active CA in place + superuser + valid CSR → cert-XXX.pem downloads, DB row created, audit log entry written.
  - Same flow but no active CA → admin error message, no row written.
  - Re-sign same device → previous cert's \`revoked_at\` set, new one active.
  - Garbage CSR → form rejects with "Invalid CSR".

Closes #663.