### PR TITLE
fix(forgekey): load all active assets on e-paper panels page

### DIFF
--- a/frontend/src/__tests__/pages/ForgeKeyEPaperPanelsPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyEPaperPanelsPage.test.tsx
@@ -118,4 +118,22 @@ describe('ForgeKeyEPaperPanelsPage', () => {
     // to the QR flow). Asset options come from the assets feed.
     expect(await screen.findByTestId('bind-select-p1')).toBeInTheDocument();
   });
+
+  test('asset list pulls all active assets, not just the first page', async () => {
+    // Default DRF PAGE_SIZE=50 means a plain listAssets() call would hide
+    // any asset past the first page from the rebind dropdown — request a
+    // page big enough to cover any realistic makerspace asset count.
+    localStorage.setItem('is_staff', 'true');
+    mockApi.listEPaperDisplays.mockResolvedValue({ data: [buildPanel()] } as any);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(mockAssets.listAssets).toHaveBeenCalledWith({
+        is_active: true,
+        page_size: 1000,
+        ordering: 'name',
+      });
+    });
+  });
 });

--- a/frontend/src/__tests__/pages/ForgeKeyEPaperPanelsPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyEPaperPanelsPage.test.tsx
@@ -138,6 +138,8 @@ describe('ForgeKeyEPaperPanelsPage', () => {
         ordering: 'name',
       });
     });
+  });
+
   test('shows reported firmware version and pending rollout target', async () => {
     localStorage.setItem('is_staff', 'true');
     mockApi.listEPaperDisplays.mockResolvedValue({

--- a/frontend/src/pages/ForgeKeyEPaperPanelsPage.tsx
+++ b/frontend/src/pages/ForgeKeyEPaperPanelsPage.tsx
@@ -53,12 +53,16 @@ const ForgeKeyEPaperPanelsPage: React.FC = () => {
     load();
   }, [isStaff, isSuperuser, load]);
 
-  // Assets for the inline "bind to asset" picker.
+  // Assets for the inline "bind to asset" picker. listAssets() is
+  // DRF-paginated (default PAGE_SIZE=50), so without page_size we'd only
+  // show the first 50 — operators couldn't bind a panel to anything past
+  // that page. Pull every active asset in one shot and sort by name; the
+  // Mantine Select filters client-side.
   useEffect(() => {
     if (!isStaff && !isSuperuser) return;
     let alive = true;
     assetsAPI
-      .listAssets()
+      .listAssets({ is_active: true, page_size: 1000, ordering: 'name' })
       .then((res) => {
         if (alive) {
           setAssets(res.data.results.map((a) => ({ value: String(a.id), label: a.name })));


### PR DESCRIPTION
## Summary
- `ForgeKeyEPaperPanelsPage` called `assetsAPI.listAssets()` with no params, so DRF capped the rebind dropdown at the first 50 assets. Pass `is_active=true`, `page_size=1000`, `ordering=name` so every active asset is reachable.

## Why
You flagged that you couldn't bind a panel to the Rotary Two Post lift or the Polar Air Compressor from the panels page — only via the Django admin. The root cause was paginated `listAssets`. 1000 is well over any realistic single-site asset count; when that ceiling ever bites we move to server-side search (same shape `ForgeKeyEPaperBindPage` already uses).

## Test plan
- [x] `npm test -- __tests__/pages/ForgeKeyEPaperPanelsPage.test.tsx` — 5 passed (4 existing + 1 new asserting the page_size/is_active/ordering args).
- [x] `npm run build` — clean.
- [x] Existing tests still mock listAssets generously, so they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)