### PR TITLE
fix(ci): skip Build Complete gate on workflow cancellation (kills phantom red ✗ on merge commits)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -312,7 +312,13 @@ jobs:
     name: ✅ Build Complete
     runs-on: ubuntu-latest
     needs: [determine-tags, build-backend, build-frontend, publish-helm]
-    if: always() && needs.determine-tags.outputs.should_build == 'true'
+    # `always()` so we report even when an upstream job fails; `!cancelled()`
+    # so we DON'T register a phantom failure on a duplicate-trigger run that
+    # the workflow's `concurrency: cancel-in-progress` supersedes. Without
+    # !cancelled() the cancelled run's dependent jobs report `cancelled`,
+    # this gate hits its else branch, exits 1, and a red ✗ "Build Complete"
+    # lands on the commit alongside the newer run's green ✓ — pure noise.
+    if: always() && !cancelled() && needs.determine-tags.outputs.should_build == 'true'
     steps:
       - name: Report completion
         run: |


### PR DESCRIPTION
## What this fixes

Every merge commit on main has been getting a phantom red ✗ "**Build Complete**" check next to the newer run's green ✓ "Build Complete". You spotted this on 1ad2f87 right after #680 landed — the commit-check view showed `4 successful, 3 cancelled, 9 skipped, and 1 failing`. The 1 failing was a cosmetic artifact from a duplicate workflow trigger.

## Sequence of events on each merge

1. A merge commit lands on main.
2. GitHub fires the Docker Containers workflow TWICE in close succession — once from the push event, once from the PR-close event.
3. `concurrency: cancel-in-progress: true` cancels the older invocation as the newer one starts. Good.
4. **But** the cancelled run's `build-complete` gate still runs (because its `if:` is `always()`), sees its upstream jobs reported `cancelled` rather than `success`, hits the else branch, and exits 1.
5. Net result: a permanent ✗ "Build Complete" registered on the commit, sitting beside the newer run's ✓ "Build Complete".

## Fix

```diff
-    if: always() && needs.determine-tags.outputs.should_build == 'true'
+    if: always() && !cancelled() && needs.determine-tags.outputs.should_build == 'true'
```

`cancelled()` is true only when the workflow itself is cancelled (concurrency supersedes, manual cancel, etc.) — not when an individual job fails. So:

- **Real build failure** → upstream job reports `failure` → gate still runs → exits 1 → ✗ registered. Unchanged behavior.
- **Workflow cancellation** → gate is skipped → no check registered → no phantom ✗. New behavior.

## Test plan

- [x] `pre-commit run --files .github/workflows/docker-build.yml` — clean
- [ ] After merge: on the next merge commit, confirm only ONE "Build Complete" check appears on the commit, and it's ✓. The previously-cancelled run should not contribute any check at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)