### PR TITLE
feat(storage_vision/ui): phone capture upload + processing status (slice 8)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -90,6 +90,7 @@ import PurchasingReportPage from './pages/PurchasingReportPage';
 import ScanPage from './pages/ScanPage';
 import SIGDashboard from './pages/SIGDashboard';
 import SiteSettingsPage from './pages/SiteSettingsPage';
+import StorageVisionCapturePage from './pages/StorageVisionCapturePage';
 import StorageVisionSetupPage from './pages/StorageVisionSetupPage';
 import SupplierDetailPage from './pages/SupplierDetailPage';
 import SupplierFormPage from './pages/SupplierFormPage';
@@ -244,6 +245,7 @@ function AppContent() {
           <Route path="/facilities/forgekey-devices/:id" element={<WorkspaceLayout><ForgeKeyDeviceDetailPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-epaper" element={<WorkspaceLayout><ForgeKeyEPaperPanelsPage /></WorkspaceLayout>} />
           <Route path="/facilities/storage-vision" element={<WorkspaceLayout><StorageVisionSetupPage /></WorkspaceLayout>} />
+          <Route path="/facilities/storage-vision/capture" element={<WorkspaceLayout><StorageVisionCapturePage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-rollouts" element={<WorkspaceLayout><ForgeKeyFirmwareRolloutsPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-certificates" element={<WorkspaceLayout><ForgeKeyCertificatesPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-device-types" element={<WorkspaceLayout><ForgeKeyDeviceTypesPage /></WorkspaceLayout>} />

--- a/frontend/src/__tests__/pages/StorageVisionCapturePage.test.tsx
+++ b/frontend/src/__tests__/pages/StorageVisionCapturePage.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * Tests for the storage_vision capture upload page (slice 8).
+ *
+ * Covers AC-9 phone upload happy path, the 2-second poll
+ * transitioning the tracked capture through processing → processed,
+ * the AC-15 no-markers surface, the AC-29 non-staff redirect, and
+ * the recent-captures history rendering.
+ */
+import { MantineProvider } from '@mantine/core';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import StorageVisionCapturePage from '../../pages/StorageVisionCapturePage';
+import { storageVisionAPI } from '../../services/api';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    storageVisionAPI: {
+      listAreas: jest.fn(),
+      listCaptures: jest.fn(),
+      uploadCapture: jest.fn(),
+      getCapture: jest.fn(),
+    },
+  };
+});
+
+const mockVision = storageVisionAPI as jest.Mocked<typeof storageVisionAPI>;
+
+const buildArea = (overrides: Partial<any> = {}) => ({
+  id: 1,
+  name: 'Bay 1',
+  location: 10,
+  location_name: 'Shop floor',
+  description: '',
+  is_active: true,
+  created_at: '2026-06-01T00:00:00Z',
+  updated_at: '2026-06-01T00:00:00Z',
+  ...overrides,
+});
+
+const buildCapture = (overrides: Partial<any> = {}) => ({
+  id: 42,
+  area: 1,
+  area_name: 'Bay 1',
+  source: 'phone' as const,
+  camera: null,
+  uploaded_by: 7,
+  original_image: null,
+  captured_at: null,
+  received_at: '2026-06-12T00:00:00Z',
+  status: 'queued' as const,
+  processor_version: '',
+  markers_detected: [],
+  failure_reason: '',
+  failure_code: '',
+  queued_at: '2026-06-12T00:00:00Z',
+  processing_at: null,
+  processed_at: null,
+  failed_at: null,
+  ...overrides,
+});
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={['/facilities/storage-vision/capture']}>
+        <Routes>
+          <Route
+            path="/facilities/storage-vision/capture"
+            element={<StorageVisionCapturePage />}
+          />
+          <Route path="/" element={<div>HOME</div>} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('StorageVisionCapturePage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  test('non-staff users are redirected (AC-29)', async () => {
+    localStorage.setItem('is_staff', 'false');
+    localStorage.setItem('is_superuser', 'false');
+    renderPage();
+    expect(await screen.findByText('HOME')).toBeInTheDocument();
+    expect(mockVision.listAreas).not.toHaveBeenCalled();
+  });
+
+  test('staff sees the area picker populated with active areas', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockVision.listAreas.mockResolvedValue({ data: [buildArea()] } as any);
+    mockVision.listCaptures.mockResolvedValue({ data: [] } as any);
+
+    renderPage();
+
+    expect(
+      await screen.findByTestId('capture-area-select'),
+    ).toBeInTheDocument();
+    // Submit button is disabled until area + file are chosen.
+    expect(screen.getByTestId('capture-submit')).toBeDisabled();
+  });
+
+  test('upload posts multipart and shows the tracked capture panel', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockVision.listAreas.mockResolvedValue({ data: [buildArea()] } as any);
+    mockVision.listCaptures.mockResolvedValue({ data: [] } as any);
+    mockVision.uploadCapture.mockResolvedValue({
+      data: buildCapture({ status: 'queued' }),
+    } as any);
+    mockVision.getCapture.mockResolvedValue({
+      data: buildCapture({
+        status: 'processed',
+        markers_detected: [
+          {
+            marker_code: 'VIS-BAY1-M3HEX',
+            bbox: [0, 0, 100, 100],
+            confidence: 0.95,
+            matched_slot_id: 99,
+          },
+        ],
+        processor_version: 'slice4',
+      }),
+    } as any);
+
+    renderPage();
+    await screen.findByTestId('capture-area-select');
+
+    // Pick the area via the Mantine combobox.
+    fireEvent.click(screen.getByPlaceholderText(/Pick the area/));
+    fireEvent.click(await screen.findByText(/Bay 1 — Shop floor/));
+
+    // Attach a file. Mantine FileInput's button has the label
+    // "Photo (JPEG or PNG)"; assigning to the underlying hidden
+    // <input type="file"> is easier than driving the picker.
+    const file = new File(['png-bytes'], 'frame.jpg', { type: 'image/jpeg' });
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('capture-submit')).not.toBeDisabled();
+    });
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    fireEvent.click(screen.getByTestId('capture-submit'));
+
+    // Tracked panel appears after the 202.
+    expect(await screen.findByTestId('tracked-capture-panel')).toBeInTheDocument();
+    expect(mockVision.uploadCapture).toHaveBeenCalled();
+    const formData = mockVision.uploadCapture.mock.calls[0][0] as FormData;
+    expect(formData.get('area')).toBe('1');
+    expect(formData.get('original_image')).toBe(file);
+
+    // Advance to the poll, which transitions to processed.
+    await act(async () => {
+      vi.advanceTimersByTime(2_100);
+    });
+
+    await waitFor(() => {
+      expect(mockVision.getCapture).toHaveBeenCalledWith(42);
+      expect(
+        screen.getByTestId('matched-markers-table'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('VIS-BAY1-M3HEX')).toBeInTheDocument();
+    });
+
+    vi.useRealTimers();
+  });
+
+  test('no-markers result surfaces the AC-15 message', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockVision.listAreas.mockResolvedValue({ data: [buildArea()] } as any);
+    mockVision.listCaptures.mockResolvedValue({ data: [] } as any);
+    mockVision.uploadCapture.mockResolvedValue({
+      data: buildCapture({ status: 'queued' }),
+    } as any);
+    mockVision.getCapture.mockResolvedValue({
+      data: buildCapture({
+        status: 'processed',
+        failure_code: 'no_markers_detected',
+        failure_reason: 'No storage-vision markers were readable in this image.',
+        markers_detected: [],
+      }),
+    } as any);
+
+    renderPage();
+    await screen.findByTestId('capture-area-select');
+    fireEvent.click(screen.getByPlaceholderText(/Pick the area/));
+    fireEvent.click(await screen.findByText(/Bay 1 — Shop floor/));
+    const file = new File(['png'], 'frame.jpg', { type: 'image/jpeg' });
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    await waitFor(() =>
+      expect(screen.getByTestId('capture-submit')).not.toBeDisabled(),
+    );
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    fireEvent.click(screen.getByTestId('capture-submit'));
+    await screen.findByTestId('tracked-capture-panel');
+    await act(async () => {
+      vi.advanceTimersByTime(2_100);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No storage-vision markers were readable/),
+      ).toBeInTheDocument();
+    });
+
+    vi.useRealTimers();
+  });
+
+  test('recent captures table renders with status + marker count', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockVision.listAreas.mockResolvedValue({ data: [buildArea()] } as any);
+    mockVision.listCaptures.mockResolvedValue({
+      data: [
+        buildCapture({
+          id: 11,
+          status: 'processed',
+          markers_detected: [
+            {
+              marker_code: 'X',
+              bbox: [0, 0, 1, 1],
+              confidence: 1.0,
+              matched_slot_id: 1,
+            },
+          ],
+        }),
+        buildCapture({
+          id: 12,
+          status: 'failed',
+          failure_code: 'detection_error',
+        }),
+      ],
+    } as any);
+
+    renderPage();
+    expect(
+      await screen.findByTestId('recent-captures-table'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('processed')).toBeInTheDocument();
+    expect(screen.getByText('failed')).toBeInTheDocument();
+  });
+
+  test('error on listAreas surfaces the alert', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockVision.listAreas.mockRejectedValue(new Error('boom'));
+    mockVision.listCaptures.mockResolvedValue({ data: [] } as any);
+
+    renderPage();
+    expect(await screen.findByText(/Failed to load areas/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -123,6 +123,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed = false, isMobileOpen = f
         { path: '/facilities/electrical', label: 'Electrical & Network', icon: '⚡', requiresStaff: true },
         { path: '/facilities/project-storage/queue', label: 'Project Storage', icon: '📦', requiresStaff: true },
         { path: '/facilities/storage-vision', label: 'Storage Vision', icon: '📸', requiresStaff: true },
+        { path: '/facilities/storage-vision/capture', label: 'Vision capture', icon: '📷', requiresStaff: true },
       ],
     },
     {

--- a/frontend/src/navigation/routeMap.ts
+++ b/frontend/src/navigation/routeMap.ts
@@ -76,6 +76,7 @@ const ENTRIES: RouteEntry[] = [
   { path: 'facilities/forgekey-rollouts', label: 'Firmware Rollouts' },
   { path: 'facilities/lockers', label: 'Lockers' },
   { path: 'facilities/storage-vision', label: 'Storage Vision' },
+  { path: 'facilities/storage-vision/capture', label: 'Vision capture' },
   { path: 'admin/audit-feed', label: 'Audit Feed' },
   { path: 'forgekey/epaper/bind', label: 'Bind ePaper Panel' },
   { path: 'forgekey/epaper/service', label: 'Log ePaper Service' },

--- a/frontend/src/pages/StorageVisionCapturePage.tsx
+++ b/frontend/src/pages/StorageVisionCapturePage.tsx
@@ -1,0 +1,441 @@
+/**
+ * Storage Vision capture upload (AC-9 phone path; second half of AC-28).
+ *
+ * Staff / Logistics page at /facilities/storage-vision/capture. Lets
+ * the operator pick a monitored area, pick or take a photo, and post
+ * it to the slice-3 capture endpoint. After the 202 the page polls
+ * the capture's status every 2 seconds until it transitions to
+ * processed or failed; the result panel surfaces the markers
+ * detected, the failure_code (e.g. ``no_markers_detected``), and a
+ * deep link into the slice-9 review queue for any observation rows
+ * the processor created.
+ *
+ * AC-10 (fixed-camera upload) lives on the device side; AC-29 gates
+ * non-staff / non-Logistics at both the route and the sidebar.
+ */
+import {
+  ActionIcon,
+  Alert,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Code,
+  FileInput,
+  Group,
+  LoadingOverlay,
+  Paper,
+  Progress,
+  Select,
+  Stack,
+  Table,
+  Text,
+  Textarea,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
+import {
+  storageVisionAPI,
+  VisionArea,
+  VisionCapture,
+  VisionCaptureStatus,
+} from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+type Tracked = {
+  capture: VisionCapture;
+  // The poll handle; cleared once the capture reaches a terminal
+  // state so the page doesn't keep hammering the API after the
+  // worker finishes.
+  pollHandle: number | null;
+};
+
+const TERMINAL_STATUSES: VisionCaptureStatus[] = ['processed', 'failed'];
+
+const POLL_INTERVAL_MS = 2_000;
+
+const unwrap = <T,>(data: { results: T[] } | T[]): T[] =>
+  Array.isArray(data) ? data : data.results;
+
+const statusColor = (s: VisionCaptureStatus): string => {
+  switch (s) {
+    case 'queued':
+      return 'gray';
+    case 'processing':
+      return 'blue';
+    case 'processed':
+      return 'green';
+    case 'failed':
+      return 'red';
+  }
+};
+
+const formatRelative = (iso: string | null): string => {
+  if (!iso) return '—';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '—';
+  const secs = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.round(hrs / 24)}d ago`;
+};
+
+const StorageVisionCapturePage: React.FC = () => {
+  const isStaff =
+    typeof window !== 'undefined' && localStorage.getItem('is_staff') === 'true';
+  const isSuperuser =
+    typeof window !== 'undefined' &&
+    localStorage.getItem('is_superuser') === 'true';
+  const isLogistics =
+    typeof window !== 'undefined' &&
+    (localStorage.getItem('is_logistics') === 'true' ||
+      (localStorage.getItem('groups') || '').includes('Logistics'));
+  const isAllowed = isStaff || isSuperuser || isLogistics;
+
+  const [areas, setAreas] = useState<VisionArea[]>([]);
+  const [areaId, setAreaId] = useState<number | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [capturedAt, setCapturedAt] = useState<string>('');
+  const [notes, setNotes] = useState<string>('');
+
+  const [recent, setRecent] = useState<VisionCapture[]>([]);
+  const [tracked, setTracked] = useState<Tracked | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Hold the poll handle in a ref too so the unmount cleanup can
+  // cancel it without depending on state freshness.
+  const pollRef = useRef<number | null>(null);
+
+  const loadAreas = useCallback(async () => {
+    try {
+      const res = await storageVisionAPI.listAreas();
+      setAreas(unwrap(res.data).filter((a) => a.is_active));
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to load areas.'));
+    }
+  }, []);
+
+  const loadRecent = useCallback(async (filterAreaId: number | null) => {
+    try {
+      const res = await storageVisionAPI.listCaptures(
+        filterAreaId != null ? { area: filterAreaId } : undefined,
+      );
+      const list = unwrap(res.data);
+      // Page list shows ten most recent.
+      setRecent(list.slice(0, 10));
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to load recent captures.'));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isAllowed) return;
+    setLoading(true);
+    Promise.all([loadAreas(), loadRecent(null)]).finally(() => setLoading(false));
+  }, [isAllowed, loadAreas, loadRecent]);
+
+  useEffect(() => {
+    return () => {
+      if (pollRef.current != null) {
+        window.clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, []);
+
+  if (!isAllowed) {
+    return <Navigate to="/" replace />;
+  }
+
+  const startPolling = (capture: VisionCapture) => {
+    if (pollRef.current != null) {
+      window.clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    setTracked({ capture, pollHandle: null });
+
+    const handle = window.setInterval(async () => {
+      try {
+        const res = await storageVisionAPI.getCapture(capture.id);
+        const next = res.data;
+        setTracked({ capture: next, pollHandle: handle });
+        if (TERMINAL_STATUSES.includes(next.status)) {
+          window.clearInterval(handle);
+          pollRef.current = null;
+          // Refresh the recent list so the new capture shows
+          // its terminal state in the history.
+          void loadRecent(areaId);
+        }
+      } catch (err) {
+        // Don't kill the page on a transient poll error — just
+        // surface it so the operator knows polling is paused.
+        setError(extractErrorMessage(err, 'Polling failed; will keep trying.'));
+      }
+    }, POLL_INTERVAL_MS);
+    pollRef.current = handle;
+  };
+
+  const submit = async () => {
+    if (areaId == null || file == null) return;
+    setUploading(true);
+    setError(null);
+    try {
+      const fd = new FormData();
+      fd.append('area', String(areaId));
+      fd.append('original_image', file);
+      if (capturedAt) fd.append('captured_at', new Date(capturedAt).toISOString());
+      const res = await storageVisionAPI.uploadCapture(fd);
+      // Reset form for the next shot.
+      setFile(null);
+      setCapturedAt('');
+      setNotes('');
+      // Track the new capture and start polling.
+      startPolling(res.data);
+      void loadRecent(areaId);
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Upload failed.'));
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const areaOptions = areas.map((a) => ({
+    value: String(a.id),
+    label: `${a.name} — ${a.location_name}`,
+  }));
+
+  return (
+    <WorkspacePage
+      hero={{
+        eyebrow: 'Facilities',
+        title: 'Upload supply capture',
+        subtitle:
+          'Pick a monitored area, snap or upload a photo, and the marker detector will queue any empty / low slot reviews for staff approval.',
+      }}
+      testId="storage-vision-capture-page"
+    >
+      <Box pos="relative">
+        <LoadingOverlay visible={loading} />
+
+        {error && (
+          <Alert
+            color="red"
+            mb="md"
+            onClose={() => setError(null)}
+            withCloseButton
+          >
+            {error}
+          </Alert>
+        )}
+
+        <Card withBorder mb="lg" padding="lg">
+          <Stack>
+            <Title order={4}>New capture</Title>
+            <Select
+              label="Area"
+              data={areaOptions}
+              value={areaId != null ? String(areaId) : null}
+              onChange={(v) => setAreaId(v ? Number(v) : null)}
+              placeholder="Pick the area you photographed"
+              searchable
+              required
+              data-testid="capture-area-select"
+              nothingFoundMessage="No active areas. Set one up in Storage Vision setup first."
+            />
+            <FileInput
+              label="Photo (JPEG or PNG)"
+              accept="image/jpeg,image/png"
+              value={file}
+              onChange={setFile}
+              placeholder="Choose or take a photo"
+              required
+              data-testid="capture-file-input"
+              description="Maximum 10 MB. Phones can capture directly from the file picker."
+            />
+            <TextInput
+              label="Captured at (optional)"
+              type="datetime-local"
+              value={capturedAt}
+              onChange={(e) => setCapturedAt(e.currentTarget.value)}
+              description="Defaults to upload time if blank."
+            />
+            <Textarea
+              label="Reviewer notes (optional, local only)"
+              value={notes}
+              onChange={(e) => setNotes(e.currentTarget.value)}
+              description="Kept on this screen for your own reference; not sent with the upload."
+            />
+            <Group justify="flex-end">
+              <Button
+                onClick={submit}
+                disabled={uploading || areaId == null || file == null}
+                loading={uploading}
+                data-testid="capture-submit"
+              >
+                Upload
+              </Button>
+            </Group>
+          </Stack>
+        </Card>
+
+        {tracked && <TrackedPanel tracked={tracked} />}
+
+        <Title order={4} mt="xl" mb="sm">
+          Recent captures
+        </Title>
+        {recent.length === 0 ? (
+          <Text c="dimmed">No captures yet.</Text>
+        ) : (
+          <Table data-testid="recent-captures-table">
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Area</Table.Th>
+                <Table.Th>Source</Table.Th>
+                <Table.Th>Status</Table.Th>
+                <Table.Th>Markers</Table.Th>
+                <Table.Th>Received</Table.Th>
+                <Table.Th>Review</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {recent.map((c) => (
+                <Table.Tr key={c.id}>
+                  <Table.Td>{c.area_name}</Table.Td>
+                  <Table.Td>
+                    <Badge variant="light">{c.source}</Badge>
+                  </Table.Td>
+                  <Table.Td>
+                    <Badge color={statusColor(c.status)}>{c.status}</Badge>
+                  </Table.Td>
+                  <Table.Td>
+                    {c.markers_detected.length || 0}
+                    {c.failure_code === 'no_markers_detected' && (
+                      <Text component="span" size="xs" c="dimmed" ml="xs">
+                        none readable
+                      </Text>
+                    )}
+                  </Table.Td>
+                  <Table.Td>{formatRelative(c.received_at)}</Table.Td>
+                  <Table.Td>
+                    <Button
+                      size="xs"
+                      variant="default"
+                      component={Link}
+                      to={`/facilities/storage-vision/review?capture=${c.id}`}
+                    >
+                      Open
+                    </Button>
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        )}
+      </Box>
+    </WorkspacePage>
+  );
+};
+
+interface TrackedPanelProps {
+  tracked: Tracked;
+}
+
+const TrackedPanel: React.FC<TrackedPanelProps> = ({ tracked }) => {
+  const { capture } = tracked;
+  const matched = capture.markers_detected.filter(
+    (m) => m.matched_slot_id != null,
+  );
+  const unmatched = capture.markers_detected.filter(
+    (m) => m.matched_slot_id == null,
+  );
+
+  return (
+    <Paper withBorder p="lg" mb="lg" data-testid="tracked-capture-panel">
+      <Stack gap="sm">
+        <Group justify="space-between">
+          <Group gap="sm">
+            <Title order={5}>Capture #{capture.id}</Title>
+            <Badge color={statusColor(capture.status)}>{capture.status}</Badge>
+            <Text size="sm" c="dimmed">
+              {capture.area_name}
+            </Text>
+          </Group>
+          <Button
+            size="xs"
+            variant="default"
+            component={Link}
+            to={`/facilities/storage-vision/review?capture=${capture.id}`}
+          >
+            Open in review
+          </Button>
+        </Group>
+
+        {capture.status === 'queued' && (
+          <Progress value={20} animated striped />
+        )}
+        {capture.status === 'processing' && (
+          <Progress value={70} animated striped />
+        )}
+        {capture.status === 'processed' && (
+          <Stack gap="xs">
+            {capture.failure_code === 'no_markers_detected' ? (
+              <Alert color="yellow">
+                No storage-vision markers were readable in this image. Try
+                another angle or check the lighting.
+              </Alert>
+            ) : (
+              <>
+                <Text size="sm">
+                  Matched {matched.length} known slot(s); {unmatched.length}{' '}
+                  marker(s) didn&apos;t resolve to a slot.
+                </Text>
+                {matched.length > 0 && (
+                  <Table data-testid="matched-markers-table">
+                    <Table.Thead>
+                      <Table.Tr>
+                        <Table.Th>Marker</Table.Th>
+                        <Table.Th>Confidence</Table.Th>
+                      </Table.Tr>
+                    </Table.Thead>
+                    <Table.Tbody>
+                      {matched.map((m) => (
+                        <Table.Tr key={m.marker_code}>
+                          <Table.Td>
+                            <Code>{m.marker_code}</Code>
+                          </Table.Td>
+                          <Table.Td>{m.confidence.toFixed(2)}</Table.Td>
+                        </Table.Tr>
+                      ))}
+                    </Table.Tbody>
+                  </Table>
+                )}
+                {unmatched.length > 0 && (
+                  <Text size="xs" c="dimmed">
+                    Unknown payloads:{' '}
+                    {unmatched.map((m) => m.marker_code).join(', ')}
+                  </Text>
+                )}
+              </>
+            )}
+          </Stack>
+        )}
+        {capture.status === 'failed' && (
+          <Alert color="red">
+            Processing failed: <Code>{capture.failure_code || 'error'}</Code>.{' '}
+            {capture.failure_reason}
+          </Alert>
+        )}
+      </Stack>
+    </Paper>
+  );
+};
+
+export default StorageVisionCapturePage;

--- a/frontend/src/pages/StorageVisionSetupPage.tsx
+++ b/frontend/src/pages/StorageVisionSetupPage.tsx
@@ -33,7 +33,7 @@ import {
   Tooltip,
 } from '@mantine/core';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import {
   inventoryAPI,
@@ -271,6 +271,15 @@ const StorageVisionSetupPage: React.FC = () => {
         subtitle:
           'Manage monitored areas, marker-backed slots, and fixed cameras for the supply-reorder workflow.',
         eyebrow: 'Facilities',
+        action: (
+          <Button
+            component={Link}
+            to="/facilities/storage-vision/capture"
+            data-testid="setup-page-upload-cta"
+          >
+            Upload capture
+          </Button>
+        ),
       }}
       testId="storage-vision-setup-page"
     >


### PR DESCRIPTION
## Summary

Eighth slice of the storage_vision MVP — the second half of AC-28: the staff phone-capture flow + processing-status surface, riding on top of the slice-3 upload API and the slice-4 marker-detection pipeline.

- New page `/facilities/storage-vision/capture` (staff/Logistics only — AC-29 gate at the route AND the sidebar). Area picker, JPEG/PNG file input, optional `captured_at` field, multipart POST to `/storage-vision/captures/`.
- After the 202, polls `GET /storage-vision/captures/{id}/` every 2 s until the row reaches `processed` or `failed` (the slice-3 state machine the operator can finally see end-to-end).
- Tracked-capture panel:
  - `queued` / `processing` → striped progress bar.
  - `processed` + matched slots → markers + confidences table.
  - `processed` + `failure_code=no_markers_detected` → AC-15 "no markers were readable" alert.
  - `failed` → sanitized failure_reason + code (no traceback leakage per AC-12 — backend already enforces this).
- Recent-captures table (last 10, scoped to the most-recently-used area): area, source badge, status badge, marker count, age, "Open in review" deep link.
- Setup page picks up an "Upload capture" hero CTA so the operator doesn't need the sidebar after first configuring.

## Acceptance criteria touched

- AC-9 — phone upload flow (multipart POST, returns 202 from the API)
- AC-15 — no-markers result surfaces with the machine-readable reason
- AC-28 — staff can upload a phone capture and view processing status
- AC-29 — non-staff blocked at route and sidebar

## Test plan

- [x] `npx vitest run StorageVisionCapturePage` — 6 passing
- [x] `npx vitest run Sidebar StorageVisionSetupPage` — 13 passing (no regression from the new sidebar entry / setup CTA)
- [x] `npm run build` — clean
- [x] `pre-commit run --files <slice-8 files>` — clean
- [x] Non-staff redirected; staff sees the area picker populated with active areas only
- [x] Upload disabled until area + file chosen; enabled once both set
- [x] Submit posts FormData with `area` + `original_image`; tracked panel appears
- [x] Poll calls `getCapture(id)` and renders matched-markers table on `processed`
- [x] No-markers result surfaces the AC-15 "No storage-vision markers..." alert
- [x] Recent-captures table renders status + marker count + area
- [x] Initial-fetch error surfaces in the page alert

## Out of scope (next slice)

- Slice 9: observation review queue + approve / reject / bulk approve UI (the `/review?capture=N` deep link this PR adds becomes live in that slice)
- Slice 10: Playwright E2E proving the full operating loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)