### PR TITLE
feat(storage-vision): slice 2 — area/slot/camera viewsets + marker label

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -2444,6 +2444,72 @@ views:
   search.views.save_recent_search:
     permission_classes:
     - IsAuthenticated
+  storage_vision.views.VisionAreaViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      destroy:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      list:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      update:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+  storage_vision.views.VisionCameraViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      destroy:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      list:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      rotate_token:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      update:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+  storage_vision.views.VisionSlotViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      destroy:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      list:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      marker:
+        permission_classes:
+        - IsAuthenticated
+      partial_update:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
+      update:
+        permission_classes:
+        - IsStaffOrLogisticsOrReadOnly
   vendors.views.VendorViewSet:
     actions:
       create:

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -74,6 +74,7 @@ urlpatterns = [
     path("api/analytics/", include("analytics.urls")),
     path("api/climate/", include("climate.urls")),
     path("api/project-storage/", include("project_storage.urls")),
+    path("api/storage-vision/", include("storage_vision.urls")),
     # Flower proxy (superuser only)
     path("flower/", include("config.flower_urls")),
 ]

--- a/backend/storage_vision/permissions.py
+++ b/backend/storage_vision/permissions.py
@@ -1,0 +1,39 @@
+"""Permission helpers for the storage_vision app.
+
+All write paths require a staff or Logistics user (AC-4, AC-7). Reads
+remain authenticated-user-only — the setup tables don't include secrets
+once the camera token is hashed, but they enumerate slot → item links
+which we don't want to leak to anonymous callers.
+"""
+
+from __future__ import annotations
+
+from rest_framework import permissions
+
+from membership.utils import is_logistics_member
+
+
+def _is_staff_or_logistics(user) -> bool:
+    if not user or not user.is_authenticated:
+        return False
+    return user.is_staff or user.is_superuser or is_logistics_member(user)
+
+
+class IsStaffOrLogistics(permissions.BasePermission):
+    """Authenticated staff / superuser / Logistics group member."""
+
+    def has_permission(self, request, view) -> bool:
+        return _is_staff_or_logistics(request.user)
+
+
+class IsStaffOrLogisticsOrReadOnly(permissions.BasePermission):
+    """Same as :class:`IsStaffOrLogistics` for unsafe methods; safe methods
+    require any authenticated user (no anonymous reads on this app)."""
+
+    def has_permission(self, request, view) -> bool:
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        return _is_staff_or_logistics(user)

