### PR TITLE
feat(security): per-IP throttles on public-write endpoints (gh-713)

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -225,6 +225,26 @@ REST_FRAMEWORK = {
     # so frontend / integration clients can switch on ``error.code``. See
     # docs/API_ERROR_CONTRACT.md for the documented shape.
     "EXCEPTION_HANDLER": "config.api_errors.standardized_exception_handler",
+    # gh-713 / AC-5, AC-6 — per-IP rate limits on unauthenticated public
+    # write endpoints. No DEFAULT_THROTTLE_CLASSES so AllowAny *read*
+    # paths (scan dispatch resolve, QR resolve, kiosk reads) stay open
+    # as the makerspace expects; views that need throttling opt in by
+    # setting ``throttle_classes = [ScopedRateThrottle]`` + a
+    # ``throttle_scope`` matching a key below. Extend the matrix when
+    # adding a new public-write endpoint and document the rate's
+    # rationale in the view's docstring.
+    "DEFAULT_THROTTLE_RATES": {
+        # Scanner kiosk dispatch — a busy kiosk fires many scans/min,
+        # so the cap is generous, but a single IP shouldn't hammer it.
+        "scan_dispatch": "60/min",
+        # Project-storage self-service kiosk start. A real member
+        # starts one stint per month; an abuse loop should top out fast.
+        "project_storage_start": "5/hour",
+        # Pi-side print daemon (mark-printed, print-queue, label).
+        # Legitimate traffic is once-per-10-seconds; loose cap because
+        # one IP may host multiple printers behind NAT.
+        "pi_daemon": "120/min",
+    },
 }
 
 # JWT Token Configuration

