### PR TITLE
feat(project_storage): warden queue list page + Storage Admin perm (PR 1/6)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -2143,31 +2143,31 @@ views:
     actions:
       by_member:
         permission_classes:
-        - IsAuthenticatedOrReadOnly
+        - IsStorageAdminOrStaff
       label:
         permission_classes:
         - AllowAny
       list:
         permission_classes:
-        - IsAuthenticatedOrReadOnly
+        - IsStorageAdminOrStaff
       mark_printed:
         permission_classes:
         - AllowAny
       mark_removed:
         permission_classes:
-        - IsAuthenticatedOrReadOnly
+        - IsAdminUser
       move_to_purgatory:
         permission_classes:
-        - IsAuthenticatedOrReadOnly
+        - IsAdminUser
       print_queue:
         permission_classes:
         - AllowAny
       retrieve:
         permission_classes:
-        - IsAuthenticatedOrReadOnly
+        - IsStorageAdminOrStaff
       send_violation_notice:
         permission_classes:
-        - IsAuthenticatedOrReadOnly
+        - IsAdminUser
       start:
         permission_classes:
         - AllowAny

--- a/backend/project_storage/migrations/0003_storage_admin_group.py
+++ b/backend/project_storage/migrations/0003_storage_admin_group.py
@@ -1,0 +1,42 @@
+"""Seed the ``Storage Admin`` Django group.
+
+Members of this group can read project-storage stints (list, retrieve,
+by-member lookup) without being platform-wide ``is_staff``. Mutating
+actions still require ``IsAdminUser`` — see
+``project_storage/permissions.py``.
+
+The group is idempotently created with ``get_or_create`` so re-running
+the migration after a manual rename is safe; the reverse migration
+removes it (the operator's group memberships go too, which is fine for
+a permission-only group).
+"""
+
+from __future__ import annotations
+
+from django.db import migrations
+
+STORAGE_ADMIN_GROUP = "Storage Admin"
+
+
+def create_storage_admin_group(apps, schema_editor):
+    Group = apps.get_model("auth", "Group")
+    Group.objects.get_or_create(name=STORAGE_ADMIN_GROUP)
+
+
+def delete_storage_admin_group(apps, schema_editor):
+    Group = apps.get_model("auth", "Group")
+    Group.objects.filter(name=STORAGE_ADMIN_GROUP).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("project_storage", "0002_projectstoragestint_printed_at"),
+        ("auth", "0012_alter_user_first_name_max_length"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            create_storage_admin_group,
+            delete_storage_admin_group,
+        ),
+    ]

--- a/backend/project_storage/permissions.py
+++ b/backend/project_storage/permissions.py
@@ -1,0 +1,35 @@
+"""Permission classes for project storage.
+
+The warden surfaces (list, retrieve, by-member lookup) gate to staff users
+*or* members of the ``Storage Admin`` Django group. The latter lets the
+shop owner delegate sweep-day duties to volunteer wardens without
+elevating them to platform-wide ``is_staff``. Mutating actions
+(send-notice, move-to-purgatory, mark-removed) keep the tighter
+``IsAdminUser`` gate because they touch member-facing email + can
+write off a member's stored work.
+
+The kiosk and Pi-daemon endpoints (start, label, print_queue,
+mark_printed) remain ``AllowAny`` — see ``views.py::get_permissions``.
+"""
+
+from __future__ import annotations
+
+from rest_framework import permissions
+
+STORAGE_ADMIN_GROUP = "Storage Admin"
+
+
+class IsStorageAdminOrStaff(permissions.BasePermission):
+    """Allow read access to staff/superuser OR members of the
+    ``Storage Admin`` group. Anonymous callers are rejected.
+    """
+
+    message = "You must be staff or a Storage Admin to view project-storage stints."
+
+    def has_permission(self, request, view) -> bool:
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+        if user.is_staff or user.is_superuser:
+            return True
+        return user.groups.filter(name=STORAGE_ADMIN_GROUP).exists()

--- a/backend/project_storage/tests/test_api.py
+++ b/backend/project_storage/tests/test_api.py
@@ -373,12 +373,8 @@ class TestListEndpoint:
 
     def test_ordering_by_expires_at(self, staff_client):
         # Soonest-to-expire first when ordering=expires_at.
