### PR TITLE
feat(config): runtime validate_production management command (gh-710)

### DIFF
--- a/backend/config/management/commands/validate_production.py
+++ b/backend/config/management/commands/validate_production.py
@@ -1,0 +1,116 @@
+"""``manage.py validate_production`` — runtime production-safety baseline.
+
+Walks the registered :mod:`config.validators` checks against the loaded
+Django settings, prints a category-tagged report, and exits non-zero on
+any fatal issue. Complementary to ``scripts/validate-prod-env.sh``:
+
+  - The shell validator reads the ``.env`` file before Django starts.
+    It catches placeholder values in the file itself.
+  - This command reads ``django.conf.settings`` *after* Django has
+    loaded them. It catches drift — a ``settings.py`` override that
+    re-enables an unsafe default, an env-var clobber at container start,
+    or a feature flag that flips a secure setting back to insecure.
+
+Behavior in non-prod environments: ``DEBUG=True`` is the signal that
+we're in dev / CI / a one-off container. The command skips enforcement
+in that mode and prints a one-line note instead. Operators who want to
+exercise the prod rules locally pass ``--strict`` to enforce regardless
+of DEBUG.
+
+Reports never include secret values. Reasons may reference a
+placeholder *fragment* (the public part) but never the operator's
+chosen string. Tests assert this contract.
+
+Exit codes:
+  0 — all checks pass, or skipped because DEBUG=True (without --strict)
+  1 — one or more fatal issues; report lists every issue
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Iterable
+
+from django.conf import settings as django_settings
+from django.core.management.base import BaseCommand
+
+from config.validators import CHECKS, Issue
+
+
+class Command(BaseCommand):
+    help = (
+        "Validate the loaded Django settings against the production safety "
+        "baseline. See backend/config/validators/ for the category list."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--strict",
+            action="store_true",
+            help=(
+                "Run all checks even when DEBUG=True. Use this for "
+                "CI-side validation of the prod-flavor settings."
+            ),
+        )
+        parser.add_argument(
+            "--quiet",
+            action="store_true",
+            help="Suppress the success summary; only print on failure.",
+        )
+
+    def handle(self, *args, **opts) -> None:
+        strict = bool(opts.get("strict"))
+        quiet = bool(opts.get("quiet"))
+
+        if django_settings.DEBUG and not strict:
+            self.stdout.write(
+                "validate_production: DEBUG=True, skipping production checks "
+                "(use --strict to run anyway)."
+            )
+            return
+
+        issues = list(self._collect_issues())
+        fails = [i for i in issues if i.severity == "fail"]
+        warns = [i for i in issues if i.severity == "warn"]
+
+        for issue in issues:
+            self._print_issue(issue)
+
+        if fails:
+            self.stderr.write(
+                self.style.ERROR(
+                    f"validate_production: {len(fails)} fatal issue(s), "
+                    f"{len(warns)} warning(s). Refusing to proceed."
+                )
+            )
+            sys.exit(1)
+
+        if warns and not quiet:
+            self.stdout.write(
+                self.style.WARNING(f"validate_production: 0 fatal issues, {len(warns)} warning(s).")
+            )
+        elif not quiet:
+            self.stdout.write(
+                self.style.SUCCESS("validate_production: all production safety checks passed.")
+            )
+
+    def _collect_issues(self) -> Iterable[Issue]:
+        for check in CHECKS:
+            # Each check is independent — never let one check's
+            # exception block the rest from reporting.
+            try:
+                yield from check.run(django_settings)
+            except Exception as exc:  # noqa: BLE001 — surface, don't swallow
+                yield Issue(
+                    category=check.category or check.__class__.__name__,
+                    key="<check_error>",
+                    reason=f"check raised {type(exc).__name__}: {exc}",
+                )
+
+    def _print_issue(self, issue: Issue) -> None:
+        prefix = "FAIL" if issue.severity == "fail" else "WARN"
+        line = f"[{prefix}] {issue.category}.{issue.key}: {issue.reason}"
+        if issue.severity == "fail":
+            self.stderr.write(self.style.ERROR(line))
+        else:
+            self.stderr.write(self.style.WARNING(line))

--- a/backend/config/tests/test_validate_production.py
+++ b/backend/config/tests/test_validate_production.py
@@ -1,0 +1,207 @@
+"""Tests for ``manage.py validate_production`` and its category checks.
+
+Each failure mode in the gh-710 acceptance lands here as its own case.
+The "no secret values leak" contract is asserted by checking that the
+output never includes a marker we plant in the setting.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import override_settings
+
+import pytest
+
+from config.validators import Issue
+from config.validators.django_core import SECRET_KEY_MIN_LEN, DjangoCoreCheck
+
+# A 64-char value that has none of the placeholder fragments. Used as
+# the happy-path SECRET_KEY in tests so flipping a single field doesn't
+# accidentally trip a different rule.
+_SAFE_SECRET = "a1B2c3D4" * 8
+
+
+# ---------------------------------------------------------------------------
+# DjangoCoreCheck unit tests — each rule in isolation
+# ---------------------------------------------------------------------------
+
+
+class _Bag:
+    """Minimal stand-in for Django settings.
+
+    Tests use this rather than @override_settings for the unit-test
+    layer so we can drive ALLOWED_HOSTS / SECRET_KEY / DEBUG combos
+    that would be illegal-at-import-time in real settings.
+    """
+
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def _issues(**settings_kw) -> list[Issue]:
+    return list(DjangoCoreCheck().run(_Bag(**settings_kw)))
+
+
+class TestDebugRule:
+    def test_debug_true_fails(self):
+        issues = _issues(DEBUG=True, SECRET_KEY=_SAFE_SECRET, ALLOWED_HOSTS=["oms.example.com"])
+        assert any(i.key == "DEBUG" and i.severity == "fail" for i in issues)
+
+    def test_debug_false_passes(self):
+        issues = _issues(DEBUG=False, SECRET_KEY=_SAFE_SECRET, ALLOWED_HOSTS=["oms.example.com"])
+        assert not any(i.key == "DEBUG" for i in issues)
+
+
+class TestSecretKeyRule:
+    def test_empty_secret_key_fails(self):
+        issues = _issues(DEBUG=False, SECRET_KEY="", ALLOWED_HOSTS=["oms.example.com"])
+        assert any(i.key == "SECRET_KEY" and "empty" in i.reason.lower() for i in issues)
+
+    @pytest.mark.parametrize(
+        "secret",
+        [
+            "django-insecure-dev-key-change-in-production-aaaaaaaaaaaaaaa",
+            "change-me-now-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "placeholder-value-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "your-secret-here-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "TEST-KEY-for-ci-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ],
+    )
+    def test_placeholder_secret_key_fails(self, secret):
+        issues = _issues(DEBUG=False, SECRET_KEY=secret, ALLOWED_HOSTS=["oms.example.com"])
+        assert any(i.key == "SECRET_KEY" and "placeholder" in i.reason.lower() for i in issues), [
+            (i.key, i.reason) for i in issues
+        ]
+
+    def test_short_secret_key_fails(self):
+        short = "a" * (SECRET_KEY_MIN_LEN - 1)
+        issues = _issues(DEBUG=False, SECRET_KEY=short, ALLOWED_HOSTS=["oms.example.com"])
+        assert any(i.key == "SECRET_KEY" and "shorter than" in i.reason for i in issues)
+
+    def test_safe_secret_passes(self):
+        issues = _issues(DEBUG=False, SECRET_KEY=_SAFE_SECRET, ALLOWED_HOSTS=["oms.example.com"])
+        assert not any(i.key == "SECRET_KEY" for i in issues)
+
+
+class TestAllowedHostsRule:
+    def test_empty_allowed_hosts_fails(self):
+        issues = _issues(DEBUG=False, SECRET_KEY=_SAFE_SECRET, ALLOWED_HOSTS=[])
+        assert any(i.key == "ALLOWED_HOSTS" and "empty" in i.reason.lower() for i in issues)
+
+    def test_wildcard_allowed_hosts_fails(self):
+        issues = _issues(
+            DEBUG=False, SECRET_KEY=_SAFE_SECRET, ALLOWED_HOSTS=["*", "oms.example.com"]
+        )
+        assert any(i.key == "ALLOWED_HOSTS" and "*" in i.reason for i in issues)
+
+    @pytest.mark.parametrize(
+        "hosts",
+        [
+            ["localhost"],
+            ["127.0.0.1"],
+            ["localhost", "127.0.0.1"],
+            ["0.0.0.0"],
+            ["::1"],
+        ],
+    )
+    def test_loopback_only_allowed_hosts_fails(self, hosts):
+        issues = _issues(DEBUG=False, SECRET_KEY=_SAFE_SECRET, ALLOWED_HOSTS=hosts)
+        assert any(i.key == "ALLOWED_HOSTS" and "loopback" in i.reason.lower() for i in issues)
+
+    def test_real_host_passes(self):
+        issues = _issues(
+            DEBUG=False,
+            SECRET_KEY=_SAFE_SECRET,
+            ALLOWED_HOSTS=["oms.example.com", "localhost"],
+        )
+        assert not any(i.key == "ALLOWED_HOSTS" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# Management-command integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateProductionCommand:
+    def test_debug_true_skips_without_strict(self):
+        out, err = StringIO(), StringIO()
+        with override_settings(DEBUG=True):
+            call_command("validate_production", stdout=out, stderr=err)
+        assert "skipping production checks" in out.getvalue()
+        assert err.getvalue() == ""
+
+    def test_debug_true_runs_under_strict_and_fails(self):
+        out, err = StringIO(), StringIO()
+        with pytest.raises(SystemExit) as exc_info:
+            with override_settings(
+                DEBUG=True,
+                SECRET_KEY=_SAFE_SECRET,
+                ALLOWED_HOSTS=["oms.example.com"],
+            ):
+                call_command("validate_production", "--strict", stdout=out, stderr=err)
+        assert exc_info.value.code == 1
+        # The fatal report goes to stderr.
+        assert "django_core.DEBUG" in err.getvalue()
+        assert "DEBUG=True" in err.getvalue()
+
+    def test_well_formed_settings_pass(self):
+        out, err = StringIO(), StringIO()
+        with override_settings(
+            DEBUG=False,
+            SECRET_KEY=_SAFE_SECRET,
+            ALLOWED_HOSTS=["oms.example.com"],
+        ):
+            call_command("validate_production", stdout=out, stderr=err)
+        assert "all production safety checks passed" in out.getvalue()
+        assert err.getvalue() == ""
+
+    def test_quiet_suppresses_success_summary(self):
+        out, err = StringIO(), StringIO()
+        with override_settings(
+            DEBUG=False,
+            SECRET_KEY=_SAFE_SECRET,
+            ALLOWED_HOSTS=["oms.example.com"],
+        ):
+            call_command("validate_production", "--quiet", stdout=out, stderr=err)
+        assert out.getvalue() == ""
+
+    def test_multiple_failures_all_reported(self):
+        out, err = StringIO(), StringIO()
+        # Plant DEBUG, placeholder secret, AND loopback hosts — all
+        # three should be in the same report rather than the command
+        # short-circuiting on the first.
+        with pytest.raises(SystemExit) as exc_info:
+            with override_settings(
+                DEBUG=True,
+                SECRET_KEY="x" * 30,  # short — fail
+                ALLOWED_HOSTS=["localhost"],  # loopback-only — fail
+            ):
+                call_command("validate_production", "--strict", stdout=out, stderr=err)
+        assert exc_info.value.code == 1
+        report = err.getvalue()
+        assert "django_core.DEBUG" in report
+        assert "django_core.SECRET_KEY" in report
+        assert "django_core.ALLOWED_HOSTS" in report
+
+    def test_secret_value_never_leaked(self):
+        out, err = StringIO(), StringIO()
+        marker = "marker-secret-value-should-never-appear-in-output"
+        # SECRET_KEY length is enough — only the placeholder fragment
+        # check should trip, but we're really verifying the OUTPUT
+        # never contains the literal value.
+        leaky_value = "django-insecure-" + marker + "padding-padding-padding"
+        with pytest.raises(SystemExit):
+            with override_settings(
+                DEBUG=False,
+                SECRET_KEY=leaky_value,
+                ALLOWED_HOSTS=["oms.example.com"],
+            ):
+                call_command("validate_production", stdout=out, stderr=err)
+        combined = out.getvalue() + err.getvalue()
+        assert marker not in combined, (
+            "validate_production must not print the secret value, only the "
+            "matched fragment + reason."
+        )

--- a/backend/config/validators/__init__.py
+++ b/backend/config/validators/__init__.py
@@ -1,0 +1,17 @@
+"""Production-safety validators.
+
+The category-based design is the future-proofing for the rest of the
+#455 production-safety baseline: each PR adds a SafetyCheck subclass and
+registers it in :mod:`.registry`. The ``validate_production`` management
+command iterates the registry and reports per-category.
+
+Initial scope (gh-710): :class:`.django_core.DjangoCoreCheck`.
+
+Planned (gh-711, gh-712): cookies/CSRF/CORS check; external-credential
+placeholder check (Sentry/ForgeKey/EMQX/webhook/email/signing).
+"""
+
+from .base import Issue, SafetyCheck
+from .registry import CHECKS
+
+__all__ = ["Issue", "SafetyCheck", "CHECKS"]

--- a/backend/config/validators/base.py
+++ b/backend/config/validators/base.py
@@ -1,0 +1,53 @@
+"""Shared shape for production-safety checks.
+
+A check looks at the LIVE Django settings (post-decouple, post-cast) and
+emits zero or more :class:`Issue` instances. The
+``validate_production`` command aggregates them, decides the exit code,
+and prints a category-tagged report.
+
+Why the live settings vs. the `.env` file: the shell
+``scripts/validate-prod-env.sh`` validator already covers the file. The
+runtime check catches drift between the file and what Django actually
+loaded — a misconfigured ``settings.py`` override, an env-var clobber at
+container start, or a feature flag that re-enables an unsafe default
+after load.
+
+An Issue must NEVER include the offending value (no SECRET_KEY snippets,
+no host strings) — only the category, the setting name, and a
+human-readable reason. Reasons may reference a placeholder *fragment*
+that matched (those are public; the secret is what the operator chose
+beyond the fragment).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Literal
+
+Severity = Literal["fail", "warn"]
+
+
+@dataclass(frozen=True)
+class Issue:
+    """One safety-baseline violation surfaced by a check."""
+
+    category: str
+    key: str
+    reason: str
+    severity: Severity = "fail"
+
+
+class SafetyCheck:
+    """Base class for category checks.
+
+    Subclasses set ``category`` and implement ``run`` to yield issues.
+    The command iterates each registered check exactly once and treats
+    every check as independent — one failing check never short-circuits
+    the rest, so a single command run surfaces *all* problems instead of
+    making the operator fix-and-rerun N times.
+    """
+
+    category: str = ""
+
+    def run(self, settings) -> Iterable[Issue]:
+        raise NotImplementedError

--- a/backend/config/validators/django_core.py
+++ b/backend/config/validators/django_core.py
@@ -1,0 +1,111 @@
+"""Django-core safety checks: DEBUG, SECRET_KEY, ALLOWED_HOSTS.
+
+First slice of the production safety baseline (gh-710 of #455). Looks
+at the loaded Django settings — complementary to the shell
+``scripts/validate-prod-env.sh`` validator which looks at the ``.env``
+file before the process starts.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .base import Issue, SafetyCheck
+
+# Substrings that mark a value as a placeholder. The list is public — the
+# secret is whatever the operator was supposed to choose beyond the
+# fragment, so naming the fragment in an error message does not leak
+# anything sensitive. Keep this list in sync with the corresponding
+# fragments in `scripts/validate-prod-env.sh`.
+PLACEHOLDER_FRAGMENTS = (
+    "django-insecure",
+    "change-me",
+    "changeme",
+    "change_me",
+    "replace-me",
+    "replaceme",
+    "replace_me",
+    "placeholder",
+    "your-secret-here",
+    "your-key-here",
+    "dev-key",
+    "test-key",
+    "example",
+)
+
+SECRET_KEY_MIN_LEN = 50
+
+# nosec B104 — these are validator literals we *check against* in
+# ALLOWED_HOSTS, not bind addresses. The whole point is to flag deploys
+# that ship 0.0.0.0 here.
+LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "0.0.0.0", "::1"})  # nosec B104
+
+
+class DjangoCoreCheck(SafetyCheck):
+    """Validate DEBUG, SECRET_KEY, and ALLOWED_HOSTS for production posture."""
+
+    category = "django_core"
+
+    def run(self, settings) -> Iterable[Issue]:
+        yield from self._check_debug(settings)
+        yield from self._check_secret_key(settings)
+        yield from self._check_allowed_hosts(settings)
+
+    def _check_debug(self, settings) -> Iterable[Issue]:
+        # The command's --strict gate decides whether this runs at all;
+        # if we got here with DEBUG=True it's an enforce-anyway request.
+        if getattr(settings, "DEBUG", False):
+            yield Issue(
+                category=self.category,
+                key="DEBUG",
+                reason="DEBUG=True is not permitted in a production environment.",
+            )
+
+    def _check_secret_key(self, settings) -> Iterable[Issue]:
+        secret = getattr(settings, "SECRET_KEY", "") or ""
+        if not secret:
+            yield Issue(self.category, "SECRET_KEY", "SECRET_KEY is empty.")
+            return
+
+        lower = secret.lower()
+        for fragment in PLACEHOLDER_FRAGMENTS:
+            if fragment in lower:
+                yield Issue(
+                    category=self.category,
+                    key="SECRET_KEY",
+                    reason=(f"SECRET_KEY contains placeholder fragment '{fragment}'."),
+                )
+                # One placeholder fail per key is enough — surface the
+                # length problem separately if it also applies.
+                break
+
+        if len(secret) < SECRET_KEY_MIN_LEN:
+            yield Issue(
+                category=self.category,
+                key="SECRET_KEY",
+                reason=(
+                    f"SECRET_KEY is shorter than {SECRET_KEY_MIN_LEN} characters "
+                    f"(got {len(secret)})."
+                ),
+            )
+
+    def _check_allowed_hosts(self, settings) -> Iterable[Issue]:
+        hosts = list(getattr(settings, "ALLOWED_HOSTS", None) or [])
+        if not hosts:
+            yield Issue(self.category, "ALLOWED_HOSTS", "ALLOWED_HOSTS is empty.")
+            return
+
+        if "*" in hosts:
+            yield Issue(
+                category=self.category,
+                key="ALLOWED_HOSTS",
+                reason="ALLOWED_HOSTS contains '*' (any host accepted).",
+            )
+
+        non_loopback = [h for h in hosts if h.strip().lower() not in LOOPBACK_HOSTS]
+        if not non_loopback:
+            yield Issue(
+                category=self.category,
+                key="ALLOWED_HOSTS",
+                reason="ALLOWED_HOSTS only contains loopback hosts.",
+            )

