### PR TITLE
fix(forgekey): inject the OMS-internal CA into forgekey_ca.h, not oms_ca.h

### DIFF
--- a/backend/forgekey/services/firmware_build.py
+++ b/backend/forgekey/services/firmware_build.py
@@ -26,9 +26,24 @@ from django.utils import timezone
 logger = logging.getLogger(__name__)
 
 # Security headers in the cloned checkout, overwritten with live values before
-# the build. The headers guard their defaults behind ``#ifndef`` / ``#pragma
-# once``, so replacing the file injects the real CA + pubkey.
-_CA_HEADER = "src/security/oms_ca.h"
+# the build. Two distinct CAs here, not one:
+#
+#   * forgekey_ca.h carries the OMS-internal CA cert — the root of the
+#     mTLS / firmware-leaf trust chain (PR #33 on the ForgeKey repo). This
+#     is what we inject from the active CertificateAuthority row on every
+#     build, so each artifact is bound to the current operator CA.
+#
+#   * oms_ca.h carries the *public* CA that signs the OMS HTTPS server cert
+#     (typically the Let's Encrypt root). That value doesn't change per
+#     build and is refreshed by scripts/build/fetch-oms-ca.sh when LE
+#     rotates roots — we do NOT touch it during automated builds, since
+#     overwriting it with the OMS-internal CA would break HTTPS server-
+#     cert verification on every device.
+#
+# (Previously oms_ca.h was getting the OMS-internal CA. Devices flashed
+# from those builds couldn't have verified the OMS HTTPS endpoint; the bug
+# never bit because no field device was flashed via the automated path yet.)
+_FORGEKEY_CA_HEADER = "src/security/forgekey_ca.h"
 _PUBKEY_HEADER = "src/security/oms_command_pubkey.h"
 
 _DEFAULT_REPO_URL = "https://github.com/uid0/ForgeKey.git"
@@ -97,12 +112,27 @@ def _c_string_literal(pem: str) -> str:
 
 
 def _write_security_headers(repo: Path, ca_pem: str, cmd_pubkey_pem: str) -> None:
