### PR TITLE
feat(project_storage): /facilities/project-storage/:stintId permalink (PR 3 roll-forward)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -338,6 +338,7 @@ function AppContent() {
           <Route path="/facilities/checklist" element={<WorkspaceLayout><FacilitiesChecklistsPage /></WorkspaceLayout>} />
           <Route path="/facilities/checklist/:checklistId/complete/:completionId" element={<WorkspaceLayout><ChecklistCompletionPage /></WorkspaceLayout>} />
           <Route path="/facilities/project-storage/queue" element={<WorkspaceLayout><FacilitiesProjectStorageListPage /></WorkspaceLayout>} />
+          <Route path="/facilities/project-storage/:stintId" element={<WorkspaceLayout><FacilitiesProjectStoragePage /></WorkspaceLayout>} />
           <Route path="/facilities/project-storage" element={<WorkspaceLayout><FacilitiesProjectStoragePage /></WorkspaceLayout>} />
 
           {/* SIGs Workspace */}

--- a/frontend/src/__tests__/pages/FacilitiesProjectStoragePage.permalink.test.tsx
+++ b/frontend/src/__tests__/pages/FacilitiesProjectStoragePage.permalink.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Permalink behavior tests for the warden page.
+ *
+ * Covers PR 3: the page auto-loads the stint when mounted at
+ * /facilities/project-storage/:stintId, and the lookup form +
+ * scanner-success path push the URL via useNavigate so back/forward
+ * works.
+ *
+ * The rest of the page surface (action buttons, status pills, history)
+ * is already exercised elsewhere — this file only asserts the
+ * permalink contract.
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+
+import FacilitiesProjectStoragePage from '../../pages/FacilitiesProjectStoragePage';
+import { projectStorageAPI } from '../../services/api';
+import { ProjectStorageStint } from '../../types';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    projectStorageAPI: {
+      get: jest.fn(),
+      byMember: jest.fn(),
+      start: jest.fn(),
+      sendViolationNotice: jest.fn(),
+      moveToPurgatory: jest.fn(),
+      markRemoved: jest.fn(),
+      labelUrl: jest.fn(() => 'https://example.com/label.png'),
+      list: jest.fn(),
+    },
+  };
+});
+
+vi.mock('../../hooks/useNotifications', () => ({
+  useNotifications: () => ({
+    showSuccess: jest.fn(),
+    showError: jest.fn(),
+    showInfo: jest.fn(),
+  }),
+}));
+
+const mockAPI = projectStorageAPI as jest.Mocked<typeof projectStorageAPI>;
+
+const buildStint = (overrides: Partial<ProjectStorageStint> = {}): ProjectStorageStint => ({
+  id: 1,
+  stint_id: 'PS-AB23CDFG',
+  username: 'alice',
+  first_name: 'Alice',
+  last_name: 'Aardvark',
+  email: 'alice@example.com',
+  display_name: 'Alice Aardvark',
+  project_title: 'Big Sculpture',
+  started_at: '2026-05-01T00:00:00Z',
+  expires_at: '2026-06-30T00:00:00Z',
+  removed_at: null,
+  notice_sent_at: null,
+  moved_to_purgatory_at: null,
+  storage_location_name: 'Shelf A',
+  purgatory_location_name: '',
+  notes: '',
+  status: 'active',
+  purgatory_at: null,
+  expiry_week: 26,
+  expiry_day_of_year: 181,
+  events: [],
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  ...overrides,
+});
+
+const ok = <T,>(data: T) =>
+  ({
+    data,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {} as never,
+  }) as never;
+
+// LocationProbe surfaces the current URL so the lookup-form-pushes-URL
+// assertion can read what navigate() did.
+const LocationProbe: React.FC = () => {
+  const loc = useLocation();
+  return <div data-testid="loc">{loc.pathname}</div>;
+};
+
+const renderAt = (path: string) =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route
+            path="/facilities/project-storage/:stintId"
+            element={
+              <>
+                <FacilitiesProjectStoragePage />
+                <LocationProbe />
+              </>
+            }
+          />
+          <Route
+            path="/facilities/project-storage"
+            element={
+              <>
+                <FacilitiesProjectStoragePage />
+                <LocationProbe />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('FacilitiesProjectStoragePage — permalink', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAPI.byMember.mockResolvedValue(ok([]));
+  });
+
+  test('auto-loads the stint from the :stintId param', async () => {
+    mockAPI.get.mockResolvedValue(ok(buildStint()));
+    renderAt('/facilities/project-storage/PS-AB23CDFG');
+    await waitFor(() => {
+      expect(mockAPI.get).toHaveBeenCalledWith('PS-AB23CDFG');
+    });
+    // The page renders multiple things that include "Alice Aardvark"
+    // (the main title, the history collapsible). All we really need is
+    // proof the stint loaded — assert findAllByText returns at least
+    // one match.
+    const matches = await screen.findAllByText((_, node) =>
+      (node?.textContent ?? '').includes('Alice Aardvark'),
+    );
+    expect(matches.length).toBeGreaterThan(0);
+  });
+
+  test('lowercases in the URL are normalized before the API call', async () => {
+    mockAPI.get.mockResolvedValue(ok(buildStint()));
+    renderAt('/facilities/project-storage/ps-ab23cdfg');
+    await waitFor(() => {
+      expect(mockAPI.get).toHaveBeenCalledWith('PS-AB23CDFG');
+    });
+  });
+
+  test('lookup form submit pushes the path-based permalink', async () => {
+    mockAPI.get.mockResolvedValue(ok(buildStint()));
+    renderAt('/facilities/project-storage');
+    // Bare lookup page mounted; no API call yet.
+    expect(mockAPI.get).not.toHaveBeenCalled();
+
+    const input = await screen.findByPlaceholderText(/PS-/i);
+    await userEvent.type(input, 'PS-WALKED1');
+    await userEvent.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loc').textContent).toBe(
+        '/facilities/project-storage/PS-WALKED1',
+      );
+    });
+  });
+
+  test('lookup form rejects empty input without navigating', async () => {
+    renderAt('/facilities/project-storage');
+    const submitBtn = await screen.findByRole('button', { name: /look up/i });
+    await userEvent.click(submitBtn);
+    expect(screen.getByTestId('loc').textContent).toBe('/facilities/project-storage');
+    expect(mockAPI.get).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/FacilitiesProjectStorageListPage.tsx
+++ b/frontend/src/pages/FacilitiesProjectStorageListPage.tsx
@@ -223,9 +223,7 @@ const FacilitiesProjectStorageListPage: React.FC = () => {
                           ff="monospace"
                           size="sm"
                           component={Link}
-                          to={`/facilities/project-storage?stint=${encodeURIComponent(
-                            s.stint_id,
-                          )}`}
+                          to={`/facilities/project-storage/${encodeURIComponent(s.stint_id)}`}
                           c="blue"
                         >
                           {s.stint_id}

--- a/frontend/src/pages/FacilitiesProjectStoragePage.tsx
+++ b/frontend/src/pages/FacilitiesProjectStoragePage.tsx
@@ -37,6 +37,7 @@ import {
   IconQrcode,
 } from '@tabler/icons-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import QRScanner from '../components/QRScanner';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import { useNotifications } from '../hooks/useNotifications';
@@ -79,8 +80,15 @@ const formatDate = (iso: string | null): string => {
 
 const FacilitiesProjectStoragePage: React.FC = () => {
   const notifications = useNotifications();
+  const navigate = useNavigate();
+  // The :stintId param is optional — the page is mounted at both
+  // /facilities/project-storage (lookup form) and
+  // /facilities/project-storage/:stintId (permalink detail). When the
+  // param is present we auto-load it so an emailed link or a row in
+  // the queue list (PR 1) deep-links straight to the warden actions.
+  const { stintId: stintIdParam } = useParams<{ stintId?: string }>();
 
-  const [stintId, setStintId] = useState<string>('');
+  const [stintId, setStintId] = useState<string>(stintIdParam ?? '');
   const [stint, setStint] = useState<ProjectStorageStint | null>(null);
   const [history, setHistory] = useState<ProjectStorageStint[] | null>(null);
   const [loading, setLoading] = useState(false);
@@ -91,12 +99,6 @@ const FacilitiesProjectStoragePage: React.FC = () => {
   >(null);
 
   const inputRef = useRef<HTMLInputElement | null>(null);
-
-  // Autofocus the HID input on mount so a barcode scanner wedge "just
-  // works" the moment the warden lands on the page.
-  useEffect(() => {
-    inputRef.current?.focus();
-  }, []);
 
   const loadStint = useCallback(
     async (rawId: string) => {
@@ -126,15 +128,32 @@ const FacilitiesProjectStoragePage: React.FC = () => {
     [],
   );
 
+  // Auto-load whenever the route param changes (mount, back/forward,
+  // navigating between queue rows). When the param is absent, fall back
+  // to autofocusing the HID input so a barcode scanner wedge "just
+  // works" on the bare lookup form.
+  useEffect(() => {
+    if (stintIdParam) {
+      const upper = stintIdParam.trim().toUpperCase();
+      setStintId(upper);
+      loadStint(upper);
+    } else {
+      inputRef.current?.focus();
+    }
+  }, [stintIdParam, loadStint]);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    loadStint(stintId);
+    const id = stintId.trim().toUpperCase();
+    if (!id) return;
+    navigate(`/facilities/project-storage/${encodeURIComponent(id)}`);
   };
 
   const handleScanSuccess = (decoded: string) => {
     setShowScanner(false);
-    setStintId(decoded);
-    loadStint(decoded);
+    const id = decoded.trim().toUpperCase();
+    setStintId(id);
+    navigate(`/facilities/project-storage/${encodeURIComponent(id)}`);
   };
 
   const refresh = () => {


### PR DESCRIPTION
## Summary

Roll-forward of the original PR 3 (#701). #701 was stacked on \`feat/project-storage-list-page\` (PR 1's branch), so when #699 squash-merged and deleted that branch, #701's content went into the orphan base rather than \`main\` — the stacked-PR drift pattern.

This is the same cherry-picked commit, retargeted to \`main\`. No content changes.

### What lands

- New \`/facilities/project-storage/:stintId\` route + auto-load via \`useParams\`.
- Lookup form + scan-success now \`navigate()\` to the permalink so back/forward and URL sharing work.
- Empty input is a no-op.
- PR 1's queue list rows swap from \`?stint=\` query to the path-based permalink.

### Tests

10/10 frontend tests pass (4 new permalink tests + the 6 list-page tests from PR 1).

## Stack status

| | | |
|---|---|---|
| PR 1 | #699 ✅ merged | List page + StorageAdmin perm |
| PR 2 | #700 ✅ merged | Scanner dispatch PS- prefix |
| PR 3 | this (was #701, drifted) | Routable permalink |
| PR 4 | next | QR encodes URL not bare ID |
| PR 5 | next | Persisted qr_code ImageField |
| PR 6 | next | Avery bulk sheet |

🤖 Generated with [Claude Code](https://claude.com/claude-code)