### PR TITLE
feat(config): external-credential placeholder detection (gh-712)

### DIFF
--- a/backend/config/tests/test_validate_production.py
+++ b/backend/config/tests/test_validate_production.py
@@ -38,6 +38,10 @@ _PROD_GOOD_SETTINGS = dict(
     SECURE_HSTS_SECONDS=3600,
     CORS_ALLOWED_ORIGINS=["https://oms.example.com"],
     CSRF_TRUSTED_ORIGINS=["https://oms.example.com"],
+    # gh-712: settings.py ships FORGEKEY_SHARED_SECRET with the
+    # "change-me-in-production" default. The credential check skips
+    # empty values; clear it for the happy-path baseline.
+    FORGEKEY_SHARED_SECRET="",
 )
 
 

--- a/backend/config/tests/test_validate_production_credentials.py
+++ b/backend/config/tests/test_validate_production_credentials.py
@@ -1,0 +1,117 @@
+"""Tests for the CredentialPlaceholderCheck (gh-712 of #455)."""
+
+from __future__ import annotations
+
+import pytest
+
+from config.validators import Issue
+from config.validators.credentials import KNOWN_CREDENTIALS, CredentialPlaceholderCheck
+
+
+class _Bag:
+    """Minimal stand-in for settings; only attributes the check reads matter."""
+
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def _issues(**settings_kw) -> list[Issue]:
+    return list(CredentialPlaceholderCheck().run(_Bag(**settings_kw)))
+
+
+class TestEmptyValues:
+    def test_all_empty_passes(self):
+        # Empty is acceptable — the dependent feature surfaces an
+        # unconfigured state at runtime (e.g. ForgeKey provisioning
+        # returns 401 server_unconfigured).
+        bag = {name: "" for name in KNOWN_CREDENTIALS}
+        assert _issues(**bag) == []
+
+    def test_settings_missing_attr_passes(self):
+        # Production deploys may not even set some keys (the
+        # `config()` default kicks in). Same effect as empty.
+        assert _issues() == []
+
+
+class TestPlaceholderDetection:
+    @pytest.mark.parametrize(
+        "credential_name",
+        [
+            "SENTRY_DSN",
+            "FORGEKEY_PROVISIONING_TOKEN",
+            "FORGEKEY_SHARED_SECRET",
+            "POSTMARK_SERVER_TOKEN",
+            "EMQX_API_KEY",
+            "EMQX_API_SECRET",
+            "POSTMARK_INBOUND_TOKEN",
+            "LOCATION_PING_TOKEN",
+            "FORGEKEY_WEBHOOK_SECRET",
+            "FORGEKEY_CA_KEY_ENCRYPTION_KEY",
+            "WHMCS_API_SECRET",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "change-me-in-production",
+            "changeme-now",
+            "placeholder-value",
+            "your-secret-here",
+            "REPLACE-ME-IN-PROD",
+            "django-insecure-still-default",
+        ],
+    )
+    def test_placeholder_value_fails(self, credential_name, value):
+        issues = _issues(**{credential_name: value})
+        assert any(
+            i.key == credential_name and "placeholder" in i.reason.lower() for i in issues
+        ), [(i.key, i.reason) for i in issues]
+
+    def test_real_value_passes(self):
+        # A real-looking token: random, no fragment match, mixed
+        # case. None of the documented PLACEHOLDER_FRAGMENTS appear
+        # so this should not trip any check.
+        bag = {name: "Z9k4mPq1WnXr7bLs2Yv8Hg5Tj0AcFd6E" for name in KNOWN_CREDENTIALS}
+        assert _issues(**bag) == []
+
+    def test_pem_value_passes(self):
+        # FORGEKEY_JWT_SIGNING_KEY ships as a PEM block — no
+        # PLACEHOLDER_FRAGMENTS appears in a real key.
+        pem = (
+            "-----BEGIN EC PRIVATE KEY-----\n"
+            "MHcCAQEEIPL3qZ6mYJ4kFn3lQwGTHFq3yJh3K1nPwRMVxYBjFmuPoAoGCCqGSM49\n"
+            "AwEHoUQDQgAEnRkY4u7P2T0K0aXNqXf3R5R9XwGmFqK7v8j8NfHd7nLM6QnGfGvR\n"
+            "0w4eJzVy8Bv5Q4WiRtZmL3rPyAB+kk5JaQ==\n"
+            "-----END EC PRIVATE KEY-----"
+        )
+        assert _issues(FORGEKEY_JWT_SIGNING_KEY=pem, FORGEKEY_FIRMWARE_SIGNING_KEY=pem) == []
+
+
+class TestReportingShape:
+    def test_one_issue_per_setting_even_with_multiple_fragments(self):
+        # "change-me-placeholder" contains both 'change-me' AND 'placeholder'.
+        # We only want one Issue per setting — surface the first match and
+        # stop, so the report stays readable.
+        issues = _issues(SENTRY_DSN="change-me-placeholder")
+        sentry_issues = [i for i in issues if i.key == "SENTRY_DSN"]
+        assert len(sentry_issues) == 1
+
+    def test_multiple_settings_each_get_their_own_issue(self):
+        # Two different placeholdered settings should produce two
+        # separate Issues so the operator sees both in one run.
+        issues = _issues(
+            SENTRY_DSN="placeholder-dsn",
+            FORGEKEY_SHARED_SECRET="change-me-in-production",
+        )
+        keys = {i.key for i in issues}
+        assert "SENTRY_DSN" in keys
+        assert "FORGEKEY_SHARED_SECRET" in keys
+
+    def test_secret_value_never_in_reason(self):
+        # The reason may name the matched FRAGMENT (public) but
+        # never the operator's full chosen string.
+        marker = "totally-unique-marker-string"
+        leaky = f"change-me-{marker}-padding"
+        issues = _issues(SENTRY_DSN=leaky)
+        assert all(marker not in i.reason for i in issues), [i.reason for i in issues]

