### PR TITLE
fix(ci): pass --yes to cosign sign-blob so Sigstore tlog prompt doesn't kill releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,8 +315,12 @@ jobs:
         run: |
           NEW_TAG="${{ needs.generate-version.outputs.new_tag }}"
 
-          # Sign the release bundle with keyless signing (Sigstore)
+          # Sign the release bundle with keyless signing (Sigstore).
+          # --yes auto-confirms the Sigstore transparency-log ToS prompt
+          # that cosign v2 added; without it CI fails with
+          # "upload to tlog: user declined the prompt" on every run.
           cosign sign-blob \
+            --yes \
             --output-signature openmakersuite-$NEW_TAG.tar.gz.sig \
             --output-certificate openmakersuite-$NEW_TAG.tar.gz.pem \
             openmakersuite-$NEW_TAG.tar.gz

--- a/.github/workflows/test-release-automation.yml
+++ b/.github/workflows/test-release-automation.yml
@@ -122,8 +122,11 @@ jobs:
         run: |
           echo "🔐 Testing cryptographic signing..."
 
-          # Sign the test file
+          # Sign the test file. --yes auto-confirms the Sigstore
+          # transparency-log ToS prompt cosign v2 added; without it
+          # CI fails with "upload to tlog: user declined the prompt".
           cosign sign-blob \
+            --yes \
             --output-signature test-file.txt.sig \
             --output-certificate test-file.txt.pem \
             test-file.txt


### PR DESCRIPTION
## Why the release workflow has been red on every main commit

The "🚀 Automated Release & Deploy" workflow has not had a successful run in the last 30 attempts. Each one dies in the same place:

```
Are you sure you would like to continue? [y/N] Error: signing openmakersuite-v1.0.0.tar.gz:
upload to tlog: user declined the prompt
main.go:74: error during command execution: signing openmakersuite-v1.0.0.tar.gz:
upload to tlog: user declined the prompt
```

cosign v2 added an interactive Sigstore transparency-log ToS prompt before keyless signing. In a non-TTY runner the prompt gets no input → defaults to N → the signing step fails.

## What's been masking this

The "🐳 Build and Publish Docker Containers" workflow is a separate pipeline that has been succeeding, so deploys themselves haven't stalled. The visible symptom was just every main commit getting a red ❌ from the release workflow and no signed release artifact ever being cut.

## Fix

`--yes` is cosign's documented unattended-signing opt-in to the ToS. Same flag added to:

- `.github/workflows/release.yml` — the production release-and-deploy pipeline
- `.github/workflows/test-release-automation.yml` — the release-pipeline smoke test (same `cosign sign-blob` shape, same prompt, same failure)

## Test plan

- [x] Verified via `gh run list --workflow="🚀 Automated Release & Deploy" --limit 30` that there are zero green runs in the visible window
- [ ] After merge: confirm the next release-on-main run reaches "Create GitHub Release" instead of dying at "Sign release artifacts"
- [ ] After merge: confirm a signed `openmakersuite-vX.Y.Z.tar.gz.sig` actually shows up on the GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)