### PR TITLE
feat(storage_vision/ui): observation review queue (slice 9)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -91,6 +91,7 @@ import ScanPage from './pages/ScanPage';
 import SIGDashboard from './pages/SIGDashboard';
 import SiteSettingsPage from './pages/SiteSettingsPage';
 import StorageVisionCapturePage from './pages/StorageVisionCapturePage';
+import StorageVisionReviewPage from './pages/StorageVisionReviewPage';
 import StorageVisionSetupPage from './pages/StorageVisionSetupPage';
 import SupplierDetailPage from './pages/SupplierDetailPage';
 import SupplierFormPage from './pages/SupplierFormPage';
@@ -246,6 +247,7 @@ function AppContent() {
           <Route path="/facilities/forgekey-epaper" element={<WorkspaceLayout><ForgeKeyEPaperPanelsPage /></WorkspaceLayout>} />
           <Route path="/facilities/storage-vision" element={<WorkspaceLayout><StorageVisionSetupPage /></WorkspaceLayout>} />
           <Route path="/facilities/storage-vision/capture" element={<WorkspaceLayout><StorageVisionCapturePage /></WorkspaceLayout>} />
+          <Route path="/facilities/storage-vision/review" element={<WorkspaceLayout><StorageVisionReviewPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-rollouts" element={<WorkspaceLayout><ForgeKeyFirmwareRolloutsPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-certificates" element={<WorkspaceLayout><ForgeKeyCertificatesPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-device-types" element={<WorkspaceLayout><ForgeKeyDeviceTypesPage /></WorkspaceLayout>} />

--- a/frontend/src/__tests__/pages/StorageVisionReviewPage.test.tsx
+++ b/frontend/src/__tests__/pages/StorageVisionReviewPage.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * Tests for the storage_vision review queue page (slice 9).
+ *
+ * Covers AC-20 (filterable list), AC-21 + AC-22 (approve creates
+ * reconciliation + may create a reorder), AC-23 (409 conflict on
+ * already-resolved), AC-24 (reject requires a reason), AC-25 (bulk
+ * approve partial results with per-id skip reasons), AC-29 (non-staff
+ * redirect), plus the slice-8 ?capture=N deep link.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import StorageVisionReviewPage from '../../pages/StorageVisionReviewPage';
+import { storageVisionAPI } from '../../services/api';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    storageVisionAPI: {
+      listObservations: jest.fn(),
+      listAreas: jest.fn(),
+      approveObservation: jest.fn(),
+      rejectObservation: jest.fn(),
+      bulkApprove: jest.fn(),
+    },
+  };
+});
+
+const mockVision = storageVisionAPI as jest.Mocked<typeof storageVisionAPI>;
+
+const buildObs = (overrides: Partial<any> = {}) => ({
+  id: 11,
+  capture: 100,
+  capture_thumbnail: null,
+  slot: 1,
+  slot_marker_code: 'VIS-BAY1-M3HEX',
+  area_id: 1,
+  area_name: 'Bay 1',
+  item_id: 'item-uuid',
+  item_name: 'M3 hex bolt',
+  classification: 'empty' as const,
+  confidence: '0.800',
+  evidence_crop: 'https://example.com/crop.jpg',
+  model_version: 'heuristic-v1',
+  suggested_action: 'reconcile_empty' as const,
+  status: 'pending' as const,
+  duplicate_count: 0,
+  last_duplicate_at: null,
+  age_seconds: 120,
+  created_at: '2026-06-12T00:00:00Z',
+  updated_at: '2026-06-12T00:00:00Z',
+  ...overrides,
+});
+
+const renderPage = (initialEntry = '/facilities/storage-vision/review') =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route
+            path="/facilities/storage-vision/review"
+            element={<StorageVisionReviewPage />}
+          />
+          <Route path="/" element={<div>HOME</div>} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('StorageVisionReviewPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockVision.listAreas.mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          name: 'Bay 1',
+          location: 10,
+          location_name: 'Shop floor',
+          description: '',
+          is_active: true,
+          created_at: '2026-06-01T00:00:00Z',
+          updated_at: '2026-06-01T00:00:00Z',
+        },
+      ],
+    } as any);
+  });
+
+  test('non-staff users are redirected (AC-29)', async () => {
+    localStorage.setItem('is_staff', 'false');
+    renderPage();
+    expect(await screen.findByText('HOME')).toBeInTheDocument();
+    expect(mockVision.listObservations).not.toHaveBeenCalled();
+  });
+
+  test('staff sees a pending-by-default queue (AC-20)', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockVision.listObservations.mockResolvedValue({
+      data: [buildObs()],
+    } as any);
+
+    renderPage();
+
+    expect(
+      await screen.findByTestId('observations-table'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('M3 hex bolt')).toBeInTheDocument();
+    expect(screen.getByText('VIS-BAY1-M3HEX')).toBeInTheDocument();
+    expect(mockVision.listObservations).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'pending' }),
+    );
+  });
+
+  test('approve calls API, updates row, and surfaces reorder badge (AC-21, AC-22)', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockVision.listObservations.mockResolvedValue({
+      data: [buildObs()],
+    } as any);
+    mockVision.approveObservation.mockResolvedValue({
+      data: {
+        ...buildObs(),
+        status: 'approved',
+        reconciliation_id: 42,
+        reorder_created: true,
+      },
+    } as any);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByTestId('approve-11'));
+
+    await waitFor(() => {
+      expect(mockVision.approveObservation).toHaveBeenCalledWith(11);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('review-resolution-alert')).toHaveTextContent(
+        /Approved observation #11/,
+      );
+      expect(screen.getByTestId('review-resolution-alert')).toHaveTextContent(
+        /reconciliation #42/,
+      );
+      expect(screen.getByTestId('review-resolution-alert')).toHaveTextContent(
+        /reorder created/,
+      );
+    });
+    // Approve button disabled after status → approved.
+    expect(screen.getByTestId('approve-11')).toBeDisabled();
+  });
+
+  test('409 conflict surfaces an AC-23 warning', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockVision.listObservations.mockResolvedValue({
+      data: [buildObs()],
+    } as any);
+    mockVision.approveObservation.mockRejectedValue({
+      response: { status: 409, data: { code: 'already_resolved' } },
+    });
+
+    renderPage();
+    fireEvent.click(await screen.findByTestId('approve-11'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('review-resolution-alert')).toHaveTextContent(
+        /already resolved/i,
+      );
+    });
+  });
+
+  test('reject requires a reason (AC-24)', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockVision.listObservations.mockResolvedValue({
+      data: [buildObs()],
+    } as any);
+    mockVision.rejectObservation.mockResolvedValue({
+      data: { ...buildObs(), status: 'rejected' },
+    } as any);
+
+    renderPage();
+    fireEvent.click(await screen.findByTestId('reject-11'));
+
+    // Modal opens asynchronously — await its confirm button.
+    const confirm = await screen.findByTestId('reject-confirm');
+    expect(confirm).toBeDisabled();
+
+    const reason = screen.getByTestId('reject-reason') as HTMLTextAreaElement;
+    fireEvent.change(reason, { target: { value: 'glare on the bin' } });
+    await waitFor(() => expect(confirm).not.toBeDisabled());
+
+    fireEvent.click(confirm);
+
+    await waitFor(() => {
+      expect(mockVision.rejectObservation).toHaveBeenCalledWith(
+        11,
+        'glare on the bin',
+      );
+      expect(screen.getByTestId('review-resolution-alert')).toHaveTextContent(
+        /Rejected observation #11/,
+      );
+    });
+  });
+
+  test('bulk approve sends selected ids + renders skipped panel (AC-25)', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockVision.listObservations.mockResolvedValue({
+      data: [
+        buildObs({ id: 1 }),
+        buildObs({ id: 2 }),
+        // review_only rows shouldn't even be selectable
+        buildObs({ id: 3, suggested_action: 'review_only' }),
+      ],
+    } as any);
+    mockVision.bulkApprove.mockResolvedValue({
+      data: {
+        approved: [
+          { id: 1, reconciliation_id: 9, reorder_created: true },
+        ],
+        skipped: [{ id: 2, reason: 'internal_error' }],
+        counts: { requested: 2, approved: 1, skipped: 1 },
+      },
+    } as any);
+
+    renderPage();
+    await screen.findByTestId('observations-table');
+
+    // Master-toggle picks up only the two reconcile_empty pending rows
+    // — the review_only row stays unselected per the disabled-checkbox guard.
+    fireEvent.click(screen.getByTestId('select-all'));
+
+    expect(
+      screen.getByTestId('bulk-approve-button'),
+    ).toHaveTextContent(/Approve selected \(2\)/);
+
+    fireEvent.click(screen.getByTestId('bulk-approve-button'));
+
+    await waitFor(() => {
+      expect(mockVision.bulkApprove).toHaveBeenCalledWith([1, 2], undefined);
+    });
+
+    await waitFor(() => {
+      const skipped = screen.getByTestId('bulk-skipped-alert');
+      expect(skipped).toHaveTextContent(/#2 — internal_error/);
+      expect(screen.getByTestId('review-resolution-alert')).toHaveTextContent(
+        /Approved 1 of 2/,
+      );
+    });
+  });
+
+  test('?capture=N scopes the queue and offers a Clear filter button', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockVision.listObservations.mockResolvedValue({
+      data: [
+        buildObs({ id: 1, capture: 100 }),
+        buildObs({ id: 2, capture: 200 }),
+      ],
+    } as any);
+
+    renderPage('/facilities/storage-vision/review?capture=100');
+    await screen.findByTestId('observations-table');
+
+    // Only observation #1 (capture 100) should be in the rendered table.
+    expect(screen.getByTestId('approve-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('approve-2')).not.toBeInTheDocument();
+    expect(screen.getByTestId('clear-capture-filter')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -124,6 +124,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed = false, isMobileOpen = f
         { path: '/facilities/project-storage/queue', label: 'Project Storage', icon: '📦', requiresStaff: true },
         { path: '/facilities/storage-vision', label: 'Storage Vision', icon: '📸', requiresStaff: true },
         { path: '/facilities/storage-vision/capture', label: 'Vision capture', icon: '📷', requiresStaff: true },
+        { path: '/facilities/storage-vision/review', label: 'Vision review', icon: '✅', requiresStaff: true },
       ],
     },
     {

--- a/frontend/src/navigation/routeMap.ts
+++ b/frontend/src/navigation/routeMap.ts
@@ -77,6 +77,7 @@ const ENTRIES: RouteEntry[] = [
   { path: 'facilities/lockers', label: 'Lockers' },
   { path: 'facilities/storage-vision', label: 'Storage Vision' },
   { path: 'facilities/storage-vision/capture', label: 'Vision capture' },
+  { path: 'facilities/storage-vision/review', label: 'Vision review' },
   { path: 'admin/audit-feed', label: 'Audit Feed' },
   { path: 'forgekey/epaper/bind', label: 'Bind ePaper Panel' },
   { path: 'forgekey/epaper/service', label: 'Log ePaper Service' },

--- a/frontend/src/pages/StorageVisionReviewPage.tsx
+++ b/frontend/src/pages/StorageVisionReviewPage.tsx
@@ -1,0 +1,720 @@
+/**
+ * Storage Vision review queue (AC-20, AC-21, AC-22, AC-23, AC-24, AC-25).
+ *
+ * Single-screen review surface at /facilities/storage-vision/review.
+ *
+ * - List with status / area / item / classification filters (AC-20),
+ *   defaulting to ``status=pending`` because that's the operator's
+ *   morning queue.
+ * - Optional ``?capture=N`` deep link from the slice-8 capture page
+ *   that scopes the list to one capture's observations and labels
+ *   the hero so the operator knows what they're looking at.
+ * - Per-row approve / reject with the slice-5 API. Approve writes
+ *   StockReconciliation + ReorderRequest where applicable (AC-21,
+ *   AC-22); reject requires a reason (AC-24). Repeating either on
+ *   an already-resolved row returns 409 (AC-23) and surfaces in the
+ *   row's status badge.
+ * - Bulk approve: selectable checkbox per row, master checkbox in
+ *   the header, "Approve selected" with an optional shared reason.
+ *   Skipped rows with per-id reasons render in an inline alert
+ *   (AC-25).
+ * - AC-29 non-staff gate at both the route and the sidebar.
+ */
+import {
+  ActionIcon,
+  Alert,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Checkbox,
+  Code,
+  Group,
+  Image,
+  LoadingOverlay,
+  Modal,
+  Select,
+  Stack,
+  Table,
+  Text,
+  Textarea,
+  Title,
+  Tooltip,
+} from '@mantine/core';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, Navigate, useSearchParams } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
+import {
+  storageVisionAPI,
+  VisionArea,
+  VisionObservation,
+  VisionObservationAction,
+  VisionObservationClass,
+  VisionObservationStatus,
+} from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+const unwrap = <T,>(data: { results: T[] } | T[]): T[] =>
+  Array.isArray(data) ? data : data.results;
+
+const STATUS_OPTIONS: { value: VisionObservationStatus; label: string }[] = [
+  { value: 'pending', label: 'Pending' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'superseded', label: 'Superseded' },
+];
+
+const CLASS_OPTIONS: { value: VisionObservationClass; label: string }[] = [
+  { value: 'empty', label: 'Empty' },
+  { value: 'low', label: 'Low' },
+  { value: 'full', label: 'Full' },
+  { value: 'unknown', label: 'Unknown' },
+];
+
+const ACTION_OPTIONS: { value: VisionObservationAction; label: string }[] = [
+  { value: 'reconcile_empty', label: 'Reconcile (zero stock)' },
+  { value: 'review_only', label: 'Review only' },
+];
+
+const statusColor = (s: VisionObservationStatus): string => {
+  switch (s) {
+    case 'pending':
+      return 'gray';
+    case 'approved':
+      return 'green';
+    case 'rejected':
+      return 'red';
+    case 'superseded':
+      return 'yellow';
+  }
+};
+
+const classificationColor = (c: VisionObservationClass): string => {
+  switch (c) {
+    case 'empty':
+      return 'orange';
+    case 'low':
+      return 'yellow';
+    case 'full':
+      return 'green';
+    case 'unknown':
+      return 'gray';
+  }
+};
+
+const formatAge = (seconds: number): string => {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.round(seconds / 3600)}h`;
+  return `${Math.round(seconds / 86400)}d`;
+};
+
+interface ResolutionMessage {
+  kind: 'success' | 'info' | 'warning' | 'error';
+  text: string;
+}
+
+const StorageVisionReviewPage: React.FC = () => {
+  const isStaff =
+    typeof window !== 'undefined' && localStorage.getItem('is_staff') === 'true';
+  const isSuperuser =
+    typeof window !== 'undefined' &&
+    localStorage.getItem('is_superuser') === 'true';
+  const isLogistics =
+    typeof window !== 'undefined' &&
+    (localStorage.getItem('is_logistics') === 'true' ||
+      (localStorage.getItem('groups') || '').includes('Logistics'));
+  const isAllowed = isStaff || isSuperuser || isLogistics;
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const captureParam = searchParams.get('capture');
+  const captureId = captureParam ? Number(captureParam) : null;
+
+  const [observations, setObservations] = useState<VisionObservation[]>([]);
+  const [areas, setAreas] = useState<VisionArea[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [statusFilter, setStatusFilter] = useState<VisionObservationStatus>('pending');
+  const [areaFilter, setAreaFilter] = useState<number | null>(null);
+  const [classFilter, setClassFilter] =
+    useState<VisionObservationClass | null>(null);
+  const [actionFilter, setActionFilter] =
+    useState<VisionObservationAction | null>(null);
+
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [busyId, setBusyId] = useState<number | null>(null);
+  const [bulkBusy, setBulkBusy] = useState(false);
+
+  const [rejectModal, setRejectModal] = useState<{
+    obs: VisionObservation | null;
+    reason: string;
+  }>({ obs: null, reason: '' });
+  const [bulkReason, setBulkReason] = useState<string>('');
+  const [resolution, setResolution] = useState<ResolutionMessage | null>(null);
+  const [bulkSkipped, setBulkSkipped] = useState<
+    Array<{ id: number; reason: string }>
+  >([]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const obsRes = await storageVisionAPI.listObservations({
+        status: statusFilter,
+        ...(areaFilter != null ? { area: areaFilter } : {}),
+        ...(classFilter ? { classification: classFilter } : {}),
+        ...(actionFilter ? { suggested_action: actionFilter } : {}),
+      });
+      let rows = unwrap(obsRes.data);
+      if (captureId != null) {
+        rows = rows.filter((o) => o.capture === captureId);
+      }
+      setObservations(rows);
+      setError(null);
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to load observations.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, areaFilter, classFilter, actionFilter, captureId]);
+
+  const loadAreas = useCallback(async () => {
+    try {
+      const res = await storageVisionAPI.listAreas();
+      setAreas(unwrap(res.data));
+    } catch {
+      // Areas filter is non-blocking; the queue still renders.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isAllowed) return;
+    void load();
+  }, [isAllowed, load]);
+
+  useEffect(() => {
+    if (!isAllowed) return;
+    void loadAreas();
+  }, [isAllowed, loadAreas]);
+
+  const areaOptions = useMemo(
+    () => areas.map((a) => ({ value: String(a.id), label: a.name })),
+    [areas],
+  );
+
+  const allSelectable = useMemo(
+    () =>
+      observations.filter(
+        (o) =>
+          o.status === 'pending' &&
+          o.suggested_action === 'reconcile_empty',
+      ),
+    [observations],
+  );
+
+  if (!isAllowed) {
+    return <Navigate to="/" replace />;
+  }
+
+  const allSelected =
+    allSelectable.length > 0 &&
+    allSelectable.every((o) => selected.has(o.id));
+
+  const toggleAll = () => {
+    if (allSelected) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(allSelectable.map((o) => o.id)));
+    }
+  };
+
+  const toggleOne = (id: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const clearCaptureFilter = () => {
+    searchParams.delete('capture');
+    setSearchParams(searchParams);
+  };
+
+  const handleApprove = async (obs: VisionObservation) => {
+    setBusyId(obs.id);
+    setResolution(null);
+    try {
+      const res = await storageVisionAPI.approveObservation(obs.id);
+      // Optimistic + authoritative update from server.
+      setObservations((prev) =>
+        prev.map((o) =>
+          o.id === obs.id ? { ...o, ...res.data, status: 'approved' } : o,
+        ),
+      );
+      setSelected((prev) => {
+        const next = new Set(prev);
+        next.delete(obs.id);
+        return next;
+      });
+      const parts: string[] = [`Approved observation #${obs.id}`];
+      if (res.data.reconciliation_id != null) {
+        parts.push(`reconciliation #${res.data.reconciliation_id}`);
+      }
+      if (res.data.reorder_created) {
+        parts.push('reorder created');
+      }
+      setResolution({ kind: 'success', text: parts.join(' · ') });
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 409) {
+        setResolution({
+          kind: 'warning',
+          text: `Observation #${obs.id} was already resolved (AC-23). Refresh the queue to see the latest state.`,
+        });
+      } else {
+        setResolution({
+          kind: 'error',
+          text: extractErrorMessage(err, 'Approve failed.'),
+        });
+      }
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleReject = async () => {
+    const obs = rejectModal.obs;
+    if (obs == null) return;
+    const reason = rejectModal.reason.trim();
+    if (!reason) return;
+    setBusyId(obs.id);
+    try {
+      const res = await storageVisionAPI.rejectObservation(obs.id, reason);
+      setObservations((prev) =>
+        prev.map((o) =>
+          o.id === obs.id ? { ...o, ...res.data, status: 'rejected' } : o,
+        ),
+      );
+      setSelected((prev) => {
+        const next = new Set(prev);
+        next.delete(obs.id);
+        return next;
+      });
+      setRejectModal({ obs: null, reason: '' });
+      setResolution({
+        kind: 'info',
+        text: `Rejected observation #${obs.id} (no inventory mutation).`,
+      });
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 409) {
+        setResolution({
+          kind: 'warning',
+          text: `Observation #${obs.id} was already resolved (AC-23).`,
+        });
+        setRejectModal({ obs: null, reason: '' });
+      } else {
+        setResolution({
+          kind: 'error',
+          text: extractErrorMessage(err, 'Reject failed.'),
+        });
+      }
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleBulkApprove = async () => {
+    const ids = Array.from(selected);
+    if (ids.length === 0) return;
+    setBulkBusy(true);
+    setResolution(null);
+    setBulkSkipped([]);
+    try {
+      const res = await storageVisionAPI.bulkApprove(
+        ids,
+        bulkReason.trim() || undefined,
+      );
+      const approvedIds = new Set(res.data.approved.map((a) => a.id));
+      setObservations((prev) =>
+        prev.map((o) =>
+          approvedIds.has(o.id) ? { ...o, status: 'approved' } : o,
+        ),
+      );
+      setSelected(new Set());
+      setBulkReason('');
+      const reorderCount = res.data.approved.filter((a) => a.reorder_created)
+        .length;
+      const parts = [
+        `Approved ${res.data.counts.approved} of ${res.data.counts.requested}`,
+      ];
+      if (reorderCount) parts.push(`${reorderCount} reorder(s) created`);
+      if (res.data.counts.skipped) parts.push(`${res.data.counts.skipped} skipped`);
+      setResolution({ kind: 'success', text: parts.join(' · ') });
+      setBulkSkipped(res.data.skipped);
+    } catch (err) {
+      setResolution({
+        kind: 'error',
+        text: extractErrorMessage(err, 'Bulk approve failed.'),
+      });
+    } finally {
+      setBulkBusy(false);
+    }
+  };
+
+  return (
+    <WorkspacePage
+      hero={{
+        eyebrow: 'Facilities',
+        title: 'Storage vision review',
+        subtitle:
+          captureId != null
+            ? `Showing observations from capture #${captureId}.`
+            : 'Pending findings the marker detector produced. Approve to zero the stock and trigger a reorder; reject to discard.',
+        action: (
+          <Group gap="sm">
+            {captureId != null && (
+              <Button
+                variant="default"
+                onClick={clearCaptureFilter}
+                data-testid="clear-capture-filter"
+              >
+                Clear capture filter
+              </Button>
+            )}
+            <Button
+              variant="default"
+              component={Link}
+              to="/facilities/storage-vision/capture"
+            >
+              New capture
+            </Button>
+          </Group>
+        ),
+      }}
+      testId="storage-vision-review-page"
+    >
+      <Box pos="relative">
+        <LoadingOverlay visible={loading} />
+
+        {error && (
+          <Alert
+            color="red"
+            mb="md"
+            onClose={() => setError(null)}
+            withCloseButton
+          >
+            {error}
+          </Alert>
+        )}
+
+        {resolution && (
+          <Alert
+            color={
+              resolution.kind === 'success'
+                ? 'green'
+                : resolution.kind === 'warning'
+                  ? 'yellow'
+                  : resolution.kind === 'error'
+                    ? 'red'
+                    : 'blue'
+            }
+            mb="md"
+            onClose={() => setResolution(null)}
+            withCloseButton
+            data-testid="review-resolution-alert"
+          >
+            {resolution.text}
+          </Alert>
+        )}
+
+        {bulkSkipped.length > 0 && (
+          <Alert
+            color="yellow"
+            mb="md"
+            onClose={() => setBulkSkipped([])}
+            withCloseButton
+            data-testid="bulk-skipped-alert"
+          >
+            <Text fw={600} mb={4}>
+              Skipped {bulkSkipped.length} observation(s):
+            </Text>
+            <Stack gap={2}>
+              {bulkSkipped.map((s) => (
+                <Text key={s.id} size="sm">
+                  #{s.id} — {s.reason}
+                </Text>
+              ))}
+            </Stack>
+          </Alert>
+        )}
+
+        <Card withBorder mb="md" padding="md">
+          <Group align="flex-end" gap="md">
+            <Select
+              label="Status"
+              data={STATUS_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
+              value={statusFilter}
+              onChange={(v) =>
+                v && setStatusFilter(v as VisionObservationStatus)
+              }
+              data-testid="filter-status"
+            />
+            <Select
+              label="Area"
+              data={areaOptions}
+              value={areaFilter != null ? String(areaFilter) : null}
+              onChange={(v) => setAreaFilter(v ? Number(v) : null)}
+              clearable
+              searchable
+              data-testid="filter-area"
+            />
+            <Select
+              label="Classification"
+              data={CLASS_OPTIONS}
+              value={classFilter}
+              onChange={(v) =>
+                setClassFilter((v as VisionObservationClass) || null)
+              }
+              clearable
+              data-testid="filter-classification"
+            />
+            <Select
+              label="Suggested action"
+              data={ACTION_OPTIONS}
+              value={actionFilter}
+              onChange={(v) =>
+                setActionFilter((v as VisionObservationAction) || null)
+              }
+              clearable
+              data-testid="filter-action"
+            />
+          </Group>
+        </Card>
+
+        {selected.size > 0 && (
+          <Card withBorder mb="md" padding="md">
+            <Group align="flex-end" gap="md">
+              <Textarea
+                label={`Bulk reason (optional, applies to ${selected.size} observation(s))`}
+                value={bulkReason}
+                onChange={(e) => setBulkReason(e.currentTarget.value)}
+                autosize
+                minRows={1}
+                style={{ flex: 1 }}
+              />
+              <Button
+                onClick={handleBulkApprove}
+                loading={bulkBusy}
+                disabled={bulkBusy}
+                data-testid="bulk-approve-button"
+              >
+                Approve selected ({selected.size})
+              </Button>
+              <Button
+                variant="default"
+                onClick={() => setSelected(new Set())}
+              >
+                Clear selection
+              </Button>
+            </Group>
+          </Card>
+        )}
+
+        {observations.length === 0 ? (
+          <Text c="dimmed">No observations match the current filter.</Text>
+        ) : (
+          <Table data-testid="observations-table">
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th style={{ width: 32 }}>
+                  <Checkbox
+                    checked={allSelected}
+                    indeterminate={
+                      !allSelected &&
+                      allSelectable.some((o) => selected.has(o.id))
+                    }
+                    onChange={toggleAll}
+                    aria-label="Select all"
+                    data-testid="select-all"
+                  />
+                </Table.Th>
+                <Table.Th>Evidence</Table.Th>
+                <Table.Th>Slot / item</Table.Th>
+                <Table.Th>Classification</Table.Th>
+                <Table.Th>Confidence</Table.Th>
+                <Table.Th>Suggested</Table.Th>
+                <Table.Th>Status</Table.Th>
+                <Table.Th>Age</Table.Th>
+                <Table.Th>Actions</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {observations.map((obs) => {
+                const isSelectable =
+                  obs.status === 'pending' &&
+                  obs.suggested_action === 'reconcile_empty';
+                return (
+                  <Table.Tr key={obs.id}>
+                    <Table.Td>
+                      <Checkbox
+                        checked={selected.has(obs.id)}
+                        onChange={() => toggleOne(obs.id)}
+                        disabled={!isSelectable}
+                        aria-label={`Select observation ${obs.id}`}
+                        data-testid={`select-${obs.id}`}
+                      />
+                    </Table.Td>
+                    <Table.Td>
+                      {obs.evidence_crop ? (
+                        <Image
+                          src={obs.evidence_crop}
+                          alt={`evidence ${obs.id}`}
+                          w={80}
+                          h={80}
+                          fit="cover"
+                          radius="sm"
+                          data-testid={`evidence-${obs.id}`}
+                        />
+                      ) : (
+                        <Text size="xs" c="dimmed">
+                          no crop
+                        </Text>
+                      )}
+                    </Table.Td>
+                    <Table.Td>
+                      <Stack gap={2}>
+                        <Code>{obs.slot_marker_code}</Code>
+                        <Text size="sm">{obs.item_name}</Text>
+                        <Text size="xs" c="dimmed">
+                          {obs.area_name}
+                          {obs.duplicate_count > 0 && (
+                            <Tooltip
+                              label={`Re-detected ${obs.duplicate_count} time(s) before the operator resolved this row`}
+                            >
+                              <Badge color="blue" ml="xs">
+                                ×{obs.duplicate_count + 1}
+                              </Badge>
+                            </Tooltip>
+                          )}
+                        </Text>
+                      </Stack>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge color={classificationColor(obs.classification)}>
+                        {obs.classification}
+                      </Badge>
+                    </Table.Td>
+                    <Table.Td>
+                      {Number(obs.confidence).toFixed(2)}
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge variant="light">
+                        {obs.suggested_action === 'reconcile_empty'
+                          ? 'reconcile'
+                          : 'review only'}
+                      </Badge>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge color={statusColor(obs.status)}>
+                        {obs.status}
+                      </Badge>
+                    </Table.Td>
+                    <Table.Td>{formatAge(obs.age_seconds)}</Table.Td>
+                    <Table.Td>
+                      <Group gap="xs">
+                        <Button
+                          size="xs"
+                          onClick={() => handleApprove(obs)}
+                          loading={busyId === obs.id}
+                          disabled={obs.status !== 'pending'}
+                          data-testid={`approve-${obs.id}`}
+                        >
+                          Approve
+                        </Button>
+                        <Button
+                          size="xs"
+                          color="red"
+                          variant="light"
+                          onClick={() =>
+                            setRejectModal({ obs, reason: '' })
+                          }
+                          disabled={
+                            obs.status !== 'pending' || busyId === obs.id
+                          }
+                          data-testid={`reject-${obs.id}`}
+                        >
+                          Reject
+                        </Button>
+                      </Group>
+                    </Table.Td>
+                  </Table.Tr>
+                );
+              })}
+            </Table.Tbody>
+          </Table>
+        )}
+      </Box>
+
+      <Modal
+        opened={rejectModal.obs != null}
+        onClose={() => setRejectModal({ obs: null, reason: '' })}
+        title={
+          rejectModal.obs
+            ? `Reject observation #${rejectModal.obs.id}`
+            : 'Reject'
+        }
+        data-testid="reject-modal"
+      >
+        <Stack>
+          {rejectModal.obs && (
+            <Text size="sm" c="dimmed">
+              {rejectModal.obs.item_name} ·{' '}
+              <Code>{rejectModal.obs.slot_marker_code}</Code> ·{' '}
+              {rejectModal.obs.area_name}
+            </Text>
+          )}
+          <Textarea
+            label="Reason"
+            value={rejectModal.reason}
+            onChange={(e) =>
+              setRejectModal((prev) => ({
+                ...prev,
+                reason: e.currentTarget.value,
+              }))
+            }
+            required
+            autosize
+            minRows={3}
+            description="A short note for the audit trail. Required."
+            data-testid="reject-reason"
+          />
+          <Group justify="flex-end">
+            <Button
+              variant="default"
+              onClick={() => setRejectModal({ obs: null, reason: '' })}
+            >
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              disabled={!rejectModal.reason.trim() || busyId != null}
+              loading={busyId === rejectModal.obs?.id}
+              onClick={handleReject}
+              data-testid="reject-confirm"
+            >
+              Reject
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </WorkspacePage>
+  );
+};
+
+export default StorageVisionReviewPage;


### PR DESCRIPTION
## Summary

Ninth slice of the storage_vision MVP — the staff review queue UI, the last surface needed for AC-28. Closes the loop the slice-5 backend opened: an operator can now capture → process → review → approve → reorder end-to-end in the browser.

- New page \`/facilities/storage-vision/review\` (staff/Logistics only — AC-29 gate at route and sidebar). Mantine table over the observation list with status / area / classification / suggested_action filters; defaults to \`status=pending\` because that's the morning queue.
- \`?capture=N\` deep link (already shipped from slice 8's "Open in review" buttons) scopes the queue to one capture's observations; the hero offers a "Clear capture filter" CTA to step back out.
- Per-row **Approve** posts \`/observations/{id}/approve/\` and surfaces the resulting reconciliation_id + reorder_created in an inline alert (AC-21, AC-22).
- Per-row **Reject** opens a modal whose confirm button stays disabled until a reason is typed (AC-24 — required reason); POSTs \`/reject/\` and flips the row without inventory mutation.
- **409 conflict** on either action renders an AC-23 "already resolved" warning so a stale tab doesn't double-write.
- **Bulk approve**: master + per-row checkboxes. Selection is gated to pending reconcile_empty rows (the only ones the bulk endpoint acts on). "Approve selected" sends ids + optional shared reason; skipped rows render with per-id reasons in a dedicated alert (AC-25).
- duplicate_count > 0 surfaces as a "×N" badge with a tooltip explaining the AC-19 re-detection (visibility into the dedup behavior).

## Acceptance criteria touched

- AC-20 — filterable review queue
- AC-21 — approve reconciles stock
- AC-22 — approve at-or-below minimum_stock surfaces the auto-created reorder
- AC-23 — 409 conflict shown when a stale approve / reject hits an already-resolved row
- AC-24 — reject requires a reason
- AC-25 — bulk approve partial results (approved + skipped with reasons)
- AC-28 — staff can approve / reject observations (review half)
- AC-29 — non-staff/non-Logistics blocked at route AND sidebar

## Test plan

- [x] \`npx vitest run StorageVisionReviewPage\` — 7 passing
- [x] \`npx vitest run Sidebar StorageVisionSetupPage StorageVisionCapturePage\` — 19 passing (no regression from the new sidebar entry / route)
- [x] \`npm run build\` — clean
- [x] \`pre-commit run --files <slice-9 files>\` — clean
- [x] Non-staff redirected; staff sees a pending-by-default queue
- [x] Approve writes reconciliation_id + reorder_created to the alert and flips the row to approved
- [x] 409 conflict on approve surfaces the AC-23 warning
- [x] Reject confirm disabled until a reason is typed; POST sends the reason and flips the row
- [x] Bulk approve sends only selected ids; bulk-skipped alert renders per-id reasons
- [x] \`?capture=N\` filters the queue and offers a Clear button

## Out of scope (next slice)

- Slice 10: Playwright E2E proving the full AC-34 staff operating loop (configure area + slot → upload capture → wait for processing → approve observation → open reorder queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)