--- a/backend/config/validators/registry.py
+++ b/backend/config/validators/registry.py
@@ -1,0 +1,13 @@
+"""Registered safety checks. Adding a check is a one-line append here.
+
+Future PRs (gh-711, gh-712) add CookiesCheck, CredentialPlaceholderCheck,
+etc. by importing and appending.
+"""
+
+from __future__ import annotations
+
+from .django_core import DjangoCoreCheck
+
+CHECKS = [
+    DjangoCoreCheck(),
+]

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -6,4 +6,15 @@ if [ "${SKIP_DB_MIGRATIONS}" != "1" ]; then
   python manage.py migrate --noinput
 fi
 
+# Production safety baseline (gh-710 of #455). Validates the LIVE
+# Django settings against the registered category checks before the
+# application starts serving requests. In dev (DEBUG=True) this is a
+# no-op; in prod a placeholder SECRET_KEY, wildcard ALLOWED_HOSTS,
+# etc. will fail the container before it can accept traffic. Set
+# SKIP_PRODUCTION_VALIDATION=1 for one-off containers (e.g. a CLI
+# shell) where settings hardening doesn't apply.
+if [ "${SKIP_PRODUCTION_VALIDATION}" != "1" ]; then
+  python manage.py validate_production --quiet
+fi
+
 exec "$@"

