### PR TITLE
feat(security): business-layer idempotency on project-storage start (gh-714)

### DIFF
--- a/backend/config/idempotency.py
+++ b/backend/config/idempotency.py
@@ -1,0 +1,69 @@
+"""Helpers for business-layer idempotency on public-write endpoints.
+
+When a kiosk QR scan or a phone form-submit retries on a flaky network,
+the second POST shouldn't surface as a 409 ("already exists") or a 500
+("duplicate key") — both look like errors to the member when the actual
+state already reflects what they wanted. This module gives endpoint
+authors a one-liner to recognize "this is a retry of a request we
+just accepted" and return the existing record with a 200 instead of
+either creating a duplicate or failing the second request.
+
+The dedup is *business-layer*: we match on the fields the operator
+would consider "the same submission" (e.g. username + project +
+location for a project-storage start), bounded by a short time window.
+That keeps the contract intuitive: same payload, same window → same
+record, 200. Different payload OR after the window → treated as a
+distinct request.
+
+Why not Idempotency-Key headers: the kiosk frontends don't generate
+them, and adding the header would require frontend churn for every
+public-write surface. Business-layer dedup catches the network-retry
+shape with zero client work. Headers can layer on top later if needed.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any, Optional
+
+from django.db.models import Model
+from django.utils import timezone
+
+DEFAULT_IDEMPOTENCY_WINDOW = timedelta(minutes=5)
+
+
+def find_recent_duplicate(
+    model: type[Model],
+    *,
+    lookup_fields: dict[str, Any],
+    window: timedelta = DEFAULT_IDEMPOTENCY_WINDOW,
+    created_at_field: str = "created_at",
+    now=None,
+) -> Optional[Model]:
+    """Return the most recent record matching ``lookup_fields`` within
+    ``window``, or None.
+
+    Use this BEFORE create()-ing a new row. If it returns a record, the
+    caller should return that record with 200 (a duplicate submit) rather
+    than creating a second row. If it returns None, proceed with the
+    normal create path.
+
+    Example:
+
+        existing = find_recent_duplicate(
+            ProjectStorageStint,
+            lookup_fields={
+                "username": payload["username"],
+                "project_title": payload.get("project_title", ""),
+                "storage_location_name": payload.get("storage_location_name", ""),
+                "removed_at__isnull": True,
+            },
+            created_at_field="started_at",
+        )
+        if existing:
+            return Response(serialize(existing), status=200)
+    """
+    now = now or timezone.now()
+    cutoff = now - window
+    qs = model.objects.filter(**lookup_fields, **{f"{created_at_field}__gte": cutoff})
+    return qs.order_by(f"-{created_at_field}").first()

--- a/backend/config/tests/test_idempotency.py
+++ b/backend/config/tests/test_idempotency.py
@@ -1,0 +1,89 @@
+"""Tests for the gh-714 ``find_recent_duplicate`` helper."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.utils import timezone
+
+import pytest
+
+from config.idempotency import DEFAULT_IDEMPOTENCY_WINDOW, find_recent_duplicate
+from project_storage.models import ProjectStorageStint
+from project_storage.tests.factories import ProjectStorageStintFactory
+
+pytestmark = pytest.mark.django_db
+
+
+class TestFindRecentDuplicate:
+    def test_matches_within_window(self):
+        stint = ProjectStorageStintFactory(username="alice")
+        match = find_recent_duplicate(
+            ProjectStorageStint,
+            lookup_fields={"username": "alice"},
+            created_at_field="started_at",
+        )
+        assert match is not None
+        assert match.id == stint.id
+
+    def test_misses_outside_window(self):
+        ProjectStorageStintFactory(
+            username="alice", started_at=timezone.now() - timedelta(hours=1)
+        )
+        match = find_recent_duplicate(
+            ProjectStorageStint,
+            lookup_fields={"username": "alice"},
+            created_at_field="started_at",
+        )
+        # Default 5-minute window — 1 hour ago is outside.
+        assert match is None
+
+    def test_returns_most_recent_when_multiple_match(self):
+        ProjectStorageStintFactory(
+            username="alice", started_at=timezone.now() - timedelta(minutes=2)
+        )
+        newer = ProjectStorageStintFactory(
+            username="alice", started_at=timezone.now() - timedelta(seconds=10)
+        )
+        match = find_recent_duplicate(
+            ProjectStorageStint,
+            lookup_fields={"username": "alice"},
+            created_at_field="started_at",
+        )
+        assert match.id == newer.id
+
+    def test_explicit_window_widens(self):
+        ProjectStorageStintFactory(
+            username="alice", started_at=timezone.now() - timedelta(minutes=30)
+        )
+        # Default 5-minute window misses.
+        assert (
+            find_recent_duplicate(
+                ProjectStorageStint,
+                lookup_fields={"username": "alice"},
+                created_at_field="started_at",
+            )
+            is None
+        )
+        # Explicit 1-hour window catches it.
+        match = find_recent_duplicate(
+            ProjectStorageStint,
+            lookup_fields={"username": "alice"},
+            created_at_field="started_at",
+            window=timedelta(hours=1),
+        )
+        assert match is not None
+
+    def test_lookup_fields_filter_correctly(self):
+        ProjectStorageStintFactory(username="alice", project_title="A")
+        # Same window, different project_title — no match.
+        match = find_recent_duplicate(
+            ProjectStorageStint,
+            lookup_fields={"username": "alice", "project_title": "B"},
+            created_at_field="started_at",
+        )
+        assert match is None
+
+    def test_default_window_constant(self):
+        # Document the default so a behavior change is visible.
+        assert DEFAULT_IDEMPOTENCY_WINDOW == timedelta(minutes=5)