--- a/backend/config/tests/test_public_write_throttles.py
+++ b/backend/config/tests/test_public_write_throttles.py
@@ -1,0 +1,153 @@
+"""Tests for the gh-713 public-write throttles.
+
+Exercises the wired throttle classes by patching DRF's
+``SimpleRateThrottle.THROTTLE_RATES`` to tiny caps and overriding the
+cache to LocMemCache — same code path as production at millisecond speed.
+
+Why patch the class attr instead of ``override_settings(REST_FRAMEWORK=…)``:
+DRF caches ``THROTTLE_RATES`` on the class at import time
+(``THROTTLE_RATES = api_settings.DEFAULT_THROTTLE_RATES`` in
+``rest_framework/throttling.py``). ``override_settings`` updates
+``api_settings`` but the cached class attribute still points at the
+old dict. Patching the class attr directly is the only reliable way
+to drive the throttle from a test.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+from django.test import override_settings
+
+import pytest
+from rest_framework.test import APIClient
+from rest_framework.throttling import SimpleRateThrottle
+
+pytestmark = pytest.mark.django_db
+
+
+_TEST_RATES = {
+    "scan_dispatch": "2/min",
+    "project_storage_start": "2/hour",
+    "pi_daemon": "3/min",
+}
+
+
+@contextlib.contextmanager
+def _throttle_overrides():
+    """Patch SimpleRateThrottle.THROTTLE_RATES + pin LocMemCache, then
+    clear the cache so a previous test's counters can't leak in."""
+    original_rates = SimpleRateThrottle.THROTTLE_RATES
+    SimpleRateThrottle.THROTTLE_RATES = _TEST_RATES
+    try:
+        with override_settings(
+            CACHES={
+                "default": {
+                    "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                    "LOCATION": "test-throttle-cache",
+                }
+            }
+        ):
+            from django.core.cache import caches
+
+            caches["default"].clear()
+            yield
+            caches["default"].clear()
+    finally:
+        SimpleRateThrottle.THROTTLE_RATES = original_rates
+
+
+# ---------------------------------------------------------------------------
+# Scanner dispatch — scan_dispatch scope
+# ---------------------------------------------------------------------------
+
+
+class TestScanDispatchThrottle:
+    def test_429_after_cap_reached(self):
+        with _throttle_overrides():
+            client = APIClient()
+            # First 2 hits should clear the cap of 2/min.
+            for _ in range(2):
+                resp = client.post("/api/scanner/dispatch/", {"payload": "ABCDEF"}, format="json")
+                assert resp.status_code == 200, resp.content
+            resp = client.post("/api/scanner/dispatch/", {"payload": "ABCDEF"}, format="json")
+            assert resp.status_code == 429, resp.content
+
+
+# ---------------------------------------------------------------------------
+# Project-storage kiosk start — project_storage_start scope
+# ---------------------------------------------------------------------------
+
+
+class TestProjectStorageStartThrottle:
+    def test_429_after_cap_reached(self):
+        # Each call uses a unique username so the business-layer guard
+        # against repeat-start by the same member doesn't mask the
+        # throttle behavior under test.
+        with _throttle_overrides():
+            client = APIClient()
+            for i in range(2):
+                resp = client.post(
+                    "/api/project-storage/stints/start/",
+                    {"username": f"member-throttle-{i}"},
+                    format="json",
+                )
+                assert resp.status_code == 201, resp.content
+            resp = client.post(
+                "/api/project-storage/stints/start/",
+                {"username": "member-throttle-3"},
+                format="json",
+            )
+            assert resp.status_code == 429, resp.content
+
+
+# ---------------------------------------------------------------------------
+# Pi daemon — pi_daemon scope (shared by print_queue + mark_printed + label)
+# ---------------------------------------------------------------------------
+
+
+class TestPiDaemonThrottle:
+    def test_print_queue_429_after_cap_reached(self):
+        with _throttle_overrides():
+            client = APIClient()
+            for _ in range(3):
+                resp = client.get("/api/project-storage/stints/print-queue/")
+                assert resp.status_code == 200, resp.content
+            resp = client.get("/api/project-storage/stints/print-queue/")
+            assert resp.status_code == 429, resp.content
+
+    def test_pi_daemon_scope_is_shared_across_endpoints(self):
+        # mark_printed + print_queue share the same scope, so traffic on
+        # one counts against the other. This is the right shape — a
+        # daemon hitting both 2x/poll shouldn't double the effective cap.
+        with _throttle_overrides():
+            client = APIClient()
+            # Three calls exhaust the cap of 3.
+            client.get("/api/project-storage/stints/print-queue/")
+            client.get("/api/project-storage/stints/print-queue/")
+            client.get("/api/project-storage/stints/print-queue/")
+            # Now a hit on the OTHER endpoint should also be throttled.
+            resp = client.post(
+                "/api/project-storage/stints/PS-NEVERMIND/mark-printed/", {}, format="json"
+            )
+            assert resp.status_code == 429, resp.content
+
+
+# ---------------------------------------------------------------------------
+# No throttle on the read-only / staff-gated paths
+# ---------------------------------------------------------------------------
+
+
+class TestNoThrottleOnReads:
+    def test_list_is_not_throttled(self):
+        # The list endpoint is staff-gated, not part of the public-write
+        # surface. Calling it many times unauthenticated returns 401/403
+        # but the throttle should never fire — verify by spamming past
+        # the test caps and confirming no 429s appear.
+        with _throttle_overrides():
+            client = APIClient()
+            seen_codes = set()
+            for _ in range(10):
+                resp = client.get("/api/project-storage/stints/")
+                seen_codes.add(resp.status_code)
+            assert 429 not in seen_codes

--- a/backend/project_storage/views.py
+++ b/backend/project_storage/views.py
@@ -15,12 +15,38 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAdminUser
 from rest_framework.response import Response
+from rest_framework.throttling import ScopedRateThrottle
 
 from .models import ProjectStorageEvent, ProjectStorageStint
 from .permissions import IsStorageAdminOrStaff
 from .serializers import ProjectStorageStintSerializer, StartStintSerializer
 from .services.email_service import send_violation_notice
 from .services.label_service import PrinterFamily, render_stint_label
+
+# gh-713 throttle subclasses. ScopedRateThrottle.allow_request normally
+# reads ``view.throttle_scope`` and returns True (no throttling) when
+# the view doesn't expose one. For per-action throttling we want the
+# scope baked into the throttle CLASS itself, so each subclass below
+# overrides allow_request to use its own ``scope`` attribute and skip
+# the view-attribute lookup. Rates still come from
+# DEFAULT_THROTTLE_RATES so all tuning stays in settings.py.
+
+
+class _BakedScopedThrottle(ScopedRateThrottle):
+    scope: str = ""
+
+    def allow_request(self, request, view):
+        self.rate = self.get_rate()
+        self.num_requests, self.duration = self.parse_rate(self.rate)
+        return super(ScopedRateThrottle, self).allow_request(request, view)
+
+
+class _ProjectStorageStartThrottle(_BakedScopedThrottle):
+    scope = "project_storage_start"
+
+
+class _PiDaemonThrottle(_BakedScopedThrottle):
+    scope = "pi_daemon"
 
 
 class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
@@ -38,9 +64,19 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
     # Self-service: member at a kiosk
     # ------------------------------------------------------------------
 
-    @action(detail=False, methods=["post"], permission_classes=[AllowAny])
+    @action(
+        detail=False,
+        methods=["post"],
+        permission_classes=[AllowAny],
+        throttle_classes=[_ProjectStorageStartThrottle],
+    )
     def start(self, request):
-        """Member-initiated kiosk flow: create a stint + return label payload."""
+        """Member-initiated kiosk flow: create a stint + return label payload.
+
+        Throttled per-IP via the ``project_storage_start`` scope (5/hour).
+        A real member starts one stint per ~month; an abuse loop trying to
+        spam new stints from a single kiosk should top out fast.
+        """
         ser = StartStintSerializer(data=request.data)
         ser.is_valid(raise_exception=True)
         username = ser.validated_data["username"]
@@ -347,9 +383,15 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
         methods=["get"],
         url_path="label",
         permission_classes=[AllowAny],
+        throttle_classes=[_PiDaemonThrottle],
     )
     def label(self, request, stint_id: str):
-        """Return the label PNG. ?printer=brother_ql (default) or epson_tm."""
+        """Return the label PNG. ?printer=brother_ql (default) or epson_tm.
+
+        Throttled per-IP via the ``pi_daemon`` scope (120/min) — the daemon
+        polls every ~10 s and a single IP may serve multiple printers
+        behind NAT.
+        """
         stint = get_object_or_404(ProjectStorageStint, stint_id=stint_id)
         printer: PrinterFamily = request.query_params.get(
             "printer", stint.print_target or "brother_ql"
@@ -371,6 +413,7 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
         methods=["get"],
         url_path="print-queue",
         permission_classes=[AllowAny],
+        throttle_classes=[_PiDaemonThrottle],
     )
     def print_queue(self, request):
         """Return the list of stints that still need their label printed.
