### PR TITLE
feat(storage_vision): capture upload + camera heartbeat (slice 3)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -746,32 +746,6 @@ views:
       update:
         permission_classes:
         - IsAuthenticatedOrReadOnly
-  forgekey.views.FirmwareBuildViewSet:
-    actions:
-      cancel:
-        permission_classes:
-        - IsAdminUser
-      create:
-        permission_classes:
-        - IsAdminUser
-      destroy:
-        permission_classes:
-        - IsAdminUser
-      list:
-        permission_classes:
-        - IsAdminUser
-      partial_update:
-        permission_classes:
-        - IsAdminUser
-      redispatch:
-        permission_classes:
-        - IsAdminUser
-      retrieve:
-        permission_classes:
-        - IsAdminUser
-      update:
-        permission_classes:
-        - IsAdminUser
   forgekey.views.EpaperFirmwareRolloutViewSet:
     actions:
       advance:
@@ -804,6 +778,32 @@ views:
       update:
         permission_classes:
         - IsAuthenticated
+  forgekey.views.FirmwareBuildViewSet:
+    actions:
+      cancel:
+        permission_classes:
+        - IsAdminUser
+      create:
+        permission_classes:
+        - IsAdminUser
+      destroy:
+        permission_classes:
+        - IsAdminUser
+      list:
+        permission_classes:
+        - IsAdminUser
+      partial_update:
+        permission_classes:
+        - IsAdminUser
+      redispatch:
+        permission_classes:
+        - IsAdminUser
+      retrieve:
+        permission_classes:
+        - IsAdminUser
+      update:
+        permission_classes:
+        - IsAdminUser
   forgekey.views.FirmwareRolloutViewSet:
     actions:
       advance:
@@ -2472,6 +2472,8 @@ views:
       destroy:
         permission_classes:
         - IsStaffOrLogisticsOrReadOnly
+      heartbeat:
+        permission_classes: []
       list:
         permission_classes:
         - IsStaffOrLogisticsOrReadOnly
@@ -2487,6 +2489,26 @@ views:
       update:
         permission_classes:
         - IsStaffOrLogisticsOrReadOnly
