### PR TITLE
feat(forgekey): CA-sign firmware signing keys + ship leaf in dispatch payload

### DIFF
--- a/backend/forgekey/admin.py
+++ b/backend/forgekey/admin.py
@@ -40,6 +40,7 @@ from .services.csr_signing import (
     CsrValidationError,
     generate_ca_keypair,
     sign_csr,
+    sign_firmware_signing_csr,
     validate_csr,
 )
 from .services.firmware_signing import (
@@ -351,6 +352,12 @@ class FirmwareSigningKeyForm(forms.ModelForm):
         key and encrypts the private PEM with the SECRET_KEY-derived KEK.
       * ``generate_new`` checked — server generates a fresh P-256 keypair
         on save (private PEM never crosses the form).
+
+    For either mode, ``sign_with_ca`` (default on when the active CA + KEK
+    are configured) issues a CODE_SIGNING leaf cert over the keypair's
+    public key, signed by the internal CA. The leaf PEM is stored on the
+    row and shipped with firmware-dispatch payloads so devices can verify
+    binaries against the CA chain instead of a single burned-in pubkey.
     """
 
     private_key_pem = forms.CharField(
@@ -368,6 +375,18 @@ class FirmwareSigningKeyForm(forms.ModelForm):
             "Tick this OR paste a private key — not both."
         ),
     )
+    sign_with_ca = forms.BooleanField(
+        required=False,
+        initial=True,
+        label="Sign with internal CA",
+        help_text=(
+            "Issue a CA-signed leaf cert over this keypair. Recommended — "
+            "lets devices verify firmware signatures against the CA chain "
+            "they already trust from /enroll/, so rotating this key doesn't "
+            "require re-flashing the embedded public key. Requires an active "
+            "CA and FORGEKEY_CA_KEY_ENCRYPTION_KEY set."
+        ),
+    )
 
     class Meta:
         model = FirmwareSigningKey
@@ -377,8 +396,11 @@ class FirmwareSigningKeyForm(forms.ModelForm):
         cleaned = super().clean()
         private_pem = (cleaned.get("private_key_pem") or "").strip()
         generate_new = bool(cleaned.get("generate_new"))
+        sign_with_ca = bool(cleaned.get("sign_with_ca"))
 
-        if self.instance.pk:
+        # `self.instance.pk` is set by the UUID default on construction; the
+        # reliable check for "is this a fresh row" is `_state.adding`.
+        if not self.instance._state.adding:
             # Editing an existing row — uploads aren't allowed via this form;
             # operators rotate by creating a new row instead.
             return cleaned
@@ -403,6 +425,32 @@ class FirmwareSigningKeyForm(forms.ModelForm):
             generated_private, generated_public = generate_signing_keypair()
             cleaned["_resolved_private_pem"] = generated_private
             cleaned["_resolved_public_pem"] = generated_public
+
+        if sign_with_ca:
+            label = (cleaned.get("label") or "").strip()
+            if not label:
+                raise forms.ValidationError(
+                    "Sign with internal CA requires a non-empty label "
+                    "(used in the leaf certificate's subject + SAN URI)."
+                )
+            active_ca = CertificateAuthority.get_active()
+            if active_ca is None:
+                raise forms.ValidationError(
+                    "Sign with internal CA is checked but no active CA "
+                    "exists. Bootstrap one in /admin/forgekey/"
+                    "certificateauthority/add/ first."
+                )
+            public_key = serialization.load_pem_public_key(
+                cleaned["_resolved_public_pem"].encode("ascii")
+            )
+            try:
+                signed = sign_firmware_signing_csr(public_key, label=label)
+            except CsrSigningError as exc:
+                # KEK unset, decrypt failure, etc. — keep this in form-error
+                # land so it doesn't propagate as a 500 / Sentry capture.
+                raise forms.ValidationError(f"Cannot CA-sign keypair: {exc}") from exc
+            cleaned["_resolved_cert_pem"] = signed.cert_pem
+            cleaned["_resolved_ca"] = active_ca
         return cleaned
 
 
@@ -429,6 +477,8 @@ class FirmwareSigningKeyAdmin(admin.ModelAdmin):
     readonly_fields = [
         "id",
         "public_key_pem",
+        "cert_pem",
+        "signed_by_ca",
         "created_at",
         "created_by",
         "rotated_at",
@@ -441,7 +491,10 @@ class FirmwareSigningKeyAdmin(admin.ModelAdmin):
         "is_active",
         "private_key_pem",
         "generate_new",
+        "sign_with_ca",
         "public_key_pem",
+        "cert_pem",
+        "signed_by_ca",
         "created_at",
         "created_by",
         "rotated_at",
@@ -459,7 +512,7 @@ class FirmwareSigningKeyAdmin(admin.ModelAdmin):
         if obj is not None:
             # Once written, the encrypted private PEM is immutable — operators
             # rotate by adding a new row.
-            ro.extend(["label", "private_key_pem", "generate_new"])
+            ro.extend(["label", "private_key_pem", "generate_new", "sign_with_ca"])
         return ro
 
     def save_model(self, request, obj, form, change):
@@ -470,6 +523,8 @@ class FirmwareSigningKeyAdmin(admin.ModelAdmin):
             if not private_pem or not public_pem:
                 raise forms.ValidationError("Internal error: signing key data missing.")
             obj.public_key_pem = public_pem
+            obj.cert_pem = cleaned.get("_resolved_cert_pem") or ""
+            obj.signed_by_ca = cleaned.get("_resolved_ca")
             # Attempt to encrypt the private PEM using the system's secret key derivation
             obj.private_key_pem_encrypted = FirmwareSigningKey.encrypt_private_pem(private_pem)
         except Exception as e:

--- a/backend/forgekey/migrations/0019_firmware_signing_key_cert.py
+++ b/backend/forgekey/migrations/0019_firmware_signing_key_cert.py
@@ -1,0 +1,47 @@
+"""Add cert_pem + signed_by_ca to FirmwareSigningKey.
+
+The new fields let a generated keypair carry a leaf certificate signed by
+the internal CA, so firmware-dispatch payloads can ship the leaf and
+devices can verify the chain back to the CA root they already trust
+(via the device-cert /enroll/ flow). Both fields are nullable / blank for
+back-compat with the keys generated before this change.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("forgekey", "0018_firmware_build"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="firmwaresigningkey",
+            name="cert_pem",
+            field=models.TextField(
+                blank=True,
+                help_text=(
+                    "PEM-encoded leaf certificate signed by the internal CA over this "
+                    "keypair. When present, the cert is shipped alongside firmware "
+                    "signatures so devices can verify the chain back to the CA root "
+                    "(rotating the firmware signer no longer requires re-flashing the "
+                    "embedded public key). Blank for legacy keys generated before the "
+                    "CA-issued path landed."
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="firmwaresigningkey",
+            name="signed_by_ca",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="The CA that signed this keypair's leaf cert (NULL for legacy keys).",
+                null=True,
+                on_delete=models.deletion.PROTECT,
+                related_name="firmware_signing_keys",
+                to="forgekey.certificateauthority",
+            ),
+        ),
+    ]

--- a/backend/forgekey/models.py
+++ b/backend/forgekey/models.py
@@ -1046,6 +1046,25 @@ class FirmwareSigningKey(models.Model):
         related_name="firmware_signing_keys_rotated",
         help_text="User who retired this key",
     )
