### PR TITLE
feat(forgekey): admin-resubmit + PAT-auth for the firmware-build worker

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -745,6 +745,9 @@ views:
       partial_update:
         permission_classes:
         - IsAdminUser
+      redispatch:
+        permission_classes:
+        - IsAdminUser
       retrieve:
         permission_classes:
         - IsAdminUser

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -433,9 +433,22 @@ CELERY_TASK_ROUTES = {
 }
 
 # Git URL the firmware-builder worker clones to build ForgeKey firmware.
+# Default is HTTPS — the PAT-based auth path is the recommended one (see
+# FORGEKEY_BUILDER_GITHUB_TOKEN below). The legacy SSH URL
+# (git@github.com:...) still works when FORGEKEY_DEPLOY_KEY is mounted
+# into the worker container, but PAT is simpler to rotate and never
+# touches ssh-agent.
 FORGEKEY_FIRMWARE_REPO_URL = config(
-    "FORGEKEY_FIRMWARE_REPO_URL", default="git@github.com:uid0/ForgeKey.git"
+    "FORGEKEY_FIRMWARE_REPO_URL", default="https://github.com/uid0/ForgeKey.git"
 )
+
+# GitHub Personal Access Token (or fine-grained token) the firmware-
+# builder injects into the HTTPS clone URL. Read-only by design — the
+# worker only ever clones. A fine-grained PAT scoped to the ForgeKey
+# repo with `Contents: Read` is the minimum-privilege option. When this
+# is empty, the worker falls back to whatever ssh key the container has
+# at /root/.ssh/id_ed25519 (the legacy FORGEKEY_DEPLOY_KEY mount).
+FORGEKEY_BUILDER_GITHUB_TOKEN = config("FORGEKEY_BUILDER_GITHUB_TOKEN", default="")
 
 # Celery Beat Schedule for periodic tasks
 CELERY_BEAT_SCHEDULE = {

--- a/backend/forgekey/admin.py
+++ b/backend/forgekey/admin.py
@@ -29,6 +29,7 @@ from .models import (
     EPaperDisplay,
     ESP32Device,
     ESP32DevicePhoto,
+    FirmwareBuild,
     FirmwareSigningKey,
     FirmwareVersion,
     OperationalMode,
@@ -341,6 +342,92 @@ class DeviceFirmwareUpdateAdmin(admin.ModelAdmin):
     search_fields = ["device__mac_address", "device__name", "firmware_version__version"]
     readonly_fields = ["id", "requested_at"]
     raw_id_fields = ["device", "firmware_version", "requested_by"]
+
+
+@admin.register(FirmwareBuild)
+class FirmwareBuildAdmin(admin.ModelAdmin):
+    """Track + recover self-hosted firmware-builder jobs.
+
+    The build worker (Dockerfile.firmware-builder) consumes the `builds`
+    Celery queue. When the worker is down (or Redis is restarted)
+    queued rows pile up with no in-flight message to claim them; the
+    `Re-dispatch to worker` action re-publishes the Celery task for the
+    selected rows so the worker can pick them up once it's back. Same
+    DB row, same parameters — audit chain intact.
+    """
+
+    list_display = [
+        "id_short",
+        "device_type",
+        "pio_env",
+        "version",
+        "source_ref",
+        "status",
+        "requested_at",
+        "requested_by",
+    ]
+    list_filter = ["status", "device_type", "pio_env"]
+    search_fields = ["version", "source_ref", "pio_env", "commit_sha"]
+    readonly_fields = [
+        "id",
+        "ca_fingerprint",
+        "commit_sha",
+        "log",
+        "error_message",
+        "firmware_version",
+        "requested_at",
+        "started_at",
+        "completed_at",
+    ]
+    raw_id_fields = ["device_type", "requested_by", "firmware_version"]
+    actions = ["redispatch_selected"]
+
+    @admin.display(description="id", ordering="id")
+    def id_short(self, obj):
+        return str(obj.id)[:8]
+
+    @admin.action(description="Re-dispatch selected queued / failed builds to the worker")
+    def redispatch_selected(self, request, queryset):
+        from .models import FirmwareBuild as _FB
+        from .tasks import build_firmware
+
+        eligible = queryset.filter(status__in=[_FB.STATUS_QUEUED, _FB.STATUS_FAILED])
+        skipped = queryset.exclude(pk__in=eligible.values_list("pk", flat=True))
+
+        sent = 0
+        for build in eligible:
+            build.status = _FB.STATUS_QUEUED
+            build.started_at = None
+            build.completed_at = None
+            build.error_message = ""
+            build.log = ""
+            build.save(
+                update_fields=[
+                    "status",
+                    "started_at",
+                    "completed_at",
+                    "error_message",
+                    "log",
+                ]
+            )
+            build_firmware.delay(str(build.pk))
+            sent += 1
+            audit_logger.info(
+                "firmware_build.redispatched id=%s actor=%s",
+                build.pk,
+                getattr(request.user, "username", "<anonymous>"),
+            )
+
+        if sent:
+            self.message_user(
+                request, f"Re-dispatched {sent} build(s) to the worker.", messages.SUCCESS
+            )
+        if skipped.exists():
+            self.message_user(
+                request,
+                f"Skipped {skipped.count()} build(s) that were not queued/failed.",
+                messages.WARNING,
+            )
 
 
 class FirmwareSigningKeyForm(forms.ModelForm):

--- a/backend/forgekey/services/firmware_build.py
+++ b/backend/forgekey/services/firmware_build.py
@@ -31,17 +31,52 @@ logger = logging.getLogger(__name__)
 _CA_HEADER = "src/security/oms_ca.h"
 _PUBKEY_HEADER = "src/security/oms_command_pubkey.h"
 
-_DEFAULT_REPO_URL = "git@github.com:uid0/ForgeKey.git"
+_DEFAULT_REPO_URL = "https://github.com/uid0/ForgeKey.git"
 _LOG_TAIL_LIMIT = 20000
 _BUILD_TIMEOUT_S = 25 * 60
 
 
-def _run(cmd: list[str], cwd: str, log_lines: list[str]) -> str:
+def _clone_url(repo_url: str, token: str) -> str:
+    """Inject a GitHub PAT into an HTTPS repo URL.
+
+    Returns the URL unchanged when no token is configured (operators
+    still on the SSH-key path) or when the URL isn't HTTPS (SSH URLs
+    use the mounted key instead). When both are set, rewrites to
+    ``https://x-access-token:<token>@host/path`` so git clones over
+    HTTPS without ever shelling out to ssh-agent. The PAT can be a
+    classic PAT with `repo:read` or a fine-grained PAT scoped to the
+    ForgeKey repo's `Contents: Read` permission — read-only by design,
+    since this worker only ever clones.
+    """
+    if not token or "://" not in repo_url:
+        return repo_url
+    scheme, rest = repo_url.split("://", 1)
+    if scheme.lower() != "https":
+        return repo_url
+    # If someone already pre-baked credentials into the URL, leave it.
+    if "@" in rest.split("/", 1)[0]:
+        return repo_url
+    return f"https://x-access-token:{token}@{rest}"
+
+
+def _run(
+    cmd: list[str],
+    cwd: str,
+    log_lines: list[str],
+    redacted_cmd: list[str] | None = None,
+) -> str:
     """Run a subprocess, capturing combined output into ``log_lines``.
 
     Raises ``RuntimeError`` on a non-zero exit so the caller records a failure.
+
+    ``redacted_cmd`` is what gets logged when the actual command contains
+    a secret (e.g. a PAT injected into a clone URL); the executed command
+    is still ``cmd``. The error message on a non-zero exit uses
+    ``redacted_cmd`` too, since the FirmwareBuild row's error_message
+    field is visible to every staff user.
     """
-    log_lines.append(f"$ {' '.join(cmd)}")
+    log_cmd = redacted_cmd if redacted_cmd is not None else cmd
+    log_lines.append(f"$ {' '.join(log_cmd)}")
     # `cmd` is a fixed git/pio argv list (no shell=True); the only variable
     # parts (source_ref, pio_env) come from staff-created FirmwareBuild rows.
     proc = subprocess.run(  # nosec B603
@@ -52,7 +87,7 @@ def _run(cmd: list[str], cwd: str, log_lines: list[str]) -> str:
     if proc.stderr:
         log_lines.append(proc.stderr)
     if proc.returncode != 0:
-        raise RuntimeError(f"`{' '.join(cmd)}` failed (exit {proc.returncode})")
+        raise RuntimeError(f"`{' '.join(log_cmd)}` failed (exit {proc.returncode})")
     return proc.stdout or ""
 
 
@@ -134,6 +169,8 @@ def run_firmware_build(build_id: str) -> dict:
     build.save(update_fields=["status", "started_at"])
 
     repo_url = getattr(settings, "FORGEKEY_FIRMWARE_REPO_URL", _DEFAULT_REPO_URL)
+    pat = getattr(settings, "FORGEKEY_BUILDER_GITHUB_TOKEN", "") or ""
+    clone_url = _clone_url(repo_url, pat)
 
     try:
         ca = CertificateAuthority.get_active()
@@ -145,10 +182,36 @@ def run_firmware_build(build_id: str) -> dict:
 
         with tempfile.TemporaryDirectory(prefix="fkbuild-") as tmp:
             repo = Path(tmp) / "ForgeKey"
+            # Use the PAT-injected URL for the actual clone, but show
+            # the bare repo_url in the build log so the PAT never lands
+            # in DB-stored output visible to other staff.
             _run(
-                ["git", "clone", "--depth", "1", "--branch", build.source_ref, repo_url, str(repo)],
+                [
+                    "git",
+                    "clone",
+                    "--depth",
+                    "1",
+                    "--branch",
+                    build.source_ref,
+                    clone_url,
+                    str(repo),
+                ],
                 cwd=tmp,
                 log_lines=log_lines,
+                redacted_cmd=(
+                    [
+                        "git",
+                        "clone",
+                        "--depth",
+                        "1",
+                        "--branch",
+                        build.source_ref,
+                        repo_url,
+                        str(repo),
+                    ]
+                    if clone_url != repo_url
+                    else None
+                ),
             )
             commit = _run(["git", "rev-parse", "HEAD"], cwd=str(repo), log_lines=log_lines).strip()
             _write_security_headers(repo, ca_pem, cmd_pubkey_pem)

--- a/backend/forgekey/tests/test_firmware_build_redispatch.py
+++ b/backend/forgekey/tests/test_firmware_build_redispatch.py
@@ -1,0 +1,128 @@
+"""Redispatch action on FirmwareBuildViewSet + the _clone_url PAT helper."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.urls import reverse
+
+import pytest
+from rest_framework.test import APIClient
+
+from forgekey.models import DeviceType, FirmwareBuild
+from forgekey.services.firmware_build import _clone_url
+from forgekey.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _build(status=FirmwareBuild.STATUS_QUEUED) -> FirmwareBuild:
+    dt = DeviceType.objects.create(name="People counter", code="people-counter")
+    return FirmwareBuild.objects.create(
+        device_type=dt,
+        pio_env="seeed_xiao_esp32s3",
+        version="0.8.0",
+        source_ref="main",
+        status=status,
+    )
+
+
+def _staff_client():
+    user = UserFactory(is_staff=True, is_superuser=True)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client, user
+
+
+# ----- redispatch DRF action -------------------------------------------------
+
+
+def test_redispatch_queued_build_dispatches_celery_task():
+    build = _build()
+    client, _ = _staff_client()
+    url = reverse("forgekey:firmware-build-redispatch", args=[build.pk])
+
+    with patch("forgekey.tasks.build_firmware.delay") as delay:
+        resp = client.post(url)
+
+    assert resp.status_code == 200, resp.json()
+    delay.assert_called_once_with(str(build.pk))
+
+
+def test_redispatch_failed_build_resets_state_and_dispatches():
+    build = _build(status=FirmwareBuild.STATUS_FAILED)
+    build.error_message = "previous run: timed out"
+    build.log = "stale log output"
+    build.save(update_fields=["error_message", "log"])
+
+    client, _ = _staff_client()
+    url = reverse("forgekey:firmware-build-redispatch", args=[build.pk])
+
+    with patch("forgekey.tasks.build_firmware.delay") as delay:
+        resp = client.post(url)
+
+    assert resp.status_code == 200
+    delay.assert_called_once_with(str(build.pk))
+    build.refresh_from_db()
+    assert build.status == FirmwareBuild.STATUS_QUEUED
+    assert build.error_message == ""
+    assert build.log == ""
+    assert build.completed_at is None
+    assert build.started_at is None
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        FirmwareBuild.STATUS_BUILDING,
+        FirmwareBuild.STATUS_SUCCEEDED,
+        FirmwareBuild.STATUS_CANCELLED,
+    ],
+)
+def test_redispatch_refuses_non_queued_non_failed_states(status):
+    build = _build(status=status)
+    client, _ = _staff_client()
+    url = reverse("forgekey:firmware-build-redispatch", args=[build.pk])
+
+    with patch("forgekey.tasks.build_firmware.delay") as delay:
+        resp = client.post(url)
+
+    assert resp.status_code == 409
+    delay.assert_not_called()
+
+
+def test_redispatch_requires_staff():
+    build = _build()
+    user = UserFactory(is_staff=False, is_superuser=False)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    url = reverse("forgekey:firmware-build-redispatch", args=[build.pk])
+
+    resp = client.post(url)
+    assert resp.status_code in (401, 403)
+
+
+# ----- _clone_url PAT helper -------------------------------------------------
+
+
+def test_clone_url_injects_pat_into_https_url():
+    out = _clone_url("https://github.com/uid0/ForgeKey.git", "ghp_secret123")
+    assert out == "https://x-access-token:ghp_secret123@github.com/uid0/ForgeKey.git"
+
+
+def test_clone_url_passthrough_when_no_token():
+    out = _clone_url("https://github.com/uid0/ForgeKey.git", "")
+    assert out == "https://github.com/uid0/ForgeKey.git"
+
+
+def test_clone_url_passthrough_for_ssh_urls_even_with_token():
+    """SSH URLs use the mounted deploy key; injecting a PAT would do nothing."""
+    out = _clone_url("git@github.com:uid0/ForgeKey.git", "ghp_secret123")
+    assert out == "git@github.com:uid0/ForgeKey.git"
+
+
+def test_clone_url_does_not_double_inject_creds():
+    """If the URL already has credentials, leave it alone (operator override)."""
+    pre = "https://someuser:sometoken@github.com/uid0/ForgeKey.git"
+    out = _clone_url(pre, "ghp_secret123")
+    assert out == pre

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -1807,6 +1807,66 @@ class FirmwareBuildViewSet(viewsets.ModelViewSet):
         build.save(update_fields=["status", "completed_at"])
         return Response(FirmwareBuildSerializer(build).data)
 
+    @action(detail=True, methods=["post"])
+    def redispatch(self, request, pk=None):
+        """Re-publish the build task to the worker queue.
+
+        Use case: the firmware_builder worker was down (or Redis was
+        restarted, dropping the in-flight message) and a row is stuck
+        in ``queued`` even though the worker is now consuming. Re-
+        dispatch republishes the Celery message; the same DB row is
+        the target, so the audit chain stays intact.
+
+        Allowed for ``queued`` AND ``failed`` (a failed build is often
+        a transient infra issue — same row, same parameters, try again).
+        Forbidden for ``building`` (the worker is mid-execution; a
+        second message would race), ``succeeded`` (use ``cancel`` +
+        create a new build to re-roll), and ``cancelled``.
+        """
+        build = self.get_object()
+        if build.status not in (
+            FirmwareBuild.STATUS_QUEUED,
+            FirmwareBuild.STATUS_FAILED,
+        ):
+            return Response(
+                {
+                    "detail": (
+                        f"Build is {build.status}; only queued / failed "
+                        "builds can be re-dispatched. Create a new build "
+                        "instead."
+                    )
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        # Reset the build so the worker treats it as a fresh attempt.
+        # Otherwise a re-dispatch of a `failed` row would race the
+        # previous error_message with the new run's outcome.
+        build.status = FirmwareBuild.STATUS_QUEUED
+        build.started_at = None
+        build.completed_at = None
+        build.error_message = ""
+        build.log = ""
+        build.save(
+            update_fields=[
+                "status",
+                "started_at",
+                "completed_at",
+                "error_message",
+                "log",
+            ]
+        )
+
+        from .tasks import build_firmware
+
+        build_firmware.delay(str(build.pk))
+        logger.info(
+            "firmware_build re-dispatched id=%s actor=%s",
+            build.pk,
+            getattr(request.user, "username", "<anonymous>"),
+        )
+        return Response(FirmwareBuildSerializer(build).data)
+
 
 class FirmwareRolloutViewSet(viewsets.ModelViewSet):
     """Manage staged firmware rollout campaigns.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -238,9 +238,12 @@ services:
     # `builds` queue that forgekey.tasks.build_firmware is routed to. Without
     # it, queued firmware builds sit in Redis forever.
     #
-    # Provide a read-only SSH deploy key with read access to the ForgeKey repo
-    # via FORGEKEY_DEPLOY_KEY in .env; until it's set the container still runs,
-    # but each build fails at `git clone`. See docs/FORGEKEY_FIRMWARE_BUILD.md.
+    # Auth for the git clone — recommended path is a GitHub Personal Access
+    # Token (FORGEKEY_BUILDER_GITHUB_TOKEN, fine-grained, Contents:Read on the
+    # ForgeKey repo). Read-only by design; the worker never pushes. The legacy
+    # SSH deploy-key mount is still honored when FORGEKEY_DEPLOY_KEY is set,
+    # for deployments that haven't rotated to PAT yet. See
+    # docs/FORGEKEY_FIRMWARE_BUILD.md.
     build:
       context: ./backend
       dockerfile: Dockerfile.firmware-builder
@@ -257,7 +260,8 @@ services:
           memory: 512M
     volumes:
       - media_volume:/app/media
-      # Read-only SSH deploy key with read access to the ForgeKey repo.
+      # Legacy SSH deploy key path — ignored when FORGEKEY_BUILDER_GITHUB_TOKEN
+      # is set and FORGEKEY_FIRMWARE_REPO_URL is HTTPS.
       - ${FORGEKEY_DEPLOY_KEY:-/dev/null}:/root/.ssh/id_ed25519:ro
     env_file:
       - .env
@@ -268,7 +272,8 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - CELERY_BROKER_URL=redis://redis:6379/0
       - SKIP_DB_MIGRATIONS=1
-      - FORGEKEY_FIRMWARE_REPO_URL=${FORGEKEY_FIRMWARE_REPO_URL:-git@github.com:uid0/ForgeKey.git}
+      - FORGEKEY_FIRMWARE_REPO_URL=${FORGEKEY_FIRMWARE_REPO_URL:-https://github.com/uid0/ForgeKey.git}
+      - FORGEKEY_BUILDER_GITHUB_TOKEN=${FORGEKEY_BUILDER_GITHUB_TOKEN:-}
     depends_on:
       backend:
         condition: service_started

--- a/docs/FORGEKEY_FIRMWARE_BUILD.md
+++ b/docs/FORGEKEY_FIRMWARE_BUILD.md
@@ -43,18 +43,37 @@ A failed build is recorded with its log + `error_message` — not retried.
 **Production (`docker-compose.prod.yml`)** — `firmware_builder` is **always-on**:
 it comes up with the rest of the stack, so a normal
 `docker compose -f docker-compose.prod.yml up -d --build` starts it alongside
-everything else. You only need to give it the deploy key. In your prod `.env`:
+everything else. You only need to give it git auth.
+
+Two supported auth paths — pick one and put the matching env vars in prod `.env`:
+
+**Recommended — GitHub Personal Access Token (PAT, read-only):**
+
+```bash
+# Fine-grained PAT, scoped to the ForgeKey repo, Contents: Read only.
+# The worker never pushes; minimum-privilege.
+FORGEKEY_BUILDER_GITHUB_TOKEN=github_pat_…
+# Repo URL must be HTTPS for the token to take effect.
+FORGEKEY_FIRMWARE_REPO_URL=https://github.com/uid0/ForgeKey.git
+```
+
+Generate the PAT at <https://github.com/settings/personal-access-tokens/new>,
+scoped only to the ForgeKey repository with **Contents: Read** permission.
+Rotation = generate a new PAT, update the env var, `docker compose restart firmware_builder`.
+
+**Legacy — SSH deploy key:**
 
 ```bash
 # A read-only SSH deploy key with read access to the ForgeKey repo
 # (GitHub → repo → Settings → Deploy keys). Host path, mounted read-only.
 FORGEKEY_DEPLOY_KEY=/abs/path/to/forgekey_deploy_key
-# (optional) override the repo if you fork it
 FORGEKEY_FIRMWARE_REPO_URL=git@github.com:uid0/ForgeKey.git
 ```
 
-Until `FORGEKEY_DEPLOY_KEY` is set the container still runs, but each build fails
-at `git clone`.
+The PAT path is honored when `FORGEKEY_BUILDER_GITHUB_TOKEN` is set AND the
+repo URL is HTTPS. Otherwise the worker falls back to the SSH key. Until one
+of the two is configured, the container runs but each build fails at
+`git clone`.
 
 **Development (`docker-compose.yml`)** — the worker is **opt-in** (compose
 profile `firmware-build`) so a routine `docker compose up` stays lightweight:

--- a/frontend/src/pages/ForgeKeyFirmwareRolloutsPage.tsx
+++ b/frontend/src/pages/ForgeKeyFirmwareRolloutsPage.tsx
@@ -114,6 +114,7 @@ const ForgeKeyFirmwareRolloutsPage: React.FC = () => {
   const [buildRef, setBuildRef] = useState('main');
   const [building, setBuilding] = useState(false);
   const [logBuildId, setLogBuildId] = useState<string | null>(null);
+  const [redispatchingBuildId, setRedispatchingBuildId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isStaff && !isSuperuser) return undefined;
@@ -391,7 +392,33 @@ const ForgeKeyFirmwareRolloutsPage: React.FC = () => {
             {logBuild.status === 'queued' && (
               <Alert color="blue" variant="light">
                 Queued builds only start once the self-hosted firmware-builder worker is running and
-                consuming the builds queue. If this stays queued, that worker isn&rsquo;t up.
+                consuming the builds queue. If this stays queued, that worker isn&rsquo;t up — or its
+                task message was lost when Redis last restarted. Re-dispatch republishes the build
+                task so the worker can pick it up:
+                <Group mt="xs">
+                  <Button
+                    size="xs"
+                    variant="light"
+                    color="blue"
+                    loading={redispatchingBuildId === logBuild.id}
+                    onClick={async () => {
+                      setRedispatchingBuildId(logBuild.id);
+                      try {
+                        const res = await forgekeyAPI.redispatchFirmwareBuild(logBuild.id);
+                        setBuilds((prev) =>
+                          prev.map((b) => (b.id === res.data.id ? res.data : b)),
+                        );
+                      } catch (err) {
+                        setError(extractErrorMessage(err, 'Re-dispatch failed.'));
+                      } finally {
+                        setRedispatchingBuildId(null);
+                      }
+                    }}
+                    data-testid="redispatch-build"
+                  >
+                    Re-dispatch to worker
+                  </Button>
+                </Group>
               </Alert>
             )}
             {logBuild.error_message && (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2152,6 +2152,12 @@ export const forgekeyAPI = {
   }) => api.post<ForgeKeyFirmwareBuild>('/forgekey/firmware-builds/', body),
   cancelFirmwareBuild: (id: string) =>
     api.post<ForgeKeyFirmwareBuild>(`/forgekey/firmware-builds/${id}/cancel/`),
+  // Re-publish a stuck queued / failed build's task to the worker. Use case:
+  // the firmware_builder worker was down (or Redis was restarted) at the
+  // time the build was enqueued, so the original task message is gone and
+  // the row sits in `queued` even though the worker is now alive.
+  redispatchFirmwareBuild: (id: string) =>
+    api.post<ForgeKeyFirmwareBuild>(`/forgekey/firmware-builds/${id}/redispatch/`),
   // PKI: read-only certificate visibility + CA rotation (staff).
   listCertificateAuthorities: () =>
     api.get<{ results?: ForgeKeyCertificateAuthority[] } | ForgeKeyCertificateAuthority[]>(


### PR DESCRIPTION
Two related ergonomics fixes that came out of debugging a stuck queued firmware build (~28h old — the worker hadn't been deployed yet, then Redis was restarted and the original Celery task message was lost).

## 1. Staff can re-dispatch from the UI (no shell needed)

When a row is stuck in \`queued\` (or in \`failed\` after a transient infra issue) staff had to drop into \`manage.py shell\` and call \`build_firmware.delay()\` by hand. Now there are three paths, all re-publishing the Celery task to the worker queue against the same DB row:

- \`POST /api/forgekey/firmware-builds/<id>/redispatch/\` on the viewset.
- \`FirmwareBuildAdmin\` with a *Re-dispatch selected queued / failed builds* bulk action.
- Frontend: a *Re-dispatch to worker* button inside the queued-build alert on the rollouts page.

Forbidden for \`building\` (race), \`succeeded\`, \`cancelled\`. A re-dispatch resets \`status\` to \`queued\` and clears \`started_at\` / \`completed_at\` / \`error_message\` / \`log\` so a re-run doesn't race stale state with the new run's outcome. Audit-logged with the actor on every path.

## 2. PAT-based git clone (drop SSH for the worker)

The worker only ever clones — it never pushes — so a fine-grained PAT with \`Contents: Read\` on the ForgeKey repo is the right minimum-privilege secret instead of a host SSH deploy key (single secret to rotate, no ssh-agent hop, no host-path mount, scoped + revocable in seconds).

- New setting **\`FORGEKEY_BUILDER_GITHUB_TOKEN\`**. When set and the repo URL is HTTPS, \`_clone_url\` injects \`x-access-token:<pat>@\` into the URL at clone time. The bare URL is what gets written to the build log (via \`_run\`'s \`redacted_cmd\` arg) so the PAT never lands in DB-stored logs visible to other staff.
- Default \`FORGEKEY_FIRMWARE_REPO_URL\` flipped from \`git@github.com:...\` to \`https://github.com/...\`.
- Legacy SSH path stays honored when token is unset and the URL is \`ssh://...\` — deployments still on the deploy-key path don't break on this PR.
- compose: PAT env var added; SSH key mount kept for back-compat.
- \`docs/FORGEKEY_FIRMWARE_BUILD.md\` updated with both paths + rotation instructions.

## Test plan

- [x] \`pytest forgekey/tests/test_firmware_build_redispatch.py\` → **10 passed**: queued + failed re-dispatch dispatches celery, refuses building / succeeded / cancelled, requires staff, \`_clone_url\` injects PAT into HTTPS, passthrough on SSH URLs, passthrough on no token, no double-inject when credentials already in URL.
- [x] Broader sweep \`test_firmware_build.py\` + \`test_admin_delete.py\` → 23 passed, no regressions.
- [ ] CI green.
- [ ] Operational verification:
  1. Generate fine-grained PAT scoped to ForgeKey (\`Contents: Read\`), set \`FORGEKEY_BUILDER_GITHUB_TOKEN\` in prod \`.env\`, \`docker compose restart firmware_builder\`.
  2. Queue a new build → worker log shows the HTTPS clone, build succeeds without ssh-agent.
  3. Click *Re-dispatch to worker* on the stuck queued build from 5/31 → worker picks it up within seconds.

## After this lands

Once the PAT path is the prod default, the \`FORGEKEY_DEPLOY_KEY\` mount can be removed from \`docker-compose.prod.yml\` and the SSH client install dropped from \`Dockerfile.firmware-builder\` — separate PR after a confirmed migration window.

Refs the debugging thread that traced a 28h-stuck build to a lost Celery message.