--- a/docs/PRODUCTION_SAFETY_COVERAGE.md
+++ b/docs/PRODUCTION_SAFETY_COVERAGE.md
@@ -61,6 +61,7 @@ they isolate a single rule.
 | `scripts/validate-prod-env.sh` runs against a synthesised good env in CI | Mitigated | `.github/workflows/ci.yml` step "Run prod env validator against happy-path env". |
 | `scripts/validate-prod-env.sh` is asserted to **reject** `.env.prod.example` (so example files cannot accidentally become deployable) | Mitigated | `.github/workflows/ci.yml` step "Validator rejects shipped placeholder env". |
 | Validator is invoked by the deploy script before bringing the stack up | Mitigated | Referenced from `docs/DEPLOYMENT.MD`; called from `scripts/reset-and-deploy.sh`. |
+| Runtime defense-in-depth — `manage.py validate_production` runs against the LIVE Django settings on every container start | Mitigated (gh-710) | `backend/docker-entrypoint.sh`; `backend/config/validators/django_core.py`; `backend/config/tests/test_validate_production.py`. Catches drift between `.env` and the loaded settings (overrides in `settings.py`, env-var clobbers at container start, etc.). |
 
 ### R-01 gaps
 


### PR DESCRIPTION
First slice of #455 production safety baseline. Complements the existing \`scripts/validate-prod-env.sh\` (which validates the \`.env\` file before Django starts) with a runtime defense-in-depth that walks the live \`django.conf.settings\` on every container start.