--- a/backend/config/validators/credentials.py
+++ b/backend/config/validators/credentials.py
@@ -1,0 +1,84 @@
+"""External-credential placeholder detection (gh-712 of #455).
+
+Third category in the runtime production-safety validator. Walks the
+list of known credential settings and fails the deploy if any of them
+contains a documented placeholder fragment (e.g. ``change-me-in-
+production``, ``placeholder``, ``replace-me``).
+
+The settings checked here are the ones with operator-meaningful
+credential semantics — empty is acceptable when the corresponding
+feature is gated off, but a placeholder is always wrong. Empty values
+do not fail this check (they would surface as a runtime issue with
+the dependent feature, e.g. ForgeKey provisioning returning 401
+server_unconfigured per the ``apps.py`` startup banner).
+
+Naming notes — the gh-712 issue body referenced canonical Django/SMTP
+names (``EMAIL_HOST_PASSWORD``, ``EMQX_USERNAME``, etc.), but OMS uses
+Anymail + Postmark instead of raw SMTP and EMQX API keys instead of
+basic-auth credentials. The check uses the actual setting names from
+``backend/config/settings.py``. Frontend ``REACT_APP_SENTRY_DSN`` is a
+build-time env var, not a Django setting — it's covered by the shell
+``scripts/validate-prod-env.sh`` already.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .base import Issue, SafetyCheck
+from .django_core import PLACEHOLDER_FRAGMENTS
+
+# Credentials we always check for placeholder values when the operator
+# has set them. Empty is acceptable here (the dependent feature self-
+# reports unconfigured); a placeholder is always a misconfiguration.
+KNOWN_CREDENTIALS: tuple[str, ...] = (
+    # Observability
+    "SENTRY_DSN",
+    # ForgeKey
+    "FORGEKEY_PROVISIONING_TOKEN",
+    "FORGEKEY_SHARED_SECRET",
+    "FORGEKEY_JWT_SIGNING_KEY",
+    "FORGEKEY_FIRMWARE_SIGNING_KEY",
+    "FORGEKEY_WEBHOOK_SECRET",
+    "FORGEKEY_CA_KEY_ENCRYPTION_KEY",
+    "FORGEKEY_BUILDER_GITHUB_TOKEN",
+    # MQTT broker
+    "EMQX_API_KEY",
+    "EMQX_API_SECRET",
+    # Email + webhook tokens
+    "POSTMARK_SERVER_TOKEN",
+    "POSTMARK_INBOUND_TOKEN",
+    "LOCATION_PING_TOKEN",
+    # WHMCS integration for maker-box verification
+    "WHMCS_API_IDENTIFIER",
+    "WHMCS_API_SECRET",
+)
+
+
+class CredentialPlaceholderCheck(SafetyCheck):
+    """Flag credential settings still set to a documented placeholder."""
+
+    category = "credentials"
+
+    def run(self, settings) -> Iterable[Issue]:
+        for name in KNOWN_CREDENTIALS:
+            value = getattr(settings, name, None) or ""
+            if not value:
+                # Empty is fine — feature gates handle the
+                # unconfigured case at runtime.
+                continue
+            yield from self._check_value(name, value)
+
+    def _check_value(self, name: str, value: str) -> Iterable[Issue]:
+        lower = value.lower()
+        for fragment in PLACEHOLDER_FRAGMENTS:
+            if fragment in lower:
+                yield Issue(
+                    category=self.category,
+                    key=name,
+                    reason=(f"{name} contains placeholder fragment '{fragment}'."),
+                )
+                # One fail per setting; surface every problematic
+                # setting in the run, but not every fragment that
+                # matches within the same value.
+                return

--- a/backend/config/validators/registry.py
+++ b/backend/config/validators/registry.py
@@ -7,9 +7,11 @@ etc. by importing and appending.
 from __future__ import annotations
 
 from .cookies import CookiesCSRFCORSCheck
+from .credentials import CredentialPlaceholderCheck
 from .django_core import DjangoCoreCheck
 
 CHECKS = [
     DjangoCoreCheck(),
     CookiesCSRFCORSCheck(),
+    CredentialPlaceholderCheck(),
 ]


### PR DESCRIPTION
Third slice of #455. Extends the validator framework with \`CredentialPlaceholderCheck\` registered in \`validators/registry.py\`.

## Covers

Walks every known credential setting and fails if the operator still has a documented placeholder fragment (\`change-me\`, \`placeholder\`, \`your-secret-here\`, etc.) in the value. Empty is acceptable — the dependent feature surfaces its own unconfigured banner at startup.

- \`SENTRY_DSN\`
- ForgeKey: \`PROVISIONING_TOKEN\`, \`SHARED_SECRET\`, \`JWT_SIGNING_KEY\`, \`FIRMWARE_SIGNING_KEY\`, \`WEBHOOK_SECRET\`, \`CA_KEY_ENCRYPTION_KEY\`, \`BUILDER_GITHUB_TOKEN\`
- \`EMQX_API_KEY\`, \`EMQX_API_SECRET\`
- \`POSTMARK_SERVER_TOKEN\`, \`POSTMARK_INBOUND_TOKEN\`, \`LOCATION_PING_TOKEN\`
- \`WHMCS_API_IDENTIFIER\`, \`WHMCS_API_SECRET\`

## Design

- Reuses \`PLACEHOLDER_FRAGMENTS\` from \`django_core\` (single source of truth, also used by the SECRET_KEY check)
- One fail per setting so the report stays readable; multiple settings each get their own Issue
- Reasons name the matched fragment (public) but never the full operator value; tests assert the no-leak contract
- Naming: the gh-712 issue body referenced canonical Django/SMTP names; OMS uses Anymail+Postmark and EMQX API keys instead — the check uses the actual \`settings.py\` names. Frontend \`REACT_APP_SENTRY_DSN\` is a build-time env, already covered by \`scripts/validate-prod-env.sh\`.

## Test plan
- [x] 73 new \`TestCredential*\` cases — parametrized matrix over (credential × placeholder shape) + reporting-shape + no-leak contract
- [x] Happy-path baseline now clears \`FORGEKEY_SHARED_SECRET\` (settings.py default is \`change-me-in-production\`) — every gh-710/711 command-level test still passes
- [x] Full \`config/\` suite — 304 passed, 101 skipped
- [x] \`pre-commit\` clean
- [ ] CI green

Fixes #712. Slice of #455.