### PR TITLE
fix(forgekey): fold today's date into e-paper snapshot ETag

### DIFF
--- a/backend/forgekey/services/epaper_render.py
+++ b/backend/forgekey/services/epaper_render.py
@@ -131,11 +131,23 @@ def _next_due_item(asset: Asset) -> MaintenanceItem | None:
 
 
 def _snapshot_fingerprint(asset: Asset, items: Iterable[MaintenanceItem]) -> str:
-    """Return a stable hex fingerprint of the inputs to the rendered image."""
+    """Return a stable hex fingerprint of the inputs to the rendered image.
+
+    Includes ``today`` because the rendered PNG carries day-level
+    derivations (``X DAYS REMAINING``, the OVERDUE/WARNING/OK bucket
+    that drives the inverted-box treatment). Without this, a panel
+    whose underlying ``MaintenanceItem.last_completed_at`` hasn't
+    changed since yesterday would keep getting 304s and display a
+    stale day count forever — the firmware wake cycle hits the
+    endpoint hourly, sees the unchanged ETag, and keeps the existing
+    paint. Folding the date in forces at most one fresh render per
+    UTC day, which is the natural granularity of what's displayed.
+    """
     parts: list[str] = [
         str(asset.pk),
         asset.name,
         f"training={int(bool(getattr(asset, 'training_required', False)))}",
+        f"date={timezone.now().date().isoformat()}",
     ]
     for item in items:
         last = item.last_completed_at.isoformat() if item.last_completed_at else "never"

--- a/backend/forgekey/tests/test_epaper.py
+++ b/backend/forgekey/tests/test_epaper.py
@@ -116,6 +116,22 @@ class TestEPaperRender:
         after = compute_snapshot_etag(asset)
         assert before != after
 
+    def test_etag_changes_when_date_changes(self):
+        # The rendered PNG shows "X DAYS REMAINING" which decrements
+        # daily, so the ETag must change at the UTC date boundary —
+        # otherwise a panel that woke yesterday keeps getting 304s
+        # and displays a stale day count. Simulate tomorrow by
+        # advancing timezone.now().
+        from datetime import timedelta as _td
+
+        asset = _make_asset("Bandsaw")
+        _make_item(asset, "Blade tension", interval_days=30, last_done_days=10)
+        before = compute_snapshot_etag(asset)
+        tomorrow = timezone.now() + _td(days=1)
+        with patch("forgekey.services.epaper_render.timezone.now", return_value=tomorrow):
+            after = compute_snapshot_etag(asset)
+        assert before != after
+
     def test_render_returns_png_bytes(self):
         asset = _make_asset()
         _make_item(asset, "Filter swap", interval_days=90)


### PR DESCRIPTION
Third attempt at this PR — previous two had CI webhook delivery dropped at the pull_request trigger. Different branch name to rule out branch-name patterns. Same one-line fix; verified locally (56/56 epaper tests pass).