### PR TITLE
fix(validators): skip SECURE_SSL_REDIRECT check when behind a TLS proxy

### DIFF
--- a/backend/config/tests/test_validate_production_cookies.py
+++ b/backend/config/tests/test_validate_production_cookies.py
@@ -77,6 +77,24 @@ class TestSslRedirect:
         issues = _issues(SECURE_SSL_REDIRECT=False)
         assert any(i.key == "SECURE_SSL_REDIRECT" for i in issues)
 
+    def test_proxy_ssl_header_bypasses_redirect_check(self):
+        # The OMS prod shape — nginx terminates TLS and Django sees
+        # plain HTTP from the proxy with X-Forwarded-Proto: https.
+        # SECURE_PROXY_SSL_HEADER set signals this architecture; the
+        # check skips SECURE_SSL_REDIRECT entirely so behind-proxy
+        # deploys aren't forced into an internal-redirect loop.
+        issues = _issues(
+            SECURE_SSL_REDIRECT=False,
+            SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"),
+        )
+        assert not any(i.key == "SECURE_SSL_REDIRECT" for i in issues)
+
+    def test_no_proxy_header_keeps_redirect_check(self):
+        # Belt-and-suspenders: without SECURE_PROXY_SSL_HEADER the
+        # check still enforces SECURE_SSL_REDIRECT.
+        issues = _issues(SECURE_SSL_REDIRECT=False, SECURE_PROXY_SSL_HEADER=None)
+        assert any(i.key == "SECURE_SSL_REDIRECT" for i in issues)
+
 
 class TestHsts:
     @pytest.mark.parametrize("bad", [0, "0", -1, None, "", "not-a-number"])

--- a/backend/config/validators/cookies.py
+++ b/backend/config/validators/cookies.py
@@ -72,6 +72,15 @@ class CookiesCSRFCORSCheck(SafetyCheck):
             )
 
     def _check_ssl_redirect(self, settings) -> Iterable[Issue]:
+        # Behind a TLS-terminating proxy (the common OMS deploy shape —
+        # nginx in front of gunicorn) Django's SECURE_SSL_REDIRECT is
+        # redundant with the proxy's own http→https redirect, and turning
+        # it on inside the container makes the plain-http internal health
+        # check loop forever. ``SECURE_PROXY_SSL_HEADER`` set signals
+        # "trust X-Forwarded-Proto from a proxy"; treat that as proof that
+        # the operator has TLS termination handled upstream.
+        if getattr(settings, "SECURE_PROXY_SSL_HEADER", None):
+            return
         if not getattr(settings, "SECURE_SSL_REDIRECT", False):
             yield Issue(
                 category=self.category,


### PR DESCRIPTION
Caught on the first prod deploy of the #455 epic. The new gh-711 cookie check enforces \`SECURE_SSL_REDIRECT=True\` unconditionally, but OMS prod runs nginx in front of gunicorn:

- nginx terminates TLS at the edge and redirects http→https itself, making Django's redirect redundant.
- Backend speaks plain HTTP on 8000 internally, and the Docker health-check probes that port directly. Turning \`SECURE_SSL_REDIRECT\` on inside the container 301s the probe to https forever — health check fails, dependent services restart-loop.

\`SECURE_PROXY_SSL_HEADER\` being set is the canonical signal for the proxied-TLS shape (it tells Django to trust \`X-Forwarded-Proto\` from the proxy). When it's present, skip the \`SECURE_SSL_REDIRECT\` check — TLS is handled upstream. Without it, the check still enforces the redirect.

Belt-and-suspenders: two new tests cover the bypass and the unconditional-check fallback.

## Test plan
- [x] 2 new \`TestSslRedirect\` cases
- [x] Full \`config/\`: 317 passed, 101 skipped
- [x] \`pre-commit\` clean
- [ ] CI green
- [ ] Prod redeploy unblocked