--- a/backend/config/tests/test_idempotency.py
+++ b/backend/config/tests/test_idempotency.py
@@ -27,9 +27,7 @@ class TestFindRecentDuplicate:
         assert match.id == stint.id
 
     def test_misses_outside_window(self):
-        ProjectStorageStintFactory(
-            username="alice", started_at=timezone.now() - timedelta(hours=1)
-        )
+        ProjectStorageStintFactory(username="alice", started_at=timezone.now() - timedelta(hours=1))
         match = find_recent_duplicate(
             ProjectStorageStint,
             lookup_fields={"username": "alice"},

--- a/backend/project_storage/tests/test_start_idempotency.py
+++ b/backend/project_storage/tests/test_start_idempotency.py
@@ -42,14 +42,10 @@ def _payload(**overrides):
 
 class TestStartIdempotency:
     def test_duplicate_in_window_returns_existing_with_200(self, client):
-        first = client.post(
-            "/api/project-storage/stints/start/", _payload(), format="json"
-        )
+        first = client.post("/api/project-storage/stints/start/", _payload(), format="json")
         assert first.status_code == 201, first.content
 
-        second = client.post(
-            "/api/project-storage/stints/start/", _payload(), format="json"
-        )
+        second = client.post("/api/project-storage/stints/start/", _payload(), format="json")
         # Idempotent: returns the existing stint, not 409 active_stint_exists.
         assert second.status_code == 200, second.content
         assert second.json()["stint_id"] == first.json()["stint_id"]
@@ -125,8 +121,7 @@ class TestStartIdempotency:
             username="clear",
             project_title="Restore Schwinn",
             storage_location_name="Shelf A",
-            removed_at=timezone.now()
-            - timedelta(days=DEFAULT_REENTRY_COOLDOWN_DAYS + 1),
+            removed_at=timezone.now() - timedelta(days=DEFAULT_REENTRY_COOLDOWN_DAYS + 1),
         )
 
         resp = client.post(

--- a/backend/project_storage/tests/test_start_idempotency.py
+++ b/backend/project_storage/tests/test_start_idempotency.py
@@ -1,0 +1,139 @@
+"""Tests for the gh-714 idempotency on POST /project-storage/stints/start/.
+
+A second submit with the same payload inside the dedup window resolves
+to the EXISTING stint with HTTP 200, not a duplicate row and not a 409.
+After the window, the second submit either creates a new stint or fires
+the existing 409 active_stint_exists path — both are the correct shapes
+for distinct user intents.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.utils import timezone
+
+import pytest
+from rest_framework.test import APIClient
+
+from project_storage.models import ProjectStorageStint
+from project_storage.tests.factories import ProjectStorageStintFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+def _payload(**overrides):
+    base = {
+        "username": "newbie",
+        "first_name": "New",
+        "last_name": "Bie",
+        "email": "newbie@example.com",
+        "project_title": "Restore Schwinn",
+        "storage_location_name": "Shelf A",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestStartIdempotency:
+    def test_duplicate_in_window_returns_existing_with_200(self, client):
+        first = client.post(
+            "/api/project-storage/stints/start/", _payload(), format="json"
+        )
+        assert first.status_code == 201, first.content
+
+        second = client.post(
+            "/api/project-storage/stints/start/", _payload(), format="json"
+        )
+        # Idempotent: returns the existing stint, not 409 active_stint_exists.
+        assert second.status_code == 200, second.content
+        assert second.json()["stint_id"] == first.json()["stint_id"]
+
+        # And no duplicate row was created.
+        assert ProjectStorageStint.objects.filter(username="newbie").count() == 1
+
+    def test_different_project_title_is_not_a_duplicate(self, client):
+        first = client.post(
+            "/api/project-storage/stints/start/",
+            _payload(project_title="Restore Schwinn"),
+            format="json",
+        )
+        assert first.status_code == 201
+
+        # Different project_title — same member but a different stint
+        # intent. The standard 409 active_stint_exists path fires
+        # because the member already has an unresolved stint; we are
+        # NOT silently treating this as a duplicate.
+        second = client.post(
+            "/api/project-storage/stints/start/",
+            _payload(project_title="Different Project"),
+            format="json",
+        )
+        assert second.status_code == 409
+        assert second.json()["code"] == "active_stint_exists"
+
+    def test_different_username_is_not_a_duplicate(self, client):
+        first = client.post(
+            "/api/project-storage/stints/start/",
+            _payload(username="ada"),
+            format="json",
+        )
+        assert first.status_code == 201
+
+        second = client.post(
+            "/api/project-storage/stints/start/",
+            _payload(username="bob"),
+            format="json",
+        )
+        # Different member entirely — distinct row.
+        assert second.status_code == 201
+        assert second.json()["stint_id"] != first.json()["stint_id"]
+        assert ProjectStorageStint.objects.count() == 2
+
+    def test_stint_older_than_window_falls_back_to_409(self, client):
+        # An older stint (outside the dedup window, but still unresolved)
+        # is the legitimate "you already have an active stint" case —
+        # the member should be told to go talk to the warden, not
+        # silently get a 200 with the old stint.
+        ProjectStorageStintFactory(
+            username="busy",
+            started_at=timezone.now() - timedelta(hours=2),
+            project_title="Old Project",
+            storage_location_name="Shelf A",
+        )
+        resp = client.post(
+            "/api/project-storage/stints/start/",
+            _payload(username="busy", project_title="Different Now"),
+            format="json",
+        )
+        assert resp.status_code == 409
+        assert resp.json()["code"] == "active_stint_exists"
+
+    def test_same_payload_after_window_with_no_active_stint_creates_new(self, client):
+        # Member's prior stint is closed (removed) more than the cooldown
+        # ago, so a new submit should land cleanly. Just verifies that
+        # the dedup helper doesn't accidentally match against removed
+        # stints — those should be invisible to it.
+        from project_storage.models import DEFAULT_REENTRY_COOLDOWN_DAYS
+
+        old = ProjectStorageStintFactory(
+            username="clear",
+            project_title="Restore Schwinn",
+            storage_location_name="Shelf A",
+            removed_at=timezone.now()
+            - timedelta(days=DEFAULT_REENTRY_COOLDOWN_DAYS + 1),
+        )
+
+        resp = client.post(
+            "/api/project-storage/stints/start/",
+            _payload(username="clear"),
+            format="json",
+        )
+        assert resp.status_code == 201, resp.content
+        # Distinct stint ID from the old (removed) one.
+        assert resp.json()["stint_id"] != old.stint_id

--- a/backend/project_storage/views.py
+++ b/backend/project_storage/views.py
@@ -17,6 +17,8 @@ from rest_framework.permissions import AllowAny, IsAdminUser
 from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle
 
+from config.idempotency import find_recent_duplicate
+
 from .models import ProjectStorageEvent, ProjectStorageStint
 from .permissions import IsStorageAdminOrStaff
 from .serializers import ProjectStorageStintSerializer, StartStintSerializer
@@ -76,10 +78,39 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
         Throttled per-IP via the ``project_storage_start`` scope (5/hour).
         A real member starts one stint per ~month; an abuse loop trying to
         spam new stints from a single kiosk should top out fast.
+
+        Idempotent against network retries (gh-714): if the same member
+        submitted the same payload within the last 5 minutes, returns the
+        existing stint with HTTP 200 instead of failing with 409. The
+        "you already have an active stint" 409 still fires when the prior
+        stint is older than the window — that's the legitimate "go talk
+        to the warden" case.
         """
         ser = StartStintSerializer(data=request.data)
         ser.is_valid(raise_exception=True)
         username = ser.validated_data["username"]
+
+        # gh-714 idempotency: a duplicate submit within 5 minutes
+        # (network blip → kiosk retry) should resolve to the existing
+        # stint, not surface as a 409 error to the member.
+        existing = find_recent_duplicate(
+            ProjectStorageStint,
+            lookup_fields={
+                "username": username,
+                "project_title": ser.validated_data.get("project_title", ""),
+                "storage_location_name": ser.validated_data.get(
+                    "storage_location_name", ""
+                ),
+                "removed_at__isnull": True,
+                "moved_to_purgatory_at__isnull": True,
+            },
+            created_at_field="started_at",
+        )
+        if existing is not None:
+            return Response(
+                ProjectStorageStintSerializer(existing).data,
+                status=status.HTTP_200_OK,
+            )
 
         if ProjectStorageStint.member_has_active_stint(username):
             return Response(

--- a/backend/project_storage/views.py
+++ b/backend/project_storage/views.py
@@ -98,9 +98,7 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
             lookup_fields={
                 "username": username,
                 "project_title": ser.validated_data.get("project_title", ""),
-                "storage_location_name": ser.validated_data.get(
-                    "storage_location_name", ""
-                ),
+                "storage_location_name": ser.validated_data.get("storage_location_name", ""),
                 "removed_at__isnull": True,
                 "moved_to_purgatory_at__isnull": True,
             },


### PR DESCRIPTION
Fifth and final slice of #455. When a kiosk QR scan or phone form-submit retries on a flaky network, the second POST shouldn't surface as a 409 \`active_stint_exists\` — the actual state already reflects what the member wanted. Business-layer dedup catches the retry shape with zero client work.

## New helper

\`backend/config/idempotency.py\`:
- \`find_recent_duplicate(model, lookup_fields=..., window=..., created_at_field=...)\` returns the most recent matching row inside the window, or None. Callers check this before \`objects.create()\` and return the existing record with 200 on a hit.
- Default window: 5 minutes. Constant exported as \`DEFAULT_IDEMPOTENCY_WINDOW\` so a future tuning is one place.

## Wired into \`project_storage.start()\`

Before the existing 409 \`active_stint_exists\` branch:
- Look up an unresolved stint with matching \`username\` + \`project_title\` + \`storage_location_name\` within 5 min.
- Match → 200 with the existing stint (kiosk retry sees success).
- No match → existing 409 fires (legitimate \"you already have an unresolved stint, talk to the warden\" case for older stints).

## Scope notes

- Scanner dispatch endpoint is read-only (no writes), so no idempotency needed there.
- \`location_checkins\` feedback/report and other public QR-report endpoints are gated by the gh-713 throttle (5/hour caps) which partially mitigates duplicate submits but doesn't return the existing record on retry. The helper is generic — those can layer \`find_recent_duplicate\` on top in a follow-up if the warden surfaces duplicate-report noise (~5 lines per endpoint).

## Test plan

- [x] 5 cases in \`project_storage/tests/test_start_idempotency.py\`:
  - Duplicate-in-window → 200 + same stint_id
  - Different \`project_title\` still hits 409 (genuinely different intent)
  - Different member creates a distinct row
  - Stint older than window correctly returns 409
  - Removed stint doesn't block a clean restart (helper ignores resolved stints)
- [x] 6 unit cases in \`config/tests/test_idempotency.py\` for the helper
- [x] Full \`config/\` + \`project_storage/\` suites: 381 passed, 101 skipped
- [x] \`pre-commit\` clean
- [ ] CI green

Fixes #714. Closes #455 epic.