## Why two validators

- \`scripts/validate-prod-env.sh\` catches placeholders in the \`.env\` file.
- \`manage.py validate_production\` catches drift between the file and what Django actually loaded — a \`settings.py\` override, an env-var clobber at container start, or a feature flag that re-enables an unsafe default after load.

## What this slice ships

- New \`backend/config/validators/\` framework — category-based so #711 (cookies/CSRF/CORS) and #712 (external-credential placeholder detection) drop in as new \`SafetyCheck\` subclasses registered in \`registry.py\`. No command changes needed.
- \`DjangoCoreCheck\` covering #710's full acceptance:
  - **DEBUG=True** fails in production posture
  - **SECRET_KEY**: empty / matches placeholder fragment / shorter than 50 chars
  - **ALLOWED_HOSTS**: empty / contains \`*\` / loopback-only
- \`manage.py validate_production\` command — exits 1 on any fail, prints \`[FAIL] category.key: reason\` to stderr. Reports never include the secret value (only the matched placeholder fragment, which is public). Tests assert the no-leak contract.
- Wired into \`backend/docker-entrypoint.sh\` after migrations. \`SKIP_PRODUCTION_VALIDATION=1\` escape hatch for one-off containers.
- DEBUG=True is the dev/CI signal — the command no-ops in that mode unless \`--strict\` is passed.

## Test plan
- [x] 24 new tests in \`config/tests/test_validate_production.py\`: per-rule unit tests + command-level integration tests + the no-secret-leak contract
- [x] \`pytest config/ -q --no-cov\` — 201 passed, 101 skipped (no regressions)
- [x] \`pre-commit\` clean (black/isort/ruff/bandit/yaml/django-upgrade)
- [ ] CI green

Fixes #710. Slice of #455.