-        ProjectStorageStintFactory(
-            username="late", expires_at=timezone.now() + timedelta(days=20)
-        )
-        ProjectStorageStintFactory(
-            username="early", expires_at=timezone.now() + timedelta(days=2)
-        )
+        ProjectStorageStintFactory(username="late", expires_at=timezone.now() + timedelta(days=20))
+        ProjectStorageStintFactory(username="early", expires_at=timezone.now() + timedelta(days=2))
         resp = staff_client.get("/api/project-storage/stints/?ordering=expires_at")
         body = resp.json()
         rows = body["results"] if isinstance(body, dict) and "results" in body else body
@@ -407,7 +403,5 @@ class TestMutatingActionsStayAdmin:
 
     def test_staff_can_mark_removed(self, staff_client):
         stint = ProjectStorageStintFactory()
-        resp = staff_client.post(
-            f"/api/project-storage/stints/{stint.stint_id}/mark-removed/"
-        )
+        resp = staff_client.post(f"/api/project-storage/stints/{stint.stint_id}/mark-removed/")
         assert resp.status_code == 200

--- a/backend/project_storage/tests/test_api.py
+++ b/backend/project_storage/tests/test_api.py
@@ -262,3 +262,152 @@ class TestLabelEndpoint:
     def test_unknown_stint_returns_404(self, client):
         resp = client.get("/api/project-storage/stints/PS-NOPE0000/label/")
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# List endpoint + status filter + StorageAdmin permission
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def storage_admin_client():
+    """Member of the 'Storage Admin' group, NOT is_staff."""
+    from django.contrib.auth.models import Group
+
+    User = get_user_model()
+    user = User.objects.create_user(username="storageadmin", password="x")
+    group, _ = Group.objects.get_or_create(name="Storage Admin")
+    user.groups.add(group)
+    api = APIClient()
+    api.force_authenticate(user=user)
+    return api
+
+
+@pytest.fixture
+def member_client():
+    """Plain authenticated member — no staff, no Storage Admin group."""
+    User = get_user_model()
+    user = User.objects.create_user(username="member", password="x")
+    api = APIClient()
+    api.force_authenticate(user=user)
+    return api
+
+
+class TestListEndpoint:
+    def test_anonymous_is_rejected(self, client):
+        ProjectStorageStintFactory()
+        resp = client.get("/api/project-storage/stints/")
+        assert resp.status_code in (401, 403)
+
+    def test_plain_member_is_rejected(self, member_client):
+        ProjectStorageStintFactory()
+        resp = member_client.get("/api/project-storage/stints/")
+        assert resp.status_code == 403
+
+    def test_staff_can_list(self, staff_client):
+        ProjectStorageStintFactory()
+        resp = staff_client.get("/api/project-storage/stints/")
+        assert resp.status_code == 200
+
+    def test_storage_admin_can_list(self, storage_admin_client):
+        # The whole point of the Storage Admin group: a warden volunteer
+        # who isn't is_staff still sees the queue.
+        ProjectStorageStintFactory()
+        resp = storage_admin_client.get("/api/project-storage/stints/")
+        assert resp.status_code == 200
+
+    def test_status_filter_active(self, staff_client):
+        # Active = fresh stint, nothing else set.
+        ProjectStorageStintFactory(
+            username="alice",
+            started_at=timezone.now() - timedelta(days=2),
+            expires_at=timezone.now() + timedelta(days=20),
+        )
+        # Removed stint that should NOT show up under active.
+        ProjectStorageStintFactory(
+            username="bob",
+            removed_at=timezone.now() - timedelta(days=1),
+        )
+        resp = staff_client.get("/api/project-storage/stints/?status=active")
+        assert resp.status_code == 200
+        body = resp.json()
+        rows = body["results"] if isinstance(body, dict) and "results" in body else body
+        usernames = {r["username"] for r in rows}
+        assert usernames == {"alice"}
+
+    def test_status_filter_expiring_soon(self, staff_client):
+        # Inside the 3-day warning window.
+        ProjectStorageStintFactory(
+            username="alice",
+            started_at=timezone.now() - timedelta(days=27),
+            expires_at=timezone.now() + timedelta(days=2),
+        )
+        # Active — outside the window.
+        ProjectStorageStintFactory(
+            username="bob",
+            expires_at=timezone.now() + timedelta(days=20),
+        )
+        resp = staff_client.get("/api/project-storage/stints/?status=expiring_soon")
+        body = resp.json()
+        rows = body["results"] if isinstance(body, dict) and "results" in body else body
+        assert {r["username"] for r in rows} == {"alice"}
+
+    def test_status_filter_purgatory_winner_takes_terminal(self, staff_client):
+        # A stint that's both expired AND in purgatory should land in
+        # the purgatory bucket — terminal states win in compute_status.
+        ProjectStorageStintFactory(
+            username="alice",
+            expires_at=timezone.now() - timedelta(days=10),
+            notice_sent_at=timezone.now() - timedelta(days=8),
+            moved_to_purgatory_at=timezone.now() - timedelta(days=1),
+        )
+        resp = staff_client.get("/api/project-storage/stints/?status=purgatory")
+        body = resp.json()
+        rows = body["results"] if isinstance(body, dict) and "results" in body else body
+        assert {r["username"] for r in rows} == {"alice"}
+        # Same stint should NOT show up under "expired".
+        resp2 = staff_client.get("/api/project-storage/stints/?status=expired")
+        body2 = resp2.json()
+        rows2 = body2["results"] if isinstance(body2, dict) and "results" in body2 else body2
+        assert not any(r["username"] == "alice" for r in rows2)
+
+    def test_ordering_by_expires_at(self, staff_client):
+        # Soonest-to-expire first when ordering=expires_at.
+        ProjectStorageStintFactory(
+            username="late", expires_at=timezone.now() + timedelta(days=20)
+        )
+        ProjectStorageStintFactory(
+            username="early", expires_at=timezone.now() + timedelta(days=2)
+        )
+        resp = staff_client.get("/api/project-storage/stints/?ordering=expires_at")
+        body = resp.json()
+        rows = body["results"] if isinstance(body, dict) and "results" in body else body
+        assert [r["username"] for r in rows[:2]] == ["early", "late"]
+
+    def test_unknown_ordering_falls_back_to_default(self, staff_client):
+        # Junk ordering value can't tank the warden queue.
+        ProjectStorageStintFactory(username="z")
+        resp = staff_client.get("/api/project-storage/stints/?ordering=drop+table")
+        assert resp.status_code == 200
+
+
+class TestMutatingActionsStayAdmin:
+    """Tightening notes: send-notice / move-to-purgatory / mark-removed
+    were previously matrix-listed as IsAuthenticatedOrReadOnly which the
+    matrix snapshotter inferred from the class default. They're tagged
+    IsAdminUser now; Storage Admin (a read-only group) must not be able
+    to trigger member-facing email or write off stored work."""
+
+    def test_storage_admin_cannot_mark_removed(self, storage_admin_client):
+        stint = ProjectStorageStintFactory()
+        resp = storage_admin_client.post(
+            f"/api/project-storage/stints/{stint.stint_id}/mark-removed/"
+        )
+        assert resp.status_code == 403
+
+    def test_staff_can_mark_removed(self, staff_client):
+        stint = ProjectStorageStintFactory()
+        resp = staff_client.post(
+            f"/api/project-storage/stints/{stint.stint_id}/mark-removed/"
+        )
+        assert resp.status_code == 200