+    cert_pem = models.TextField(
+        blank=True,
+        help_text=(
+            "PEM-encoded leaf certificate signed by the internal CA over this "
+            "keypair. When present, the cert is shipped alongside firmware "
+            "signatures so devices can verify the chain back to the CA root "
+            "(rotating the firmware signer no longer requires re-flashing the "
+            "embedded public key). Blank for legacy keys generated before the "
+            "CA-issued path landed."
+        ),
+    )
+    signed_by_ca = models.ForeignKey(
+        "CertificateAuthority",
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+        related_name="firmware_signing_keys",
+        help_text="The CA that signed this keypair's leaf cert (NULL for legacy keys).",
+    )
 
     class Meta:
         ordering = ["-created_at"]

--- a/backend/forgekey/services/csr_signing.py
+++ b/backend/forgekey/services/csr_signing.py
@@ -277,6 +277,110 @@ def generate_ca_keypair(
     return private_pem, cert
 
 
+def sign_firmware_signing_csr(
+    public_key: ec.EllipticCurvePublicKey,
+    *,
+    label: str,
+    validity_days: int | None = None,
+) -> SignedCertificate:
+    """Issue a CA-signed leaf cert intended for firmware signature verification.
+
+    Differences from :func:`sign_csr`:
+
+    * Operates on a public key rather than a CSR PEM — firmware signing keys
+      live in :class:`forgekey.models.FirmwareSigningKey`, the caller already
+      has the keypair in hand and there is no separate CSR to validate.
+    * ``ExtendedKeyUsage = CODE_SIGNING`` (OID 1.3.6.1.5.5.7.3.3) rather than
+      CLIENT_AUTH; this leaf is **not** an mTLS client cert and must not be
+      accepted as one by the broker / firmware-download endpoints.
+    * ``SubjectAlternativeName`` carries a ``forgekey://firmware-signers/<label>``
+      URI so devices can introspect which logical signer (not which device)
+      authored a given firmware artifact.
+
+    Returns a :class:`SignedCertificate`; the caller persists ``cert_pem`` on
+    the :class:`FirmwareSigningKey` row.
+    """
+    if not isinstance(public_key, ec.EllipticCurvePublicKey):
+        raise CsrSigningError("firmware signing public key must be elliptic-curve.")
+    if public_key.curve.name != "secp256r1":
+        raise CsrSigningError(
+            f"firmware signing public key must be P-256; got {public_key.curve.name}."
+        )
+
+    ca_cert, ca_private_key, _ca_name = _load_ca()
+
+    if validity_days is None:
+        validity_days = int(getattr(settings, "FORGEKEY_FIRMWARE_SIGNER_CERT_VALIDITY_DAYS", 730))
+    if validity_days <= 0:
+        raise CsrSigningError("validity_days must be positive.")
+
+    now = datetime.now(timezone.utc)
+    not_before = now - timedelta(minutes=1)
+    not_after = now + timedelta(days=validity_days)
+    if not_after > ca_cert.not_valid_after_utc:
+        not_after = ca_cert.not_valid_after_utc
+
+    serial = x509.random_serial_number()
+    subject = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, f"forgekey-firmware-signer-{label}")]
+    )
+
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(ca_cert.subject)
+        .public_key(public_key)
+        .serial_number(serial)
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.ExtendedKeyUsage([x509.ExtendedKeyUsageOID.CODE_SIGNING]),
+            critical=True,
+        )
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [x509.UniformResourceIdentifier(f"forgekey://firmware-signers/{label}")]
+            ),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(public_key),
+            critical=False,
+        )
+        .add_extension(
+            _authority_key_identifier_from(ca_cert),
+            critical=False,
+        )
+    )
+
+    cert = builder.sign(private_key=ca_private_key, algorithm=hashes.SHA256())
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode("ascii")
+    fingerprint = cert.fingerprint(hashes.SHA256()).hex()
+    return SignedCertificate(
+        cert_pem=cert_pem,
+        serial=format(serial, "x"),
+        fingerprint_sha256=fingerprint,
+        not_before=not_before,
+        not_after=not_after,
+        subject=cert.subject.rfc4514_string(),
+    )
+
+
 __all__ = (
     "CsrSigningError",
     "CsrValidationError",

--- a/backend/forgekey/services/firmware_dispatch.py
+++ b/backend/forgekey/services/firmware_dispatch.py
@@ -17,7 +17,7 @@ from typing import Iterable, List, Sequence, Union
 from django.db.models import QuerySet
 
 from ..audit import record_event as record_audit_event
-from ..models import DeviceFirmwareUpdate, ESP32Device, FirmwareVersion
+from ..models import DeviceFirmwareUpdate, ESP32Device, FirmwareSigningKey, FirmwareVersion
 from ..tasks import get_mqtt_client
 from ..utils import get_mqtt_firmware_topic, normalize_mac_address
 
@@ -34,13 +34,22 @@ def _coerce_devices(devices: DeviceArg) -> List[ESP32Device]:
 
 
 def _build_payload(firmware: FirmwareVersion) -> dict:
-    return {
+    payload = {
         "url": firmware.effective_binary_url,
         "sha256": firmware.sha256,
         "signature": firmware.signature or "",
         "version": firmware.version,
         "mandatory": firmware.mandatory,
     }
+    # When the active firmware-signing key carries a CA-issued leaf cert,
+    # ship the leaf alongside the signature. Verifying firmware can then
+    # validate signature → leaf → CA root, instead of relying on a single
+    # burned-in pubkey. Devices older than the chain-verifier ignore
+    # unknown fields and continue to verify with the embedded pubkey.
+    active_key = FirmwareSigningKey.get_active()
+    if active_key is not None and active_key.cert_pem:
+        payload["signing_cert"] = active_key.cert_pem
+    return payload
 
 
 def publish_firmware_update(

--- a/backend/forgekey/tests/test_firmware_ca_signing.py
+++ b/backend/forgekey/tests/test_firmware_ca_signing.py
@@ -1,0 +1,246 @@
+"""
+CA-signed firmware-signing leaf cert: admin path issues the leaf, the
+dispatch payload ships it, and legacy keys (no leaf) still dispatch
+unchanged for back-compat with devices not yet upgraded.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest import mock
+
+from django.contrib import admin
+from django.core.management import call_command
+from django.test import RequestFactory
+
+import pytest
+from cryptography import x509
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import serialization
+from cryptography.x509.oid import ExtendedKeyUsageOID
+
+from forgekey.admin import FirmwareSigningKeyAdmin, FirmwareSigningKeyForm
+from forgekey.models import CertificateAuthority, FirmwareSigningKey, FirmwareVersion
+from forgekey.services.firmware_dispatch import _build_payload
+from forgekey.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+# ----- fixtures --------------------------------------------------------------
+
+
+@pytest.fixture
+def kek(settings):
+    settings.FORGEKEY_CA_KEY_ENCRYPTION_KEY = Fernet.generate_key().decode("ascii")
+
+
+@pytest.fixture
+def active_ca(kek):
+    out = StringIO()
+    call_command("forgekey_ca", "init", "--validity-years", "1", stdout=out)
+    return CertificateAuthority.get_active()
+
+
+def _admin():
+    return FirmwareSigningKeyAdmin(FirmwareSigningKey, admin.site)
+
+
+def _add_request(user):
+    request = RequestFactory().post("/admin/forgekey/firmwaresigningkey/add/")
+    request.user = user
+    from django.contrib.messages.storage.fallback import FallbackStorage
+
+    request.session = {}
+    request._messages = FallbackStorage(request)
+    return request
+
+
+def _stub_secret_key(settings):
+    # FirmwareSigningKey.encrypt_private_pem derives the at-rest KEK from
+    # settings.SECRET_KEY; a fixed value keeps the tests deterministic.
+    settings.SECRET_KEY = "test-secret-key-for-firmware-signing"
+
+
+# ----- generate + sign with CA -----------------------------------------------
+
+
+def test_generate_and_sign_with_ca_persists_leaf_cert(active_ca, settings):
+    _stub_secret_key(settings)
+    user = UserFactory(is_staff=True, is_superuser=True)
+    request = _add_request(user)
+
+    form = FirmwareSigningKeyForm(
+        data={
+            "label": "prod-2026-q2",
+            "description": "",
+            "is_active": "on",
+            "generate_new": "on",
+            "sign_with_ca": "on",
+        }
+    )
+    assert form.is_valid(), form.errors
+    obj = form.save(commit=False)
+
+    _admin().save_model(request, obj, form, change=False)
+
+    saved = FirmwareSigningKey.objects.get(pk=obj.pk)
+    assert saved.public_key_pem.startswith("-----BEGIN PUBLIC KEY-----")
+    assert saved.cert_pem.startswith("-----BEGIN CERTIFICATE-----")
+    assert saved.signed_by_ca_id == active_ca.id
+
+    # The leaf cert is a real x509 with the right EKU + SAN.
+    leaf = x509.load_pem_x509_certificate(saved.cert_pem.encode("ascii"))
+    eku = leaf.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
+    assert ExtendedKeyUsageOID.CODE_SIGNING in list(eku.value)
+    san = leaf.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+    uris = [u.value for u in san.value if isinstance(u, x509.UniformResourceIdentifier)]
+    assert any("firmware-signers/prod-2026-q2" in u for u in uris)
+    # Leaf public key matches the row's public PEM.
+    leaf_pub = leaf.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    assert leaf_pub.decode("ascii").strip() == saved.public_key_pem.strip()
+
+
+def test_generate_without_sign_with_ca_skips_leaf(active_ca, settings):
+    _stub_secret_key(settings)
+    user = UserFactory(is_staff=True, is_superuser=True)
+    request = _add_request(user)
+
+    form = FirmwareSigningKeyForm(
+        data={
+            "label": "legacy-style",
+            "description": "",
+            "is_active": "on",
+            "generate_new": "on",
+            # sign_with_ca omitted → unchecked
+        }
+    )
+    assert form.is_valid(), form.errors
+    obj = form.save(commit=False)
+    _admin().save_model(request, obj, form, change=False)
+
+    saved = FirmwareSigningKey.objects.get(pk=obj.pk)
+    assert saved.cert_pem == ""
+    assert saved.signed_by_ca is None
+
+
+def test_sign_with_ca_without_active_ca_errors(settings):
+    _stub_secret_key(settings)
+    form = FirmwareSigningKeyForm(
+        data={
+            "label": "prod",
+            "description": "",
+            "is_active": "on",
+            "generate_new": "on",
+            "sign_with_ca": "on",
+        }
+    )
+    assert not form.is_valid()
+    assert any("no active CA" in e for e in form.non_field_errors())
+
+
+def test_sign_with_ca_without_kek_errors(active_ca, settings):
+    """KEK was set by the active_ca fixture; clear it after the CA is
+    bootstrapped to simulate a misconfigured deploy that has an existing CA
+    but lost its KEK. sign_firmware_signing_csr needs KEK to unwrap the CA
+    private key."""
+    _stub_secret_key(settings)
+    settings.FORGEKEY_CA_KEY_ENCRYPTION_KEY = ""
+
+    form = FirmwareSigningKeyForm(
+        data={
+            "label": "prod",
+            "description": "",
+            "is_active": "on",
+            "generate_new": "on",
+            "sign_with_ca": "on",
+        }
+    )
+    assert not form.is_valid()
+    assert any("Cannot CA-sign keypair" in e for e in form.non_field_errors())
+
+
+def test_sign_with_ca_requires_label(active_ca, settings):
+    _stub_secret_key(settings)
+    form = FirmwareSigningKeyForm(
+        data={
+            "label": "",
+            "description": "",
+            "is_active": "on",
+            "generate_new": "on",
+            "sign_with_ca": "on",
+        }
+    )
+    assert not form.is_valid()
+    assert any("non-empty label" in e for e in form.non_field_errors())
+
+
+# ----- dispatch payload includes leaf cert ----------------------------------
+
+
+def test_dispatch_payload_includes_signing_cert_when_key_has_one(active_ca, settings):
+    _stub_secret_key(settings)
+    user = UserFactory(is_staff=True, is_superuser=True)
+    request = _add_request(user)
+    form = FirmwareSigningKeyForm(
+        data={
+            "label": "prod-ca",
+            "description": "",
+            "is_active": "on",
+            "generate_new": "on",
+            "sign_with_ca": "on",
+        }
+    )
+    assert form.is_valid(), form.errors
+    obj = form.save(commit=False)
+    _admin().save_model(request, obj, form, change=False)
+
+    firmware = mock.Mock(spec=FirmwareVersion)
+    firmware.effective_binary_url = "https://example.com/fw.bin"
+    firmware.sha256 = "abc123"
+    firmware.signature = "sig=="
+    firmware.version = "2.0.0"
+    firmware.mandatory = False
+
+    payload = _build_payload(firmware)
+    assert "signing_cert" in payload
+    assert payload["signing_cert"].startswith("-----BEGIN CERTIFICATE-----")
+    # The cert in the payload matches the saved row.
+    assert payload["signing_cert"] == FirmwareSigningKey.objects.get(pk=obj.pk).cert_pem
+
+
+def test_dispatch_payload_omits_signing_cert_for_legacy_key(settings):
+    _stub_secret_key(settings)
+    # Build a legacy key by hand: no leaf cert, no signed_by_ca.
+    FirmwareSigningKey.objects.create(
+        label="legacy",
+        public_key_pem="-----BEGIN PUBLIC KEY-----\nMG==\n-----END PUBLIC KEY-----",
+        private_key_pem_encrypted=b"x",
+        is_active=True,
+    )
+
+    firmware = mock.Mock(spec=FirmwareVersion)
+    firmware.effective_binary_url = "https://example.com/fw.bin"
+    firmware.sha256 = "abc123"
+    firmware.signature = "sig=="
+    firmware.version = "1.0.0"
+    firmware.mandatory = False
+
+    payload = _build_payload(firmware)
+    assert "signing_cert" not in payload
+
+
+def test_dispatch_payload_omits_signing_cert_when_no_active_key(settings):
+    _stub_secret_key(settings)
+    firmware = mock.Mock(spec=FirmwareVersion)
+    firmware.effective_binary_url = "https://example.com/fw.bin"
+    firmware.sha256 = "abc"
+    firmware.signature = ""
+    firmware.version = "0.0.1"
+    firmware.mandatory = False
+
+    payload = _build_payload(firmware)
+    assert "signing_cert" not in payload


### PR DESCRIPTION
First half of the *use the CA for firmware too* thread. Server-only; devices that don't yet know how to verify a chain ignore the new field and keep working against their embedded pubkey. Follow-up PRs will add the mTLS download path and the firmware-side chain verifier.

## What

Server-side primitives so a new \`FirmwareSigningKey\` generated from the admin gets a CA-signed leaf certificate over its public key and ships that cert with every firmware-dispatch MQTT payload:

- **\`FirmwareSigningKey.cert_pem\`** (TextField, blank=True) + **\`signed_by_ca\`** FK to \`CertificateAuthority\`. Migration 0019. Both nullable / blank for back-compat with keys generated before this change.
- **\`forgekey.services.csr_signing.sign_firmware_signing_csr(public_key, label, validity_days)\`** — same CA-signing primitive as \`sign_csr\`, but \`ExtendedKeyUsage = CODE_SIGNING\` (not CLIENT_AUTH) and SAN URI = \`forgekey://firmware-signers/<label>\`. **Critically these leaves are NOT mTLS client certs and must not be accepted as such.**
- **\`FirmwareSigningKeyAdmin\` / \`FirmwareSigningKeyForm\`**: new \`sign_with_ca\` checkbox (default ON). When set on a generate-new or paste-PEM submission, the form derives the public key, calls \`sign_firmware_signing_csr\`, and stashes the leaf PEM + CA FK onto the saved row. Validates presence of an active CA + label upfront so failure modes are form errors, not 500s.
- **\`forgekey.services.firmware_dispatch._build_payload\`**: emits \`signing_cert\` (PEM) alongside the existing \`signature\` when the active signing key carries a leaf. Devices on older firmware ignore unknown fields; devices on the chain-verifying firmware (next PR in the ForgeKey repo) can validate \`signature → leaf → CA root\`.

Also fixes the same \`self.instance.pk\`-with-UUID-default bug that bit \`CertificateAuthorityForm\` in #664 — the form's *is editing* check short-circuited because \`pk\` is set by the UUID default at construct time; switched to \`_state.adding\`.

## Test plan

- [x] \`pytest test_firmware_ca_signing.py\` → 8 passed: generate+sign, generate-without-sign skips leaf, form errors on no CA / no KEK / empty label, dispatch payload contains leaf when set, omits it for legacy and missing-active keys.
- [x] Broader sweep across \`test_firmware_signing.py\`, \`test_ota_dispatch.py\`, \`test_csr_signing.py\`, \`test_enrollment.py\`, \`test_admin_csr_sign.py\`, \`test_admin_ca_generate.py\`, \`test_admin_add_blocked.py\`, \`test_admin_delete.py\`, \`test_forgekey_ca_command.py\` → 112 passed, no regressions.
- [ ] CI green.
- [ ] Spot-check in dev: generate a new \`FirmwareSigningKey\` with \`sign_with_ca\` ticked → row shows \`cert_pem\` populated, \`signed_by_ca\` set, MQTT dispatch payload contains \`signing_cert\`.

## Follow-ups (next PRs)

1. \`/api/forgekey/firmware/<id>/download\`: add mTLS auth path (additive — keep HMAC/JWT during transition).
2. ForgeKey firmware repo: bake CA pubkey, parse \`signing_cert\` from MQTT, verify chain.
3. ForgeKey firmware repo: switch OTA HTTP client to mTLS using the enrolled device cert.

Refs \"use the CA for signing firmware and validating update software requests\".