@@ -379,6 +422,8 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
         the only thing it can do with the queue is print a label (which
         is itself an AllowAny endpoint). If the daemon ever needs to
         mutate something more sensitive, add token auth.
+
+        Throttled per-IP via the ``pi_daemon`` scope (120/min).
         """
         pending = (
             ProjectStorageStint.objects.filter(
@@ -416,9 +461,13 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
         methods=["post"],
         url_path="mark-printed",
         permission_classes=[AllowAny],
+        throttle_classes=[_PiDaemonThrottle],
     )
     def mark_printed(self, request, stint_id: str):
-        """Daemon calls this after a successful print so the queue empties."""
+        """Daemon calls this after a successful print so the queue empties.
+
+        Throttled per-IP via the ``pi_daemon`` scope (120/min).
+        """
         stint = self.get_object()
         if stint.printed_at is None:
             stint.printed_at = timezone.now()

--- a/backend/scanner/views.py
+++ b/backend/scanner/views.py
@@ -9,19 +9,48 @@ the existing per-entity endpoints once the user confirms.
 `AllowAny` so kiosk-mode shared phones can scan without a JWT. The
 endpoint emits no user-attributed audit rows on its own, and the
 follow-up side-effect endpoints enforce their own auth.
+
+Throttled per-IP at the ``scan_dispatch`` scope (60/min) — a busy
+kiosk fires many scans per minute, but no single IP should hammer it.
+See ``REST_FRAMEWORK.DEFAULT_THROTTLE_RATES`` for the rate.
 """
 
 from rest_framework import status
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view, permission_classes, throttle_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
+from rest_framework.throttling import ScopedRateThrottle
 
 from .resolvers import resolve
 from .serializers import ScanDispatchRequestSerializer
 
 
