### PR TITLE
feat(forgekey): expose asset_location_name on OperationalModeSerializer

### DIFF
--- a/backend/forgekey/serializers.py
+++ b/backend/forgekey/serializers.py
@@ -63,6 +63,9 @@ class OperationalModeSerializer(serializers.ModelSerializer):
     """Serializer for OperationalMode model."""
 
     asset_name = serializers.CharField(source="asset.name", read_only=True)
+    asset_location_name = serializers.CharField(
+        source="asset.location.name", read_only=True, allow_null=True
+    )
     classroom_mode_enabled_by_username = serializers.CharField(
         source="classroom_mode_enabled_by.username", read_only=True
     )


### PR DESCRIPTION
## Summary

Scantty's **o** (operational modes) screen showed bare asset UUIDs in each row. PR uid0/scantty#29 plumbed \`asset_name\` through the omsapi struct, but the operator wants to see *where* the asset lives too. The serializer already exposes \`asset_name\` via \`source='asset.name'\`; add \`asset_location_name\` via \`source='asset.location.name'\` (\`allow_null=True\` because not every asset has a location set).

The follow-up scantty PR will render the row as \`{asset_name} @ {location}\`.

## Test plan

- [x] \`pytest forgekey/tests -k operational\` — 4 passing
- [x] \`pre-commit run --files backend/forgekey/serializers.py\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)