### PR TITLE
fix(config): safe-by-default values so the gh-711/712 checks pass on a vanilla prod deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -792,6 +792,13 @@ jobs:
           # would loop livez to https forever. The validator has its own
           # unit tests; the escape hatch is the right shape here.
           SKIP_PRODUCTION_VALIDATION=1
+          # The new safe-by-default values in settings.py (gh-720 follow-up)
+          # turn SSL_REDIRECT on whenever DEBUG=False. Override to 0/0 for
+          # this smoke since /api/health/livez/ is hit over plain http
+          # inside the backend container — a 301 to https would never
+          # complete.
+          SECURE_SSL_REDIRECT=0
+          SECURE_HSTS_SECONDS=0
           EOF
 
           # bootstrap_users for EMQX is normally rendered by deploy.sh; the

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -65,6 +65,23 @@ CSRF_TRUSTED_ORIGINS = config(
 # Trust X-Forwarded-Proto header from proxy to determine if request is HTTPS
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
+# HTTPS hardening defaults — secure-by-default when DEBUG is off, opt-out
+# is explicit via the env var. These two settings are validated by
+# config.validators.cookies (gh-711); shipping safe defaults means an
+# operator who doesn't set them still passes the entrypoint check and
+# gets a hardened deploy by default. The proxy header above means
+# SECURE_SSL_REDIRECT works correctly behind nginx without infinite
+# redirect loops.
+SECURE_SSL_REDIRECT = config("SECURE_SSL_REDIRECT", default=not DEBUG, cast=bool)
+# One year HSTS — same value Django's own deployment-checklist suggests.
+# Disabled (0) when DEBUG=True so local dev with a real domain doesn't
+# get its browser pinned to https.
+SECURE_HSTS_SECONDS = config(
+    "SECURE_HSTS_SECONDS",
+    default=0 if DEBUG else 31536000,
+    cast=int,
+)
+
 # Spool uploaded files larger than this to /tmp instead of holding them in
 # the gunicorn worker heap. Django's default (2.5 MiB) is fine for form posts
 # but lets a 3MP ESP32 device photo (5–10 MB) sit on the heap until the
@@ -591,8 +608,12 @@ EMQX_API_SECRET = config("EMQX_API_SECRET", default="")
 # Device JWTs are signed with ES256 (ECDSA P-256) so EMQX's JWT authenticator
 # can verify them by fetching the matching public key from /api/forgekey/jwks/.
 # The PEM may include literal "\n" newlines (env-friendly). FORGEKEY_SHARED_SECRET
-# is retained for legacy callers but unused by the JWT path.
-FORGEKEY_SHARED_SECRET = config("FORGEKEY_SHARED_SECRET", default="change-me-in-production")
+# is retained for legacy callers but unused by the JWT path. Default empty
+# rather than a "change-me-in-production" placeholder — the placeholder
+# string used to ship as the default but it trips the gh-712 credential
+# check on every prod deploy that doesn't override it. Empty is the right
+# unconfigured state since the JWT path is the active code path now.
+FORGEKEY_SHARED_SECRET = config("FORGEKEY_SHARED_SECRET", default="")
 
 # Low-battery threshold for XIAO ePaper PM-display panels — telemetry
 # reports below this percent emit a Sentry warning so ops can prep a


### PR DESCRIPTION
Follow-up to the #455 epic — the new entrypoint validator from gh-710/711/712 fails on a deploy to today's prod \`.env\` because three settings rely on Django defaults that don't match the safety baseline.

## Settings touched

| Setting | Before | After | Why |
|---|---|---|---|
| \`SECURE_SSL_REDIRECT\` | Not defined → Django default \`False\` | \`default=not DEBUG\` | gh-711 cookie check fails in prod. \`SECURE_PROXY_SSL_HEADER\` two lines above ensures no redirect loop behind nginx. |
| \`SECURE_HSTS_SECONDS\` | Not defined → \`0\` | \`default=0 if DEBUG else 31536000\` | gh-711 HSTS check fails. One-year matches Django's own deployment checklist. |
| \`FORGEKEY_SHARED_SECRET\` | \`default="change-me-in-production"\` | \`default=""\` | gh-712 credential check fails on the placeholder string. Setting is legacy (active path is the JWT key); empty is the right unconfigured state. |

Prod \`.env\` can override any of these; the defaults just keep the secure-by-default contract from the safety baseline coherent when an operator doesn't set them explicitly.

## Test plan
- [x] \`pytest config/ -q --no-cov\`: 315 passed, 101 skipped
- [x] \`pre-commit\` clean
- [ ] CI green
- [ ] Deploy to prod after merge