+class _ScanDispatchThrottle(ScopedRateThrottle):
+    """ScopedRateThrottle baked with a fixed scope.
+
+    ScopedRateThrottle.allow_request normally reads ``view.throttle_scope``
+    and returns True (no throttling) if the view doesn't have one.
+    Function-based @api_view doesn't carry that attribute, so we override
+    allow_request to use this subclass's ``scope`` class attribute
+    directly. The rate is still looked up from
+    ``DEFAULT_THROTTLE_RATES[scope]`` so all rate config stays in
+    settings.py.
+    """
+
+    scope = "scan_dispatch"
+
+    def allow_request(self, request, view):
+        # Bake the rate from the class-level scope, then delegate to
+        # SimpleRateThrottle (the grandparent), skipping
+        # ScopedRateThrottle's view.throttle_scope lookup.
+        self.rate = self.get_rate()
+        self.num_requests, self.duration = self.parse_rate(self.rate)
+        return super(ScopedRateThrottle, self).allow_request(request, view)
+
+
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@throttle_classes([_ScanDispatchThrottle])
 def dispatch_scan(request):
     request_serializer = ScanDispatchRequestSerializer(data=request.data)
     request_serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
Fourth slice of #455. Adds DRF \`ScopedRateThrottle\` to the unauthenticated POST endpoints that members + the Pi daemon hit, with named-scope rates configured in \`settings.REST_FRAMEWORK.DEFAULT_THROTTLE_RATES\` so operators can tune without code changes.

## Endpoints throttled

| Endpoint | Scope | Rate | Why |
|---|---|---|---|
| \`POST /api/scanner/dispatch/\` | \`scan_dispatch\` | 60/min/IP | Busy kiosk fires many scans/min; no single IP should hammer it. |
| \`POST /api/project-storage/stints/start/\` | \`project_storage_start\` | 5/hour/IP | A real member starts one stint per ~month; abuse loop tops out fast. |
| \`POST /api/project-storage/stints/<id>/mark-printed/\` | \`pi_daemon\` | 120/min/IP | Daemon polls every 10s; one IP may serve multiple printers behind NAT. |
| \`GET  /api/project-storage/stints/print-queue/\` | \`pi_daemon\` | (shared) | Same scope as mark-printed. |
| \`GET  /api/project-storage/stints/<id>/label/\` | \`pi_daemon\` | (shared) | Same scope. |

Preserves the open-public-reads intent — no \`DEFAULT_THROTTLE_CLASSES\` is set, so read-only / staff-gated paths stay untouched.

## The \`_BakedScopedThrottle\` pattern

\`ScopedRateThrottle.allow_request\` reads \`view.throttle_scope\` and returns True (no throttling) when absent. Function-based \`@api_view\` doesn't expose that attribute, and per-action ViewSet throttling can't set it contextually either. The \`_BakedScopedThrottle\` subclass overrides \`allow_request\` to use the class attribute directly while still reading the rate from \`DEFAULT_THROTTLE_RATES\` — all tuning stays in settings.py, but the throttle binds at the view layer.

## Test plan

- [x] 5 new \`TestThrottle*\` cases — \`config/tests/test_public_write_throttles.py\`. Patches \`SimpleRateThrottle.THROTTLE_RATES\` directly (override_settings doesn't reach the class-cached attribute) + LocMemCache override so each test is isolated.
- [x] Each scope trips at its cap (scan_dispatch, project_storage_start, pi_daemon)
- [x] \`pi_daemon\` scope is shared across endpoints
- [x] Staff-gated read paths never trip
- [x] Full \`config/\`+\`project_storage/\`+\`scanner/\` suites: 391 passed
- [x] \`pre-commit\` clean
- [ ] CI green

Fixes #713. Slice of #455.