### PR TITLE
feat(forgekey): show reported + target firmware on e-paper panels page

### DIFF
--- a/backend/forgekey/serializers.py
+++ b/backend/forgekey/serializers.py
@@ -271,6 +271,9 @@ class EPaperDisplaySerializer(serializers.ModelSerializer):
     asset_tag = serializers.SerializerMethodField()
     device_mac_address = serializers.SerializerMethodField()
     is_low_battery = serializers.BooleanField(read_only=True)
+    target_firmware_version_string = serializers.CharField(
+        source="target_firmware_version.version", read_only=True, default=None
+    )
 
     class Meta:
         model = EPaperDisplay
@@ -286,6 +289,9 @@ class EPaperDisplaySerializer(serializers.ModelSerializer):
             "last_battery_at",
             "last_image_etag",
             "last_image_at",
+            "firmware_version",
+            "target_firmware_version",
+            "target_firmware_version_string",
             "is_active",
             "created_at",
             "updated_at",

--- a/backend/forgekey/tests/test_epaper_panels.py
+++ b/backend/forgekey/tests/test_epaper_panels.py
@@ -8,6 +8,7 @@ import pytest
 from rest_framework.test import APIClient
 
 from forgekey.models import EPaperDisplay
+from forgekey.tests.factories import FirmwareVersionFactory
 from inventory.tests.factories import AssetFactory
 
 pytestmark = pytest.mark.django_db
@@ -73,3 +74,23 @@ def test_set_active_unknown_display_returns_404(api_client):
         format="json",
     )
     assert response.status_code == 404
+
+
+def test_list_includes_firmware_and_target(api_client):
+    target = FirmwareVersionFactory(version="2.0.0")
+    reported = EPaperDisplay.objects.create(firmware_version="1.5.0")
+    pending = EPaperDisplay.objects.create(firmware_version="1.5.0", target_firmware_version=target)
+    unknown = EPaperDisplay.objects.create()
+
+    response = api_client.get(LIST_URL)
+    assert response.status_code == 200, response.data
+    by_id = {row["id"]: row for row in response.json()}
+
+    assert by_id[str(reported.id)]["firmware_version"] == "1.5.0"
+    assert by_id[str(reported.id)]["target_firmware_version_string"] is None
+
+    assert by_id[str(pending.id)]["firmware_version"] == "1.5.0"
+    assert by_id[str(pending.id)]["target_firmware_version_string"] == "2.0.0"
+
+    assert by_id[str(unknown.id)]["firmware_version"] == ""
+    assert by_id[str(unknown.id)]["target_firmware_version_string"] is None

--- a/frontend/src/__tests__/pages/ForgeKeyEPaperPanelsPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyEPaperPanelsPage.test.tsx
@@ -38,6 +38,9 @@ const buildPanel = (overrides: Partial<any> = {}) => ({
   last_battery_at: null,
   last_image_etag: '',
   last_image_at: null,
+  firmware_version: '',
+  target_firmware_version: null,
+  target_firmware_version_string: null,
   is_active: true,
   created_at: '2026-05-01T00:00:00Z',
   updated_at: '2026-05-01T00:00:00Z',
@@ -117,5 +120,31 @@ describe('ForgeKeyEPaperPanelsPage', () => {
     // The inline picker means rebinding happens from this page (not a bounce
     // to the QR flow). Asset options come from the assets feed.
     expect(await screen.findByTestId('bind-select-p1')).toBeInTheDocument();
+  });
+
+  test('shows reported firmware version and pending rollout target', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockApi.listEPaperDisplays.mockResolvedValue({
+      data: [
+        buildPanel({
+          id: 'reported',
+          asset_name: 'Lathe',
+          firmware_version: '1.5.0',
+        }),
+        buildPanel({
+          id: 'pending',
+          asset_name: 'Drill',
+          firmware_version: '1.5.0',
+          target_firmware_version: 'fv-2',
+          target_firmware_version_string: '2.0.0',
+        }),
+      ],
+    } as any);
+
+    renderPage();
+
+    await screen.findByText('Lathe');
+    expect(screen.getAllByText('1.5.0')).toHaveLength(2);
+    expect(screen.getByText('→ 2.0.0')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ForgeKeyEPaperPanelsPage.tsx
+++ b/frontend/src/pages/ForgeKeyEPaperPanelsPage.tsx
@@ -140,6 +140,7 @@ const ForgeKeyEPaperPanelsPage: React.FC = () => {
                   <Table.Th>Battery</Table.Th>
                   <Table.Th>Last refresh</Table.Th>
                   <Table.Th>Device</Table.Th>
+                  <Table.Th>Firmware</Table.Th>
                   <Table.Th>Status</Table.Th>
                   <Table.Th>Actions</Table.Th>
                 </Table.Tr>
@@ -184,6 +185,23 @@ const ForgeKeyEPaperPanelsPage: React.FC = () => {
                       <Text size="sm" c="dimmed">
                         {p.device_mac_address || '—'}
                       </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      {p.firmware_version ? (
+                        <Text size="sm">
+                          {p.firmware_version}
+                          {p.target_firmware_version_string &&
+                            p.target_firmware_version_string !== p.firmware_version && (
+                              <Text size="xs" c="orange" span ml={4}>
+                                → {p.target_firmware_version_string}
+                              </Text>
+                            )}
+                        </Text>
+                      ) : (
+                        <Text size="sm" c="dimmed">
+                          —
+                        </Text>
+                      )}
                     </Table.Td>
                     <Table.Td>
                       <Badge color={p.is_active ? 'green' : 'gray'}>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1856,6 +1856,9 @@ export interface ForgeKeyEPaperDisplay {
   last_battery_at: string | null;
   last_image_etag: string;
   last_image_at: string | null;
+  firmware_version: string;
+  target_firmware_version: string | null;
+  target_firmware_version_string: string | null;
   is_active: boolean;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary
- Add `firmware_version` and `target_firmware_version_string` to `EPaperDisplaySerializer` (data was already on the model — just not exposed).
- Add a **Firmware** column to `ForgeKeyEPaperPanelsPage`, between Device and Status. Reported version renders plain; when a rollout is in progress (target ≠ reported), the target trails as an orange `→ 2.0.0` to make stuck panels obvious.

## Why
`EPaperDisplay` already tracks the firmware version each panel reports on every wake (via `/firmware-check/`) plus a target FK from the rollout campaign. The fleet view ignored both. Operators triaging a panel had to drop into Django admin or the DB to answer "what version is this thing on?" — same surface that already shows asset binding and battery should answer it.

## Test plan
- [x] `pytest forgekey/tests/test_epaper_panels.py` — 5 passed (4 existing + 1 new covering reported-only, reported + pending target, and fresh/unknown panels).
- [x] `npm test -- __tests__/pages/ForgeKeyEPaperPanelsPage.test.tsx` — 5 passed (4 existing + 1 new asserting both columns + rollout indicator).
- [x] `npm run build` — clean.
- [x] `pre-commit run` on changed files — black, isort, ruff, bandit, npm test all pass. (`typescript-check` skipped: 59 pre-existing TS errors on `origin/main` unrelated to this diff; this PR doesn't introduce any.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)