### PR TITLE
feat(forgekey): mTLS auth on /api/forgekey/firmware/<id>/download

### DIFF
--- a/backend/forgekey/services/mtls_auth.py
+++ b/backend/forgekey/services/mtls_auth.py
@@ -1,0 +1,113 @@
+"""
+Verify an mTLS client certificate forwarded by the reverse proxy.
+
+nginx terminates TLS, validates the client cert against the OMS CA, and
+forwards three headers when ``ssl_verify_client on`` is configured on
+the listen block:
+
+  * ``X-SSL-Client-Verify``  — ``SUCCESS`` when nginx accepted the chain.
+  * ``X-SSL-Client-S-DN``    — RFC4514 subject DN of the client cert.
+  * ``X-SSL-Client-Cert``    — URL-escaped PEM of the client cert (via
+                               nginx's ``$ssl_client_escaped_cert``).
+
+This module re-checks the chain inside Django for defense-in-depth (the
+proxy could be misconfigured to forward headers it didn't actually
+verify), pins the issuer to the *currently active* CA row, and looks
+up the cert in ``DeviceCertificate`` so revocation flows still gate
+access without needing nginx-side CRL plumbing.
+
+Returns ``(authorized, device_id_or_None, reason)`` so callers can log
+the rejection reason without branching on header values themselves.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+from urllib.parse import unquote
+
+from cryptography import x509
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from ..models import CertificateAuthority, DeviceCertificate, DeviceIdentity
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MtlsAuthResult:
+    authorized: bool
+    device_id: Optional[str]
+    reason: str
+
+
+_OK = "ok"
+
+
+def verify_mtls_request(request) -> MtlsAuthResult:
+    """Validate an incoming nginx-forwarded mTLS client cert.
+
+    Rejects with a structured reason for every failure mode rather than a
+    bare ``False`` so the caller (and Sentry, when logged) can distinguish
+    "proxy didn't verify" from "we don't know this cert".
+    """
+    verify = request.headers.get("x-ssl-client-verify", "")
+    if verify != "SUCCESS":
+        return MtlsAuthResult(False, None, f"proxy verify status {verify!r}")
+
+    cert_header = request.headers.get("x-ssl-client-cert", "")
+    if not cert_header:
+        return MtlsAuthResult(False, None, "no client cert header")
+
+    cert_pem = unquote(cert_header)
+    try:
+        cert = x509.load_pem_x509_certificate(cert_pem.encode("ascii"))
+    except Exception as exc:
+        return MtlsAuthResult(False, None, f"client cert unparseable: {exc}")
+
+    active_ca = CertificateAuthority.get_active()
+    if active_ca is None:
+        return MtlsAuthResult(False, None, "no active CA configured")
+    try:
+        ca_cert = x509.load_pem_x509_certificate(active_ca.cert_pem.encode("ascii"))
+    except Exception as exc:
+        return MtlsAuthResult(False, None, f"active CA unparseable: {exc}")
+
+    # Verify the leaf was actually signed by the active CA — never trust the
+    # proxy's verify result alone, in case it's been reconfigured to a
+    # different trust bundle.
+    ca_public_key = ca_cert.public_key()
+    if not isinstance(ca_public_key, ec.EllipticCurvePublicKey):
+        return MtlsAuthResult(False, None, "active CA public key is not EC")
+    try:
+        ca_public_key.verify(
+            cert.signature,
+            cert.tbs_certificate_bytes,
+            ec.ECDSA(cert.signature_hash_algorithm),
+        )
+    except InvalidSignature:
+        return MtlsAuthResult(False, None, "client cert not signed by active CA")
+    except Exception as exc:
+        return MtlsAuthResult(False, None, f"signature verify error: {exc}")
+
+    now = datetime.now(timezone.utc)
+    if cert.not_valid_before_utc > now:
+        return MtlsAuthResult(False, None, "client cert not yet valid")
+    if cert.not_valid_after_utc <= now:
+        return MtlsAuthResult(False, None, "client cert expired")
+
+    # Pin to a row in DeviceCertificate so an admin-side revoke
+    # (revoked_at != NULL) takes effect immediately, without nginx-side CRL.
+    serial_hex = format(cert.serial_number, "x")
+    db_cert = DeviceCertificate.objects.select_related("device").filter(serial=serial_hex).first()
+    if db_cert is None:
+        return MtlsAuthResult(False, None, f"client cert serial {serial_hex} unknown")
+    if db_cert.revoked_at is not None:
+        return MtlsAuthResult(False, None, f"client cert serial {serial_hex} revoked")
+    if db_cert.device.status == DeviceIdentity.STATUS_DECOMMISSIONED:
+        return MtlsAuthResult(False, None, f"device {db_cert.device.device_id!r} decommissioned")
+
+    return MtlsAuthResult(True, db_cert.device.device_id, _OK)

--- a/backend/forgekey/tests/test_mtls_auth.py
+++ b/backend/forgekey/tests/test_mtls_auth.py
@@ -1,0 +1,268 @@
+"""
+Server-side mTLS verification for the firmware download endpoint.
+
+verify_mtls_request reads the X-SSL-Client-* headers nginx forwards from
+the dedicated mTLS listener, re-checks the cert chain against the
+currently active CA (defense-in-depth — never trusts the proxy alone),
+and gates on the DB-side revoke / decommission flags so an admin-side
+state change takes effect immediately without nginx-side CRL plumbing.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from io import StringIO
+from urllib.parse import quote
+
+from django.core.management import call_command
+from django.test import RequestFactory
+
+import pytest
+from cryptography import x509
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from forgekey.models import CertificateAuthority, DeviceCertificate, DeviceIdentity
+from forgekey.services.mtls_auth import verify_mtls_request
+
+pytestmark = pytest.mark.django_db
+
+
+# ----- fixtures --------------------------------------------------------------
+
+
+@pytest.fixture
+def kek(settings):
+    settings.FORGEKEY_CA_KEY_ENCRYPTION_KEY = Fernet.generate_key().decode("ascii")
+
+
+@pytest.fixture
+def active_ca(kek):
+    out = StringIO()
+    call_command("forgekey_ca", "init", "--validity-years", "1", stdout=out)
+    return CertificateAuthority.get_active()
+
+
+@pytest.fixture
+def device():
+    return DeviceIdentity.objects.create(device_id="chip-aabbccddeeff")
+
+
+@pytest.fixture
+def signed_device_cert(active_ca, device):
+    """Issue a device cert via the same sign_csr path /enroll/ uses, persist
+    the metadata row, return (cert_pem, private_key) so the test can craft
+    realistic mTLS headers."""
+    from forgekey.services.csr_signing import sign_csr
+
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "forgekey-aabbccddeeff")])
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(subject)
+        .sign(private_key=private_key, algorithm=hashes.SHA256())
+    )
+    csr_pem = csr.public_bytes(serialization.Encoding.PEM).decode("ascii")
+
+    signed = sign_csr(csr_pem, device_id=device.device_id)
+    DeviceCertificate.objects.create(
+        device=device,
+        serial=signed.serial,
+        subject=signed.subject,
+        fingerprint_sha256=signed.fingerprint_sha256,
+        not_before=signed.not_before,
+        not_after=signed.not_after,
+        issued_by=active_ca.name,
+    )
+    return signed.cert_pem, private_key
+
+
+def _request_with_mtls_headers(cert_pem: str, verify: str = "SUCCESS"):
+    """Build a request mirroring what nginx forwards from the mTLS listener."""
+    request = RequestFactory().get("/api/forgekey/firmware/xxx/download")
+    request.META["HTTP_X_SSL_CLIENT_VERIFY"] = verify
+    # nginx's $ssl_client_escaped_cert is URL-encoded so the PEM newlines
+    # survive the HTTP header byte set.
+    request.META["HTTP_X_SSL_CLIENT_CERT"] = quote(cert_pem)
+    return request
+
+
+# ----- happy path ------------------------------------------------------------
+
+
+def test_valid_cert_authorizes_and_returns_device_id(signed_device_cert, device):
+    cert_pem, _key = signed_device_cert
+    request = _request_with_mtls_headers(cert_pem)
+
+    result = verify_mtls_request(request)
+
+    assert result.authorized is True
+    assert result.device_id == device.device_id
+    assert result.reason == "ok"
+
+
+# ----- rejection paths --------------------------------------------------------
+
+
+def test_missing_verify_header_rejects():
+    request = RequestFactory().get("/")
+    result = verify_mtls_request(request)
+    assert result.authorized is False
+    assert "proxy verify status" in result.reason
+
+
+def test_verify_header_not_success_rejects():
+    request = RequestFactory().get("/")
+    request.META["HTTP_X_SSL_CLIENT_VERIFY"] = "FAILED:self-signed certificate"
+    result = verify_mtls_request(request)
+    assert result.authorized is False
+    assert "FAILED" in result.reason
+
+
+def test_verify_success_but_no_cert_header_rejects():
+    request = RequestFactory().get("/")
+    request.META["HTTP_X_SSL_CLIENT_VERIFY"] = "SUCCESS"
+    # X-SSL-Client-Cert intentionally missing
+    result = verify_mtls_request(request)
+    assert result.authorized is False
+    assert "no client cert header" in result.reason
+
+
+def test_unparseable_cert_rejects():
+    request = _request_with_mtls_headers("not a valid PEM at all")
+    result = verify_mtls_request(request)
+    assert result.authorized is False
+    assert "unparseable" in result.reason
+
+
+def test_no_active_ca_rejects(signed_device_cert):
+    cert_pem, _key = signed_device_cert
+    # Deactivate the only CA after a cert was signed against it.
+    CertificateAuthority.objects.update(is_active=False)
+    request = _request_with_mtls_headers(cert_pem)
+    result = verify_mtls_request(request)
+    assert result.authorized is False
+    assert "no active CA" in result.reason
+
+
+def test_cert_signed_by_different_ca_rejects(signed_device_cert, kek):
+    """Issue a leaf against an outsider CA, present it under the active CA's
+    listener — must fail signature verification."""
+    from forgekey.services.csr_signing import generate_ca_keypair
+
+    cert_pem, _key = signed_device_cert
+    # Tear down the original active CA and stand up a different one — the
+    # original-signed leaf must no longer verify under the new active CA.
+    CertificateAuthority.objects.all().delete()
+    other_private_pem, other_cert = generate_ca_keypair(cn="other CA", validity_days=30)
+    from forgekey.services.ca_key_storage import encrypt_ca_key
+
+    ct, kid = encrypt_ca_key(other_private_pem)
+    CertificateAuthority.objects.create(
+        name="other-root",
+        cert_pem=other_cert.public_bytes(serialization.Encoding.PEM).decode("ascii"),
+        encrypted_private_key=ct,
+        key_kid=kid,
+        not_before=other_cert.not_valid_before_utc,
+        not_after=other_cert.not_valid_after_utc,
+        is_active=True,
+    )
+
+    request = _request_with_mtls_headers(cert_pem)
+    result = verify_mtls_request(request)
+    assert result.authorized is False
+    assert "not signed by active CA" in result.reason
+
+
+def test_revoked_cert_rejects(signed_device_cert):
+    cert_pem, _key = signed_device_cert
+    DeviceCertificate.objects.update(revoked_at=datetime.now(timezone.utc))
+    request = _request_with_mtls_headers(cert_pem)
+    result = verify_mtls_request(request)
+    assert result.authorized is False
+    assert "revoked" in result.reason
+
+
+def test_decommissioned_device_rejects(signed_device_cert, device):
+    cert_pem, _key = signed_device_cert
+    device.status = DeviceIdentity.STATUS_DECOMMISSIONED
+    device.save()
+    request = _request_with_mtls_headers(cert_pem)
+    result = verify_mtls_request(request)
+    assert result.authorized is False
+    assert "decommissioned" in result.reason
+
+
+def test_unknown_serial_rejects(active_ca, device):
+    """A leaf signed by the active CA but with no DeviceCertificate row —
+    e.g., a cert issued out-of-band that bypassed our admin/enroll flow."""
+    from forgekey.services.csr_signing import sign_csr
+
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "forgekey-aabbccddeeff")])
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(subject)
+        .sign(private_key=private_key, algorithm=hashes.SHA256())
+    )
+    csr_pem = csr.public_bytes(serialization.Encoding.PEM).decode("ascii")
+    signed = sign_csr(csr_pem, device_id=device.device_id)
+    # Intentionally do NOT persist a DeviceCertificate row.
+
+    request = _request_with_mtls_headers(signed.cert_pem)
+    result = verify_mtls_request(request)
+    assert result.authorized is False
+    assert "serial" in result.reason and "unknown" in result.reason
+
+
+def test_expired_cert_rejects(active_ca, device, monkeypatch):
+    """sign_csr enforces a non-trivial validity floor; simulate expiry by
+    monkeypatching `datetime.now` in mtls_auth so the validity window
+    arithmetic treats our newly-signed cert as past its not_after."""
+    from forgekey.services.csr_signing import sign_csr
+
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "forgekey-aabbccddeeff")])
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(subject)
+        .sign(private_key=private_key, algorithm=hashes.SHA256())
+    )
+    csr_pem = csr.public_bytes(serialization.Encoding.PEM).decode("ascii")
+    signed = sign_csr(csr_pem, device_id=device.device_id)
+    DeviceCertificate.objects.create(
+        device=device,
+        serial=signed.serial,
+        subject=signed.subject,
+        fingerprint_sha256=signed.fingerprint_sha256,
+        not_before=signed.not_before,
+        not_after=signed.not_after,
+        issued_by=active_ca.name,
+    )
+
+    # Fast-forward time past the cert's not_after.
+    from forgekey.services import mtls_auth
+
+    fake_now = signed.not_after + timedelta(days=1)
+    monkeypatch.setattr(mtls_auth, "datetime", _FrozenDatetime.with_now(fake_now))
+
+    request = _request_with_mtls_headers(signed.cert_pem)
+    result = verify_mtls_request(request)
+    assert result.authorized is False
+    assert "expired" in result.reason
+
+
+class _FrozenDatetime(datetime):
+    """A datetime subclass with a pinned ``now()`` for monkeypatching."""
+
+    _frozen: datetime
+
+    @classmethod
+    def with_now(cls, when: datetime) -> "type[_FrozenDatetime]":
+        return type("_FrozenAt", (cls,), {"_frozen": when})
+
+    @classmethod
+    def now(cls, tz=None):
+        return cls._frozen if tz is None else cls._frozen.astimezone(tz)

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -90,6 +90,7 @@ from .services.jwt_signing import (
     get_jwt_public_key_pem,
     is_jwt_signing_configured,
 )