-    (repo / _CA_HEADER).write_text(
-        "#pragma once\n#define OMS_CA_PEM \\\n" + _c_string_literal(ca_pem)
+    """Inject the live OMS-internal CA + command public key into the checkout.
+
+    ``ca_pem`` lands in ``forgekey_ca.h`` (firmware-leaf-cert trust root),
+    NOT ``oms_ca.h`` (HTTPS server-cert trust root). ``oms_ca.h`` is left
+    untouched on purpose — see the module-level comment on _FORGEKEY_CA_HEADER.
+
+    Both rewrites preserve the `extern const char* k…;` declaration that
+    the original headers carry. Without it, every consumer .cpp that uses
+    the symbol fails with `'kX' was not declared in this scope` even
+    though the defining .cpp would still compile fine (it picks up the
+    macro and does `const char* kX = MACRO;`).
+    """
+    (repo / _FORGEKEY_CA_HEADER).write_text(
+        "#pragma once\n"
+        "#define FORGEKEY_INTERNAL_CA_PEM \\\n" + _c_string_literal(ca_pem) + "\n"
+        "extern const char* kForgekeyInternalCaPem;\n"
     )
     (repo / _PUBKEY_HEADER).write_text(
-        "#pragma once\n#define FORGEKEY_OMS_COMMAND_PUBKEY_PEM \\\n"
-        + _c_string_literal(cmd_pubkey_pem)
+        "#pragma once\n"
+        "#define FORGEKEY_OMS_COMMAND_PUBKEY_PEM \\\n" + _c_string_literal(cmd_pubkey_pem) + "\n"
+        "extern const char* kOmsCommandPubKeyPem;\n"
     )
 
 

--- a/backend/forgekey/tests/test_firmware_build.py
+++ b/backend/forgekey/tests/test_firmware_build.py
@@ -231,3 +231,60 @@ class TestFirmwareBuildViewSet:
         assert resp.status_code == 200, resp.data
         build.refresh_from_db()
         assert build.status == FirmwareBuild.STATUS_CANCELLED
+
+
+class TestWriteSecurityHeaders:
+    """Cover the contract for `_write_security_headers` that the firmware
+    worker calls between `git clone` and `pio run`."""
+
+    def _setup(self, tmp_path: Path) -> Path:
+        (tmp_path / "src" / "security").mkdir(parents=True)
+        # Place a sentinel `oms_ca.h` so we can prove the rewrite leaves
+        # it alone — overwriting it with the OMS-internal CA would break
+        # HTTPS server-cert verification on every flashed device.
+        (tmp_path / "src/security/oms_ca.h").write_text(
+            "/* canary — must survive _write_security_headers */\n"
+        )
+        return tmp_path
+
+    def test_writes_forgekey_ca_with_extern(self, tmp_path):
+        self._setup(tmp_path)
+        fb._write_security_headers(
+            tmp_path,
+            ca_pem="-----BEGIN CERTIFICATE-----\nABC\n-----END CERTIFICATE-----",
+            cmd_pubkey_pem="-----BEGIN PUBLIC KEY-----\nXYZ\n-----END PUBLIC KEY-----",
+        )
+        out = (tmp_path / "src/security/forgekey_ca.h").read_text()
+        assert "#define FORGEKEY_INTERNAL_CA_PEM" in out
+        # extern declaration is what consumer .cpp files link against.
+        assert "extern const char* kForgekeyInternalCaPem;" in out
+
+    def test_writes_command_pubkey_with_extern(self, tmp_path):
+        self._setup(tmp_path)
+        fb._write_security_headers(
+            tmp_path,
+            ca_pem="-----BEGIN CERTIFICATE-----\nABC\n-----END CERTIFICATE-----",
+            cmd_pubkey_pem="-----BEGIN PUBLIC KEY-----\nXYZ\n-----END PUBLIC KEY-----",
+        )
+        out = (tmp_path / "src/security/oms_command_pubkey.h").read_text()
+        assert "#define FORGEKEY_OMS_COMMAND_PUBKEY_PEM" in out
+        # Regression: every consumer (command_validation.cpp, register.cpp)
+        # needs this extern; an early version dropped it and every build
+        # failed to compile.
+        assert "extern const char* kOmsCommandPubKeyPem;" in out
+
+    def test_does_not_touch_oms_ca(self, tmp_path):
+        """oms_ca.h is the LE root for HTTPS server-cert verification —
+        rewriting it with the OMS-internal CA would break every device's
+        ability to verify the OMS HTTPS endpoint."""
+        self._setup(tmp_path)
+        fb._write_security_headers(
+            tmp_path,
+            ca_pem="-----BEGIN CERTIFICATE-----\nABC\n-----END CERTIFICATE-----",
+            cmd_pubkey_pem="-----BEGIN PUBLIC KEY-----\nXYZ\n-----END PUBLIC KEY-----",
+        )
+        # Sentinel intact.
+        assert (
+            "/* canary — must survive _write_security_headers */"
+            in (tmp_path / "src/security/oms_ca.h").read_text()
+        )


### PR DESCRIPTION
Follow-up to #670. Two distinct CAs live in the firmware, and the build worker had been conflating them — overwriting the wrong header.

## The two CAs

- **\`forgekey_ca.h\`** carries the **OMS-internal CA** — the root of the mTLS / firmware-leaf trust chain (ForgeKey repo PR #33). This is what should rotate per-build with \`CertificateAuthority.get_active()\` so each artifact is bound to the current operator CA.
- **\`oms_ca.h\`** carries the **public CA** that signs the OMS HTTPS server cert (Let's Encrypt root in our deployment). Static per-LE-rotation, refreshed by \`scripts/build/fetch-oms-ca.sh\` when LE rotates; the build worker MUST NOT touch it — overwriting it with the OMS-internal CA would break every device's ability to verify the OMS HTTPS endpoint.

Pre-fix, \`_write_security_headers\` wrote the OMS-internal CA into \`oms_ca.h\`. Field devices weren't affected because they've all been flashed manually with the unmodified header; the first automated build that would have shipped a broken artifact failed at compile time (extern issue) before producing a binary. Devices flashed from the automated pipeline now get correct trust roots for both purposes.

## Externs (re-fix from #670)

The squash merge of #670 dropped my extern fix (the permission-matrix fix made it through; the extern fix didn't — looks like a Github auto-merge race against my back-to-back pushes). Re-applied here for \`oms_command_pubkey.h\` and added for the new \`forgekey_ca.h\` rewrite. Both consumer-side .cpp files (\`mqtt_client.cpp\`, \`ota_updater.cpp\`, \`command_validation.cpp\`, \`register.cpp\`, \`security/firmware_verify.cpp\`) \`#include\` the headers to use the symbols, so they need the \`extern const char* k…;\` declaration to compile.

## Tests

- \`TestWriteSecurityHeaders.test_writes_forgekey_ca_with_extern\`
- \`TestWriteSecurityHeaders.test_writes_command_pubkey_with_extern\`
- \`TestWriteSecurityHeaders.test_does_not_touch_oms_ca\` — sentinel proof the LE-root file survives the rewrite.

\`pytest forgekey/tests/test_firmware_build.py\` → **12 passed** (9 existing + 3 new).

## Test plan

- [x] Unit tests above.
- [ ] CI green.
- [ ] After merge + prod redeploy: click *Re-dispatch to worker* on the stuck queued build → compile succeeds → artifact has both trust roots correctly populated.

Refs #670 / ForgeKey #33 (firmware-side chain verifier consumer of \`forgekey_ca.h\`).