+  storage_vision.views.VisionCaptureViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsCameraOrStaffOrLogistics
+      destroy:
+        permission_classes:
+        - IsCameraOrStaffOrLogistics
+      list:
+        permission_classes:
+        - IsCameraOrStaffOrLogistics
+      partial_update:
+        permission_classes:
+        - IsCameraOrStaffOrLogistics
+      retrieve:
+        permission_classes:
+        - IsCameraOrStaffOrLogistics
+      update:
+        permission_classes:
+        - IsCameraOrStaffOrLogistics
   storage_vision.views.VisionSlotViewSet:
     actions:
       create:

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -438,6 +438,12 @@ STORAGE_VISION_ENABLED = config("STORAGE_VISION_ENABLED", default=False, cast=bo
 # (operator opt-in; not the default because hi-res JPEGs balloon the
 # media volume fast).
 STORAGE_VISION_RETENTION_DAYS = config("STORAGE_VISION_RETENTION_DAYS", default=30, cast=int)
+# Maximum bytes accepted per capture upload (AC-12). Modern phone JPEGs
+# land between 2–6 MB; 10 MB caps a misconfigured phone or a 30 MP
+# camera from flooding /tmp on the worker.
+STORAGE_VISION_MAX_UPLOAD_BYTES = config(
+    "STORAGE_VISION_MAX_UPLOAD_BYTES", default=10 * 1024 * 1024, cast=int
+)
 
 # Cache configuration
 CACHES = {

--- a/backend/storage_vision/authentication.py
+++ b/backend/storage_vision/authentication.py
@@ -1,0 +1,48 @@
+"""Camera-token authentication for storage-vision uploads (AC-10).
+
+A fixed camera authenticates via the ``X-Vision-Camera-Token`` header.
+The header value is the raw bearer that ``VisionCamera.issue_token``
+emitted exactly once when the camera was provisioned.
+
+DRF authentication contract:
+
+  - No header, or empty header → return None so the regular auth chain
+    (JWT, session) gets a chance. A staff user hitting this endpoint
+    from their phone with a JWT still authenticates normally.
+  - Header present but the token doesn't match an active camera →
+    raise AuthenticationFailed (401). We're explicit about the failure
+    rather than silently falling through, because a phone wouldn't
+    send this header by mistake.
+  - Header valid → return (AnonymousUser, VisionCamera). request.user
+    stays anonymous on purpose — cameras are not Users — but
+    request.auth carries the camera instance so the view layer can
+    attribute the capture.
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth.models import AnonymousUser
+
+from rest_framework import authentication, exceptions
+
+from .models import VisionCamera
+
+VISION_CAMERA_TOKEN_HEADER = "HTTP_X_VISION_CAMERA_TOKEN"
+
+
+class VisionCameraTokenAuthentication(authentication.BaseAuthentication):
+    """Resolves X-Vision-Camera-Token → VisionCamera (or fails 401)."""
+
+    def authenticate(self, request):
+        raw = request.META.get(VISION_CAMERA_TOKEN_HEADER, "").strip()
+        if not raw:
+            return None
+        camera = VisionCamera.find_by_token(raw)
+        if camera is None:
+            raise exceptions.AuthenticationFailed("Invalid camera token.")
+        return (AnonymousUser(), camera)
+
+    def authenticate_header(self, request):
+        # Returned in the WWW-Authenticate header on 401. Custom scheme
+        # so a phone reading this header knows it's a camera-only path.
+        return "X-Vision-Camera-Token"

--- a/backend/storage_vision/permissions.py
+++ b/backend/storage_vision/permissions.py
@@ -37,3 +37,20 @@ class IsStaffOrLogisticsOrReadOnly(permissions.BasePermission):
         if request.method in permissions.SAFE_METHODS:
             return True
         return _is_staff_or_logistics(user)
+
+
+class IsCameraOrStaffOrLogistics(permissions.BasePermission):
+    """Capture upload path (AC-9, AC-10, AC-11).
+
+    Accepts EITHER a valid camera bearer (request.auth is a VisionCamera —
+    set by :class:`VisionCameraTokenAuthentication`) OR a staff/Logistics
+    user. Everything else is rejected. Anonymous callers with no token
+    and no JWT can never write.
+    """
+
+    def has_permission(self, request, view) -> bool:
+        from .models import VisionCamera
+
+        if isinstance(request.auth, VisionCamera):
+            return True
+        return _is_staff_or_logistics(request.user)

--- a/backend/storage_vision/serializers.py
+++ b/backend/storage_vision/serializers.py
@@ -13,9 +13,16 @@ two shapes:
 
 from __future__ import annotations
 
+from io import BytesIO
+
+from django.conf import settings
+
+from PIL import Image, UnidentifiedImageError
 from rest_framework import serializers
 
-from .models import VisionArea, VisionCamera, VisionSlot
+from .models import VisionArea, VisionCamera, VisionCapture, VisionSlot
+
+ALLOWED_UPLOAD_CONTENT_TYPES = ("image/jpeg", "image/png")
 
 
 class VisionAreaSerializer(serializers.ModelSerializer):
@@ -115,3 +122,89 @@ class VisionCameraTokenSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
         ]
+
+
+class VisionCaptureSerializer(serializers.ModelSerializer):
+    """Read shape for an uploaded capture.
+
+    Slice-3 surface: includes the bookkeeping fields the frontend
+    polls for. The original_image URL is included so the review UI
+    (slice 5) can render the thumbnail without a second round trip;
+    we don't gate it behind extra auth because the staff/Logistics
+    reads gate the list endpoint upstream.
+    """
+
+    area_name = serializers.CharField(source="area.name", read_only=True)
+
+    class Meta:
+        model = VisionCapture
+        fields = [
+            "id",
+            "area",
+            "area_name",
+            "source",
+            "camera",
+            "uploaded_by",
+            "original_image",
+            "captured_at",
+            "received_at",
+            "status",
+            "processor_version",
+            "markers_detected",
+            "failure_reason",
+            "failure_code",
+            "queued_at",
+            "processing_at",
+            "processed_at",
+            "failed_at",
+        ]
+        read_only_fields = fields  # captures are write-once at create
+
+
+class VisionCaptureCreateSerializer(serializers.ModelSerializer):
+    """Write-side serializer for capture uploads (AC-9, AC-10, AC-12).
+
+    Source / camera / uploaded_by are stamped by the view from the
+    authenticated principal — never accepted from the request body.
+
+    ``area`` is declared optional here so a camera bound to an area
+    can omit it; the view falls back to camera.area in that case.
+    For phone uploads the view re-validates that area is present.
+    """
+
+    area = serializers.PrimaryKeyRelatedField(
+        queryset=VisionArea.objects.all(),
+        required=False,
+        allow_null=True,
+    )
+
+    class Meta:
+        model = VisionCapture
+        fields = ["area", "original_image", "captured_at"]
+
+    def validate_original_image(self, value):
+        max_bytes = getattr(settings, "STORAGE_VISION_MAX_UPLOAD_BYTES", 10 * 1024 * 1024)
+        size = getattr(value, "size", None)
+        if size is not None and size > max_bytes:
+            raise serializers.ValidationError(
+                f"Image exceeds the {max_bytes}-byte cap.",
+            )
+
+        # AC-12: file-system paths and raw exception traces must not
+        # leak. We do our own content-type + Pillow decode check and
+        # surface a stable, sanitized message.
+        content_type = getattr(value, "content_type", None)
+        if content_type and content_type not in ALLOWED_UPLOAD_CONTENT_TYPES:
+            raise serializers.ValidationError(
+                "Only JPEG or PNG uploads are accepted.",
+            )
+
+        try:
+            data = value.read()
+            value.seek(0)
+            Image.open(BytesIO(data)).verify()
+        except UnidentifiedImageError:
+            raise serializers.ValidationError("Image could not be decoded.")
+        except Exception:  # noqa: BLE001 — sanitize everything else
+            raise serializers.ValidationError("Image could not be decoded.")
+        return value

--- a/backend/storage_vision/tasks.py
+++ b/backend/storage_vision/tasks.py
@@ -1,0 +1,66 @@
+"""Storage Vision Celery tasks — slice 3 stub.
+
+The full marker-detection pipeline lands in slice 4 (AC-13, AC-14,
+AC-16). For now ``process_capture`` exists only so the upload view has
+something to call. It transitions the row through processing →
+processed without doing any inference; observations get created later
+when slice 4 fills in the OpenCV/Pillow body.
+
+Slice 3 ships this stub so the upload endpoint returns 202 cleanly
+(AC-9, AC-10) and the capture status state machine moves at all,
+giving the frontend (slice 8) something to poll on.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.utils import timezone
+
+from celery import shared_task
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(name="storage_vision.process_capture")
+def process_capture(capture_id: int) -> dict:
+    """Move the capture through processing → processed (no inference yet).
+
+    The slice-4 body will:
+      - load the original image via Pillow + decode with OpenCV
+      - run marker detection (QR pyzbar / OpenCV QRCodeDetector)
+      - match each detected marker payload against VisionSlot.marker_code
+      - create one VisionObservation per matched slot
+      - record unmatched markers in ``capture.markers_detected``
+
+    For now we just record the timestamps so the row doesn't sit in
+    ``queued`` forever and the polling frontend can stop waiting.
+    """
+    from .models import VisionCapture
+
+    try:
+        capture = VisionCapture.objects.get(pk=capture_id)
+    except VisionCapture.DoesNotExist:
+        logger.warning("process_capture: capture %s vanished before processing", capture_id)
+        return {"status": "missing"}
+
+    if capture.status != VisionCapture.STATUS_QUEUED:
+        logger.info(
+            "process_capture: capture %s already in status %s — no-op",
+            capture_id,
+            capture.status,
+        )
+        return {"status": capture.status}
+
+    now = timezone.now()
+    capture.status = VisionCapture.STATUS_PROCESSING
+    capture.processing_at = now
+    capture.save(update_fields=["status", "processing_at"])
+
+    # No-op body until slice 4. Mark processed so the state machine
+    # advances and the frontend can show "done".
+    capture.status = VisionCapture.STATUS_PROCESSED
+    capture.processed_at = timezone.now()
+    capture.processor_version = "slice3-stub"
+    capture.save(update_fields=["status", "processed_at", "processor_version"])
+    return {"status": capture.status, "id": capture_id}

--- a/backend/storage_vision/tests/test_capture.py
+++ b/backend/storage_vision/tests/test_capture.py
@@ -1,0 +1,353 @@
+"""Storage Vision slice-3 capture + heartbeat API tests.
+
+Covers AC-8 (camera heartbeat), AC-9 (phone capture upload via staff /
+Logistics JWT), AC-10 (camera capture upload via scoped bearer), AC-11
+(anonymous capture upload rejected), and AC-12 (capture validation:
+max size, JPEG/PNG only, Pillow-decodable, sanitized error messages).
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+import pytest
+from PIL import Image
+from rest_framework.test import APIClient
+
+from inventory.models import Location
+from storage_vision.authentication import VISION_CAMERA_TOKEN_HEADER
+from storage_vision.models import VisionArea, VisionCamera, VisionCapture
+
+pytestmark = pytest.mark.django_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def staff_client():
+    User = get_user_model()
+    user = User.objects.create_user(username="warden", password="x", is_staff=True)
+    api = APIClient()
+    api.force_authenticate(user=user)
+    return api
+
+
+@pytest.fixture
+def logistics_client():
+    User = get_user_model()
+    user = User.objects.create_user(username="logi", password="x")
+    group, _ = Group.objects.get_or_create(name="Logistics")
+    user.groups.add(group)
+    api = APIClient()
+    api.force_authenticate(user=user)
+    return api
+
+
+@pytest.fixture
+def member_client():
+    User = get_user_model()
+    user = User.objects.create_user(username="rando", password="x")
+    api = APIClient()
+    api.force_authenticate(user=user)
+    return api
+
+
+@pytest.fixture
+def anon_client():
+    return APIClient()
+
+
+@pytest.fixture
+def area():
+    location = Location.objects.create(name="Shop floor")
+    return VisionArea.objects.create(name="Bay 1", location=location)
+
+
+@pytest.fixture
+def camera(area):
+    cam = VisionCamera.objects.create(name="bay1-cam", area=area)
+    raw = cam.issue_token()
+    cam.save()
+    cam.raw_token = raw
+    return cam
+
+
+@pytest.fixture
+def feature_on(settings):
+    settings.STORAGE_VISION_ENABLED = True
+
+
+@pytest.fixture
+def feature_off(settings):
+    settings.STORAGE_VISION_ENABLED = False
+
+
+def _jpeg_bytes(size=(64, 64), color=(120, 120, 120)) -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", size, color).save(buf, format="JPEG", quality=70)
+    return buf.getvalue()
+
+
+def _png_bytes(size=(64, 64), color=(120, 120, 120)) -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", size, color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _upload(name="capture.jpg", content_type="image/jpeg", data=None) -> SimpleUploadedFile:
+    return SimpleUploadedFile(name, data if data is not None else _jpeg_bytes(), content_type)
+
+
+# ---------------------------------------------------------------------------
+# Capture upload — AC-9 / AC-10 / AC-11 / AC-12
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("feature_on")
+class TestCaptureUpload:
+    """AC-9, AC-10, AC-11, AC-12 — upload paths and validation."""
+
+    def test_phone_upload_by_staff_returns_202(self, staff_client, area):
+        with patch("storage_vision.views.process_capture.delay") as delay:
+            resp = staff_client.post(
+                "/api/storage-vision/captures/",
+                {"area": area.id, "original_image": _upload()},
+                format="multipart",
+            )
+        assert resp.status_code == 202, resp.content
+        body = resp.json()
+        assert body["source"] == VisionCapture.SOURCE_PHONE
+        assert body["camera"] is None
+        assert body["status"] == VisionCapture.STATUS_QUEUED
+        delay.assert_called_once_with(body["id"])
+
+    def test_phone_upload_by_logistics_returns_202(self, logistics_client, area):
+        with patch("storage_vision.views.process_capture.delay"):
+            resp = logistics_client.post(
+                "/api/storage-vision/captures/",
+                {
+                    "area": area.id,
+                    "original_image": _upload(content_type="image/png", data=_png_bytes()),
+                },
+                format="multipart",
+            )
+        assert resp.status_code == 202, resp.content
+        assert resp.json()["source"] == VisionCapture.SOURCE_PHONE
+
+    def test_phone_upload_by_member_rejected(self, member_client, area):
+        resp = member_client.post(
+            "/api/storage-vision/captures/",
+            {"area": area.id, "original_image": _upload()},
+            format="multipart",
+        )
+        assert resp.status_code == 403
+
+    def test_anonymous_upload_rejected(self, anon_client, area):
+        resp = anon_client.post(
+            "/api/storage-vision/captures/",
+            {"area": area.id, "original_image": _upload()},
+            format="multipart",
+        )
+        # AC-11: anonymous gets 401 from the auth chain (no auth header).
+        assert resp.status_code in (401, 403)
+        assert not VisionCapture.objects.exists()
+
+    def test_camera_upload_returns_202(self, anon_client, camera):
+        # Camera bearer is the ONLY credential — verifies AC-10 dual-auth.
+        with patch("storage_vision.views.process_capture.delay") as delay:
+            resp = anon_client.post(
+                "/api/storage-vision/captures/",
+                {"area": camera.area.id, "original_image": _upload()},
+                format="multipart",
+                **{VISION_CAMERA_TOKEN_HEADER: camera.raw_token},
+            )
+        assert resp.status_code == 202, resp.content
+        body = resp.json()
+        assert body["source"] == VisionCapture.SOURCE_CAMERA
+        assert body["camera"] == camera.id
+        assert body["uploaded_by"] is None
+        delay.assert_called_once()
+
+    def test_camera_upload_defaults_area_from_camera(self, anon_client, camera):
+        # AC-10: a camera bound to an area shouldn't need to spell out
+        # area=<id> on every upload.
+        with patch("storage_vision.views.process_capture.delay"):
+            resp = anon_client.post(
+                "/api/storage-vision/captures/",
+                {"original_image": _upload()},
+                format="multipart",
+                **{VISION_CAMERA_TOKEN_HEADER: camera.raw_token},
+            )
+        assert resp.status_code == 202, resp.content
+        assert resp.json()["area"] == camera.area.id
+
+    def test_invalid_camera_token_returns_401(self, anon_client, area):
+        resp = anon_client.post(
+            "/api/storage-vision/captures/",
+            {"area": area.id, "original_image": _upload()},
+            format="multipart",
+            **{VISION_CAMERA_TOKEN_HEADER: "not-a-real-token"},
+        )
+        assert resp.status_code == 401
+
+    def test_oversized_upload_rejected(self, staff_client, area, settings):
+        settings.STORAGE_VISION_MAX_UPLOAD_BYTES = 1024  # 1 KB cap
+        big = _jpeg_bytes(size=(512, 512))
+        assert len(big) > 1024
+        resp = staff_client.post(
+            "/api/storage-vision/captures/",
+            {"area": area.id, "original_image": _upload(data=big)},
+            format="multipart",
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        # AC-12: error must be sanitized — no filesystem paths or
+        # stack-trace residue.
+        message = str(body)
+        assert "Traceback" not in message
+        assert "/tmp" not in message
+        assert "1024" in message
+
+    def test_non_image_upload_rejected(self, staff_client, area):
+        bogus = SimpleUploadedFile("notes.txt", b"hello world", content_type="text/plain")
+        resp = staff_client.post(
+            "/api/storage-vision/captures/",
+            {"area": area.id, "original_image": bogus},
+            format="multipart",
+        )
+        assert resp.status_code == 400
+        message = str(resp.json())
+        # AC-12: no traceback residue or path leakage in the response.
+        assert "Traceback" not in message
+        assert "/tmp" not in message
+        assert "/app" not in message
+
+    def test_corrupt_jpeg_rejected(self, staff_client, area):
+        # Right content-type, but the bytes don't decode.
+        corrupt = SimpleUploadedFile(
+            "bad.jpg", b"\xff\xd8\xff\xe0garbage", content_type="image/jpeg"
+        )
+        resp = staff_client.post(
+            "/api/storage-vision/captures/",
+            {"area": area.id, "original_image": corrupt},
+            format="multipart",
+        )
+        assert resp.status_code == 400
+        message = str(resp.json())
+        # AC-12: any rejection wording is fine — what matters is no
+        # traceback / filesystem leakage.
+        assert "Traceback" not in message
+        assert "/tmp" not in message
+        assert "/app" not in message
+
+
+@pytest.mark.usefixtures("feature_off")
+class TestCaptureFeatureGate:
+    """AC-2: writes return 503 when the feature flag is off."""
+
+    def test_upload_returns_503_when_disabled(self, staff_client, area):
+        resp = staff_client.post(
+            "/api/storage-vision/captures/",
+            {"area": area.id, "original_image": _upload()},
+            format="multipart",
+        )
+        assert resp.status_code == 503
+        assert resp.json()["code"] == "feature_disabled"
+
+    def test_list_still_works_when_disabled(self, staff_client):
+        resp = staff_client.get("/api/storage-vision/captures/")
+        assert resp.status_code == 200
+
+
+@pytest.mark.usefixtures("feature_on")
+class TestCaptureList:
+    """Reads require staff/Logistics — a camera bearer can write but
+    not enumerate the queue."""
+
+    def test_member_cannot_list(self, member_client):
+        resp = member_client.get("/api/storage-vision/captures/")
+        assert resp.status_code == 403
+
+    def test_camera_cannot_list(self, anon_client, camera):
+        resp = anon_client.get(
+            "/api/storage-vision/captures/",
+            **{VISION_CAMERA_TOKEN_HEADER: camera.raw_token},
+        )
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Camera heartbeat — AC-8
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("feature_on")
+class TestCameraHeartbeat:
+    """AC-8: cameras stamp last_seen_at via their scoped bearer."""
+
+    def test_heartbeat_updates_last_seen(self, anon_client, camera):
+        assert camera.last_seen_at is None
+        resp = anon_client.post(
+            f"/api/storage-vision/cameras/{camera.id}/heartbeat/",
+            {"status": "ok", "queue_depth": 0},
+            format="json",
+            **{VISION_CAMERA_TOKEN_HEADER: camera.raw_token},
+        )
+        assert resp.status_code == 200, resp.content
+        camera.refresh_from_db()
+        assert camera.last_seen_at is not None
+        assert camera.last_seen_status == {"status": "ok", "queue_depth": 0}
+
+    def test_heartbeat_without_body_still_stamps(self, anon_client, camera):
+        resp = anon_client.post(
+            f"/api/storage-vision/cameras/{camera.id}/heartbeat/",
+            **{VISION_CAMERA_TOKEN_HEADER: camera.raw_token},
+        )
+        assert resp.status_code == 200
+        camera.refresh_from_db()
+        assert camera.last_seen_at is not None
+
+    def test_heartbeat_with_bad_token_returns_401(self, anon_client, camera):
+        resp = anon_client.post(
+            f"/api/storage-vision/cameras/{camera.id}/heartbeat/",
+            **{VISION_CAMERA_TOKEN_HEADER: "garbage"},
+        )
+        assert resp.status_code == 401
+        camera.refresh_from_db()
+        assert camera.last_seen_at is None
+
+    def test_heartbeat_without_token_returns_401(self, anon_client, camera):
+        # No bearer header at all — auth chain returns nothing, so the
+        # action's empty permission_classes still rejects via the view.
+        resp = anon_client.post(f"/api/storage-vision/cameras/{camera.id}/heartbeat/")
+        assert resp.status_code == 401
+
+    def test_heartbeat_rejects_jwt_user(self, staff_client, camera):
+        # AC-8: heartbeat is camera-bearer-ONLY. A staff JWT must not
+        # be able to fake liveness on the device's behalf.
+        resp = staff_client.post(f"/api/storage-vision/cameras/{camera.id}/heartbeat/")
+        assert resp.status_code == 401
+
+    def test_heartbeat_other_camera_404(self, anon_client, area):
+        # Camera A's bearer must not stamp camera B.
+        cam_a = VisionCamera.objects.create(name="a", area=area)
+        cam_a.raw_token = cam_a.issue_token()
+        cam_a.save()
+        cam_b = VisionCamera.objects.create(name="b", area=area)
+        cam_b.issue_token()
+        cam_b.save()
+        resp = anon_client.post(
+            f"/api/storage-vision/cameras/{cam_b.id}/heartbeat/",
+            **{VISION_CAMERA_TOKEN_HEADER: cam_a.raw_token},
+        )
+        assert resp.status_code == 404
+        cam_b.refresh_from_db()
+        assert cam_b.last_seen_at is None

--- a/backend/storage_vision/urls.py
+++ b/backend/storage_vision/urls.py
@@ -1,4 +1,4 @@
-"""URL routing for the storage_vision app — slice 2."""
+"""URL routing for the storage_vision app — slice 3."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from django.urls import include, path
 
 from rest_framework.routers import DefaultRouter
 
-from .views import VisionAreaViewSet, VisionCameraViewSet, VisionSlotViewSet
+from .views import VisionAreaViewSet, VisionCameraViewSet, VisionCaptureViewSet, VisionSlotViewSet
 
 app_name = "storage_vision"
 
@@ -14,6 +14,7 @@ router = DefaultRouter()
 router.register(r"areas", VisionAreaViewSet, basename="area")
 router.register(r"slots", VisionSlotViewSet, basename="slot")
 router.register(r"cameras", VisionCameraViewSet, basename="camera")
+router.register(r"captures", VisionCaptureViewSet, basename="capture")
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/backend/storage_vision/views.py
+++ b/backend/storage_vision/views.py
@@ -13,23 +13,36 @@ existing rows.
 from __future__ import annotations
 
 from django.conf import settings
+from django.db import transaction
 from django.http import HttpResponse
+from django.utils import timezone
 
 from rest_framework import status, viewsets
+from rest_framework.authentication import BasicAuthentication, SessionAuthentication
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework_simplejwt.authentication import JWTAuthentication
 
-from .models import VisionArea, VisionCamera, VisionSlot
-from .permissions import IsStaffOrLogisticsOrReadOnly
+from .authentication import VisionCameraTokenAuthentication
+from .models import VisionArea, VisionCamera, VisionCapture, VisionSlot
+from .permissions import (
+    IsCameraOrStaffOrLogistics,
+    IsStaffOrLogisticsOrReadOnly,
+    _is_staff_or_logistics,
+)
 from .serializers import (
     VisionAreaSerializer,
     VisionCameraSerializer,
     VisionCameraTokenSerializer,
+    VisionCaptureCreateSerializer,
+    VisionCaptureSerializer,
     VisionSlotSerializer,
 )
 from .services.marker_label import render_slot_marker_label
+from .tasks import process_capture
 
 
 def _feature_disabled_response():
@@ -185,3 +198,167 @@ class VisionCameraViewSet(_FeatureFlagGatedWritesMixin, viewsets.ModelViewSet):
 
         serializer = VisionCameraTokenSerializer(cam, context={"request": request})
         return Response(serializer.data)
+
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="heartbeat",
+        authentication_classes=[VisionCameraTokenAuthentication],
+        permission_classes=[],
+    )
+    def heartbeat(self, request, pk=None):
+        """Camera-side liveness ping (AC-8).
+
+        Auth is the scoped camera bearer ONLY — no JWT path, because a
+        human operator pressing "ping" doesn't tell us anything about
+        whether the device is alive. The camera resolved by the bearer
+        must match the URL ``pk`` (otherwise a camera with one bearer
+        could ping another camera's row).
+
+        Body is optional. Accepted shape:
+          ``{"status": "ok" | "degraded" | "error", "note": "..."}``
+        Stamps ``last_seen_at = now()`` regardless of body, plus
+        ``last_seen_status`` if a value was supplied.
+
+        The feature flag is intentionally NOT enforced — turning the
+        feature off shouldn't make the device think the network is
+        broken. Reads stay on too.
+        """
+        camera = request.auth
+        if not isinstance(camera, VisionCamera):
+            # Bearer was missing entirely. The authentication class
+            # already 401s on an invalid bearer; this path catches the
+            # "no header at all" case where authenticate() returned None.
+            return Response(
+                {"detail": "Authentication credentials were not provided."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        target = self.get_object()
+        if camera.pk != target.pk:
+            # Cross-camera ping attempt — refuse silently with 404 so
+            # we don't tell a stolen bearer that the other ID exists.
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        body = request.data if isinstance(request.data, dict) else {}
+        update_fields = ["last_seen_at"]
+        camera.last_seen_at = timezone.now()
+        # last_seen_status is a free-form JSON blob — accept any dict
+        # body the device sends (firmware version, queue depth, last
+        # error string). Strings get wrapped so the column stays a dict.
+        if body:
+            if isinstance(body, dict):
+                camera.last_seen_status = body
+            else:
+                camera.last_seen_status = {"status": str(body)}
+            update_fields.append("last_seen_status")
+        camera.save(update_fields=update_fields)
+
+        serializer = VisionCameraSerializer(camera, context={"request": request})
+        return Response(serializer.data)
+
+
+class VisionCaptureViewSet(_FeatureFlagGatedWritesMixin, viewsets.ModelViewSet):
+    """Capture upload + listing (AC-9, AC-10, AC-11, AC-12).
+
+    Dual auth: a request carrying ``X-Vision-Camera-Token`` is treated
+    as a camera POSTing on its own behalf (source=camera); a request
+    carrying a normal JWT for a staff/Logistics user is treated as a
+    phone upload (source=phone). Anonymous callers are rejected.
+
+    Write surface is POST-only — there's no point in PATCH/PUT/DELETE
+    for an immutable capture row. The mixin still gates the path on
+    the feature flag for symmetry with the other viewsets.
+    """
+
+    queryset = VisionCapture.objects.select_related("area", "camera", "uploaded_by").all()
+    http_method_names = ["get", "head", "options", "post"]
+    authentication_classes = [
+        VisionCameraTokenAuthentication,
+        JWTAuthentication,
+        SessionAuthentication,
+        BasicAuthentication,
+    ]
+    permission_classes = [IsCameraOrStaffOrLogistics]
+    parser_classes = [MultiPartParser, FormParser]
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        if hasattr(self, "request"):
+            area_id = self.request.query_params.get("area")
+            if area_id:
+                qs = qs.filter(area_id=area_id)
+            status_value = self.request.query_params.get("status")
+            if status_value:
+                qs = qs.filter(status=status_value)
+        return qs
+
+    def get_serializer_class(self):
+        if self.action == "create":
+            return VisionCaptureCreateSerializer
+        return VisionCaptureSerializer
+
+    def list(self, request, *args, **kwargs):
+        # Reads require a logged-in operator — a camera bearer can
+        # write its own captures but shouldn't be able to enumerate
+        # the queue.
+        if not _is_staff_or_logistics(request.user):
+            raise PermissionDenied()
+        return super().list(request, *args, **kwargs)
+
+    def retrieve(self, request, *args, **kwargs):
+        if not _is_staff_or_logistics(request.user):
+            raise PermissionDenied()
+        return super().retrieve(request, *args, **kwargs)
+
+    def create(self, request, *args, **kwargs):
+        if getattr(self, "_feature_flag_blocked", False):
+            return _feature_disabled_response()
+
+        write_serializer = self.get_serializer(data=request.data)
+        write_serializer.is_valid(raise_exception=True)
+
+        # Stamp source / camera / uploaded_by from the authenticated
+        # principal — the request body must NOT be able to influence
+        # these (a camera bearer claiming source=phone would dodge
+        # camera-side audit logs).
+        camera = request.auth if isinstance(request.auth, VisionCamera) else None
+        if camera is not None:
+            source = VisionCapture.SOURCE_CAMERA
+            uploaded_by = None
+            area = write_serializer.validated_data.get("area") or camera.area
+        else:
+            source = VisionCapture.SOURCE_PHONE
+            uploaded_by = request.user
+            area = write_serializer.validated_data.get("area")
+            if area is None:
+                # Phones must spell out the area — there's no implicit
+                # fallback like there is for cameras.
+                return Response(
+                    {"area": ["This field is required for phone uploads."]},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+        with transaction.atomic():
+            capture = VisionCapture.objects.create(
+                area=area,
+                source=source,
+                camera=camera,
+                uploaded_by=uploaded_by,
+                original_image=write_serializer.validated_data["original_image"],
+                captured_at=write_serializer.validated_data.get("captured_at"),
+                received_at=timezone.now(),
+                status=VisionCapture.STATUS_QUEUED,
+                queued_at=timezone.now(),
+            )
+
+        # Enqueued AFTER the inner atomic commits — by the time we
+        # call .delay() the row is durable. We can't use on_commit
+        # because the outer request transaction (test client and ATOMIC
+        # _REQUESTS in prod) wouldn't fire the callback until after the
+        # response is already on its way out, and we'd rather see the
+        # broker error inline than discover it next morning.
+        process_capture.delay(capture.pk)
+
+        read_serializer = VisionCaptureSerializer(capture, context={"request": request})
+        return Response(read_serializer.data, status=status.HTTP_202_ACCEPTED)

--- a/docs/CELERY_TASKS.md
+++ b/docs/CELERY_TASKS.md
@@ -131,6 +131,12 @@ operator surface for inspecting status, args, and tracebacks
 | --- | --- | --- | --- | --- | --- | --- |
 | `config.celery.debug_task` | Manual only | Prints request metadata (`ignore_result=True`) | None | 30 min global | **Yes** | N/A |
 
+### storage_vision
+
+| Task | Trigger | Side effects | Retries | Timeout | Idempotency | Recovery |
+| --- | --- | --- | --- | --- | --- | --- |
+| `storage_vision.process_capture` | Enqueued from `VisionCaptureViewSet.create` after a phone or fixed-camera upload (AC-9, AC-10). | Slice-3 stub: transitions the `VisionCapture` row `queued → processing → processed`, stamps `processing_at`/`processed_at`/`processor_version = "slice3-stub"`, and returns. Slice 4 fills in the real Pillow + OpenCV decode, marker detection (QR), match-to-`VisionSlot`, and `VisionObservation` creation. | None (`@shared_task` defaults) | 30 min global | **Yes** — the no-op early-returns if the row is already past `queued`, so retries / re-enqueues never re-stamp a processed capture. | Failed rows surface in Django admin → `VisionCapture` (status=`failed`, `failure_reason`/`failure_code` populated). Replay by flipping the row back to `queued` and re-enqueueing via the management command planned for slice 4. |
+
 ## Failed task recovery (AC-31)
 
 Failed and retrying tasks are visible to staff and operators through three


### PR DESCRIPTION
## Summary

Third slice of the storage_vision MVP (`.criteria/storage-vision-supply-reorder.md`). Lands the dual-auth capture-upload surface, the scoped camera bearer, and the heartbeat ping; the inference body itself stays a no-op stub until slice 4.

- `VisionCaptureViewSet` — POST `/api/storage-vision/captures/` accepts either a staff/Logistics JWT (source=phone) or an `X-Vision-Camera-Token` bearer (source=camera). Anonymous → 401. Stamps source/camera/uploaded_by from the authenticated principal, never the request body. Returns 202 Accepted and enqueues `process_capture.delay(...)` after the inner transaction commits.
- `VisionCameraTokenAuthentication` — new auth class that resolves the bearer header to a `VisionCamera`. 401 on invalid; chains through when missing.
- `IsCameraOrStaffOrLogistics` permission — accepts either a camera bearer or a staff/Logistics user; writes only.
- Capture validation (AC-12) — image field caps at `STORAGE_VISION_MAX_UPLOAD_BYTES` (10 MB default), only `image/jpeg` and `image/png`, Pillow `verify()` round-trip. All error messages sanitized — no traceback or filesystem-path residue.
- Heartbeat — POST `/api/storage-vision/cameras/<id>/heartbeat/` accepts the camera bearer ONLY (no JWT bypass) and stamps `last_seen_at`. Body is optional; if present, gets recorded in the JSONB `last_seen_status` blob. Cross-camera bearer → 404 (silent).
- `process_capture` Celery stub — flips queued → processing → processed so the polling frontend has something to watch. Slice 4 fills in the actual marker detection.
- Permission matrix YAML regenerated to include the new viewset + heartbeat action.

## Acceptance criteria touched

- AC-8 — camera heartbeat with bearer auth
- AC-9 — phone capture upload via staff/Logistics JWT
- AC-10 — camera capture upload via scoped X-Vision-Camera-Token bearer
- AC-11 — anonymous capture upload rejected
- AC-12 — capture validation (max size, JPEG/PNG only, Pillow-decodable, sanitized errors)

## Test plan

- [x] `pytest backend/storage_vision/` — 52 passing (20 new in `test_capture.py`, slice 1+2 tests still green)
- [x] `python manage.py check_permission_matrix` — clean
- [x] `pre-commit run --files <slice-3 files>` — clean (black, isort, ruff, bandit, django-upgrade)
- [x] Phone upload by staff/Logistics returns 202 and triggers `process_capture.delay`
- [x] Phone upload by member returns 403; anonymous returns 401
- [x] Camera upload with valid bearer returns 202 and stamps source=camera; missing area falls back to camera.area
- [x] Invalid camera bearer returns 401
- [x] Oversized / non-image / corrupt-JPEG uploads return 400 with sanitized messages (no traceback or path leakage)
- [x] Feature flag off → writes return 503 / reads still work
- [x] Heartbeat updates last_seen_at and records body to JSONB status; bad bearer → 401; cross-camera bearer → 404; staff JWT → 401 (camera-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)