--- a/backend/project_storage/views.py
+++ b/backend/project_storage/views.py
@@ -17,6 +17,7 @@ from rest_framework.permissions import AllowAny, IsAdminUser
 from rest_framework.response import Response
 
 from .models import ProjectStorageEvent, ProjectStorageStint
+from .permissions import IsStorageAdminOrStaff
 from .serializers import (
     ProjectStorageStintSerializer,
     StartStintSerializer,
@@ -29,15 +30,12 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = ProjectStorageStint.objects.all().prefetch_related("events")
     serializer_class = ProjectStorageStintSerializer
     lookup_field = "stint_id"
-
-    def get_permissions(self):
-        # AllowAny on the kiosk + Pi-daemon paths; staff for everything
-        # else. The decorators below also set permission_classes so the
-        # routing is obvious at the call site, but this central list is
-        # the safety net for actions reached through self.get_object().
-        if self.action in ("start", "label", "print_queue", "mark_printed"):
-            return [AllowAny()]
-        return [IsAdminUser()]
+    # Class-level default for list + retrieve (the DRF-built-in actions
+    # that have no @action decorator). Each @action overrides this with
+    # its own permission_classes, kept verbatim on the decorator so the
+    # API permission-matrix gate (config/permission_matrix.py) snapshots
+    # them without re-implementing the get_permissions() logic.
+    permission_classes = [IsStorageAdminOrStaff]
 
     # ------------------------------------------------------------------
     # Self-service: member at a kiosk
@@ -103,6 +101,7 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
         detail=False,
         methods=["get"],
         url_path=r"by-member/(?P<username>[^/.]+)",
+        permission_classes=[IsStorageAdminOrStaff],
     )
     def by_member(self, request, username: str):
         """All stints (most recent first) for one member."""
@@ -113,11 +112,86 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
         )
         return Response(ProjectStorageStintSerializer(stints, many=True).data)
 
