### PR TITLE
feat(project_storage): switch QR payload to URL form (PR 4/6)

### DIFF
--- a/backend/project_storage/services/label_service.py
+++ b/backend/project_storage/services/label_service.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 from io import BytesIO
 from typing import Iterable, Literal
 
+from django.conf import settings
+
 import qrcode
 from PIL import Image, ImageDraw, ImageFont
 
@@ -117,7 +119,17 @@ def render_stint_label(
 
     margin = 12
     qr_px = height - 2 * margin
-    qr = _build_qr_image(stint.stint_id, qr_px)
+    # Encode a deep-link URL so a phone camera scan opens the warden
+    # detail page directly. The Pi print daemon still pulls the PNG by
+    # bare stint_id via /api/project-storage/stints/<id>/label/ — that's
+    # a different code path. Wedge scanners and the warden console hit
+    # the universal scanner dispatcher (backend/scanner/resolvers.py)
+    # which recognizes both the URL form and the bare PS- prefix, so
+    # this switch is backward-compatible with existing label-prints
+    # sitting on shelves today.
+    frontend_url = getattr(settings, "FRONTEND_URL", "http://localhost:3000").rstrip("/")
+    qr_payload = f"{frontend_url}/scan/project-storage/{stint.stint_id}"
+    qr = _build_qr_image(qr_payload, qr_px)
     canvas.paste(qr, (margin, margin))
 
     text_x = margin + qr_px + 16

--- a/backend/scanner/resolvers.py
+++ b/backend/scanner/resolvers.py
@@ -98,13 +98,28 @@ def _strip_url(payload: str) -> tuple[str, bool]:
 
 
 def _parse_scan_url(path: str) -> Optional[tuple[str, str]]:
-    """Match `/inventory/scan/<type>/<id>` or `/inventory/scan/<id>`.
+    """Match the project's QR URL conventions.
 
-    Returns `(type, id)` or None. Type defaults to `"inventory_item"`
-    when only an id segment follows `/scan/`.
+    Recognized shapes:
+
+      - ``/inventory/scan/<type>/<id>`` — legacy inventory QR routes
+        (asset / location / fixture / donation-item).
+      - ``/inventory/scan/<id>`` — bare InventoryItem.
+      - ``/scan/project-storage/<stint_id>`` — project storage label
+        encoded URL (PR 4); the dispatcher routes this to the warden
+        detail page.
+
+    Returns ``(target_type, target_id)`` or ``None``.
     """
     # Normalize: strip trailing slash, split on /.
     parts = [seg for seg in path.strip("/").split("/") if seg]
+
+    # /scan/project-storage/<stint_id> — emitted by PR 4's label
+    # encoder. Match BEFORE the /inventory/scan/… arm so the deeper
+    # path takes priority over any future overlap.
+    if len(parts) == 3 and parts[0] == "scan" and parts[1] == "project-storage":
+        return ("project_storage_stint", parts[2])
+
     if len(parts) < 3 or parts[0] != "inventory" or parts[1] != "scan":
         return None
 
@@ -259,6 +274,14 @@ def _resolve_known_target(target_type: str, target_id: str, raw: str) -> Resolve
             target_name=getattr(donation, "name", str(donation.id)),
             target_url=f"/inventory/scan/donation-item/{donation.id}",
             raw_payload=raw,
+        )
+
+    if target_type == "project_storage_stint":
+        # /scan/project-storage/<stint_id> URL form (PR 4). Same shape
+        # as the bare PS- resolver further below — just reached via the
+        # URL parser instead of the prefix regex.
+        return _resolve_project_storage_stint(target_id.upper(), raw) or _not_found(
+            "project-storage stint", target_id, raw
         )
 
     return _not_found(target_type, target_id, raw)

--- a/backend/scanner/tests/test_dispatch.py
+++ b/backend/scanner/tests/test_dispatch.py
@@ -188,6 +188,33 @@ class TestScannerDispatch:
         assert response.status_code == status.HTTP_200_OK
         assert response.data["action"] == "unknown"
 
+    def test_project_storage_url_form_resolves(self, api_client):
+        # PR 4: labels encode /scan/project-storage/<stint_id>. The
+        # dispatcher's URL parser routes this to the same handler as a
+        # bare PS- payload.
+        from project_storage.tests.factories import ProjectStorageStintFactory
+
+        stint = ProjectStorageStintFactory(
+            stint_id="PS-URLZ23CD",
+            first_name="Bob",
+            last_name="Builder",
+        )
+        response = _dispatch(
+            api_client,
+            f"https://oms.example.com/scan/project-storage/{stint.stint_id}",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["action"] == "project_storage_stint"
+        assert response.data["target_id"] == stint.stint_id
+        assert response.data["target_url"] == f"/facilities/project-storage/{stint.stint_id}"
+
+    def test_project_storage_url_form_unknown_stint(self, api_client):
+        # URL-form scan that doesn't resolve to a real row falls through
+        # to the generic unknown — same behavior as the bare-ID form.
+        response = _dispatch(api_client, "https://oms.example.com/scan/project-storage/PS-99999999")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["action"] == "unknown"
+
     def test_ps_prefixed_asset_tag_still_routes_to_stint_format_first(self, api_client):
         # An asset_tag that happens to look like "PS-NOTREAL" is NOT a
         # stint — should fall through to asset-tag matching. The PS-

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -181,6 +181,16 @@ const RedirectScanDonationItem = () => {
   return <Navigate to={`/inventory/scan/donation-item/${itemId}`} replace />;
 };
 
+// Phone-camera scan target: a project-storage label QR encodes
+// /scan/project-storage/<stint_id>. The warden detail page lives at
+// /facilities/project-storage/<stint_id>, so this redirect bridges the
+// two so the QR keeps a friendly "/scan/..." shape while the routing
+// matches the rest of the warden surface.
+const RedirectScanProjectStorageStint = () => {
+  const { stintId } = useParams();
+  return <Navigate to={`/facilities/project-storage/${stintId}`} replace />;
+};
+
 const RedirectChecklist = () => {
   const { checklistId, completionId } = useParams();
   return <Navigate to={`/facilities/checklist/${checklistId}/complete/${completionId}`} replace />;
@@ -375,6 +385,7 @@ function AppContent() {
           <Route path="/scan/asset/:assetId" element={<RedirectScanAsset />} />
           <Route path="/scan/location/:locationId" element={<RedirectScanLocation />} />
           <Route path="/scan/donation-item/:itemId" element={<RedirectScanDonationItem />} />
+          <Route path="/scan/project-storage/:stintId" element={<RedirectScanProjectStorageStint />} />
           <Route path="/checklist/:checklistId/complete/:completionId" element={<RedirectChecklist />} />
 
           {/* Other routes */}


### PR DESCRIPTION
## Summary

PR 4 of 6 in the project-storage workflow refactor. Today the label QR encodes the bare \`stint_id\` string, so a phone-camera scan shows \"PS-AB23CDFG\" as plain text instead of opening the warden detail page. This switches to a deep-link URL aligned with the inventory \`/scan/<entity>/<id>\` convention.

### Backend

- \`label_service.render_stint_label\` now encodes \`{FRONTEND_URL}/scan/project-storage/<stint_id>\` into the QR. Default fallback \`http://localhost:3000\` matches \`inventory.services.qr_code_service\`.
- \`scanner.resolvers._parse_scan_url\` learns the new path shape and routes it through the existing project_storage stint resolver. **Backward-compatible** — the bare PS- prefix still resolves (#700), so labels sitting on shelves today keep working.
- Pi print daemon untouched — it GETs the PNG by \`stint_id\` at \`/api/project-storage/stints/<id>/label/\`, a different code path.

### Frontend

- New \`/scan/project-storage/:stintId\` redirect route forwards a phone-camera scan to the warden detail page (PR 3 / #702). Same pattern as \`/scan/asset/\`, \`/scan/location/\`, \`/scan/donation-item/\`.

### Tests

- 2 new dispatcher tests: URL form with real stint resolves correctly, URL form with no row falls through to unknown.
- All 50 existing scanner + project-storage tests still pass.

## Stack

| | | |
|---|---|---|
| PR 1 | #699 ✅ merged | List page + StorageAdmin perm |
| PR 2 | #700 ✅ merged | Scanner dispatch PS- prefix |
| PR 3 | #702 | Routable permalink (roll-forward) |
| **PR 4** | **this** | **QR encodes URL not bare ID** |
| PR 5 | next | Persisted qr_code ImageField |
| PR 6 | next | Avery bulk sheet |

## Test plan

- [ ] Print a new label — QR encodes the URL not the bare ID.
- [ ] Scan that label with a phone camera → warden detail page opens.
- [ ] Scan an OLD label (bare PS-) → still resolves via the PS- prefix path (#700).
- [ ] Pi print daemon still pulls PNGs at the existing endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)