### PR TITLE
fix(forgekey): pin FORGEKEY_FIRMWARE_VERSION env into OMS pio builds

### DIFF
--- a/backend/forgekey/services/firmware_build.py
+++ b/backend/forgekey/services/firmware_build.py
@@ -79,6 +79,7 @@ def _run(
     cwd: str,
     log_lines: list[str],
     redacted_cmd: list[str] | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> str:
     """Run a subprocess, capturing combined output into ``log_lines``.
 
@@ -89,13 +90,28 @@ def _run(
     is still ``cmd``. The error message on a non-zero exit uses
     ``redacted_cmd`` too, since the FirmwareBuild row's error_message
     field is visible to every staff user.
+
+    ``extra_env`` is merged on top of the worker's environment for
+    this one call. Used to pin FORGEKEY_FIRMWARE_VERSION /
+    FIRMWARE_GIT_COMMIT into the pio invocation so version.py picks
+    the operator-supplied version instead of the source-tree default.
     """
+    import os
+
     log_cmd = redacted_cmd if redacted_cmd is not None else cmd
     log_lines.append(f"$ {' '.join(log_cmd)}")
+    proc_env = None
+    if extra_env:
+        proc_env = {**os.environ, **extra_env}
     # `cmd` is a fixed git/pio argv list (no shell=True); the only variable
     # parts (source_ref, pio_env) come from staff-created FirmwareBuild rows.
     proc = subprocess.run(  # nosec B603
-        cmd, cwd=cwd, capture_output=True, text=True, timeout=_BUILD_TIMEOUT_S
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=_BUILD_TIMEOUT_S,
+        env=proc_env,
     )
     if proc.stdout:
         log_lines.append(proc.stdout)
@@ -245,7 +261,25 @@ def run_firmware_build(build_id: str) -> dict:
             )
             commit = _run(["git", "rev-parse", "HEAD"], cwd=str(repo), log_lines=log_lines).strip()
             _write_security_headers(repo, ca_pem, cmd_pubkey_pem)
-            _run(["pio", "run", "-e", build.pio_env], cwd=str(repo), log_lines=log_lines)
+            # version.py inside the firmware checkout respects these env vars
+            # and bakes them in as compile-time macros. Without them, the
+            # script falls back to the FORGEKEY_FIRMWARE_VERSION literal in
+            # src/provisioning/device_config.h — which means a build labeled
+            # "0.2.0" in OMS would ship firmware that self-reports the
+            # source-tree default ("0.1.0"). That mismatch breaks rollout
+            # convergence: the panel POSTs current="0.1.0", firmware-check
+            # compares to target="0.2.0" and re-dispatches, every wake,
+            # forever. Pinning both also pins commit_sha so the firmware
+            # log line at boot matches the FirmwareBuild row's commit_sha.
+            _run(
+                ["pio", "run", "-e", build.pio_env],
+                cwd=str(repo),
+                log_lines=log_lines,
+                extra_env={
+                    "FORGEKEY_FIRMWARE_VERSION": build.version,
+                    "FIRMWARE_GIT_COMMIT": commit[:12],
+                },
+            )
 
             bin_path = repo / ".pio" / "build" / build.pio_env / "firmware.bin"
             if not bin_path.exists():

--- a/backend/forgekey/tests/test_firmware_build.py
+++ b/backend/forgekey/tests/test_firmware_build.py
@@ -40,7 +40,7 @@ def device_type():
     return dt
 
 
-def _fake_run(cmd, cwd=None, capture_output=True, text=True, timeout=None):
+def _fake_run(cmd, cwd=None, capture_output=True, text=True, timeout=None, env=None):
     """Stand in for subprocess.run: materialise the files the real git/pio
     would, and report success."""
     result = MagicMock()
@@ -54,8 +54,8 @@ def _fake_run(cmd, cwd=None, capture_output=True, text=True, timeout=None):
     elif cmd[:2] == ["git", "rev-parse"]:
         result.stdout = "abc1234deadbeefcafebabe\n"
     elif cmd[0] == "pio":