+from .services.mtls_auth import verify_mtls_request
 from .tasks import (
     disable_device,
     enable_device,
@@ -2029,6 +2030,22 @@ class ForgeKeyFirmwareDownloadView(APIView):
 
     @staticmethod
     def _authorize(request, firmware_id: str) -> bool:
+        # mTLS path: nginx terminates on the dedicated mTLS listener
+        # (FORGEKEY_MTLS_PORT, default 8443) and forwards the verified
+        # client cert as X-SSL-Client-* headers. Re-verify here so a
+        # misconfigured proxy can't grant access by sending bare
+        # headers, and so admin-side revoke (revoked_at) gates without
+        # nginx-side CRL plumbing. This path is tried first because
+        # devices on chain-aware firmware should use it exclusively;
+        # token / JWT fallbacks remain for the transition window.
+        mtls = verify_mtls_request(request)
+        if mtls.authorized:
+            return True
+        if request.headers.get("x-ssl-client-verify"):
+            # Headers present but rejected — log so operators can debug
+            # cert issues at the proxy layer instead of silent 401s.
+            logger.info("ForgeKey firmware download: mTLS rejected — %s", mtls.reason)
+
         token = request.query_params.get("token") or request.GET.get("token")
         exp = request.query_params.get("exp") or request.GET.get("exp")
         if token and exp:

--- a/nginx/docker-entrypoint.d/20-mtls.sh
+++ b/nginx/docker-entrypoint.d/20-mtls.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Activate the ForgeKey mTLS listener template when FORGEKEY_MTLS_ENABLED=1.
+#
+# The template ships as `mtls.conf.template.disabled` so nginx's normal
+# entrypoint ignores it by default; if you renamed it eagerly, nginx would
+# fail to start in deployments that haven't yet mounted the CA cert at
+# FORGEKEY_MTLS_CA_PATH.
+#
+# This script runs BEFORE nginx's 20-envsubst-on-templates.sh, so the
+# rename happens in time for envsubst to render `mtls.conf` into
+# /etc/nginx/conf.d/.
+set -eu
+
+if [ "${FORGEKEY_MTLS_ENABLED:-0}" != "1" ]; then
+    exit 0
+fi
+
+: "${FORGEKEY_MTLS_PORT:=8443}"
+export FORGEKEY_MTLS_PORT
+
+if [ -z "${FORGEKEY_MTLS_CA_PATH:-}" ]; then
+    echo "20-mtls: FORGEKEY_MTLS_ENABLED=1 but FORGEKEY_MTLS_CA_PATH is unset." >&2
+    echo "20-mtls: bind-mount the OMS CA PEM into the nginx container and set the path." >&2
+    exit 1
+fi
+if [ ! -r "$FORGEKEY_MTLS_CA_PATH" ]; then
+    echo "20-mtls: FORGEKEY_MTLS_CA_PATH=$FORGEKEY_MTLS_CA_PATH is not readable." >&2
+    exit 1
+fi
+export FORGEKEY_MTLS_CA_PATH
+
+disabled=/etc/nginx/templates/mtls.conf.template.disabled
+enabled=/etc/nginx/templates/mtls.conf.template
+if [ -f "$disabled" ] && [ ! -f "$enabled" ]; then
+    mv "$disabled" "$enabled"
+    echo "20-mtls: mTLS template activated on :$FORGEKEY_MTLS_PORT (CA=$FORGEKEY_MTLS_CA_PATH)"
+fi

--- a/nginx/templates/mtls.conf.template.disabled
+++ b/nginx/templates/mtls.conf.template.disabled
@@ -1,0 +1,57 @@
+# Dedicated mTLS listener for the ForgeKey firmware-download endpoint.
+#
+# Renamed to `mtls.conf.template` (and consumed by nginx's normal
+# template-rendering pass) only when FORGEKEY_MTLS_ENABLED=1 is set,
+# via the 20-mtls.sh entrypoint. Keeping it inert by default avoids
+# nginx failing to start in deployments that haven't yet set up the
+# CA cert mount.
+#
+# Required env vars when enabled:
+#   FORGEKEY_MTLS_PORT     — listener port (default 8443)
+#   FORGEKEY_MTLS_CA_PATH  — bind-mount path to the OMS CA PEM
+#   LETSENCRYPT_DOMAINS    — already set by the main template
+#   DOMAIN                 — already set by the main template
+
+server {
+    listen ${FORGEKEY_MTLS_PORT} ssl http2;
+    server_name ${LETSENCRYPT_DOMAINS};
+
+    # Server cert (the public LE chain) — same as :443; devices verify
+    # they're talking to the real OMS before presenting their own cert.
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN}-0001/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}-0001/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+
+    # Client cert verification against the OMS CA — only certs signed by
+    # the CA mounted at FORGEKEY_MTLS_CA_PATH are accepted. ssl_verify_depth 1
+    # because we issue leaf certs directly (no intermediate).
+    ssl_client_certificate ${FORGEKEY_MTLS_CA_PATH};
+    ssl_verify_client on;
+    ssl_verify_depth 1;
+
+    # Only the firmware-download endpoint accepts mTLS. Everything else
+    # 404s here so an operator misroute doesn't accidentally expose other
+    # routes to cert-authenticated principals.
+    location /api/forgekey/firmware/ {
+        proxy_pass http://backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # Forward the verified client cert to Django — verify_mtls_request
+        # re-checks the chain server-side, the headers are an
+        # untrusted-by-Django carrier. Use $ssl_client_escaped_cert so
+        # PEM newlines survive the HTTP header byte set.
+        proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
+        proxy_set_header X-SSL-Client-S-DN $ssl_client_s_dn;
+        proxy_set_header X-SSL-Client-Cert $ssl_client_escaped_cert;
+        proxy_redirect off;
+    }
+
+    location / {
+        return 404 "Only /api/forgekey/firmware/ is exposed on the mTLS listener.\n";
+    }
+}


