### PR TITLE
feat(config): cookie/CSRF/CORS validator category (gh-711)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -786,6 +786,12 @@ jobs:
           EMQX_DASHBOARD_PASSWORD=Strong1Password
           FORGEKEY_PROVISIONING_TOKEN=ci-provisioning-token-not-for-production-padding
           FORGEKEY_JWT_SIGNING_KEY=${jwt_env}
+          # validate_production runs on container start (gh-710) and would
+          # require SECURE_SSL_REDIRECT=1 + SECURE_HSTS_SECONDS>0, but this
+          # smoke boots the backend without an nginx TLS terminator — both
+          # would loop livez to https forever. The validator has its own
+          # unit tests; the escape hatch is the right shape here.
+          SKIP_PRODUCTION_VALIDATION=1
           EOF
 
           # bootstrap_users for EMQX is normally rendered by deploy.sh; the

--- a/backend/config/tests/test_validate_production.py
+++ b/backend/config/tests/test_validate_production.py
@@ -23,6 +23,24 @@ from config.validators.django_core import SECRET_KEY_MIN_LEN, DjangoCoreCheck
 _SAFE_SECRET = "a1B2c3D4" * 8
 
 
+# Settings shape that passes every registered category. Each happy-path
+# command-level test layers this in via override_settings; growing the
+# set of categories means appending here once, not editing every test.
+_PROD_GOOD_SETTINGS = dict(
+    DEBUG=False,
+    SECRET_KEY=_SAFE_SECRET,
+    ALLOWED_HOSTS=["oms.example.com"],
+    SESSION_COOKIE_SECURE=True,
+    CSRF_COOKIE_SECURE=True,
+    SESSION_COOKIE_SAMESITE="Lax",
+    CSRF_COOKIE_SAMESITE="Lax",
+    SECURE_SSL_REDIRECT=True,
+    SECURE_HSTS_SECONDS=3600,
+    CORS_ALLOWED_ORIGINS=["https://oms.example.com"],
+    CSRF_TRUSTED_ORIGINS=["https://oms.example.com"],
+)
+
+
 # ---------------------------------------------------------------------------
 # DjangoCoreCheck unit tests — each rule in isolation
 # ---------------------------------------------------------------------------
@@ -136,11 +154,7 @@ class TestValidateProductionCommand:
     def test_debug_true_runs_under_strict_and_fails(self):
         out, err = StringIO(), StringIO()
         with pytest.raises(SystemExit) as exc_info:
-            with override_settings(
-                DEBUG=True,
-                SECRET_KEY=_SAFE_SECRET,
-                ALLOWED_HOSTS=["oms.example.com"],
-            ):
+            with override_settings(**{**_PROD_GOOD_SETTINGS, "DEBUG": True}):
                 call_command("validate_production", "--strict", stdout=out, stderr=err)
         assert exc_info.value.code == 1
         # The fatal report goes to stderr.
@@ -149,22 +163,14 @@ class TestValidateProductionCommand:
 
     def test_well_formed_settings_pass(self):
         out, err = StringIO(), StringIO()
-        with override_settings(
-            DEBUG=False,
-            SECRET_KEY=_SAFE_SECRET,
-            ALLOWED_HOSTS=["oms.example.com"],
-        ):
+        with override_settings(**_PROD_GOOD_SETTINGS):
             call_command("validate_production", stdout=out, stderr=err)
         assert "all production safety checks passed" in out.getvalue()
         assert err.getvalue() == ""
 
     def test_quiet_suppresses_success_summary(self):
         out, err = StringIO(), StringIO()
-        with override_settings(
-            DEBUG=False,
-            SECRET_KEY=_SAFE_SECRET,
-            ALLOWED_HOSTS=["oms.example.com"],
-        ):
+        with override_settings(**_PROD_GOOD_SETTINGS):
             call_command("validate_production", "--quiet", stdout=out, stderr=err)
         assert out.getvalue() == ""
 
@@ -194,11 +200,7 @@ class TestValidateProductionCommand:
         # never contains the literal value.
         leaky_value = "django-insecure-" + marker + "padding-padding-padding"
         with pytest.raises(SystemExit):
