### PR TITLE
feat(project-storage): Avery 5371 bulk sticker sheet

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -2165,6 +2165,9 @@ views:
       print_queue:
         permission_classes:
         - AllowAny
+      print_sheet:
+        permission_classes:
+        - IsStorageAdminOrStaff
       retrieve:
         permission_classes:
         - IsStorageAdminOrStaff

--- a/backend/project_storage/services/sheet_service.py
+++ b/backend/project_storage/services/sheet_service.py
@@ -1,0 +1,150 @@
+"""Render a printable Avery 5371 business-card sheet of stint labels.
+
+10 cards per US Letter page (2 columns × 5 rows), each 3.5" × 2".
+Drawn at 300 DPI so a 1:1 print on plain paper or pre-cut Avery 5371
+stock has the same proportions as the Brother QL labels — same QR
+payload (URL deep link), same eye-readable stint id, same big
+expiry-week stack the warden uses to triage a shelf at a glance.
+
+Layout per card:
+
+    ┌─────────────────────────────────┐
+    │  [QR ~552px]   Wk 47            │
+    │                Day 327          │
+    │                                 │
+    │                PS-AB23CDFG      │
+    │                Member Name      │
+    │                Proj: <title>    │
+    └─────────────────────────────────┘
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Iterable, Sequence
+
+from django.conf import settings
+
+import qrcode
+from PIL import Image, ImageDraw, ImageFont
+
+# Avery 5371 / 5371X — 10 business cards per US Letter sheet.
+DPI = 300
+SHEET_PX = (int(8.5 * DPI), int(11 * DPI))  # 2550 × 3300
+COLUMNS = 2
+ROWS = 5
+CARDS_PER_SHEET = COLUMNS * ROWS
+CARD_PX = (int(3.5 * DPI), int(2 * DPI))  # 1050 × 600
+TOP_MARGIN_PX = int(0.5 * DPI)  # 150
+SIDE_MARGIN_PX = int(0.75 * DPI)  # 225
+
+
+def _try_font(size: int) -> ImageFont.ImageFont:
+    candidates: Iterable[str] = (
+        "DejaVuSans-Bold.ttf",
+        "DejaVuSans.ttf",
+        "Arial Bold.ttf",
+        "Arial.ttf",
+    )
+    for name in candidates:
+        try:
+            return ImageFont.truetype(name, size=size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def _build_qr_image(value: str, target_px: int) -> Image.Image:
+    qr = qrcode.QRCode(
+        error_correction=qrcode.constants.ERROR_CORRECT_H,
+        box_size=10,
+        border=1,
+    )
+    qr.add_data(value)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white").convert("RGB")
+    # Round-trip through PNG bytes — qrcode returns a wrapper that
+    # some consumers can't isinstance-check. Same pattern as
+    # project_storage/services/label_service.py.
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    real = Image.open(buf).convert("RGB")
+    return real.resize((target_px, target_px), Image.Resampling.NEAREST)
+
+
+def _shrink_to_fit(
+    draw: ImageDraw.ImageDraw,
+    lines: Sequence[str],
+    available_w: int,
+    start_size: int,
+    min_size: int,
+) -> ImageFont.ImageFont:
+    size = start_size
+    while size > min_size:
+        font = _try_font(size)
+        widest = max(draw.textbbox((0, 0), line, font=font)[2] for line in lines)
+        if widest <= available_w:
+            return font
+        size -= 4
+    return _try_font(min_size)
+
+
+def _render_card(card: Image.Image, stint) -> None:
+    """Render one stint into a pre-allocated card canvas."""
+    draw = ImageDraw.Draw(card)
+    width, height = card.size
+    margin = 24
+
+    qr_px = height - 2 * margin
+    frontend_url = getattr(settings, "FRONTEND_URL", "http://localhost:3000").rstrip("/")
+    qr_payload = f"{frontend_url}/scan/project-storage/{stint.stint_id}"
+    qr = _build_qr_image(qr_payload, qr_px)
+    card.paste(qr, (margin, margin))
+
+    text_x = margin + qr_px + 24
+    available_w = width - text_x - margin
+
+    week, doy = stint.expiry_week_and_day
+    big_lines = [f"Wk {week:02d}", f"Day {doy:03d}"]
+    big = _shrink_to_fit(draw, big_lines, available_w, start_size=84, min_size=36)
+    h1 = draw.textbbox((0, 0), big_lines[0], font=big)[3]
+    draw.text((text_x, margin), big_lines[0], fill="black", font=big)
+    draw.text((text_x, margin + h1 + 6), big_lines[1], fill="black", font=big)
+
+    bottom_lines = [stint.stint_id, stint.display_name]
+    if stint.project_title:
+        bottom_lines.append(f"Proj: {stint.project_title[:32]}")
+    small = _shrink_to_fit(draw, bottom_lines, available_w, start_size=34, min_size=18)
+    bottom_y = margin + (h1 + 6) * 2 + 24
+    y = bottom_y
+    for line in bottom_lines:
+        draw.text((text_x, y), line, fill="black", font=small)
+        bbox = draw.textbbox((0, 0), line, font=small)
+        y += (bbox[3] - bbox[1]) + 6
+
+
+def render_business_card_sheet(stints: Sequence) -> bytes:
+    """Return PNG bytes for an Avery 5371 sheet (up to 10 stints).
+
+    Stints beyond the 10th are dropped — the caller paginates if they
+    have more. Unused slots are left blank so the warden can print on
+    half-empty sheets without rendering glitches.
+    """
+    sheet = Image.new("RGB", SHEET_PX, "white")
+    card_w, card_h = CARD_PX
+
+    for idx, stint in enumerate(list(stints)[:CARDS_PER_SHEET]):
+        col = idx % COLUMNS
+        row = idx // COLUMNS
+        x = SIDE_MARGIN_PX + col * card_w
+        y = TOP_MARGIN_PX + row * card_h
+
+        card = Image.new("RGB", CARD_PX, "white")
+        _render_card(card, stint)
+        sheet.paste(card, (x, y))
+
+    out = BytesIO()
+    sheet.save(out, format="PNG", dpi=(DPI, DPI))
+    out.seek(0)
+    return out.getvalue()

--- a/backend/project_storage/tests/test_api.py
+++ b/backend/project_storage/tests/test_api.py
@@ -458,3 +458,76 @@ class TestGenerateQrEndpoint:
         resp = staff_client.get(f"/api/project-storage/stints/{stint.stint_id}/")
         assert resp.status_code == 200
         assert resp.json()["qr_code_url"] is None
+
+
+# ---------------------------------------------------------------------------
+# Print-sheet endpoint (Avery 5371 bulk multi-up)
+# ---------------------------------------------------------------------------
+
+
+class TestPrintSheetEndpoint:
+    def test_anonymous_rejected(self, client):
+        resp = client.post(
+            "/api/project-storage/stints/print-sheet/",
+            data={"stint_ids": ["PS-XXXXXXXX"]},
+            format="json",
+        )
+        assert resp.status_code in (401, 403)
+
+    def test_member_rejected(self, member_client):
+        stint = ProjectStorageStintFactory()
+        resp = member_client.post(
+            "/api/project-storage/stints/print-sheet/",
+            data={"stint_ids": [stint.stint_id]},
+            format="json",
+        )
+        assert resp.status_code == 403
+
+    def test_storage_admin_can_render(self, storage_admin_client):
+        stints = [ProjectStorageStintFactory() for _ in range(3)]
+        resp = storage_admin_client.post(
+            "/api/project-storage/stints/print-sheet/",
+            data={"stint_ids": [s.stint_id for s in stints]},
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+        assert resp["Content-Type"] == "image/png"
+        # PNG magic bytes — 89 50 4E 47 0D 0A 1A 0A
+        assert resp.content[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_empty_stint_ids_400(self, staff_client):
+        resp = staff_client.post(
+            "/api/project-storage/stints/print-sheet/",
+            data={"stint_ids": []},
+            format="json",
+        )
+        assert resp.status_code == 400
+
+    def test_non_list_stint_ids_400(self, staff_client):
+        resp = staff_client.post(
+            "/api/project-storage/stints/print-sheet/",
+            data={"stint_ids": "PS-XYZ"},
+            format="json",
+        )
+        assert resp.status_code == 400
+
+    def test_all_unknown_ids_404(self, staff_client):
+        resp = staff_client.post(
+            "/api/project-storage/stints/print-sheet/",
+            data={"stint_ids": ["PS-NOPE0001", "PS-NOPE0002"]},
+            format="json",
+        )
+        assert resp.status_code == 404
+
+    def test_caps_at_ten_stints(self, staff_client):
+        # 12 stints supplied → endpoint silently caps to the first 10.
+        # Validates by checking the response is still a single PNG
+        # (no error, no pagination headers required for v1).
+        stints = [ProjectStorageStintFactory() for _ in range(12)]
+        resp = staff_client.post(
+            "/api/project-storage/stints/print-sheet/",
+            data={"stint_ids": [s.stint_id for s in stints]},
+            format="json",
+        )
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "image/png"

--- a/backend/project_storage/views.py
+++ b/backend/project_storage/views.py
@@ -18,12 +18,10 @@ from rest_framework.response import Response
 
 from .models import ProjectStorageEvent, ProjectStorageStint
 from .permissions import IsStorageAdminOrStaff
-from .serializers import (
-    ProjectStorageStintSerializer,
-    StartStintSerializer,
-)
+from .serializers import ProjectStorageStintSerializer, StartStintSerializer
 from .services.email_service import send_violation_notice
 from .services.label_service import PrinterFamily, render_stint_label
+from .services.sheet_service import CARDS_PER_SHEET, render_business_card_sheet
 
 
 class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
@@ -363,6 +361,48 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         png_bytes = render_stint_label(stint, printer=printer)
+        return HttpResponse(png_bytes, content_type="image/png")
+
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="print-sheet",
+        permission_classes=[IsStorageAdminOrStaff],
+    )
+    def print_sheet(self, request):
+        """Render up to 10 stints into an Avery 5371 (10-up, 2×5) PNG.
+
+        Body: ``{"stint_ids": ["PS-...", "PS-..."]}``. The caller's order
+        is preserved so the warden can lay cards out next to shelves in
+        a predictable sequence. IDs beyond the 10th are dropped (caller
+        paginates); unknown IDs are silently skipped so a typo doesn't
+        block the whole print job. The PNG is 8.5"×11" at 300 DPI —
+        scale-to-fit when printing.
+        """
+        stint_ids = request.data.get("stint_ids") or []
+        if not isinstance(stint_ids, list):
+            return Response(
+                {"detail": "stint_ids must be a list.", "code": "bad_request"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not stint_ids:
+            return Response(
+                {"detail": "stint_ids is required.", "code": "bad_request"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        stints_by_id = {
+            s.stint_id: s
+            for s in ProjectStorageStint.objects.filter(stint_id__in=stint_ids[:CARDS_PER_SHEET])
+        }
+        ordered = [stints_by_id[sid] for sid in stint_ids[:CARDS_PER_SHEET] if sid in stints_by_id]
+        if not ordered:
+            return Response(
+                {"detail": "No matching stints found.", "code": "not_found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        png_bytes = render_business_card_sheet(ordered)
         return HttpResponse(png_bytes, content_type="image/png")
 
     # ------------------------------------------------------------------

--- a/frontend/src/pages/FacilitiesProjectStorageListPage.tsx
+++ b/frontend/src/pages/FacilitiesProjectStorageListPage.tsx
@@ -70,11 +70,16 @@ const fmtDate = (iso: string | null): string => {
   }
 };
 
+// Avery 5371 holds 10 cards per sheet. The backend caps at this anyway,
+// but we surface it in the UI so the warden knows what they'll print.
+const SHEET_CAPACITY = 10;
+
 const FacilitiesProjectStorageListPage: React.FC = () => {
   const [stints, setStints] = useState<ProjectStorageStint[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [printing, setPrinting] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -97,6 +102,29 @@ const FacilitiesProjectStorageListPage: React.FC = () => {
   useEffect(() => {
     load();
   }, [load]);
+
+  const handlePrintSheet = useCallback(async () => {
+    if (stints.length === 0) return;
+    setPrinting(true);
+    setError(null);
+    try {
+      const ids = stints.slice(0, SHEET_CAPACITY).map((s) => s.stint_id);
+      const res = await projectStorageAPI.printSheet(ids);
+      // Axios with responseType:'arraybuffer' returns the bytes in
+      // res.data; wrap in a Blob and open in a new tab so the warden
+      // can print from the browser print dialog.
+      const blob = new Blob([res.data], { type: 'image/png' });
+      const url = URL.createObjectURL(blob);
+      window.open(url, '_blank');
+      // Don't revoke immediately — the new tab needs the URL to fetch
+      // the bytes. 60s is plenty for browser pickup.
+      setTimeout(() => URL.revokeObjectURL(url), 60_000);
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to render Avery sheet.'));
+    } finally {
+      setPrinting(false);
+    }
+  }, [stints]);
 
   const counts = useMemo(() => {
     const out: Record<ProjectStorageStatus, number> = {
@@ -132,9 +160,22 @@ const FacilitiesProjectStorageListPage: React.FC = () => {
       <Stack gap="md">
         <Paper p="md" withBorder>
           <Stack gap="sm">
-            <Text size="sm" c="dimmed">
-              Filter by status
-            </Text>
+            <Group justify="space-between" align="flex-end" wrap="wrap">
+              <Text size="sm" c="dimmed">
+                Filter by status
+              </Text>
+              <Button
+                size="xs"
+                variant="light"
+                onClick={handlePrintSheet}
+                loading={printing}
+                disabled={stints.length === 0}
+                data-testid="print-avery-sheet"
+              >
+                Print Avery sheet (
+                {Math.min(stints.length, SHEET_CAPACITY)}/{SHEET_CAPACITY})
+              </Button>
+            </Group>
             <SegmentedControl
               value={statusFilter}
               onChange={(v) => setStatusFilter(v as StatusFilter)}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3555,6 +3555,17 @@ export const projectStorageAPI = {
       `/project-storage/stints/${stintId}/generate-qr/`,
       { include_logo: includeLogo },
     ),
+
+  // Avery 5371 (10-up business card) sheet PNG. The endpoint caps at 10
+  // — callers paginate. Response is a binary PNG, so we ask axios for an
+  // arraybuffer and let the caller turn it into a blob URL for download
+  // or a new-tab preview.
+  printSheet: (stintIds: string[]) =>
+    api.post<ArrayBuffer>(
+      '/project-storage/stints/print-sheet/',
+      { stint_ids: stintIds },
+      { responseType: 'arraybuffer' },
+    ),
 };
 
 // Universal scanner dispatcher — resolves any barcode/QR payload to an


### PR DESCRIPTION
PR 6 of 6 in the project-storage QR-code refactor — completes the warden tooling chain.

## What

- **New endpoint** \`POST /api/project-storage/stints/print-sheet/\`
  - Body \`{stint_ids: [...]}\`
  - Returns an 8.5\"×11\" PNG at 300 DPI laid out as Avery 5371 (10 business cards per sheet, 2 cols × 5 rows, 3.5\"×2\" each)
  - \`IsStorageAdminOrStaff\`
  - Caller order is preserved (warden lays cards out next to shelves)
  - Caps at 10 stints per call; unknown IDs are silently skipped so a typo doesn't kill the whole job

- **Card layout** mirrors the existing Brother QL label (\`label_service.py\`):
  - Square QR on the left — same URL payload (\`{FRONTEND_URL}/scan/project-storage/<id>\`) as PR 4
  - Right column: big \`Wk NN\` / \`Day DDD\` stack, then \`PS-XXXXXXXX\`, member name, project title

- **List page button** — \`/facilities/project-storage/queue\` gains a \"Print Avery sheet (N/10)\" action that POSTs the top-N visible stint IDs and opens the resulting PNG in a new tab; the warden prints via the browser dialog

## Why

The warden needed a way to print multiple labels at once on plain-paper Avery business-card stock when the Brother QL is busy or for bulk relabel sweeps. The QR payload is identical to PR 4's labels so a scanner can't tell them apart.

## Test plan
- [x] Backend: 7 new tests in \`TestPrintSheetEndpoint\` cover auth (anon/member rejected, storage-admin OK), validation (empty/non-list 400, all-unknown 404), and the 10-card cap
- [x] Backend full project_storage suite + permission matrix gate (70 passed locally)
- [x] Frontend: \`npm run build\` clean
- [ ] CI green