### PR TITLE
fix(ci): pipe release changelog through env, not direct ${{ }} interpolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,23 +331,35 @@ jobs:
 
       - name: Create GitHub Release
         id: create_release
+        env:
+          # Pipe new_tag + changelog through env vars, NOT direct
+          # ${{ ... }} interpolation. Actions substitutes ${{ ... }}
+          # into the script verbatim BEFORE bash parses it, so a
+          # changelog value containing literal parens (e.g.
+          # "Fix(#143): ... (#144)") blows up with
+          # "syntax error near unexpected token '('".
+          # Going through env makes the value a runtime string that
+          # bash never tries to parse as code.
+          NEW_TAG: ${{ needs.generate-version.outputs.new_tag }}
+          CHANGELOG: ${{ needs.generate-version.outputs.changelog }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          NEW_TAG="${{ needs.generate-version.outputs.new_tag }}"
+          # Write the changelog to a file so any embedded quotes,
+          # backticks, or shell metacharacters never reach the
+          # command line at all.
+          printf '%s' "$CHANGELOG" > release-notes.md
 
-          # Create the release
           gh release create "$NEW_TAG" \
             --title "🚀 Release $NEW_TAG" \
-            --notes "${{ needs.generate-version.outputs.changelog }}" \
+            --notes-file release-notes.md \
             --latest \
-            openmakersuite-$NEW_TAG.tar.gz \
-            openmakersuite-$NEW_TAG.tar.gz.sha256 \
-            openmakersuite-$NEW_TAG.tar.gz.sig \
-            openmakersuite-$NEW_TAG.tar.gz.pem
+            "openmakersuite-$NEW_TAG.tar.gz" \
+            "openmakersuite-$NEW_TAG.tar.gz.sha256" \
+            "openmakersuite-$NEW_TAG.tar.gz.sig" \
+            "openmakersuite-$NEW_TAG.tar.gz.pem"
 
           echo "✅ GitHub release created: $NEW_TAG"
-          echo "release_url=$(gh release view $NEW_TAG --json url --jq .url)" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          echo "release_url=$(gh release view "$NEW_TAG" --json url --jq .url)" >> "$GITHUB_OUTPUT"
 
   notify-success:
     name: 🎉 Notification


### PR DESCRIPTION
## What this fixes

Follow-on from #679. The cosign `--yes` fix unblocked the "Sign release artifacts" step — and the very next release run died one step later with:

```
/home/runner/work/_temp/...sh: line 69: syntax error near unexpected token '('
##[error]Process completed with exit code 2.
```

…in the "Create GitHub Release" step.

## Root cause

The step was using:

```yaml
run: |
  gh release create "$NEW_TAG" \
    --notes "${{ needs.generate-version.outputs.changelog }}" \
    ...
```

GitHub Actions inlines `${{ ... }}` into the script **source verbatim, BEFORE bash parses it**. So the changelog string becomes part of the shell program text, and any unbalanced or special characters in it break shell parsing.

The auto-generated changelog included PR titles like:

- `Fix(#143): Sigs is empty. (#144)`
- `Feature(#117): Purchase Order Typeahead (#120)`

Those literal parens land in the source of the bash script and crash the parser.

## Fix

Standard "GHA secrets/inputs through env, not interpolation" pattern:

- Pass `NEW_TAG`, `CHANGELOG`, `GH_TOKEN` via the step's `env:` block. They become **runtime strings** that bash sees as variables, never source.
- Write the changelog to `release-notes.md` and use `gh release create --notes-file`, so even quotes/backticks/`$`/etc in PR titles never reach the command line.
- Quote every `"openmakersuite-$NEW_TAG.tar.gz*"` arg defensively (a tag with a shell metacharacter would re-trigger the same class of bug; unlikely with semver but cheap to defend).

No other workflow uses `gh release create`, so this is the only place that needs the fix.

## Test plan

- [x] `pre-commit run --files .github/workflows/release.yml` — clean
- [ ] After merge: confirm the next release run completes "Create GitHub Release" instead of dying at the syntax error, and that a release with notes actually appears on the Releases page

After this lands, the full release pipeline (build → sign → tag → release) should be fully green for the first time in 30+ commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)