### PR TITLE
feat(inventory/ui): live search on the inventory overview

### DIFF
--- a/frontend/src/__tests__/pages/InventoryOverviewPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryOverviewPage.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Tests for the inventory overview search box.
+ *
+ * The page already existed pre-this-PR; this file covers the live
+ * search filter added so an operator can find items by name / SKU /
+ * category without using the browser's ctrl-F.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import InventoryOverviewPage from '../../pages/InventoryOverviewPage';
+import { inventoryAPI } from '../../services/api';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    inventoryAPI: {
+      ...(actual as any).inventoryAPI,
+      listItems: jest.fn(),
+      listCategories: jest.fn(),
+    },
+  };
+});
+
+const mockInv = inventoryAPI as jest.Mocked<typeof inventoryAPI>;
+
+const buildItem = (overrides: Partial<any> = {}) => ({
+  id: 'item-1',
+  name: 'M3 hex bolt',
+  sku: 'SKU-BOLT',
+  category_name: 'Fasteners',
+  current_stock: 10,
+  minimum_stock: 5,
+  is_active: true,
+  needs_reorder: false,
+  has_pending_reorder: false,
+  ...overrides,
+});
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={['/inventory']}>
+        <InventoryOverviewPage />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('InventoryOverviewPage search', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInv.listCategories.mockResolvedValue({
+      data: { results: [{ id: 1, name: 'Fasteners' }] },
+    } as any);
+    mockInv.listItems.mockResolvedValue({
+      data: {
+        count: 3,
+        next: null,
+        previous: null,
+        results: [
+          buildItem({ id: 'a', name: 'M3 hex bolt', sku: 'SKU-BOLT' }),
+          buildItem({
+            id: 'b',
+            name: 'Wood glue',
+            sku: 'SKU-GLUE',
+            category_name: 'Adhesives',
+          }),
+          buildItem({
+            id: 'c',
+            name: 'Sandpaper 220',
+            sku: 'SKU-SAND',
+            category_name: 'Abrasives',
+          }),
+        ],
+      },
+    } as any);
+  });
+
+  test('search box renders once items load', async () => {
+    renderPage();
+    expect(
+      await screen.findByTestId('inventory-overview-search'),
+    ).toBeInTheDocument();
+  });
+
+  test('typing in the search filters by item name', async () => {
+    renderPage();
+    await screen.findByText('M3 hex bolt');
+    const input = screen.getByLabelText('Search inventory');
+    fireEvent.change(input, { target: { value: 'wood' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Wood glue')).toBeInTheDocument();
+      expect(screen.queryByText('M3 hex bolt')).not.toBeInTheDocument();
+      expect(screen.queryByText('Sandpaper 220')).not.toBeInTheDocument();
+    });
+  });
+
+  test('search matches SKU', async () => {
+    renderPage();
+    await screen.findByText('M3 hex bolt');
+    const input = screen.getByLabelText('Search inventory');
+    fireEvent.change(input, { target: { value: 'sku-sand' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Sandpaper 220')).toBeInTheDocument();
+      expect(screen.queryByText('Wood glue')).not.toBeInTheDocument();
+    });
+  });
+
+  test('search matches category name', async () => {
+    renderPage();
+    await screen.findByText('M3 hex bolt');
+    const input = screen.getByLabelText('Search inventory');
+    fireEvent.change(input, { target: { value: 'adhes' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Wood glue')).toBeInTheDocument();
+      expect(screen.queryByText('M3 hex bolt')).not.toBeInTheDocument();
+    });
+  });
+
+  test('no-match state surfaces a clear-search link', async () => {
+    renderPage();
+    await screen.findByTestId('inventory-overview-search');
+    const input = screen.getByLabelText('Search inventory');
+    fireEvent.change(input, { target: { value: 'zzzzz' } });
+
+    const empty = await screen.findByTestId(
+      'inventory-overview-no-matches',
+    );
+    expect(empty).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Clear search'));
+    await waitFor(() => {
+      expect(screen.getByText('Wood glue')).toBeInTheDocument();
+    });
+  });
+
+  test('pressing "/" focuses the search box from outside an input', async () => {
+    renderPage();
+    await screen.findByTestId('inventory-overview-search');
+    const input = screen.getByLabelText('Search inventory');
+    expect(document.activeElement).not.toBe(input);
+
+    // Slash keypress on document.body — not an input — should focus
+    // the search box.
+    fireEvent.keyDown(window, { key: '/' });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(input);
+    });
+  });
+});

--- a/frontend/src/pages/InventoryOverviewPage.tsx
+++ b/frontend/src/pages/InventoryOverviewPage.tsx
@@ -23,10 +23,16 @@ import {
   SimpleGrid,
   Stack,
   Text,
+  TextInput,
   Title,
 } from '@mantine/core';