+    def get_queryset(self):
+        """Apply ?status=… and ?ordering=… to the read-only list endpoint.
+
+        compute_status() is Python-side, so we translate each STATUS_*
+        bucket into the column predicates that compute_status() uses
+        and filter at the DB. Order matters in compute_status (terminal
+        wins) so each filter has to exclude the rows a higher-priority
+        status would claim.
+
+        Supported orderings: ``expires_at``, ``-expires_at``,
+        ``started_at``, ``-started_at``. Anything else falls back to the
+        default (-started_at, newest first) so an operator can't tank
+        the warden queue by passing a junk field.
+        """
+        from datetime import timedelta as _td
+
+        from django.utils import timezone as _tz
+
+        from .models import EXPIRING_SOON_WINDOW_DAYS
+
+        qs = super().get_queryset()
+        status_filter = (
+            self.request.query_params.get("status") if hasattr(self, "request") else None
+        )
+        if status_filter:
+            now = _tz.now()
+            soon = now + _td(days=EXPIRING_SOON_WINDOW_DAYS)
+            if status_filter == ProjectStorageStint.STATUS_REMOVED:
+                qs = qs.filter(removed_at__isnull=False)
+            elif status_filter == ProjectStorageStint.STATUS_PURGATORY:
+                qs = qs.filter(removed_at__isnull=True, moved_to_purgatory_at__isnull=False)
+            elif status_filter == ProjectStorageStint.STATUS_PURGATORY_WARNED:
+                qs = qs.filter(
+                    removed_at__isnull=True,
+                    moved_to_purgatory_at__isnull=True,
+                    notice_sent_at__isnull=False,
+                )
+            elif status_filter == ProjectStorageStint.STATUS_EXPIRED:
+                qs = qs.filter(
+                    removed_at__isnull=True,
+                    moved_to_purgatory_at__isnull=True,
+                    notice_sent_at__isnull=True,
+                    expires_at__lte=now,
+                )
+            elif status_filter == ProjectStorageStint.STATUS_EXPIRING_SOON:
+                qs = qs.filter(
+                    removed_at__isnull=True,
+                    moved_to_purgatory_at__isnull=True,
+                    notice_sent_at__isnull=True,
+                    expires_at__gt=now,
+                    expires_at__lte=soon,
+                )
+            elif status_filter == ProjectStorageStint.STATUS_ACTIVE:
+                qs = qs.filter(
+                    removed_at__isnull=True,
+                    moved_to_purgatory_at__isnull=True,
+                    notice_sent_at__isnull=True,
+                    expires_at__gt=soon,
+                )
+            # Unknown status values fall through unchanged — DRF will
+            # return whatever the queryset has, the frontend's pill
+            # filter only sends known values.
+
+        ordering = self.request.query_params.get("ordering") if hasattr(self, "request") else None
+        if ordering in ("expires_at", "-expires_at", "started_at", "-started_at"):
+            qs = qs.order_by(ordering)
+        else:
+            qs = qs.order_by("-started_at")
+        return qs
+
     # ------------------------------------------------------------------
     # Warden mutating actions
     # ------------------------------------------------------------------
 
-    @action(detail=True, methods=["post"], url_path="send-violation-notice")
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="send-violation-notice",
+        permission_classes=[IsAdminUser],
+    )
     def send_violation_notice(self, request, stint_id: str):
         stint = self.get_object()
         if stint.compute_status() not in (
@@ -156,7 +230,12 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
         )
         return Response(ProjectStorageStintSerializer(stint).data)
 
-    @action(detail=True, methods=["post"], url_path="move-to-purgatory")
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="move-to-purgatory",
+        permission_classes=[IsAdminUser],
+    )
     def move_to_purgatory(self, request, stint_id: str):
         stint = self.get_object()
         if stint.notice_sent_at is None:
@@ -189,7 +268,9 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
         )
         return Response(ProjectStorageStintSerializer(stint).data)
 
-    @action(detail=True, methods=["post"], url_path="mark-removed")
+    @action(
+        detail=True, methods=["post"], url_path="mark-removed", permission_classes=[IsAdminUser]
+    )
     def mark_removed(self, request, stint_id: str):
         stint = self.get_object()
         if stint.removed_at is not None:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ import ElectricalCircuitsPage from './pages/ElectricalCircuitsPage';
 import ElectricalOverviewPage from './pages/ElectricalOverviewPage';
 import FacilitiesChecklistsPage from './pages/FacilitiesChecklistsPage';
 import FacilitiesOverviewPage from './pages/FacilitiesOverviewPage';
