### PR TITLE
fix(forgekey): fold today's date into e-paper snapshot ETag

### DIFF
--- a/backend/forgekey/services/epaper_render.py
+++ b/backend/forgekey/services/epaper_render.py
@@ -131,11 +131,23 @@ def _next_due_item(asset: Asset) -> MaintenanceItem | None:
 
 
 def _snapshot_fingerprint(asset: Asset, items: Iterable[MaintenanceItem]) -> str:
-    """Return a stable hex fingerprint of the inputs to the rendered image."""
+    """Return a stable hex fingerprint of the inputs to the rendered image.
+
+    Includes ``today`` because the rendered PNG carries day-level
+    derivations (``X DAYS REMAINING``, the OVERDUE/WARNING/OK bucket
+    that drives the inverted-box treatment). Without this, a panel
+    whose underlying ``MaintenanceItem.last_completed_at`` hasn't
+    changed since yesterday would keep getting 304s and display a
+    stale day count forever — the firmware wake cycle hits the
+    endpoint hourly, sees the unchanged ETag, and keeps the existing
+    paint. Folding the date in forces at most one fresh render per
+    UTC day, which is the natural granularity of what's displayed.
+    """
     parts: list[str] = [
         str(asset.pk),
         asset.name,
         f"training={int(bool(getattr(asset, 'training_required', False)))}",
+        f"date={timezone.now().date().isoformat()}",
     ]
     for item in items:
         last = item.last_completed_at.isoformat() if item.last_completed_at else "never"

--- a/backend/forgekey/tests/test_epaper.py
+++ b/backend/forgekey/tests/test_epaper.py
@@ -116,6 +116,22 @@ class TestEPaperRender:
         after = compute_snapshot_etag(asset)
         assert before != after
 
+    def test_etag_changes_when_date_changes(self):
+        # The rendered PNG shows "X DAYS REMAINING" which decrements
+        # daily, so the ETag must change at the UTC date boundary —
+        # otherwise a panel that woke yesterday keeps getting 304s
+        # and displays a stale day count. Simulate tomorrow by
+        # advancing timezone.now().
+        from datetime import timedelta as _td
+
+        asset = _make_asset("Bandsaw")
+        _make_item(asset, "Blade tension", interval_days=30, last_done_days=10)
+        before = compute_snapshot_etag(asset)
+        tomorrow = timezone.now() + _td(days=1)
+        with patch("forgekey.services.epaper_render.timezone.now", return_value=tomorrow):
+            after = compute_snapshot_etag(asset)
+        assert before != after
+
     def test_render_returns_png_bytes(self):
         asset = _make_asset()
         _make_item(asset, "Filter swap", interval_days=90)


### PR DESCRIPTION
## Summary

Operators reported e-paper panels weren't updating on the hour. Looking at prod:

\`\`\`
did      | bound | last_image_at        | last_battery_at      | mins_since_img
ca4cbe29 | t     | 2026-06-03 23:15 UTC | 2026-06-05 01:19 UTC | 1599
61cb3f38 | t     | 2026-06-04 06:06 UTC |                      | 1188
9da81476 | t     | 2026-06-03 05:31 UTC |                      | 2663
\`\`\`

\`ca4cbe29\` hit the battery endpoint 58 min ago but \`last_image_at\` is 27 hours stale — proving the firmware wake cycle is alive but the image GET keeps short-circuiting on a stale ETag.

## Why

The rendered PNG body has day-level derivations:
- \`_days_until_due\` → "X DAYS REMAINING" / "OVERDUE BY N DAYS" headline
- \`_item_status\` → OVERDUE/WARNING bucket → drives the inverted-box treatment
- "Last serviced: YYYY-MM-DD" footer

But \`_snapshot_fingerprint\` only hashed identity + last_completed_at. So a panel showing "12 DAYS REMAINING" today would still show "12 DAYS REMAINING" three days later — the etag matches, the server returns 304, the panel keeps yesterday's paint.

## Fix

Fold \`timezone.now().date().isoformat()\` into the fingerprint. ETag flips at the UTC date boundary; panels redraw at most once per day in the quiet case. Existing invalidations (service logged, training toggled, certs wired, OOS opened, reservation booked) still fire mid-day.

## Test plan

- [x] New unit test: \`test_etag_changes_when_date_changes\` — patches \`timezone.now\` to tomorrow, asserts ETag flips.
- [x] All 56 epaper tests pass.
- [ ] After deploy: \`last_image_at\` on each bound panel ticks forward within one wake cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)