-import { IconAlertTriangle, IconBoxSeam, IconPlus } from '@tabler/icons-react';
-import React, { useEffect, useMemo, useState } from 'react';
+import {
+  IconAlertTriangle,
+  IconBoxSeam,
+  IconPlus,
+  IconSearch,
+} from '@tabler/icons-react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import WorkspacePage from '../components/landing/WorkspacePage';
@@ -100,6 +106,30 @@ const InventoryOverviewPage: React.FC = () => {
   const [items, setItems] = useState<InventoryItem[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const searchRef = useRef<HTMLInputElement | null>(null);
+
+  // "/" focuses the search box from anywhere on the page — same
+  // muscle memory as GitHub/Linear, no ctrl-F dance needed.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== '/' || e.metaKey || e.ctrlKey || e.altKey) return;
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      e.preventDefault();
+      searchRef.current?.focus();
+      searchRef.current?.select();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -131,9 +161,25 @@ const InventoryOverviewPage: React.FC = () => {
     };
   }, []);
 
+  // Live filter — case-insensitive substring match across name, SKU,
+  // and category. Empty query → no filter (everything visible).
+  const trimmedQuery = searchQuery.trim().toLowerCase();
+  const filteredItems = trimmedQuery
+    ? items.filter((item) => {
+        const name = (item.name || '').toLowerCase();
+        const sku = (item.sku || '').toLowerCase();
+        const category = (item.category_name || '').toLowerCase();
+        return (
+          name.includes(trimmedQuery) ||
+          sku.includes(trimmedQuery) ||
+          category.includes(trimmedQuery)
+        );
+      })
+    : items;
+
   const flaggedItems = useMemo(
     () =>
-      items
+      filteredItems
         .filter(flagged)
         .sort((a, b) => {
           // pending reorders first (in flight, watch them), then low-stock by deficit
@@ -144,7 +190,7 @@ const InventoryOverviewPage: React.FC = () => {
           const bDeficit = (b.minimum_stock || 0) - b.current_stock;
           return bDeficit - aDeficit;
         }),
-    [items],
+    [filteredItems],
   );
 
   const categoryGroups = useMemo<CategoryGroup[]>(() => {
@@ -152,7 +198,7 @@ const InventoryOverviewPage: React.FC = () => {
     for (const cat of categories) {
       byName.set(cat.name, []);
     }
-    for (const item of items) {
+    for (const item of filteredItems) {
       const name = item.category_name || UNCATEGORIZED;
       if (!byName.has(name)) byName.set(name, []);
       byName.get(name)!.push(item);
@@ -169,7 +215,7 @@ const InventoryOverviewPage: React.FC = () => {
         if (b.name === UNCATEGORIZED) return -1;
         return a.name.localeCompare(b.name);
       });
-  }, [items, categories]);
+  }, [filteredItems, categories]);
 
   const goItem = (id: string) => navigate(`/inventory/items/${id}`);
 
@@ -200,6 +246,18 @@ const InventoryOverviewPage: React.FC = () => {
         ),
       }}
     >
+      {!loading && items.length > 0 && (
+        <TextInput
+          ref={searchRef}
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.currentTarget.value)}
+          placeholder="Search inventory — name, SKU, or category (press / to focus)"
+          leftSection={<IconSearch size={16} />}
+          size="md"
+          data-testid="inventory-overview-search"
+          aria-label="Search inventory"
+        />
+      )}
       {loading ? (
         <Center mih={240}>
           <Loader />
@@ -210,6 +268,17 @@ const InventoryOverviewPage: React.FC = () => {
             <Text c="dimmed">No inventory items yet.</Text>
             <Anchor onClick={() => navigate('/inventory/items/new')} component="button">
               Add the first one
+            </Anchor>
+          </Stack>
+        </Center>
+      ) : filteredItems.length === 0 ? (
+        <Center mih={120} data-testid="inventory-overview-no-matches">
+          <Stack align="center" gap="xs">
+            <Text c="dimmed">
+              No items match &ldquo;{searchQuery}&rdquo;.
+            </Text>
+            <Anchor onClick={() => setSearchQuery('')} component="button">
+              Clear search
             </Anchor>
           </Stack>
         </Center>


### PR DESCRIPTION
## Summary

Adds a search box pinned above the Needs-attention and category rails on `/inventory` so an operator can find an item by name, SKU, or category name without using the browser's ctrl-F.

- Live, case-insensitive substring match. Empty query is a no-op (every item visible).
- "/" anywhere on the page focuses + selects the search box (same shortcut as GitHub / Linear). Skips when focus is already in a text input or contenteditable so typing "/" in another field still works.
- No-match state surfaces a "Clear search" link so the operator has a one-click exit.
- Search box only renders once items have loaded (no flash of an empty input on first paint).

## Test plan

- [x] `npx vitest run InventoryOverviewPage` — 6 passing
- [x] `npm run build` — clean
- [x] `pre-commit run --files frontend/src/pages/InventoryOverviewPage.tsx frontend/src/__tests__/pages/InventoryOverviewPage.test.tsx` — clean
- [x] Search box only shows once items load
- [x] Filter by item name (e.g. "wood" → only Wood glue)
- [x] Filter by SKU (e.g. "SKU-SAND" → only Sandpaper)
- [x] Filter by category name (e.g. "Adhes" → only Adhesives items)
- [x] No-match state renders "Clear search" link that resets the query
- [x] "/" focuses the search box from outside an input

🤖 Generated with [Claude Code](https://claude.com/claude-code)