### PR DESCRIPTION
Second half of *use the CA for firmware too* (after #666). **Additive** — HMAC token and device JWT keep working, so existing devices on old firmware aren't disrupted. A device that presents a valid CA-issued mTLS cert at the dedicated mTLS listener gets through without needing either of those.

## Why

The download endpoint's existing auth shapes (short-lived HMAC token embedded in the MQTT trigger payload, device JWT tied to MAC) are both workarounds for the absence of a real device-identity primitive. Now that \`/enroll/\` + the admin CSR-sign path (#665) hand every device a CA-issued mTLS client cert, **that *is* the identity** — proving possession of the cert proves the device, full stop. No more JWT minting, no more token-in-URL window.

## What

**\`forgekey/services/mtls_auth.py\`** — \`verify_mtls_request(request)\`:

1. Reads \`X-SSL-Client-Verify\` / \`X-SSL-Client-Cert\` headers nginx forwards from \`$ssl_client_escaped_cert\`.
2. **Re-verifies the chain server-side**, never trusts the proxy alone — the leaf must sign-validate against the currently-active CA's public key. A reconfigured proxy can't grant access by sending bare headers.
3. Validity window check.
4. **Pins to a \`DeviceCertificate\` row** so admin-side revoke (\`revoked_at != NULL\`) takes effect immediately, no nginx CRL plumbing needed.
5. Rejects if the bound \`DeviceIdentity.status\` is decommissioned.
6. Returns a structured \`MtlsAuthResult\` with the rejection reason so the caller can log it without branching on header values.

**\`ForgeKeyFirmwareDownloadView._authorize\`**: try mTLS first; fall through to token / JWT on miss. When headers are present but rejected, log the reason so operators can debug cert issues at the proxy without hunting silent 401s.

**\`nginx/templates/mtls.conf.template.disabled\`**: dedicated mTLS listener config (\`ssl_verify_client on\`, mounts the OMS CA PEM, proxies only \`/api/forgekey/firmware/\` — every other route 404s to limit blast radius if the CA cert is wrong).

**\`nginx/docker-entrypoint.d/20-mtls.sh\`**: activates the template by renaming \`.template.disabled\` → \`.template\` only when \`FORGEKEY_MTLS_ENABLED=1\` AND \`FORGEKEY_MTLS_CA_PATH\` is set + readable. Otherwise inert, so deployments that haven't yet generated a CA still start cleanly. Runs before nginx's own \`20-envsubst-on-templates.sh\` so the envsubst pass sees the renamed file.

## Test plan

- [x] \`pytest forgekey/tests/test_mtls_auth.py\` → 11 passed: happy path, missing headers (2), \`verify != SUCCESS\`, unparseable PEM, no active CA, signed-by-different-CA, revoked, decommissioned, unknown serial, expired cert.
- [x] Sweep across \`test_firmware_signing.py\`, \`test_ota_dispatch.py\`, \`test_csr_signing.py\`, \`test_enrollment.py\`, \`test_crl.py\`, \`test_forgekey_ca_command.py\`, \`test_command_jwt.py\` → 103 passed, no regressions to existing token/JWT auth paths.
- [ ] CI green.
- [ ] Operational dry-run: with \`FORGEKEY_MTLS_ENABLED=0\` (default), nginx starts cleanly and the download endpoint accepts only token / JWT (unchanged behavior).
- [ ] Operational enablement (separate ops change, not this PR):
  1. Export CA cert: \`docker compose exec backend python manage.py forgekey_ca export-cert > ca.pem\`
  2. Bind-mount into nginx: add to \`docker-compose.prod.yml\` nginx \`volumes\` \`- ./ca.pem:/etc/nginx/forgekey-ca.pem:ro\` and expose \`8443:8443\`
  3. Set in \`.env\`: \`FORGEKEY_MTLS_ENABLED=1\`, \`FORGEKEY_MTLS_CA_PATH=/etc/nginx/forgekey-ca.pem\`
  4. Restart nginx, verify with \`curl --cert dev.crt --key dev.key https://host:8443/api/forgekey/firmware/<id>/download\`.

## Follow-ups in the ForgeKey firmware repo

- Bake CA pubkey, parse \`signing_cert\` from MQTT, verify chain (#666's consumer side).
- Switch OTA HTTP client to mTLS using the enrolled device cert + key.

Refs the *use the CA for signing firmware and validating update software requests* thread.