### PR TITLE
docs(testing): fix Vitest reference + ratchet frontend coverage (gh-460)

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -90,19 +90,24 @@ Run unit and integration tests:
 npm run test:ci
 ```
 
-Run coverage with the configured Jest thresholds:
+Run coverage with the configured Vitest thresholds:
 
 ```bash
 npm run test:ci:coverage
 ```
 
-The current global Jest thresholds live in `frontend/package.json` under
-`jest.coverageThreshold.global`. They were set from the measured baseline on
-2026-05-20 (oms-8q38) and the file-level `collectCoverageFrom` exclusions are
-limited to the React bootstrap (`index.tsx`), web-vitals reporting, type
-declaration packages, and `.d.ts` files. Application pages and components are
-not excluded; raise the thresholds incrementally rather than excluding files
-that are merely undertested.
+The current global Vitest thresholds live in `frontend/vite.config.ts` under
+`test.coverage.thresholds` (provider: v8). They were set from the measured
+baseline on 2026-05-20 (oms-8q38) and the file-level `coverage.exclude` list
+is limited to `.d.ts` files, the React bootstrap (`index.tsx`), web-vitals
+reporting, and type declaration packages. Application pages and components
+are not excluded; raise the thresholds incrementally rather than excluding
+files that are merely undertested.
+
+When raising the thresholds, measure first (`npm run test:ci:coverage` shows
+the per-file + global percentages) and ratchet to `current - 1` so day-to-day
+fluctuation doesn't trip the gate. Update this doc + the values in
+`vite.config.ts` in the same PR so the rationale is captured.
 
 Build the production bundle:
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -98,11 +98,17 @@ const config: UserConfig & { test?: unknown } = {
         'src/reportWebVitals.ts',
         'src/types/**',
       ],
+      // Ratcheted 2026-06-09 (gh-460 follow-up) from
+      //   branches 35 / functions 33 / lines 40 / statements 39
+      // to current-1 of the measured baseline:
+      //   branches 41.57 / functions 37.9 / lines 47.23 / statements 46.18.
+      // The -1 buffer absorbs small per-PR fluctuation so the gate doesn't
+      // trip on a refactor that nudges a single percentage point down.
       thresholds: {
-        branches: 35,
-        functions: 33,
-        lines: 40,
-        statements: 39,
+        branches: 40,
+        functions: 36,
+        lines: 46,
+        statements: 45,
       },
     },
   },


### PR DESCRIPTION
Two long-tail items from the #460 epic that didn't ship in #474:

## docs/TESTING.md drift

The doc still says "Jest thresholds live in \`frontend/package.json\` under \`jest.coverageThreshold.global\`", but the project moved to Vitest at some point — thresholds now live in \`frontend/vite.config.ts\` under \`test.coverage.thresholds\`. Updated copy + added a "measure-first, ratchet to current-1" note for next time.

## Frontend coverage ratchet

The thresholds were the symbolic 35/33/40/39 set on 2026-05-20. Measured \`npm run test:ci:coverage\` baseline today is:

| Metric | Configured | Measured | Ratcheted to |
|---|---|---|---|
| Branches | 35 | 41.57 | 40 |
| Functions | 33 | 37.9 | 36 |
| Lines | 40 | 47.23 | 46 |
| Statements | 39 | 46.18 | 45 |

Ratchet is \`current - 1\` so day-to-day fluctuation doesn't trip the gate.

Backend pytest collection + \`--cov-fail-under=85\` remain in place from PR #474.

## Test plan
- [x] Coverage run passes the new thresholds locally
- [ ] CI green

Fixes #460.