### PR TITLE
feat(scanner): dispatch recognizes PS-XXXXXXXX stints (PR 2/6)

### DIFF
--- a/backend/scanner/resolvers.py
+++ b/backend/scanner/resolvers.py
@@ -33,7 +33,15 @@ ACTION_ASSET_CHECKIN = "asset_checkin"
 ACTION_LOCATION_CHECKIN = "location_checkin"
 ACTION_FIXTURE = "fixture"
 ACTION_DONATION_ITEM = "donation_item"
+ACTION_PROJECT_STORAGE_STINT = "project_storage_stint"
 ACTION_UNKNOWN = "unknown"
+
+# stint_id format: "PS-" + 8 chars of the Crockford-base32-ish alphabet
+# (no I/L/O/0/1). Mirrors project_storage.models._generate_stint_id so a
+# scanner-bound payload here matches what the label-printing pipeline
+# encodes into the QR. A regex (rather than a startswith) keeps free-text
+# strings that just happen to begin with "PS-" out of the dispatcher.
+_PROJECT_STORAGE_STINT_RE = re.compile(r"^PS-[23456789ABCDEFGHJKMNPQRSTUVWXYZ]{8}$")
 
 # UUID pattern (lowercase or mixed) for matching trailing IDs in QR URLs.
 _UUID_RE = re.compile(
@@ -148,12 +156,20 @@ def resolve(payload: str) -> ResolvedScan:
     if _LOCATION_CODE_RE.match(raw.upper()):
         return _resolve_location_code(raw.upper())
 
-    # 4) Asset tag (exact match — no format constraint).
+    # 4) Project-storage stint (PS-XXXXXXXX). Format-guarded so a
+    # free-text asset tag that just happens to start with "PS-" doesn't
+    # land in the stint table.
+    if _PROJECT_STORAGE_STINT_RE.match(raw.upper()):
+        stint = _resolve_project_storage_stint(raw.upper(), raw)
+        if stint is not None:
+            return stint
+
+    # 5) Asset tag (exact match — no format constraint).
     asset = _resolve_asset_tag(raw)
     if asset is not None:
         return asset
 
-    # 5) Unknown.
+    # 6) Unknown.
     return ResolvedScan(
         action=ACTION_UNKNOWN,
         message=(
@@ -319,6 +335,34 @@ def _resolve_asset_tag(payload: str) -> Optional[ResolvedScan]:
         target_name=asset.name,
         target_url=f"/inventory/assets/{asset.id}",
         raw_payload=payload,
+    )
+
+
+def _resolve_project_storage_stint(stint_id: str, raw: str) -> Optional[ResolvedScan]:
+    """Resolve a PS-XXXXXXXX stint_id scan.
+
+    Returns None when the prefix matches but the stint doesn't exist —
+    the caller falls through to ACTION_UNKNOWN with the generic
+    "couldn't identify" message instead of asserting "PS-FOO123 isn't
+    a stint", which would be misleading if a future operator reused the
+    PS- prefix for something else.
+
+    The frontend route assumes /facilities/project-storage/<stint_id>
+    will exist (PR 3 wires the permalink). Until PR 3 lands the warden
+    page redirects to its lookup form on a missing :stintId param.
+    """
+    from project_storage.models import ProjectStorageStint
+
+    stint = ProjectStorageStint.objects.filter(stint_id=stint_id).first()
+    if stint is None:
+        return None
+    return ResolvedScan(
+        action=ACTION_PROJECT_STORAGE_STINT,
+        target_type="project_storage_stint",
+        target_id=stint.stint_id,
+        target_name=stint.display_name,
+        target_url=f"/facilities/project-storage/{stint.stint_id}",
+        raw_payload=raw,
     )
 
 

--- a/backend/scanner/tests/test_dispatch.py
+++ b/backend/scanner/tests/test_dispatch.py
@@ -147,3 +147,56 @@ class TestScannerDispatch:
         item = InventoryItemFactory()
         response = _dispatch(api_client, f"/inventory/scan/{item.id}")
         assert response.status_code == status.HTTP_200_OK
+
+    # ------------------------------------------------------------------
+    # Project storage stints (PS-XXXXXXXX)
+    # ------------------------------------------------------------------
+
+    def test_project_storage_stint_resolved(self, api_client):
+        from project_storage.tests.factories import ProjectStorageStintFactory
+
+        stint = ProjectStorageStintFactory(
+            stint_id="PS-AB23CDFG",
+            username="alice",
+            first_name="Alice",
+            last_name="A",
+        )
+        response = _dispatch(api_client, "PS-AB23CDFG")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["action"] == "project_storage_stint"
+        assert response.data["target_type"] == "project_storage_stint"
+        assert response.data["target_id"] == stint.stint_id
+        assert response.data["target_name"] == "Alice A"
+        assert response.data["target_url"] == f"/facilities/project-storage/{stint.stint_id}"
+
+    def test_project_storage_stint_lowercase_resolved(self, api_client):
+        # The stint_id alphabet is uppercase; the resolver normalizes
+        # before matching so a wedge scanner that down-cases the QR
+        # text still routes correctly.
+        from project_storage.tests.factories import ProjectStorageStintFactory
+
+        ProjectStorageStintFactory(stint_id="PS-AB23CDFG")
+        response = _dispatch(api_client, "ps-ab23cdfg")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["action"] == "project_storage_stint"
+
+    def test_project_storage_unknown_stint_falls_through(self, api_client):
+        # PS-format string but no row by that id — caller gets the
+        # generic "unknown" so the dispatcher doesn't half-confirm
+        # something that isn't real.
+        response = _dispatch(api_client, "PS-99999999")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["action"] == "unknown"
+
+    def test_ps_prefixed_asset_tag_still_routes_to_stint_format_first(self, api_client):
+        # An asset_tag that happens to look like "PS-NOTREAL" is NOT a
+        # stint — should fall through to asset-tag matching. The PS-
+        # format regex is strict enough (8 chars from the Crockford
+        # alphabet) that a free-text tag is unlikely to match by accident.
+        asset = AssetFactory(asset_tag="PS-LATHE")
+        response = _dispatch(api_client, "PS-LATHE")
+        # "PS-LATHE" has only 5 chars after the prefix, so the regex
+        # rejects it and we fall through to asset-tag.
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["action"] == "asset_checkin"
+        assert response.data["target_id"] == str(asset.id)

--- a/frontend/src/pages/UniversalScannerPage.tsx
+++ b/frontend/src/pages/UniversalScannerPage.tsx
@@ -136,6 +136,13 @@ const UniversalScannerPage: React.FC = () => {
           case 'donation_item': {
             return { outcome: 'success', message: 'Resolved — open the target.' };
           }
+          case 'project_storage_stint': {
+            // The warden console reads the stint server-side; the
+            // dispatcher just confirms the QR matched a real PS-XXX row.
+            // The scan history surfaces target_url so the user can
+            // click into the warden detail page.
+            return { outcome: 'success', message: 'Stint resolved — open to take warden action.' };
+          }
           case 'unknown':
           default:
             return { outcome: 'error', message: result.message ?? 'Unknown payload.' };

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3551,6 +3551,7 @@ export interface ScanDispatchResult {
     | 'location_checkin'
     | 'fixture'
     | 'donation_item'
+    | 'project_storage_stint'
     | 'unknown';
   target_type?: string;
   target_id?: string;


### PR DESCRIPTION
## Summary

PR 2 of 6 in the project-storage workflow refactor. The universal scanner silently no-op'd PS- payloads — wardens hitting the kiosk to lookup a stint got \"unknown\". This adds PS- to the resolver's priority chain.

### Backend

- New \`ACTION_PROJECT_STORAGE_STINT\` action.
- Strict regex \`^PS-[Crockford alphabet]{8}$\` matching the format \`project_storage.models._generate_stint_id\` emits, so a free-text asset tag starting with \"PS-\" doesn't accidentally hit the stint table.
- \`_resolve_project_storage_stint\` returns \`{action, target_type, target_id, target_name=display_name, target_url=/facilities/project-storage/<stint_id>}\` — the target_url is forward-looking for PR 3's permalink.
- Missing stint returns None → caller falls through to \"unknown\" rather than asserting \"PS-XYZ isn't a stint.\"
- Slotted before asset-tag fallback so a regex-matched PS- always routes to stints.

### Frontend

- Added \`project_storage_stint\` to the \`ScanDispatchResult.action\` union.
- \`UniversalScannerPage\` acknowledges the resolved stint with a success message. The \`target_url\` already renders as a link in the existing history surface, so once PR 3 wires the permalink the operator flow is one click.

### Tests

- 4 new dispatcher tests: real stint resolves with the right action/url, lowercase wedge-scanner input still routes, PS-format with no row falls through to unknown, and a free-text asset_tag of \"PS-LATHE\" (too short for the regex) goes to asset_checkin.
- All 19 existing dispatch tests still pass.

## Stack

| | | |
|---|---|---|
| PR 1 | #699 | List page + StorageAdmin perm |
| **PR 2** | **this** | **Scanner dispatch PS- prefix** |
| PR 3 | next | Routable permalink |
| PR 4 | next | QR encodes URL not bare ID |
| PR 5 | next | Persisted qr_code ImageField |
| PR 6 | next | Avery bulk sheet |

## Test plan

- [ ] Scan a real PS-XXXXXXXX → universal scanner history shows the success row with a clickable target URL.
- [ ] Scan a non-existent PS-XXXXXXXX → history shows the standard unknown message.
- [ ] Scan a lowercased \"ps-xxxxxxxx\" → still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)