-        env = cmd[-1]
-        build_dir = Path(cwd) / ".pio" / "build" / env
+        pio_env = cmd[-1]
+        build_dir = Path(cwd) / ".pio" / "build" / pio_env
         build_dir.mkdir(parents=True, exist_ok=True)
         (build_dir / "firmware.bin").write_bytes(b"\x00FIRMWARE\xff" * 16)
         result.stdout = "Building...\n[SUCCESS]\n"
@@ -184,6 +184,84 @@ class TestBuildCompletionNotifications:
         with patch("forgekey.models.CertificateAuthority.get_active", return_value=None):
             fb.run_firmware_build(str(build.id))
         assert not Notification.objects.exists()
+
+
+class TestBuildEnvInjection:
+    """The pio invocation must pin FORGEKEY_FIRMWARE_VERSION and
+    FIRMWARE_GIT_COMMIT in its environment so the firmware
+    self-reports the version the operator typed in OMS — not the
+    source-tree default in device_config.h.
+
+    Without this, a build labeled "0.2.0" would ship a binary that
+    self-reports the literal in device_config.h (currently "0.1.0"),
+    and the firmware-check view would loop the panel through an
+    infinite re-dispatch: current="0.1.0" != target="0.2.0" every
+    wake forever."""
+
+    def test_pio_invocation_pins_version_env(self, device_type, admin_user):
+        build = FirmwareBuild.objects.create(
+            device_type=device_type,
+            pio_env="seeed_xiao_epaper",
+            source_ref="main",
+            version="0.2.0",
+            requested_by=admin_user,
+        )
+        with (
+            patch("forgekey.models.CertificateAuthority.get_active", return_value=_FAKE_CA),
+            patch(
+                "forgekey.services.jwt_signing.get_jwt_public_key_pem",
+                return_value=_FAKE_PUBKEY,
+            ),
+            patch(
+                "forgekey.services.firmware_build.subprocess.run",
+                side_effect=_fake_run,
+            ) as mock_run,
+        ):
+            fb.run_firmware_build(str(build.id))
+
+        # Find the pio invocation among the recorded calls.
+        pio_call = None
+        for call in mock_run.call_args_list:
+            cmd = call.args[0] if call.args else call.kwargs.get("args") or []
+            if cmd and cmd[0] == "pio":
+                pio_call = call
+                break
+        assert pio_call is not None, "pio was not invoked"
+
+        env = pio_call.kwargs.get("env")
+        assert env is not None, "pio call did not pass env=; build will inherit device_config.h"
+        assert env["FORGEKEY_FIRMWARE_VERSION"] == "0.2.0"
+        # Commit comes from `git rev-parse HEAD` (mocked above as
+        # "abc1234deadbeefcafebabe"); we slice to 12 chars.
+        assert env["FIRMWARE_GIT_COMMIT"] == "abc1234deadb"
+
+    def test_git_subprocess_does_not_get_pio_env_overrides(self, device_type):
+        """Only the pio call needs the version env; the earlier git
+        clone / rev-parse calls must not carry it (no semantic effect,
+        but pinning the contract makes it obvious if someone moves the
+        env injection one rung up the call stack later)."""
+        build = FirmwareBuild.objects.create(
+            device_type=device_type, pio_env="x", source_ref="main", version="1.2.3"
+        )
+        with (
+            patch("forgekey.models.CertificateAuthority.get_active", return_value=_FAKE_CA),
+            patch(
+                "forgekey.services.jwt_signing.get_jwt_public_key_pem",
+                return_value=_FAKE_PUBKEY,
+            ),
+            patch(
+                "forgekey.services.firmware_build.subprocess.run",
+                side_effect=_fake_run,
+            ) as mock_run,
+        ):
+            fb.run_firmware_build(str(build.id))
+
+        for call in mock_run.call_args_list:
+            cmd = call.args[0] if call.args else call.kwargs.get("args") or []
+            if cmd and cmd[0] == "git":
+                # git calls go through _run without extra_env, so env
+                # kwarg is None (inherit worker's process env).
+                assert call.kwargs.get("env") is None
 
 
 class TestFirmwareBuildViewSet:


### PR DESCRIPTION
## TL;DR

Every OMS-built firmware artifact so far has shipped self-reporting **the source-tree default version ("0.1.0")**, regardless of what version label the operator typed in the Build Firmware form. The label is just a database string; the binary's compiled-in `FORGEKEY_FIRMWARE_VERSION` came from `device_config.h`.

That mismatch silently breaks rollout convergence: the firmware-check view sees `current="0.1.0"` != `target="0.2.0"` on every wake and re-dispatches forever.

## Proof from the most recent build

```
build row: version=0.2.0
build log: [version] build_id=seeed_xiao_epaper-0.1.0-43be86f13bd5-dirty-...
                                              ^^^^^ ← the firmware itself
artifact:  forgekey-epaper-display-0.1.0-43be86f13bd5-dirty-seeed_xiao_epaper-...bin
                                  ^^^^^ ← labeled with self-reported version
```

The OMS "0.2.0" label and the firmware "0.1.0" identity have been diverging since the OMS build pipeline landed.

## Root cause

`scripts/build/version.py` inside the firmware checkout prefers `os.environ["FORGEKEY_FIRMWARE_VERSION"]` first; falls back to parsing the literal from `src/provisioning/device_config.h` only when the env is unset. OMS's `firmware_build.py` ran `pio run -e <env>` without setting the env, so version.py always took the device_config.h fallback.

## What changed

`_run()` grows an `extra_env: dict[str, str] | None` kwarg that merges on top of the worker's environment for that single subprocess invocation. The pio call now passes:

| Env var | Value |
|---|---|
| `FORGEKEY_FIRMWARE_VERSION` | `build.version` (operator label wins) |
| `FIRMWARE_GIT_COMMIT` | `commit[:12]` (matches FirmwareBuild.commit_sha; shows up in the boot log via main.cpp:584) |

git subprocess calls keep `env=None` (inherit worker env). Pinning the contract so it's obvious if a future change moves the injection upstream.

## Tests

2 new in `TestBuildEnvInjection`:

- `test_pio_invocation_pins_version_env` — inspects `subprocess.run` call args, asserts `pio run` gets `env["FORGEKEY_FIRMWARE_VERSION"] == build.version` and the mocked rev-parse output's first 12 chars as `env["FIRMWARE_GIT_COMMIT"]`.
- `test_git_subprocess_does_not_get_pio_env_overrides` — locks in that git invocations don't carry the pio overrides.

Plus `_fake_run` test fixture grows `env=None` (mirrors subprocess.run; MagicMock would otherwise reject the unexpected kwarg).

All 8 tests in the affected classes pass.

## Operator impact post-merge

- The next OMS-triggered build of "0.2.0" (or any version) will ship firmware that self-reports the typed version.
- The `firmware-check` view will converge — current==target after one OTA cycle.
- Existing in-flight 0.2.0 builds need to be re-run.
- Boot log on the next-flashed panel will show the typed version and a commit hash that matches `FirmwareBuild.commit_sha` (closes the user's "print version/git hash in serial logs on OMS builds" ask).

## Test plan

- [x] `pytest forgekey/tests/test_firmware_build.py::TestBuildEnvInjection TestRunFirmwareBuild TestBuildCompletionNotifications` — 8 passed
- [x] `pre-commit run --files <touched>` — all hooks pass
- [ ] After merge: re-run the 0.2.0 build via Build Firmware page; inspect the build log for `[version] FORGEKEY_FIRMWARE_VERSION=0.2.0 FIRMWARE_GIT_COMMIT=<12char>`; flash a panel; confirm the boot serial reads `Firmware version: 0.2.0` and `Git commit: <matching>`

Independent of #676 (auto-stage rollout). Both touch `firmware_build.py` but at different lines; they should merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)