+import FacilitiesProjectStorageListPage from './pages/FacilitiesProjectStorageListPage';
 import FacilitiesProjectStoragePage from './pages/FacilitiesProjectStoragePage';
 import PowerBreakerFormPage from './pages/PowerBreakerFormPage';
 import PowerCircuitFormPage from './pages/PowerCircuitFormPage';
@@ -336,6 +337,7 @@ function AppContent() {
           <Route path="/maintenance/location-problems/:id" element={<WorkspaceLayout><LocationProblemDetailPage /></WorkspaceLayout>} />
           <Route path="/facilities/checklist" element={<WorkspaceLayout><FacilitiesChecklistsPage /></WorkspaceLayout>} />
           <Route path="/facilities/checklist/:checklistId/complete/:completionId" element={<WorkspaceLayout><ChecklistCompletionPage /></WorkspaceLayout>} />
+          <Route path="/facilities/project-storage/queue" element={<WorkspaceLayout><FacilitiesProjectStorageListPage /></WorkspaceLayout>} />
           <Route path="/facilities/project-storage" element={<WorkspaceLayout><FacilitiesProjectStoragePage /></WorkspaceLayout>} />
 
           {/* SIGs Workspace */}

--- a/frontend/src/__tests__/pages/FacilitiesProjectStorageListPage.test.tsx
+++ b/frontend/src/__tests__/pages/FacilitiesProjectStorageListPage.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Tests for the project-storage warden queue list page.
+ *
+ * Covers the API contract (status filter forwarded), the empty state, the
+ * row count badges on the "all" view, and the SegmentedControl filter
+ * re-fetching with the right query param.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import FacilitiesProjectStorageListPage from '../../pages/FacilitiesProjectStorageListPage';
+import { projectStorageAPI } from '../../services/api';
+import { ProjectStorageStint } from '../../types';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    projectStorageAPI: {
+      list: jest.fn(),
+    },
+  };
+});
+
+const mockAPI = projectStorageAPI as jest.Mocked<typeof projectStorageAPI>;
+
+const buildStint = (overrides: Partial<ProjectStorageStint> = {}): ProjectStorageStint => ({
+  id: 1,
+  stint_id: 'PS-AB23CDFG',
+  username: 'alice',
+  first_name: 'Alice',
+  last_name: 'Aardvark',
+  email: 'alice@example.com',
+  display_name: 'Alice Aardvark',
+  project_title: 'Big Sculpture',
+  started_at: '2026-05-01T00:00:00Z',
+  expires_at: '2026-06-30T00:00:00Z',
+  removed_at: null,
+  notice_sent_at: null,
+  moved_to_purgatory_at: null,
+  storage_location_name: 'Shelf A',
+  purgatory_location_name: '',
+  notes: '',
+  status: 'active',
+  purgatory_at: null,
+  expiry_week: 26,
+  expiry_day_of_year: 181,
+  events: [],
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  ...overrides,
+});
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <FacilitiesProjectStorageListPage />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+const ok = <T,>(data: T) =>
+  ({
+    data,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {} as never,
+  }) as never;
+
+describe('FacilitiesProjectStorageListPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders rows from the list endpoint', async () => {
+    mockAPI.list.mockResolvedValue(
+      ok({ count: 1, next: null, previous: null, results: [buildStint()] }),
+    );
+    renderPage();
+    expect(await screen.findByTestId('stint-row-PS-AB23CDFG')).toBeInTheDocument();
+    expect(screen.getByText('Alice Aardvark')).toBeInTheDocument();
+    expect(screen.getByText('Big Sculpture')).toBeInTheDocument();
+  });
+
+  test('starts on the "all" filter and omits the status param', async () => {
+    mockAPI.list.mockResolvedValue(
+      ok({ count: 0, next: null, previous: null, results: [] }),
+    );
+    renderPage();
+    await waitFor(() => {
+      expect(mockAPI.list).toHaveBeenCalledWith({
+        status: undefined,
+        ordering: 'expires_at',
+        page_size: 100,
+      });
+    });
+  });
+
+  test('changing the filter re-fetches with the right status', async () => {
+    mockAPI.list.mockResolvedValue(
+      ok({ count: 0, next: null, previous: null, results: [] }),
+    );
+    renderPage();
+    await waitFor(() => expect(mockAPI.list).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByText('Expired'));
+    await waitFor(() =>
+      expect(mockAPI.list).toHaveBeenLastCalledWith({
+        status: 'expired',
+        ordering: 'expires_at',
+        page_size: 100,
+      }),
+    );
+  });
+
+  test('empty bucket shows the empty placeholder', async () => {
+    mockAPI.list.mockResolvedValue(
+      ok({ count: 0, next: null, previous: null, results: [] }),
+    );
+    renderPage();
+    expect(await screen.findByTestId('list-empty')).toBeInTheDocument();
+  });
+
+  test('renders status count badges in the "all" view only', async () => {
+    mockAPI.list.mockResolvedValue(
+      ok({
+        count: 2,
+        next: null,
+        previous: null,
+        results: [
+          buildStint({ stint_id: 'PS-1', status: 'expired' }),
+          buildStint({ stint_id: 'PS-2', status: 'expiring_soon' }),
+        ],
+      }),
+    );
+    renderPage();
+    expect(await screen.findByText('Expired: 1')).toBeInTheDocument();
+    expect(screen.getByText('Expiring soon: 1')).toBeInTheDocument();
+  });
+
+  test('uses purgatory_location_name when status=purgatory', async () => {
+    mockAPI.list.mockResolvedValue(
+      ok({
+        count: 1,
+        next: null,
+        previous: null,
+        results: [
+          buildStint({
+            stint_id: 'PS-PURG',
+            status: 'purgatory',
+            storage_location_name: 'Shelf A',
+            purgatory_location_name: 'Back room',
+          }),
+        ],
+      }),
+    );
+    renderPage();
+    expect(await screen.findByText('Back room')).toBeInTheDocument();
+    expect(screen.queryByText('Shelf A')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -121,6 +121,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed = false, isMobileOpen = f
         { path: '/facilities/forgekey-certificates', label: 'Certificates (PKI)', icon: '🔐', requiresStaff: true },
         { path: '/facilities/lockers', label: 'Lockers', icon: '🔒', requiresStaff: true },
         { path: '/facilities/electrical', label: 'Electrical & Network', icon: '⚡', requiresStaff: true },
+        { path: '/facilities/project-storage/queue', label: 'Project Storage', icon: '📦', requiresStaff: true },
       ],
     },
     {

--- a/frontend/src/navigation/routeMap.ts
+++ b/frontend/src/navigation/routeMap.ts
@@ -53,6 +53,8 @@ const ENTRIES: RouteEntry[] = [
   { path: 'facilities/checklist', label: 'Checklist' },
   { path: 'facilities/screens', label: 'Screens' },
   { path: 'facilities/maker-boxes', label: 'Maker Boxes' },
+  { path: 'facilities/project-storage', label: 'Project Storage' },
+  { path: 'facilities/project-storage/queue', label: 'Queue' },
   { path: 'facilities/electrical', label: 'Electrical' },
   // Power-topology visualization ([6/7]). Resource leaves are not their
   // own listing pages — they're surfaced via the panel detail view — so

--- a/frontend/src/pages/FacilitiesProjectStorageListPage.tsx
+++ b/frontend/src/pages/FacilitiesProjectStorageListPage.tsx
@@ -1,0 +1,246 @@
+/**
+ * Staff queue for the project-storage warden workflow.
+ *
+ * The original FacilitiesProjectStoragePage is a lookup-and-act panel —
+ * useful when you already know a stint ID, useless for sweep day. This
+ * page lists every stint with status filters so a warden can pick a
+ * bucket ("expiring soon" / "in purgatory") and walk the list.
+ *
+ * Status filtering happens server-side via /api/project-storage/stints/
+ * ?status=… so the frontend doesn't have to recompute the same priority
+ * rules backend/project_storage/models.py::compute_status already owns.
+ *
+ * Permissions: backend gates this with IsStorageAdminOrStaff, so a
+ * member of the "Storage Admin" Django group can browse without being
+ * platform-wide is_staff.
+ */
+import {
+  Alert,
+  Badge,
+  Button,
+  Group,
+  Loader,
+  Paper,
+  SegmentedControl,
+  Stack,
+  Table,
+  Text,
+} from '@mantine/core';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import WorkspacePage from '../components/landing/WorkspacePage';
+import { projectStorageAPI } from '../services/api';
+import { ProjectStorageStatus, ProjectStorageStint } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+type StatusFilter = 'all' | ProjectStorageStatus;
+
+const STATUS_BADGE: Record<
+  ProjectStorageStatus,
+  { color: string; label: string }
+> = {
+  active: { color: 'teal', label: 'Active' },
+  expiring_soon: { color: 'yellow', label: 'Expiring soon' },
+  expired: { color: 'orange', label: 'Expired' },
+  purgatory_warned: { color: 'red', label: 'Warned — 7d grace' },
+  purgatory: { color: 'dark', label: 'In purgatory' },
+  removed: { color: 'gray', label: 'Removed' },
+};
+
+// Order matters — these are also the SegmentedControl tabs left-to-right.
+// "All" is first so a warden landing fresh sees the global queue; the
+// urgency-ordered tabs follow.
+const STATUS_FILTERS: { value: StatusFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'expired', label: 'Expired' },
+  { value: 'expiring_soon', label: 'Expiring soon' },
+  { value: 'purgatory_warned', label: 'Warned' },
+  { value: 'purgatory', label: 'Purgatory' },
+  { value: 'active', label: 'Active' },
+  { value: 'removed', label: 'Removed' },
+];
+
+const fmtDate = (iso: string | null): string => {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toLocaleDateString();
+  } catch {
+    return iso;
+  }
+};
+
+const FacilitiesProjectStorageListPage: React.FC = () => {
+  const [stints, setStints] = useState<ProjectStorageStint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await projectStorageAPI.list({
+        status: statusFilter === 'all' ? undefined : statusFilter,
+        // Soonest-to-expire first — the urgency order the warden cares about.
+        ordering: 'expires_at',
+        page_size: 100,
+      });
+      setStints(res.data.results ?? []);
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to load project-storage stints.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const counts = useMemo(() => {
+    const out: Record<ProjectStorageStatus, number> = {
+      active: 0,
+      expiring_soon: 0,
+      expired: 0,
+      purgatory_warned: 0,
+      purgatory: 0,
+      removed: 0,
+    };
+    stints.forEach((s) => {
+      out[s.status] = (out[s.status] ?? 0) + 1;
+    });
+    return out;
+  }, [stints]);
+
+  return (
+    <WorkspacePage
+      testId="facilities-project-storage-list-page"
+      hero={{
+        eyebrow: 'Facilities',
+        title: 'Project storage queue',
+        description:
+          'Walk the storage queue by status — expiring soon, expired, in purgatory. ' +
+          'Pick a row to open the warden actions (notice, purgatory, remove).',
+        action: (
+          <Button component={Link} to="/facilities/project-storage" variant="light">
+            Lookup by stint ID
+          </Button>
+        ),
+      }}
+    >
+      <Stack gap="md">
+        <Paper p="md" withBorder>
+          <Stack gap="sm">
+            <Text size="sm" c="dimmed">
+              Filter by status
+            </Text>
+            <SegmentedControl
+              value={statusFilter}
+              onChange={(v) => setStatusFilter(v as StatusFilter)}
+              data={STATUS_FILTERS.map((f) => ({
+                label: f.label,
+                value: f.value,
+              }))}
+              data-testid="status-filter"
+            />
+            {statusFilter === 'all' && stints.length > 0 && (
+              <Group gap="sm" wrap="wrap">
+                {(
+                  Object.entries(counts) as [ProjectStorageStatus, number][]
+                ).map(([s, n]) => (
+                  <Badge
+                    key={s}
+                    color={STATUS_BADGE[s].color}
+                    variant={n === 0 ? 'light' : 'filled'}
+                  >
+                    {STATUS_BADGE[s].label}: {n}
+                  </Badge>
+                ))}
+              </Group>
+            )}
+          </Stack>
+        </Paper>
+
+        {error && (
+          <Alert color="red" variant="light" data-testid="list-error">
+            {error}
+          </Alert>
+        )}
+
+        {loading ? (
+          <Group justify="center" p="xl">
+            <Loader />
+          </Group>
+        ) : stints.length === 0 ? (
+          <Paper p="xl" withBorder>
+            <Text c="dimmed" ta="center" data-testid="list-empty">
+              No stints in this bucket.
+            </Text>
+          </Paper>
+        ) : (
+          <Paper withBorder>
+            <Table.ScrollContainer minWidth={760}>
+              <Table highlightOnHover>
+                <Table.Thead>
+                  <Table.Tr>
+                    <Table.Th>Status</Table.Th>
+                    <Table.Th>Member</Table.Th>
+                    <Table.Th>Project</Table.Th>
+                    <Table.Th>Location</Table.Th>
+                    <Table.Th>Expires</Table.Th>
+                    <Table.Th>Stint</Table.Th>
+                  </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                  {stints.map((s) => (
+                    <Table.Tr
+                      key={s.stint_id}
+                      data-testid={`stint-row-${s.stint_id}`}
+                    >
+                      <Table.Td>
+                        <Badge color={STATUS_BADGE[s.status].color}>
+                          {STATUS_BADGE[s.status].label}
+                        </Badge>
+                      </Table.Td>
+                      <Table.Td>
+                        <Text fw={500}>{s.display_name}</Text>
+                        {s.email && (
+                          <Text size="xs" c="dimmed">
+                            {s.email}
+                          </Text>
+                        )}
+                      </Table.Td>
+                      <Table.Td>{s.project_title || '—'}</Table.Td>
+                      <Table.Td>
+                        {s.status === 'purgatory'
+                          ? s.purgatory_location_name || '—'
+                          : s.storage_location_name || '—'}
+                      </Table.Td>
+                      <Table.Td>{fmtDate(s.expires_at)}</Table.Td>
+                      <Table.Td>
+                        <Text
+                          ff="monospace"
+                          size="sm"
+                          component={Link}
+                          to={`/facilities/project-storage?stint=${encodeURIComponent(
+                            s.stint_id,
+                          )}`}
+                          c="blue"
+                        >
+                          {s.stint_id}
+                        </Text>
+                      </Table.Td>
+                    </Table.Tr>
+                  ))}
+                </Table.Tbody>
+              </Table>
+            </Table.ScrollContainer>
+          </Paper>
+        )}
+      </Stack>
+    </WorkspacePage>
+  );
+};
+
+export default FacilitiesProjectStorageListPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,7 +2,7 @@
  * API service for communicating with the Django backend
  */
 import axios from 'axios';
-import { ActiveMaintenanceRow, Asset, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
+import { ActiveMaintenanceRow, Asset, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
 
 /**
  * Resolves the API base URL based on environment.
@@ -3505,6 +3505,19 @@ export const pulseAPI = {
 // ---------------------------------------------------------------------------
 
 export const projectStorageAPI = {
+  list: (params?: {
+    status?: ProjectStorageStatus;
+    ordering?: 'expires_at' | '-expires_at' | 'started_at' | '-started_at';
+    page?: number;
+    page_size?: number;
+  }) =>
+    api.get<{
+      count: number;
+      next: string | null;
+      previous: string | null;
+      results: ProjectStorageStint[];
+    }>('/project-storage/stints/', { params }),
+
   get: (stintId: string) =>
     api.get<ProjectStorageStint>(`/project-storage/stints/${stintId}/`),
 


### PR DESCRIPTION
## Summary

PR 1 of 6 in the project-storage frontend + QR workflow refactor (see workflow synthesis 2026-06-06). Replaces the lookup-and-act warden panel with a proper queue list page + introduces a delegate-able Storage Admin role.

### Backend

- New \`IsStorageAdminOrStaff\` permission + data migration seeding the \`Storage Admin\` Django group. Lets the shop owner delegate sweep-day to a volunteer without granting platform-wide \`is_staff\`.
- \`ProjectStorageStintViewSet.get_queryset\` folds \`?status=…\` into the queryset by translating each \`STATUS_*\` into the column predicates \`compute_status()\` uses (terminal wins). Supports \`?ordering=\` with safe fallback.
- Replaces the central \`get_permissions()\` switch with class-level \`permission_classes\` and explicit \`@action(permission_classes=…)\` decorators so the matrix snapshot picks them up. Reconciles the YAML/source drift the research turned up.
- Mutating warden actions (send-notice, move-to-purgatory, mark-removed) stay \`IsAdminUser\` — Storage Admin is read-only.

### Frontend

- New \`FacilitiesProjectStorageListPage\` at \`/facilities/project-storage/queue\` with \`SegmentedControl\` status filter, count badges on the "all" view, Mantine Table of stints.
- Sidebar gets a \"Project Storage\" entry.
- \`projectStorageAPI.list({status, ordering, page, page_size})\`.

### Tests

- 11 new backend tests covering perm gate (anonymous / member / staff / Storage Admin), each status filter, terminal-state precedence (purgatory wins over expired), ordering safety, Storage Admin cannot mark-removed.
- 6 new frontend tests covering rendering, default \"all\" semantics, filter re-fetch, empty state, count badges, purgatory location swap.

### Why first

The research workflow flagged this as the highest-value gap — the warden surface was invisible without typing a URL and there was no way to browse the queue at all. Sweep-day unblocker.

## Test plan

- [ ] Sidebar shows \"Project Storage\" → opens /facilities/project-storage/queue.
- [ ] Status filter switches the list and updates the URL contract.
- [ ] Count badges only show on \"All\".
- [ ] Storage Admin group member (non-staff) can see the page; gets 403 on mark-removed.
- [ ] No matrix drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)