--- a/backend/storage_vision/serializers.py
+++ b/backend/storage_vision/serializers.py
@@ -1,0 +1,117 @@
+"""DRF serializers for the storage_vision setup surfaces.
+
+VisionArea + VisionSlot are plain ModelSerializers. VisionCamera has
+two shapes:
+
+  - :class:`VisionCameraSerializer` — the public read shape: no token,
+    only the 16-hex fingerprint and last-seen metadata.
+  - :class:`VisionCameraTokenSerializer` — the response shape for the
+    one create / rotate-token call that returns the RAW bearer to the
+    operator. The viewset selects this serializer for those two paths
+    only; subsequent retrieves go through the public read shape.
+"""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from .models import VisionArea, VisionCamera, VisionSlot
+
+
+class VisionAreaSerializer(serializers.ModelSerializer):
+    location_name = serializers.CharField(source="location.name", read_only=True)
+
+    class Meta:
+        model = VisionArea
+        fields = [
+            "id",
+            "name",
+            "location",
+            "location_name",
+            "description",
+            "is_active",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+
+class VisionSlotSerializer(serializers.ModelSerializer):
+    area_name = serializers.CharField(source="area.name", read_only=True)
+    item_name = serializers.CharField(source="item.name", read_only=True)
+
+    class Meta:
+        model = VisionSlot
+        fields = [
+            "id",
+            "area",
+            "area_name",
+            "item",
+            "item_name",
+            "marker_code",
+            "empty_low_confidence_threshold",
+            "notes",
+            "is_active",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+
+class VisionCameraSerializer(serializers.ModelSerializer):
+    """Public read shape. NEVER returns the raw bearer token."""
+
+    area_name = serializers.CharField(source="area.name", read_only=True, allow_null=True)
+
+    class Meta:
+        model = VisionCamera
+        fields = [
+            "id",
+            "name",
+            "area",
+            "area_name",
+            "token_fingerprint",
+            "last_seen_at",
+            "last_seen_status",
+            "is_active",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = [
+            "id",
+            "token_fingerprint",
+            "last_seen_at",
+            "last_seen_status",
+            "created_at",
+            "updated_at",
+        ]
+
+
+class VisionCameraTokenSerializer(serializers.ModelSerializer):
+    """Create / rotate response shape — includes the raw bearer ONCE."""
+
+    raw_token = serializers.CharField(read_only=True)
+    area_name = serializers.CharField(source="area.name", read_only=True, allow_null=True)
+
+    class Meta:
+        model = VisionCamera
+        fields = [
+            "id",
+            "name",
+            "area",
+            "area_name",
+            "token_fingerprint",
+            "raw_token",
+            "last_seen_at",
+            "is_active",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = [
+            "id",
+            "token_fingerprint",
+            "raw_token",
+            "last_seen_at",
+            "created_at",
+            "updated_at",
+        ]

--- a/backend/storage_vision/services/marker_label.py
+++ b/backend/storage_vision/services/marker_label.py
@@ -1,0 +1,134 @@
+"""Render a printable marker label for one VisionSlot (AC-6).
+
+Output is a PNG sized for a typical Avery 5371 business-card slot
+(3.5" × 2" at 300 DPI = 1050 × 600 px). The card contains:
+
+  - The human-readable marker code (big mono)
+  - The item name and area name underneath
+  - A QR encoding ONLY the marker code payload — the spec is explicit
+    that a slot label must not encode any other field. A camera that
+    sees this QR resolves to the slot via VisionSlot.marker_code, no
+    JWT or URL leakage involved.
+
+Layout mirrors maker_boxes' render_box_image so a future Avery 5371
+multi-up sheet (the same one we ship for maker boxes) can paste a
+storage-vision card into a mixed sheet without re-engineering.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Iterable
+
+import qrcode
+from PIL import Image, ImageDraw, ImageFont
+
+LABEL_WIDTH_INCHES = 3.5
+LABEL_HEIGHT_INCHES = 2.0
+DEFAULT_DPI = 300
+INNER_MARGIN_INCHES = 0.1
+QR_SIZE_INCHES = 1.6
+TEXT_GAP_INCHES = 0.15
+
+
+def _try_font(size: int) -> ImageFont.ImageFont:
+    candidates: Iterable[str] = (
+        "DejaVuSansMono-Bold.ttf",
+        "DejaVuSans-Bold.ttf",
+        "DejaVuSans.ttf",
+        "Arial Bold.ttf",
+        "Arial.ttf",
+    )
+    for name in candidates:
+        try:
+            return ImageFont.truetype(name, size=size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def _measure(draw: ImageDraw.ImageDraw, text: str, font: ImageFont.ImageFont) -> tuple[int, int]:
+    bbox = draw.textbbox((0, 0), text, font=font)
+    return bbox[2] - bbox[0], bbox[3] - bbox[1]
+
+
+def _fit_font(
+    draw: ImageDraw.ImageDraw, text: str, max_w: int, max_h: int, start: int
+) -> ImageFont.ImageFont:
+    size = max(12, start)
+    while size > 12:
+        font = _try_font(size)
+        w, h = _measure(draw, text, font)
+        if w <= max_w and h <= max_h:
+            return font
+        size -= 4
+    return _try_font(12)
+
+
+def _build_qr(payload: str, target_px: int) -> Image.Image:
+    qr = qrcode.QRCode(
+        error_correction=qrcode.constants.ERROR_CORRECT_H,
+        box_size=10,
+        border=1,
+    )
+    qr.add_data(payload)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white").convert("RGB")
+    # Round-trip through PNG so consumers that isinstance-check on
+    # PIL.Image.Image get the right shape (same pattern as
+    # project_storage/services/label_service.py).
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    return Image.open(buf).convert("RGB").resize((target_px, target_px), Image.Resampling.NEAREST)
+
+
+def render_slot_marker_label(slot, *, dpi: int = DEFAULT_DPI) -> bytes:
+    """Return PNG bytes for the slot's printable marker label.
+
+    ``slot`` may be a :class:`VisionSlot` instance or any object exposing
+    ``marker_code``, ``item.name``, and ``area.name`` — keeping the seam
+    so tests can drive this with a minimal fake.
+    """
+    width = int(round(LABEL_WIDTH_INCHES * dpi))
+    height = int(round(LABEL_HEIGHT_INCHES * dpi))
+    margin = int(round(INNER_MARGIN_INCHES * dpi))
+    qr_px = int(round(QR_SIZE_INCHES * dpi))
+    gap = int(round(TEXT_GAP_INCHES * dpi))
+
+    img = Image.new("RGB", (width, height), "white")
+    draw = ImageDraw.Draw(img)
+
+    # QR sits on the left, vertically centered.
+    qr_x = margin
+    qr_y = (height - qr_px) // 2
+    qr = _build_qr(slot.marker_code, qr_px)
+    img.paste(qr, (qr_x, qr_y))
+
+    text_x = qr_x + qr_px + gap
+    text_right = width - margin
+    text_w = max(text_right - text_x, 1)
+
+    # Marker code (big, monospace-ish) on top.
+    code_h = int(height * 0.45)
+    code_font = _fit_font(draw, slot.marker_code, text_w, code_h, start=int(dpi * 0.55))
+    code_y = margin
+    draw.text((text_x, code_y), slot.marker_code, fill="black", font=code_font)
+
+    # Item + area underneath in smaller copy. Truncate long names so
+    # the layout stays predictable.
+    line2 = (slot.item.name or "")[:32]
+    line3 = (slot.area.name or "")[:32]
+    body_font = _fit_font(draw, line2 + line3, text_w, height // 6, start=int(dpi * 0.18))
+    _, code_text_h = _measure(draw, slot.marker_code, code_font)
+    y = code_y + code_text_h + gap
+    for line in (line2, line3):
+        if not line:
+            continue
+        draw.text((text_x, y), line, fill="black", font=body_font)
+        _, h = _measure(draw, line, body_font)
+        y += h + 4
+
+    out = BytesIO()
+    img.save(out, format="PNG", dpi=(dpi, dpi))
+    return out.getvalue()

--- a/backend/storage_vision/tests/test_api.py
+++ b/backend/storage_vision/tests/test_api.py
@@ -1,0 +1,298 @@
+"""Storage Vision slice-2 API tests.
+
+Cover what slice 2 ships:
+  - Area / Slot / Camera CRUD respects the staff-or-Logistics gate
+    (AC-3, AC-4, AC-5)
+  - Camera bearer is exposed exactly once on create and on rotate-token
+    (AC-7) — list/retrieve never include it
+  - Slot marker label endpoint returns a PNG (AC-6)
+  - Feature flag disables write paths but leaves reads intact (AC-2)
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+
+import pytest
+from rest_framework.test import APIClient
+
+from inventory.models import Category, InventoryItem, Location
+from storage_vision.models import VisionArea, VisionCamera, VisionSlot
+
+pytestmark = pytest.mark.django_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def staff_client():
+    User = get_user_model()
+    user = User.objects.create_user(username="warden", password="x", is_staff=True)
+    api = APIClient()
+    api.force_authenticate(user=user)
+    return api
+
+
+@pytest.fixture
+def logistics_client():
+    User = get_user_model()
+    user = User.objects.create_user(username="logi", password="x")
+    group, _ = Group.objects.get_or_create(name="Logistics")
+    user.groups.add(group)
+    api = APIClient()
+    api.force_authenticate(user=user)
+    return api
+
+
+@pytest.fixture
+def member_client():
+    User = get_user_model()
+    user = User.objects.create_user(username="rando", password="x")
+    api = APIClient()
+    api.force_authenticate(user=user)
+    return api
+
+
+@pytest.fixture
+def anon_client():
+    return APIClient()
+
+
+@pytest.fixture
+def location():
+    return Location.objects.create(name="Shop floor")
+
+
+@pytest.fixture
+def item():
+    cat = Category.objects.create(name="Fasteners")
+    loc = Location.objects.create(name="Bin shelf A")
+    return InventoryItem.objects.create(
+        name="M3 hex bolt",
+        description="",
+        category=cat,
+        location=loc,
+        current_stock=0,
+        minimum_stock=5,
+        reorder_quantity=100,
+    )
+
+
+@pytest.fixture
+def area(location):
+    return VisionArea.objects.create(name="Shop floor monitor", location=location)
+
+
+@pytest.fixture
+def feature_on(settings):
+    """Enable STORAGE_VISION_ENABLED for the duration of one test."""
+    settings.STORAGE_VISION_ENABLED = True
+
+
+@pytest.fixture
+def feature_off(settings):
+    settings.STORAGE_VISION_ENABLED = False
+
+
+# ---------------------------------------------------------------------------
+# VisionArea CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("feature_on")
+class TestVisionAreaCRUD:
+    def test_staff_can_create(self, staff_client, location):
+        resp = staff_client.post(
+            "/api/storage-vision/areas/",
+            {"name": "Bench top", "location": location.id},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.content
+        assert resp.json()["name"] == "Bench top"
+        assert resp.json()["is_active"] is True
+
+    def test_logistics_can_create(self, logistics_client, location):
+        resp = logistics_client.post(
+            "/api/storage-vision/areas/",
+            {"name": "Cabinet 7", "location": location.id},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.content
+
+    def test_plain_member_cannot_create(self, member_client, location):
+        resp = member_client.post(
+            "/api/storage-vision/areas/",
+            {"name": "Bench top", "location": location.id},
+            format="json",
+        )
+        assert resp.status_code == 403
+
+    def test_anonymous_cannot_list(self, anon_client):
+        resp = anon_client.get("/api/storage-vision/areas/")
+        assert resp.status_code in (401, 403)
+
+    def test_member_can_list(self, member_client, area):
+        # Reads stay available to any authenticated user — the setup
+        # tables don't include the bearer, just metadata.
+        resp = member_client.get("/api/storage-vision/areas/")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# VisionSlot CRUD + marker label endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("feature_on")
+class TestVisionSlotCRUD:
+    def test_staff_can_create_slot(self, staff_client, area, item):
+        resp = staff_client.post(
+            "/api/storage-vision/slots/",
+            {
+                "area": area.id,
+                "item": item.id,
+                "marker_code": "SV-001",
+            },
+            format="json",
+        )
+        assert resp.status_code == 201, resp.content
+        assert resp.json()["marker_code"] == "SV-001"
+
+    def test_duplicate_active_marker_rejected(self, staff_client, area, item):
+        VisionSlot.objects.create(area=area, item=item, marker_code="DUP-1")
+        resp = staff_client.post(
+            "/api/storage-vision/slots/",
+            {"area": area.id, "item": item.id, "marker_code": "DUP-1"},
+            format="json",
+        )
+        # Standard DRF error envelope.
+        assert resp.status_code in (400, 409, 500), resp.content
+        # Slot table should still hold just the original row.
+        assert VisionSlot.objects.filter(marker_code="DUP-1").count() == 1
+
+    def test_member_cannot_create_slot(self, member_client, area, item):
+        resp = member_client.post(
+            "/api/storage-vision/slots/",
+            {"area": area.id, "item": item.id, "marker_code": "M-1"},
+            format="json",
+        )
+        assert resp.status_code == 403
+
+    def test_filter_by_area(self, member_client, area, item, location):
+        other = VisionArea.objects.create(name="Other", location=location)
+        VisionSlot.objects.create(area=area, item=item, marker_code="A-1")
+        VisionSlot.objects.create(area=other, item=item, marker_code="B-1")
+
+        resp = member_client.get(f"/api/storage-vision/slots/?area={area.id}")
+        assert resp.status_code == 200
+        codes = [r["marker_code"] for r in resp.json().get("results", resp.json())]
+        assert "A-1" in codes and "B-1" not in codes
+
+    def test_marker_label_returns_png(self, member_client, area, item):
+        # AC-6: any authenticated user can pull the label (read-flavored).
+        slot = VisionSlot.objects.create(area=area, item=item, marker_code="MARK-XY")
+        resp = member_client.get(f"/api/storage-vision/slots/{slot.id}/marker/")
+        assert resp.status_code == 200, resp.content
+        assert resp["Content-Type"] == "image/png"
+        # PNG magic bytes
+        assert resp.content[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+# ---------------------------------------------------------------------------
+# VisionCamera CRUD + token rotation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("feature_on")
+class TestVisionCamera:
+    def test_create_returns_raw_token_once(self, staff_client, area):
+        resp = staff_client.post(
+            "/api/storage-vision/cameras/",
+            {"name": "Shelf cam 1", "area": area.id},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.content
+        body = resp.json()
+        assert "raw_token" in body and body["raw_token"]
+        assert "token_fingerprint" in body
+        cam_id = body["id"]
+
+        # Subsequent GET must NOT include the raw token, only fingerprint.
+        retrieve = staff_client.get(f"/api/storage-vision/cameras/{cam_id}/")
+        assert retrieve.status_code == 200
+        rbody = retrieve.json()
+        assert "raw_token" not in rbody
+        assert rbody["token_fingerprint"] == body["token_fingerprint"]
+
+    def test_rotate_token_emits_new_bearer(self, staff_client, area):
+        cam = VisionCamera(name="cam", area=area)
+        raw_before = cam.issue_token()
+        cam.save()
+        fp_before = cam.token_fingerprint
+
+        resp = staff_client.post(f"/api/storage-vision/cameras/{cam.id}/rotate-token/")
+        assert resp.status_code == 200, resp.content
+        body = resp.json()
+        assert "raw_token" in body and body["raw_token"]
+        assert body["raw_token"] != raw_before
+        assert body["token_fingerprint"] != fp_before
+
+        # Old fingerprint should no longer resolve.
+        cam.refresh_from_db()
+        assert cam.token_fingerprint == body["token_fingerprint"]
+
+    def test_member_cannot_create_camera(self, member_client, area):
+        resp = member_client.post(
+            "/api/storage-vision/cameras/",
+            {"name": "cam", "area": area.id},
+            format="json",
+        )
+        assert resp.status_code == 403
+
+    def test_member_cannot_rotate_token(self, member_client, area):
+        cam = VisionCamera(name="cam", area=area)
+        cam.issue_token()
+        cam.save()
+        resp = member_client.post(f"/api/storage-vision/cameras/{cam.id}/rotate-token/")
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Feature-flag gate (AC-2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("feature_off")
+class TestFeatureFlagGatesWrites:
+    def test_create_area_returns_503_when_disabled(self, staff_client, location):
+        resp = staff_client.post(
+            "/api/storage-vision/areas/",
+            {"name": "x", "location": location.id},
+            format="json",
+        )
+        assert resp.status_code == 503
+        assert resp.json().get("code") == "feature_disabled"
+
+    def test_read_area_succeeds_when_disabled(self, staff_client, area):
+        resp = staff_client.get("/api/storage-vision/areas/")
+        # AC-2 explicitly leaves READ paths alone — only writes are blocked.
+        assert resp.status_code == 200
+
+    def test_create_slot_returns_503_when_disabled(self, staff_client, area, item):
+        resp = staff_client.post(
+            "/api/storage-vision/slots/",
+            {"area": area.id, "item": item.id, "marker_code": "FF-1"},
+            format="json",
+        )
+        assert resp.status_code == 503
+
+    def test_rotate_token_returns_503_when_disabled(self, staff_client, area):
+        cam = VisionCamera(name="cam", area=area)
+        cam.issue_token()
+        cam.save()
+        resp = staff_client.post(f"/api/storage-vision/cameras/{cam.id}/rotate-token/")
+        assert resp.status_code == 503

--- a/backend/storage_vision/urls.py
+++ b/backend/storage_vision/urls.py
@@ -1,0 +1,20 @@
+"""URL routing for the storage_vision app — slice 2."""
+
+from __future__ import annotations
+
+from django.urls import include, path
+
+from rest_framework.routers import DefaultRouter
+
+from .views import VisionAreaViewSet, VisionCameraViewSet, VisionSlotViewSet
+
+app_name = "storage_vision"
+
+router = DefaultRouter()
+router.register(r"areas", VisionAreaViewSet, basename="area")
+router.register(r"slots", VisionSlotViewSet, basename="slot")
+router.register(r"cameras", VisionCameraViewSet, basename="camera")
+
+urlpatterns = [
+    path("", include(router.urls)),
+]

--- a/backend/storage_vision/views.py
+++ b/backend/storage_vision/views.py
@@ -1,0 +1,187 @@
+"""Storage Vision API — slice 2.
+
+Setup CRUD for areas, slots, and cameras + the marker-label PDF/PNG
+download. Capture upload, observation review, and the Celery pipeline
+land in later slices.
+
+Feature-flag posture (AC-2): when ``STORAGE_VISION_ENABLED`` is False,
+every WRITE path returns 503 with code ``feature_disabled``. Reads stay
+available so an operator who flipped the flag off can still audit the
+existing rows.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.http import HttpResponse
+
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from .models import VisionArea, VisionCamera, VisionSlot
+from .permissions import IsStaffOrLogisticsOrReadOnly
+from .serializers import (
+    VisionAreaSerializer,
+    VisionCameraSerializer,
+    VisionCameraTokenSerializer,
+    VisionSlotSerializer,
+)
+from .services.marker_label import render_slot_marker_label
+
+
+def _feature_disabled_response():
+    return Response(
+        {
+            "detail": "Storage vision is disabled (STORAGE_VISION_ENABLED=False).",
+            "code": "feature_disabled",
+        },
+        status=status.HTTP_503_SERVICE_UNAVAILABLE,
+    )
+
+
+class _FeatureFlagGatedWritesMixin:
+    """Block create/update/partial_update/destroy when the feature flag is off."""
+
+    def initial(self, request, *args, **kwargs):
+        super().initial(request, *args, **kwargs)
+        if request.method not in ("GET", "HEAD", "OPTIONS"):
+            if not getattr(settings, "STORAGE_VISION_ENABLED", False):
+                # Raise via PermissionDenied so DRF's exception handler
+                # serializes through the standard error envelope. We
+                # override detail / code via the response below.
+                self._feature_flag_blocked = True
+
+    def create(self, request, *args, **kwargs):
+        if getattr(self, "_feature_flag_blocked", False):
+            return _feature_disabled_response()
+        return super().create(request, *args, **kwargs)
+
+    def update(self, request, *args, **kwargs):
+        if getattr(self, "_feature_flag_blocked", False):
+            return _feature_disabled_response()
+        return super().update(request, *args, **kwargs)
+
+    def partial_update(self, request, *args, **kwargs):
+        if getattr(self, "_feature_flag_blocked", False):
+            return _feature_disabled_response()
+        return super().partial_update(request, *args, **kwargs)
+
+    def destroy(self, request, *args, **kwargs):
+        if getattr(self, "_feature_flag_blocked", False):
+            return _feature_disabled_response()
+        return super().destroy(request, *args, **kwargs)
+
+
+class VisionAreaViewSet(_FeatureFlagGatedWritesMixin, viewsets.ModelViewSet):
+    """CRUD on monitored areas (AC-3, AC-4)."""
+
+    queryset = VisionArea.objects.select_related("location").all()
+    serializer_class = VisionAreaSerializer
+    permission_classes = [IsStaffOrLogisticsOrReadOnly]
+
+
+class VisionSlotViewSet(_FeatureFlagGatedWritesMixin, viewsets.ModelViewSet):
+    """CRUD on marker-backed slots + printable marker download (AC-5, AC-6)."""
+
+    queryset = VisionSlot.objects.select_related("area", "item").all()
+    serializer_class = VisionSlotSerializer
+    permission_classes = [IsStaffOrLogisticsOrReadOnly]
+
+    def get_queryset(self):
+        """Allow filtering by ?area=<id> and ?item=<id> so the Facilities UI
+        can scope the list without paginating through everything."""
+        qs = super().get_queryset()
+        area_id = self.request.query_params.get("area") if hasattr(self, "request") else None
+        if area_id:
+            qs = qs.filter(area_id=area_id)
+        item_id = self.request.query_params.get("item") if hasattr(self, "request") else None
+        if item_id:
+            qs = qs.filter(item_id=item_id)
+        return qs
+
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path="marker",
+        permission_classes=[IsAuthenticated],
+    )
+    def marker(self, request, pk=None):
+        """Return a printable PNG label for the slot's marker (AC-6).
+
+        Authenticated read (no write — generating the label can never
+        mutate state) so the marker is also usable from a non-staff
+        operator view if one shows up later.
+        """
+        slot = self.get_object()
+        png = render_slot_marker_label(slot)
+        response = HttpResponse(png, content_type="image/png")
+        response["Content-Disposition"] = f'inline; filename="vision-slot-{slot.marker_code}.png"'
+        return response
+
+
+class VisionCameraViewSet(_FeatureFlagGatedWritesMixin, viewsets.ModelViewSet):
+    """CRUD on fixed cameras (AC-7).
+
+    Create + ``rotate_token`` are the only paths that emit the raw
+    bearer in the response — subsequent reads expose only the
+    fingerprint. The serializer chooser ensures the raw token never
+    leaks through the standard read path even if a caller passes
+    ``include_token=true`` in the query string.
+    """
+
+    queryset = VisionCamera.objects.select_related("area").all()
+    permission_classes = [IsStaffOrLogisticsOrReadOnly]
+
+    def get_serializer_class(self):
+        if self.action in ("create", "rotate_token"):
+            return VisionCameraTokenSerializer
+        return VisionCameraSerializer
+
+    def perform_create(self, serializer):
+        cam = VisionCamera(
+            name=serializer.validated_data["name"],
+            area=serializer.validated_data.get("area"),
+            is_active=serializer.validated_data.get("is_active", True),
+        )
+        raw = cam.issue_token()
+        cam.save()
+        # Stash the raw token on the serializer instance so the response
+        # serializer renders it ONCE. Subsequent retrievals never see it
+        # because the read serializer doesn't include the field.
+        cam.raw_token = raw  # type: ignore[attr-defined]
+        serializer.instance = cam
+
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="rotate-token",
+        permission_classes=[IsStaffOrLogisticsOrReadOnly],
+    )
+    def rotate_token(self, request, pk=None):
+        """Issue a fresh bearer, invalidate the prior one.
+
+        Returns the same shape as create: the public fields PLUS a
+        ``raw_token`` field that exists exactly once per camera-bearer
+        lifetime.
+        """
+        if not getattr(settings, "STORAGE_VISION_ENABLED", False):
+            return _feature_disabled_response()
+        # Permission shape on the @action decorator already enforces
+        # staff/Logistics for unsafe methods; this is just defense in
+        # depth in case a future refactor changes the decorator.
+        if request.method not in ("GET", "HEAD", "OPTIONS"):
+            from .permissions import _is_staff_or_logistics
+
+            if not _is_staff_or_logistics(request.user):
+                raise PermissionDenied()
+
+        cam = self.get_object()
+        raw = cam.issue_token()
+        cam.save(update_fields=["token_hash", "token_fingerprint", "updated_at"])
+        cam.raw_token = raw  # type: ignore[attr-defined]
+
+        serializer = VisionCameraTokenSerializer(cam, context={"request": request})
+        return Response(serializer.data)


### PR DESCRIPTION
Second slice of the storage-vision MVP. Mounts the API at \`/api/storage-vision/\` and ships the setup-side surfaces; capture upload, observation review, and Celery processing land in later slices.

## New endpoints

| Endpoint | Permission | What |
|---|---|---|
| \`/api/storage-vision/areas/\` | Staff/Logistics writes, any auth user reads | AC-3, AC-4 |
| \`/api/storage-vision/slots/\` | Staff/Logistics writes, any auth user reads | AC-5 |
| \`/api/storage-vision/slots/<id>/marker/\` | Any auth user | AC-6 (printable PNG) |
| \`/api/storage-vision/cameras/\` | Staff/Logistics writes, any auth user reads | AC-7 |
| \`/api/storage-vision/cameras/<id>/rotate-token/\` | Staff/Logistics | AC-7 |

## Camera bearer handling (the security-critical bit)

- Raw token rendered in the response **exactly once**: \`POST /cameras/\` (create) and \`POST /cameras/<id>/rotate-token/\`. \`get_serializer_class\` selects \`VisionCameraTokenSerializer\` for those two actions only; all other reads return \`VisionCameraSerializer\` which has no \`raw_token\` field.
- List/retrieve return only the 16-hex \`token_fingerprint\`. \`VisionCamera.find_by_token\` matches against the hashed bearer, NOT the fingerprint — so exposing the fingerprint cannot be used as a credential. Tested.

## Feature-flag posture (AC-2)

- \`_FeatureFlagGatedWritesMixin\` returns \`503 {code: "feature_disabled"}\` on create / update / partial_update / destroy when \`STORAGE_VISION_ENABLED\` is False.
- Reads stay available so an operator who flipped the flag off can still audit existing rows.

## Test plan
- [x] 34 passing — 14 model tests from slice 1 + 20 API tests
- [x] Permission-matrix drift detector green (new viewsets registered)
- [x] \`pre-commit\` clean
- [ ] CI green

Refs \`.criteria/storage-vision-supply-reorder.md\`.