### PR TITLE
feat(forgekey): OOS + reservation faces + rotation picker for e-paper

### DIFF
--- a/backend/forgekey/services/epaper_render.py
+++ b/backend/forgekey/services/epaper_render.py
@@ -35,7 +35,7 @@ from django.utils import timezone
 
 from PIL import Image, ImageDraw, ImageFont
 
-from inventory.models import Asset, MaintenanceItem
+from inventory.models import Asset, AssetOutOfService, AssetReservation, MaintenanceItem
 
 EPAPER_WIDTH = 800
 EPAPER_HEIGHT = 480
@@ -319,3 +319,330 @@ def render_pm_image(asset: Asset, *, service_url: str | None = None) -> bytes:
     buffer = io.BytesIO()
     img.save(buffer, format="PNG", optimize=True)
     return buffer.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Face selection — PM / reservation / OOS
+# ---------------------------------------------------------------------------
+
+
+FACE_PM = "pm"
+FACE_RESERVATION = "reservation"
+FACE_OOS = "oos"
+
+
+def _current_oos(asset: Asset) -> AssetOutOfService | None:
+    """Open (unrestored) OOS row for this asset, if any."""
+    return (
+        AssetOutOfService.objects.filter(asset=asset, restored_at__isnull=True)
+        .order_by("-placed_out_at")
+        .first()
+    )
+
+
+def _current_reservation(asset: Asset) -> AssetReservation | None:
+    """Reservation whose [starts_at, ends_at) window contains now."""
+    now = timezone.now()
+    return (
+        AssetReservation.objects.filter(
+            asset=asset,
+            cancelled_at__isnull=True,
+            starts_at__lte=now,
+            ends_at__gt=now,
+        )
+        .order_by("starts_at")
+        .first()
+    )
+
+
+def _pick_face(asset: Asset, display) -> tuple[str, AssetOutOfService | AssetReservation | None]:
+    """Choose which face the panel should show on this request.
+
+    Precedence (highest first):
+    1. Open OOS — preempts everything. There is no rotation; the panel
+       belongs to the OOS narrative until the asset is restored.
+    2. Current reservation AND eligible PM task — rotate based on the
+       per-display ``event_face_weight`` / ``pm_face_weight``. The
+       ``rotation_counter`` modulo the weight sum picks this fetch's
+       face; the caller advances the counter after rendering so the
+       next fetch picks the next face in the cycle.
+    3. Current reservation only (or PM-eligibility check fails) — show
+       the reservation face every wake.
+    4. Default — PM face.
+
+    Returns ``(face, source_row)`` where ``source_row`` is the OOS or
+    reservation feeding the chosen face (None for PM).
+    """
+    oos = _current_oos(asset)
+    if oos is not None:
+        return FACE_OOS, oos
+
+    reservation = _current_reservation(asset)
+    pm_eligible = _next_due_item(asset) is not None
+
+    if reservation is not None and pm_eligible:
+        event_w = max(0, getattr(display, "event_face_weight", 2)) if display is not None else 2
+        pm_w = max(0, getattr(display, "pm_face_weight", 1)) if display is not None else 1
+        total = event_w + pm_w
+        if total == 0:
+            # Operator set both weights to zero; treat as "always PM" so the
+            # panel still has something to draw.
+            return FACE_PM, None
+        counter = int(getattr(display, "rotation_counter", 0)) if display is not None else 0
+        if (counter % total) < event_w:
+            return FACE_RESERVATION, reservation
+        return FACE_PM, None
+
+    if reservation is not None:
+        return FACE_RESERVATION, reservation
+
+    return FACE_PM, None
+
+
+# ---------------------------------------------------------------------------
+# OOS + Reservation renderers
+# ---------------------------------------------------------------------------
+
+
+def _draw_eyebrow(draw, eyebrow_text: str, right: int, *, inverted: bool = False) -> int:
+    """Render the eyebrow + rule and return the y-coordinate of the rule.
+
+    When ``inverted`` is True, the eyebrow is drawn as a black bar with
+    white text — used to make the OOS face read across the shop floor
+    without anyone having to walk up.
+    """
+    font = _font("mono_bold", 24)
+    if inverted:
+        bar_top = _MARGIN - 12
+        bar_bottom = _MARGIN + 22
+        draw.rectangle([(_MARGIN - 10, bar_top), (right + 10, bar_bottom)], fill=_FG)
+        draw.text((_MARGIN, _MARGIN - 8), eyebrow_text, font=font, fill=_BG)
+        rule_y = bar_bottom + 6
+    else:
+        draw.text((_MARGIN, _MARGIN - 8), eyebrow_text, font=font, fill=_FG)
+        rule_y = _MARGIN + 26
+    draw.line([(_MARGIN, rule_y), (right, rule_y)], fill=_FG, width=2)
+    return rule_y
+
+
+def _draw_asset_headline(draw, name: str, rule_y: int, right: int) -> int:
+    """Asset name auto-fit + wrapped to 2 lines. Returns the new y cursor."""
+    name = (name or "UNNAMED ASSET").upper()
+    name_font = _fit_font(draw, name, "sans_bold", 52, 30, EPAPER_WIDTH - 2 * _MARGIN)
+    name_lines = _wrap(draw, name, name_font, EPAPER_WIDTH - 2 * _MARGIN, max_lines=2)
+    y = rule_y + 18
+    for line in name_lines:
+        draw.text((_MARGIN, y), line, font=name_font, fill=_FG)
+        y += _text_size(draw, line, name_font)[1] + 8
+    return y
+
+
+def render_oos_image(asset: Asset, oos: AssetOutOfService) -> bytes:
+    """Render the OUT OF SERVICE face for ``asset``.
+
+    Layout reflects the user's spec: when the asset was placed out, who
+    placed it out, and the expected return date when known. Eyebrow is
+    inverted so the alarm reads from across the room.
+    """
+    img = Image.new("L", (EPAPER_WIDTH, EPAPER_HEIGHT), color=_BG)
+    draw = ImageDraw.Draw(img)
+    right = EPAPER_WIDTH - _MARGIN
+
+    # Thicker frame than the PM face — distinct silhouette.
+    draw.rectangle([(5, 5), (EPAPER_WIDTH - 6, EPAPER_HEIGHT - 6)], outline=_FG, width=6)
+
+    rule_y = _draw_eyebrow(draw, "OUT OF SERVICE", right, inverted=True)
+    y = _draw_asset_headline(draw, asset.name, rule_y, right)
+
+    body_font = _font("sans", 26)
+    meta_font = _font("mono_bold", 22)
+    y += 10
+
+    placed_local = timezone.localtime(oos.placed_out_at).strftime("%Y-%m-%d %H:%M")
+    placed_by_name = (
+        oos.placed_by.get_full_name() or oos.placed_by.username
+        if oos.placed_by_id is not None
+        else "—"
+    )
+    rows = [
+        ("PLACED OUT", placed_local),
+        ("BY", placed_by_name),
+    ]
+    if oos.expected_return_at is not None:
+        rows.append(
+            ("EXPECTED BACK", timezone.localtime(oos.expected_return_at).strftime("%Y-%m-%d"))
+        )
+    else:
+        rows.append(("EXPECTED BACK", "TBD"))
+
+    label_w = max(_text_size(draw, label, meta_font)[0] for label, _ in rows)
+    for label, value in rows:
+        draw.text((_MARGIN, y), label, font=meta_font, fill=_FG)
+        draw.text((_MARGIN + label_w + 20, y), value, font=body_font, fill=_FG)
+        y += max(_text_size(draw, label, meta_font)[1], _text_size(draw, value, body_font)[1]) + 12
+
+    # Reason — multi-line, fills remaining vertical room.
+    y += 6
+    draw.line([(_MARGIN, y), (right, y)], fill=_FG, width=1)
+    y += 10
+    reason_font = _font("sans", 24)
+    reason_lines = _wrap(
+        draw,
+        oos.reason or "(no reason recorded)",
+        reason_font,
+        right - _MARGIN,
+        max_lines=6,
+    )
+    for line in reason_lines:
+        draw.text((_MARGIN, y), line, font=reason_font, fill=_FG)
+        y += _text_size(draw, line, reason_font)[1] + 6
+
+    # Footer.
+    foot_y = EPAPER_HEIGHT - _MARGIN - 18
+    draw.line([(_MARGIN, foot_y - 8), (right, foot_y - 8)], fill=_FG, width=1)
+    tag = getattr(asset, "asset_tag", "") or ""
+    footer = "Do not operate"
+    if tag:
+        footer = f"{footer}   ·   {tag}"
+    draw.text((_MARGIN, foot_y), footer, font=_font("sans", 19), fill=_FG)
+
+    buffer = io.BytesIO()
+    img.save(buffer, format="PNG", optimize=True)
+    return buffer.getvalue()
+
+
+def render_reservation_image(asset: Asset, reservation: AssetReservation) -> bytes:
+    """Render the RESERVED face — title, reserver, ends_at, remaining."""
+    img = Image.new("L", (EPAPER_WIDTH, EPAPER_HEIGHT), color=_BG)
+    draw = ImageDraw.Draw(img)
+    right = EPAPER_WIDTH - _MARGIN
+
+    draw.rectangle([(5, 5), (EPAPER_WIDTH - 6, EPAPER_HEIGHT - 6)], outline=_FG, width=4)
+
+    rule_y = _draw_eyebrow(draw, "RESERVED", right)
+    y = _draw_asset_headline(draw, asset.name, rule_y, right)
+
+    title_font = _fit_font(draw, reservation.title, "sans_bold", 38, 22, EPAPER_WIDTH - 2 * _MARGIN)
+    for line in _wrap(draw, reservation.title, title_font, EPAPER_WIDTH - 2 * _MARGIN, max_lines=2):
+        draw.text((_MARGIN, y), line, font=title_font, fill=_FG)
+        y += _text_size(draw, line, title_font)[1] + 6
+
+    meta_font = _font("mono_bold", 22)
+    body_font = _font("sans", 26)
+    y += 14
+
+    reserved_by_name = (
+        reservation.reserved_by.get_full_name() or reservation.reserved_by.username
+        if reservation.reserved_by_id is not None
+        else "—"
+    )
+    ends_local = timezone.localtime(reservation.ends_at)
+    rows = [
+        ("RESERVED BY", reserved_by_name),
+        ("ENDS", ends_local.strftime("%Y-%m-%d %H:%M")),
+    ]
+    label_w = max(_text_size(draw, label, meta_font)[0] for label, _ in rows)
+    for label, value in rows:
+        draw.text((_MARGIN, y), label, font=meta_font, fill=_FG)
+        draw.text((_MARGIN + label_w + 20, y), value, font=body_font, fill=_FG)
+        y += max(_text_size(draw, label, meta_font)[1], _text_size(draw, value, body_font)[1]) + 10
+
+    # Time remaining — big glanceable number, mirror of PM's status box.
+    remaining = ends_local - timezone.localtime()
+    minutes_left = int(remaining.total_seconds() // 60)
+    if minutes_left < 0:
+        time_text = "ENDED"
+    elif minutes_left < 60:
+        time_text = f"{minutes_left}m LEFT"
+    elif minutes_left < 24 * 60:
+        time_text = f"{minutes_left // 60}h {minutes_left % 60:02d}m LEFT"
+    else:
+        time_text = f"{minutes_left // (24 * 60)}d LEFT"
+
+    box_top = max(y + 14, EPAPER_HEIGHT - _MARGIN - 130)
+    box_bottom = EPAPER_HEIGHT - _MARGIN - 36
+    box_left = _MARGIN
+    box_right = right
+    status_font = _fit_font(draw, time_text, "sans_bold", 60, 26, (box_right - box_left) - 36)
+    sw, sh = _text_size(draw, time_text, status_font)
+    cx = box_left + (box_right - box_left) // 2
+    cy = box_top + (box_bottom - box_top) // 2
+    draw.rectangle([(box_left, box_top), (box_right, box_bottom)], outline=_FG, width=3)
+    draw.text((cx - sw // 2, cy - sh // 2 - 6), time_text, font=status_font, fill=_FG)
+
+    foot_y = EPAPER_HEIGHT - _MARGIN - 18
+    draw.line([(_MARGIN, foot_y - 8), (right, foot_y - 8)], fill=_FG, width=1)
+    tag = getattr(asset, "asset_tag", "") or ""
+    footer_left = f"Started {timezone.localtime(reservation.starts_at).strftime('%Y-%m-%d %H:%M')}"
+    if tag:
+        footer_left = f"{footer_left}   ·   {tag}"
+    draw.text((_MARGIN, foot_y), footer_left, font=_font("sans", 19), fill=_FG)
+
+    buffer = io.BytesIO()
+    img.save(buffer, format="PNG", optimize=True)
+    return buffer.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point + multi-face etag
+# ---------------------------------------------------------------------------
+
+
+def compute_display_etag(asset: Asset, display) -> str:
+    """Etag that covers the chosen face, not just the PM snapshot.
+
+    Includes (face, source-row pk, OOS pk, reservation pk, plus the
+    existing PM fingerprint). The rotation slot is only folded in when
+    rotation actually competes — i.e. both a current reservation AND
+    an eligible PM are present — so single-face panels still 304 on
+    repeat fetches even though the counter advances server-side.
+    """
+    face, source = _pick_face(asset, display)
+
+    pm_part = compute_snapshot_etag(asset)
+    parts: list[str] = [face, pm_part]
+    if source is not None:
+        parts.append(str(source.pk))
+        if face == FACE_OOS:
+            parts.append(source.updated_at.isoformat())
+        elif face == FACE_RESERVATION:
+            parts.append(source.ends_at.isoformat())
+            # Bucket the time remaining to ~5-minute precision so the
+            # "time left" headline updates without thrashing every minute.
+            now = timezone.now()
+            buckets_left = max(0, int((source.ends_at - now).total_seconds() // 300))
+            parts.append(str(buckets_left))
+    if display is not None and _rotation_competes(asset):
+        event_w = max(0, getattr(display, "event_face_weight", 2))
+        pm_w = max(0, getattr(display, "pm_face_weight", 1))
+        counter = int(getattr(display, "rotation_counter", 0))
+        total = event_w + pm_w
+        if total > 0:
+            parts.append(f"rot:{counter % total}/{total}")
+    digest = hashlib.sha256("\n".join(parts).encode("utf-8")).hexdigest()
+    return digest[:32]
+
+
+def _rotation_competes(asset: Asset) -> bool:
+    """True iff the panel would alternate faces — both PM and a current
+    reservation are eligible, no OOS preempting."""
+    if _current_oos(asset) is not None:
+        return False
+    return _current_reservation(asset) is not None and _next_due_item(asset) is not None
+
+
+def render_image(
+    asset: Asset, display=None, *, service_url: str | None = None
+) -> tuple[bytes, str]:
+    """Pick the face, render it, and report which face we drew.
+
+    Caller is expected to advance ``display.rotation_counter`` after a
+    successful response when ``display`` is not None and the chosen
+    face was the rotation outcome — see views.EPaperDisplayImageView.
+    """
+    face, source = _pick_face(asset, display)
+    if face == FACE_OOS:
+        return render_oos_image(asset, source), face
+    if face == FACE_RESERVATION:
+        return render_reservation_image(asset, source), face
+    return render_pm_image(asset, service_url=service_url), face

--- a/backend/forgekey/tests/test_epaper_faces.py
+++ b/backend/forgekey/tests/test_epaper_faces.py
@@ -1,0 +1,345 @@
+"""Tests for the OOS + reservation faces and the rotation picker.
+
+Layered on top of test_epaper.py — the PM face behaviour stays under
+that file, this one covers:
+
+- _pick_face precedence (OOS > reservation+PM rotation > reservation > PM).
+- Weighted rotation (event:pm ratios produce the right distribution).
+- render_oos_image / render_reservation_image return valid PNGs.
+- compute_display_etag changes when the chosen face changes, and is
+  stable for the same face when the underlying data hasn't moved.
+- EPaperDisplayImageView advances rotation_counter on each fetch.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from io import BytesIO
+from uuid import uuid4
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from django.utils.crypto import get_random_string
+
+import pytest
+from PIL import Image
+
+from forgekey.models import EPaperDisplay
+from forgekey.services.epaper_render import (
+    FACE_OOS,
+    FACE_PM,
+    FACE_RESERVATION,
+    _pick_face,
+    compute_display_etag,
+    render_image,
+    render_oos_image,
+    render_reservation_image,
+)
+from inventory.models import (
+    Asset,
+    AssetOutOfService,
+    AssetReservation,
+    Location,
+    MaintenanceItem,
+)
+
+pytestmark = pytest.mark.django_db
+User = get_user_model()
+
+
+def _user() -> User:
+    return User.objects.create_user(
+        username=get_random_string(12),
+        email=f"{get_random_string(8)}@example.com",
+        password=get_random_string(24),
+        is_staff=True,
+    )
+
+
+def _asset() -> Asset:
+    suffix = uuid4().hex[:8].upper()
+    location = Location.objects.create(name=f"OOS/Res Loc {suffix}")
+    return Asset.objects.create(name="Welder", location=location, asset_tag=f"TEST-{suffix}")
+
+
+def _display(asset: Asset, **overrides) -> EPaperDisplay:
+    return EPaperDisplay.objects.create(asset=asset, **overrides)
+
+
+def _current_reservation(
+    asset: Asset, user: User, *, title: str = "Welding 101"
+) -> AssetReservation:
+    now = timezone.now()
+    return AssetReservation.objects.create(
+        asset=asset,
+        title=title,
+        reserved_by=user,
+        starts_at=now - timedelta(minutes=10),
+        ends_at=now + timedelta(hours=2),
+    )
+
+
+def _open_oos(asset: Asset, user: User) -> AssetOutOfService:
+    return AssetOutOfService.objects.create(
+        asset=asset,
+        placed_by=user,
+        reason="Belt snapped",
+        expected_return_at=timezone.now() + timedelta(days=3),
+    )
+
+
+def _eligible_pm(asset: Asset) -> MaintenanceItem:
+    item = MaintenanceItem.objects.create(asset=asset, title="Lube ways", interval_days=30)
+    # Make it overdue so it's definitely the "next due item".
+    item.last_completed_at = timezone.now() - timedelta(days=60)
+    item.save(update_fields=["last_completed_at"])
+    return item
+
+
+# ---------------------------------------------------------------------------
+# Face precedence
+# ---------------------------------------------------------------------------
+
+
+class TestPickFacePrecedence:
+    def test_oos_preempts_reservation_and_pm(self):
+        u = _user()
+        a = _asset()
+        d = _display(a)
+        _eligible_pm(a)
+        _current_reservation(a, u)
+        _open_oos(a, u)
+        face, source = _pick_face(a, d)
+        assert face == FACE_OOS
+        assert isinstance(source, AssetOutOfService)
+
+    def test_reservation_only_when_no_pm(self):
+        u = _user()
+        a = _asset()
+        d = _display(a)
+        _current_reservation(a, u)
+        face, source = _pick_face(a, d)
+        assert face == FACE_RESERVATION
+        assert isinstance(source, AssetReservation)
+
+    def test_pm_only_when_no_reservation(self):
+        a = _asset()
+        d = _display(a)
+        _eligible_pm(a)
+        face, source = _pick_face(a, d)
+        assert face == FACE_PM
+        assert source is None
+
+    def test_default_pm_when_nothing(self):
+        a = _asset()
+        d = _display(a)
+        face, source = _pick_face(a, d)
+        assert face == FACE_PM
+        assert source is None
+
+    def test_past_reservation_does_not_drive(self):
+        u = _user()
+        a = _asset()
+        d = _display(a)
+        AssetReservation.objects.create(
+            asset=a,
+            title="past",
+            reserved_by=u,
+            starts_at=timezone.now() - timedelta(days=2),
+            ends_at=timezone.now() - timedelta(days=1),
+        )
+        face, _ = _pick_face(a, d)
+        assert face == FACE_PM
+
+    def test_cancelled_reservation_does_not_drive(self):
+        u = _user()
+        a = _asset()
+        d = _display(a)
+        r = _current_reservation(a, u)
+        r.cancelled_at = timezone.now()
+        r.save()
+        face, _ = _pick_face(a, d)
+        assert face == FACE_PM
+
+    def test_restored_oos_does_not_drive(self):
+        u = _user()
+        a = _asset()
+        d = _display(a)
+        oos = _open_oos(a, u)
+        oos.restored_at = timezone.now()
+        oos.save()
+        face, _ = _pick_face(a, d)
+        assert face == FACE_PM
+
+
+# ---------------------------------------------------------------------------
+# Rotation
+# ---------------------------------------------------------------------------
+
+
+class TestPickFaceRotation:
+    def test_default_2_1_ratio(self):
+        u = _user()
+        a = _asset()
+        d = _display(a, event_face_weight=2, pm_face_weight=1)
+        _eligible_pm(a)
+        _current_reservation(a, u)
+        # 6 simulated renders: counter 0..5. With 2:1, we expect
+        # event/event/pm repeating.
+        faces = []
+        for i in range(6):
+            d.rotation_counter = i
+            face, _ = _pick_face(a, d)
+            faces.append(face)
+        # Two thirds reservation.
+        event_count = sum(1 for f in faces if f == FACE_RESERVATION)
+        pm_count = sum(1 for f in faces if f == FACE_PM)
+        assert event_count == 4
+        assert pm_count == 2
+
+    def test_zero_event_weight_means_always_pm(self):
+        u = _user()
+        a = _asset()
+        d = _display(a, event_face_weight=0, pm_face_weight=1)
+        _eligible_pm(a)
+        _current_reservation(a, u)
+        for i in range(5):
+            d.rotation_counter = i
+            face, _ = _pick_face(a, d)
+            assert face == FACE_PM
+
+    def test_zero_both_weights_picks_pm(self):
+        u = _user()
+        a = _asset()
+        d = _display(a, event_face_weight=0, pm_face_weight=0)
+        _eligible_pm(a)
+        _current_reservation(a, u)
+        face, _ = _pick_face(a, d)
+        assert face == FACE_PM
+
+    def test_3_1_ratio(self):
+        u = _user()
+        a = _asset()
+        d = _display(a, event_face_weight=3, pm_face_weight=1)
+        _eligible_pm(a)
+        _current_reservation(a, u)
+        events = 0
+        pms = 0
+        for i in range(8):
+            d.rotation_counter = i
+            face, _ = _pick_face(a, d)
+            if face == FACE_RESERVATION:
+                events += 1
+            else:
+                pms += 1
+        assert events == 6
+        assert pms == 2
+
+
+# ---------------------------------------------------------------------------
+# Image bytes
+# ---------------------------------------------------------------------------
+
+
+class TestFaceImages:
+    def test_oos_image_is_valid_png(self):
+        u = _user()
+        a = _asset()
+        oos = _open_oos(a, u)
+        png = render_oos_image(a, oos)
+        image = Image.open(BytesIO(png))
+        assert image.format == "PNG"
+        assert image.size == (800, 480)
+
+    def test_reservation_image_is_valid_png(self):
+        u = _user()
+        a = _asset()
+        r = _current_reservation(a, u)
+        png = render_reservation_image(a, r)
+        image = Image.open(BytesIO(png))
+        assert image.format == "PNG"
+        assert image.size == (800, 480)
+
+    def test_render_image_dispatches_to_oos(self):
+        u = _user()
+        a = _asset()
+        d = _display(a)
+        _open_oos(a, u)
+        png, face = render_image(a, d)
+        assert face == FACE_OOS
+        assert Image.open(BytesIO(png)).size == (800, 480)
+
+
+# ---------------------------------------------------------------------------
+# Etag
+# ---------------------------------------------------------------------------
+
+
+class TestDisplayEtag:
+    def test_etag_changes_when_face_changes(self):
+        u = _user()
+        a = _asset()
+        d = _display(a)
+        _eligible_pm(a)
+        pm_only = compute_display_etag(a, d)
+        _open_oos(a, u)
+        with_oos = compute_display_etag(a, d)
+        assert pm_only != with_oos
+
+    def test_etag_stable_for_same_face(self):
+        u = _user()
+        a = _asset()
+        d = _display(a)
+        _current_reservation(a, u)
+        first = compute_display_etag(a, d)
+        second = compute_display_etag(a, d)
+        assert first == second
+
+    def test_etag_changes_when_rotation_advances_with_competition(self):
+        u = _user()
+        a = _asset()
+        d = _display(a, event_face_weight=2, pm_face_weight=1)
+        _eligible_pm(a)
+        _current_reservation(a, u)
+        d.rotation_counter = 0
+        first = compute_display_etag(a, d)
+        d.rotation_counter = 2  # crosses event→pm boundary
+        second = compute_display_etag(a, d)
+        assert first != second
+
+
+# ---------------------------------------------------------------------------
+# Image endpoint integration — counter advances per fetch
+# ---------------------------------------------------------------------------
+
+
+class TestImageEndpointRotation:
+    def _url(self, display_id) -> str:
+        return f"/api/forgekey/epaper/{display_id}/image.png"
+
+    def test_counter_advances_on_each_fetch(self, client):
+        u = _user()
+        a = _asset()
+        d = _display(a, event_face_weight=2, pm_face_weight=1)
+        _eligible_pm(a)
+        _current_reservation(a, u)
+        baseline = d.rotation_counter
+        client.get(self._url(d.pk))
+        d.refresh_from_db()
+        assert d.rotation_counter == baseline + 1
+        client.get(self._url(d.pk))
+        d.refresh_from_db()
+        assert d.rotation_counter == baseline + 2
+
+    def test_304_returns_no_advance(self, client):
+        a = _asset()
+        d = _display(a)
+        _eligible_pm(a)
+        first = client.get(self._url(d.pk))
+        d.refresh_from_db()
+        counter_after_first = d.rotation_counter
+        etag = first["ETag"].strip('"')
+        nm = client.get(self._url(d.pk), HTTP_IF_NONE_MATCH=f'"{etag}"')
+        assert nm.status_code == 304
+        d.refresh_from_db()
+        assert d.rotation_counter == counter_after_first

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.db import transaction
+from django.db.models import F
 from django.http import FileResponse, HttpResponse, StreamingHttpResponse
 from django.utils import timezone
 
@@ -2438,9 +2439,9 @@ class EPaperDisplayImageView(APIView):
 
         # Lazy imports keep the boot path light — Pillow only loads
         # when a device actually hits this endpoint.
-        from .services.epaper_render import compute_snapshot_etag, render_pm_image
+        from .services.epaper_render import compute_display_etag, render_image
 
-        etag = compute_snapshot_etag(display.asset)
+        etag = compute_display_etag(display.asset, display)
         if_none_match = request.headers.get("if-none-match", "").strip().strip('"')
         if if_none_match and if_none_match == etag:
             return HttpResponse(status=304)
@@ -2451,12 +2452,19 @@ class EPaperDisplayImageView(APIView):
         # dev/staging/prod without a hardcoded domain — front-end and API
         # share the origin behind nginx in prod.
         service_url = epaper_service_url(request, display.pk)
-        png_bytes = render_pm_image(display.asset, service_url=service_url)
+        png_bytes, _face = render_image(display.asset, display, service_url=service_url)
+
         # Record what version the panel just flashed; the operator
         # dashboard reads `last_image_at` to spot stale panels.
+        # Always advance the rotation counter — when no rotation is in
+        # play (single-face panel) the increment is harmless because
+        # _pick_face only consults counter % (event+pm) and the result
+        # is never read; when rotation IS active, this gives the
+        # next fetch the right next face.
         EPaperDisplay.objects.filter(pk=display.pk).update(
             last_image_etag=etag,
             last_image_at=timezone.now(),
+            rotation_counter=F("rotation_counter") + 1,
         )
         response = HttpResponse(png_bytes, content_type="image/png")
         response["ETag"] = f'"{etag}"'


### PR DESCRIPTION
## Summary
**PR 2 of 4 — stacked on #685.** Adds the actual e-paper rendering for the OOS and reservation faces, plus the rotation picker that drives panel face selection.

### Renderer additions

- **\`_pick_face(asset, display)\`** — single source of truth for "which face is the panel showing right now?"
    - OOS (open) preempts everything (no rotation).
    - Reservation (current) + eligible PM → rotation via \`rotation_counter % (event_w + pm_w) < event_w\`.
    - Reservation alone → reservation.
    - Nothing or PM only → PM (existing behaviour).
- **\`render_oos_image\`** — inverted OUT OF SERVICE eyebrow + PLACED OUT / BY / EXPECTED BACK rows + full reason text. Footer reads "Do not operate".
- **\`render_reservation_image\`** — RESERVED eyebrow, title, RESERVED BY / ENDS rows, and a big "Xh Ym LEFT" headline box.
- **\`render_image(asset, display)\`** — new top-level entry that picks and dispatches.
- **\`compute_display_etag\`** — folds face + source row identity + 5-min reservation-remaining bucket into the cache key. Only includes the rotation slot when rotation actually competes, so single-face panels still 304 on repeat fetches.

### View

\`EPaperDisplayImageView\` swaps the PM-only renderer for \`render_image\` and the PM-only etag for \`compute_display_etag\`. Every 200 advances \`rotation_counter\` (\`F("rotation_counter")+1\`).

### Tests

19 new cases in \`test_epaper_faces.py\`:
- **Precedence**: OOS preempts; reservation+PM rotates; cancelled/past reservations don't drive; restored OOS doesn't drive.
- **Rotation distribution**: 2:1 → 4/2 over 6 ticks; 3:1 → 6/2 over 8 ticks; 0:1 pins to PM; 0:0 falls back to PM.
- **Image bytes**: both faces decode as 800×480 PNG.
- **Etag**: changes when face changes; stable for same face; flips when rotation crosses the boundary.
- **Endpoint**: counter advances on each 200, stays put on 304.

Full forgekey ePaper suite green: 96/96 across test_epaper + test_epaper_faces + test_epaper_panels + asset-reservation tests from #685.

## Follow-ups
- **PR 3** — web AssetDetailPage: reserve / OOS buttons + history panels + per-panel rotation-weight controls on the e-paper panels admin.
- **PR 4** — scantty: same surfaces in the TUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)