-            with override_settings(
-                DEBUG=False,
-                SECRET_KEY=leaky_value,
-                ALLOWED_HOSTS=["oms.example.com"],
-            ):
+            with override_settings(**{**_PROD_GOOD_SETTINGS, "SECRET_KEY": leaky_value}):
                 call_command("validate_production", stdout=out, stderr=err)
         combined = out.getvalue() + err.getvalue()
         assert marker not in combined, (

--- a/backend/config/tests/test_validate_production_cookies.py
+++ b/backend/config/tests/test_validate_production_cookies.py
@@ -1,0 +1,118 @@
+"""Tests for the CookiesCSRFCORSCheck (gh-711 of #455)."""
+
+from __future__ import annotations
+
+import pytest
+
+from config.validators import Issue
+from config.validators.cookies import CookiesCSRFCORSCheck
+
+
+class _Bag:
+    """Minimal stand-in for settings, same pattern as the gh-710 tests."""
+
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+# A baseline that passes every cookie/CSRF/CORS rule. Tests flip ONE
+# field at a time to exercise each rule in isolation.
+_GOOD = dict(
+    SESSION_COOKIE_SECURE=True,
+    CSRF_COOKIE_SECURE=True,
+    SESSION_COOKIE_SAMESITE="Lax",
+    CSRF_COOKIE_SAMESITE="Lax",
+    SECURE_SSL_REDIRECT=True,
+    SECURE_HSTS_SECONDS=3600,
+    CORS_ALLOWED_ORIGINS=["https://oms.example.com"],
+    CSRF_TRUSTED_ORIGINS=["https://oms.example.com"],
+)
+
+
+def _issues(**overrides) -> list[Issue]:
+    settings = _Bag(**{**_GOOD, **overrides})
+    return list(CookiesCSRFCORSCheck().run(settings))
+
+
+class TestSessionCookieSecure:
+    @pytest.mark.parametrize("falsy", [False, 0, None, ""])
+    def test_non_truthy_fails(self, falsy):
+        issues = _issues(SESSION_COOKIE_SECURE=falsy)
+        assert any(i.key == "SESSION_COOKIE_SECURE" for i in issues)
+
+    def test_true_passes(self):
+        issues = _issues(SESSION_COOKIE_SECURE=True)
+        assert not any(i.key == "SESSION_COOKIE_SECURE" for i in issues)
+
+
+class TestCsrfCookieSecure:
+    def test_false_fails(self):
+        issues = _issues(CSRF_COOKIE_SECURE=False)
+        assert any(i.key == "CSRF_COOKIE_SECURE" for i in issues)
+
+
+class TestSessionCookieSamesite:
+    @pytest.mark.parametrize("bad", ["None", "none", "", None, "lax", "STRICT"])
+    def test_non_safe_fails(self, bad):
+        # 'lax' / 'STRICT' fail because Django's matcher is case-sensitive
+        # — we want operators to use the canonical capitalization.
+        issues = _issues(SESSION_COOKIE_SAMESITE=bad)
+        assert any(i.key == "SESSION_COOKIE_SAMESITE" for i in issues)
+
+    @pytest.mark.parametrize("good", ["Lax", "Strict"])
+    def test_safe_passes(self, good):
+        issues = _issues(SESSION_COOKIE_SAMESITE=good)
+        assert not any(i.key == "SESSION_COOKIE_SAMESITE" for i in issues)
+
+
+class TestCsrfCookieSamesite:
+    def test_none_fails(self):
+        issues = _issues(CSRF_COOKIE_SAMESITE="None")
+        assert any(i.key == "CSRF_COOKIE_SAMESITE" for i in issues)
+
+
+class TestSslRedirect:
+    def test_false_fails(self):
+        issues = _issues(SECURE_SSL_REDIRECT=False)
+        assert any(i.key == "SECURE_SSL_REDIRECT" for i in issues)
+
+
+class TestHsts:
+    @pytest.mark.parametrize("bad", [0, "0", -1, None, "", "not-a-number"])
+    def test_non_positive_fails(self, bad):
+        issues = _issues(SECURE_HSTS_SECONDS=bad)
+        assert any(i.key == "SECURE_HSTS_SECONDS" for i in issues)
+
+    @pytest.mark.parametrize("good", [3600, "3600", 31536000])
+    def test_positive_passes(self, good):
+        issues = _issues(SECURE_HSTS_SECONDS=good)
+        assert not any(i.key == "SECURE_HSTS_SECONDS" for i in issues)
+
+
+class TestWildcardOrigins:
+    def test_cors_wildcard_fails(self):
+        issues = _issues(CORS_ALLOWED_ORIGINS=["*"])
+        assert any(i.key == "CORS_ALLOWED_ORIGINS" for i in issues)
+
+    def test_csrf_trusted_wildcard_fails(self):
+        issues = _issues(CSRF_TRUSTED_ORIGINS=["https://oms.example.com", "*"])
+        assert any(i.key == "CSRF_TRUSTED_ORIGINS" for i in issues)
+
+    def test_real_origins_pass(self):
+        issues = _issues(
+            CORS_ALLOWED_ORIGINS=["https://oms.example.com"],
+            CSRF_TRUSTED_ORIGINS=["https://oms.example.com"],
+        )
+        assert not any(i.key in ("CORS_ALLOWED_ORIGINS", "CSRF_TRUSTED_ORIGINS") for i in issues)
+
+    def test_string_value_normalized(self):
+        # Some operators set CSRF_TRUSTED_ORIGINS to a bare string when
+        # there's only one origin. The check should still catch '*'.
+        issues = _issues(CSRF_TRUSTED_ORIGINS="*")
+        assert any(i.key == "CSRF_TRUSTED_ORIGINS" for i in issues)
+
+
+class TestGoodBaseline:
+    def test_full_good_baseline_passes(self):
+        assert _issues() == []

--- a/backend/config/validators/cookies.py
+++ b/backend/config/validators/cookies.py
@@ -1,0 +1,114 @@
+"""Cookie / CSRF / CORS / HSTS safety checks (gh-711 of #455).
+
+Second category in the runtime production-safety validator. Same shape
+as :mod:`.django_core`: yields :class:`Issue` instances against the
+loaded Django settings; never prints values, only the setting name and
+a category-tagged reason.
+
+What this check covers:
+
+  - ``SESSION_COOKIE_SECURE`` and ``CSRF_COOKIE_SECURE`` must be True
+    (plaintext cookies disable the secure-by-default deploy contract).
+  - ``SESSION_COOKIE_SAMESITE`` and ``CSRF_COOKIE_SAMESITE`` must be
+    set to ``Lax`` or ``Strict``. ``None`` (the cross-site shape) is
+    only safe when paired with Secure, and bare unset would also fall
+    back to browser defaults that vary by version.
+  - ``SECURE_SSL_REDIRECT`` must be truthy in production posture so
+    plaintext clients are bounced to https before any cookie work.
+  - ``SECURE_HSTS_SECONDS`` must be non-zero so a returning client
+    can't be downgraded back to http on a hostile network.
+  - ``CORS_ALLOWED_ORIGINS`` and ``CSRF_TRUSTED_ORIGINS`` must not
+    contain ``*`` (the trust-anyone shape).
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .base import Issue, SafetyCheck
+
+SAFE_SAMESITE_VALUES = frozenset({"Lax", "Strict"})
+
+
+class CookiesCSRFCORSCheck(SafetyCheck):
+    """Validate session/CSRF cookie hardening + CORS origin allowlists."""
+
+    category = "cookies_csrf_cors"
+
+    def run(self, settings) -> Iterable[Issue]:
+        yield from self._check_cookie_secure(settings, "SESSION_COOKIE_SECURE")
+        yield from self._check_cookie_secure(settings, "CSRF_COOKIE_SECURE")
+        yield from self._check_samesite(settings, "SESSION_COOKIE_SAMESITE")
+        yield from self._check_samesite(settings, "CSRF_COOKIE_SAMESITE")
+        yield from self._check_ssl_redirect(settings)
+        yield from self._check_hsts(settings)
+        yield from self._check_wildcard_origins(settings, "CORS_ALLOWED_ORIGINS")
+        yield from self._check_wildcard_origins(settings, "CSRF_TRUSTED_ORIGINS")
+
+    def _check_cookie_secure(self, settings, name: str) -> Iterable[Issue]:
+        if not getattr(settings, name, False):
+            yield Issue(
+                category=self.category,
+                key=name,
+                reason=(
+                    f"{name} must be True in production — plaintext cookies "
+                    "break the secure-by-default deploy contract."
+                ),
+            )
+
+    def _check_samesite(self, settings, name: str) -> Iterable[Issue]:
+        value = getattr(settings, name, None)
+        if value not in SAFE_SAMESITE_VALUES:
+            # We don't print the actual value because a misconfigured
+            # SAMESITE could in theory be set to something operator-
+            # specific. Naming the safe set is enough to remediate.
+            yield Issue(
+                category=self.category,
+                key=name,
+                reason=(
+                    f"{name} must be 'Lax' or 'Strict'. Other values fall back "
+                    "to browser defaults that vary by vendor + version."
+                ),
+            )
+
+    def _check_ssl_redirect(self, settings) -> Iterable[Issue]:
+        if not getattr(settings, "SECURE_SSL_REDIRECT", False):
+            yield Issue(
+                category=self.category,
+                key="SECURE_SSL_REDIRECT",
+                reason=(
+                    "SECURE_SSL_REDIRECT must be True in production so "
+                    "plaintext clients are bounced to https before cookies work."
+                ),
+            )
+
+    def _check_hsts(self, settings) -> Iterable[Issue]:
+        seconds = getattr(settings, "SECURE_HSTS_SECONDS", 0) or 0
+        try:
+            seconds = int(seconds)
+        except (TypeError, ValueError):
+            seconds = 0
+        if seconds <= 0:
+            yield Issue(
+                category=self.category,
+                key="SECURE_HSTS_SECONDS",
+                reason=(
+                    "SECURE_HSTS_SECONDS must be > 0 in production so a "
+                    "returning client can't be downgraded to http."
+                ),
+            )
+
+    def _check_wildcard_origins(self, settings, name: str) -> Iterable[Issue]:
+        origins = list(getattr(settings, name, None) or [])
+        # CSRF_TRUSTED_ORIGINS / CORS_ALLOWED_ORIGINS may be a string in
+        # some configs; normalize to a list. We never print the values
+        # themselves — origins can be operator-specific (internal hosts,
+        # vendor URLs) and shouldn't show up in container logs.
+        if isinstance(origins, str):
+            origins = [origins]
+        if any(o.strip() == "*" for o in origins):
+            yield Issue(
+                category=self.category,
+                key=name,
+                reason=f"{name} must not contain '*' (the trust-anyone shape).",
+            )

--- a/backend/config/validators/registry.py
+++ b/backend/config/validators/registry.py
@@ -6,8 +6,10 @@ etc. by importing and appending.
 
 from __future__ import annotations
 
+from .cookies import CookiesCSRFCORSCheck
 from .django_core import DjangoCoreCheck
 
 CHECKS = [
     DjangoCoreCheck(),
+    CookiesCSRFCORSCheck(),
 ]


### PR DESCRIPTION
Second slice of #455. Extends the framework from #715 (gh-710) with a new \`CookiesCSRFCORSCheck\` and registers it in \`validators/registry.py\`.

## Covers
- \`SESSION_COOKIE_SECURE\` / \`CSRF_COOKIE_SECURE\` must be truthy
- \`SESSION_COOKIE_SAMESITE\` / \`CSRF_COOKIE_SAMESITE\` must be \`Lax\` or \`Strict\` (case-sensitive — \`None\` falls back to varying browser defaults; \`lax\`/\`STRICT\` are likely typos that won't be honored by Django)
- \`SECURE_SSL_REDIRECT\` must be truthy
- \`SECURE_HSTS_SECONDS\` must be > 0 (coerced from string for env-var shapes; bad string also fails)
- \`CORS_ALLOWED_ORIGINS\` and \`CSRF_TRUSTED_ORIGINS\` must not contain \`*\`; string-form \`CSRF_TRUSTED_ORIGINS\` normalized to a list before the check

## Framework upkeep
Extracted \`_PROD_GOOD_SETTINGS\` in the gh-710 tests so happy-path command-level tests pick up new categories by updating one constant instead of editing every test. Future slices (#712 credentials) update the same dict.

## Test plan
- [x] 30 new \`TestCookies*\` cases + 7 reused command-level cases now running against the fuller baseline
- [x] \`pytest config/ -q --no-cov\` — 231 passed, 101 skipped
- [x] \`pre-commit\` clean
- [ ] CI green

Fixes #711. Slice of #455.