### PR TITLE
fix(notifications): make the notifications drawer list scrollable

### DIFF
--- a/frontend/src/components/NotificationCenter.tsx
+++ b/frontend/src/components/NotificationCenter.tsx
@@ -154,7 +154,16 @@ const NotificationCenter: React.FC<NotificationCenterProps> = ({ isOpen, onClose
           <Text size="sm" fw={500} mb="xs">
             {filter === 'unread' ? 'Unread Notifications' : 'All Notifications'}
           </Text>
-          <ScrollArea h={400}>
+          {/*
+           * `ScrollArea.Autosize mah` grows the area with the list and
+           * caps it at the viewport so the drawer (taking the right side
+           * of the screen) stays usable on every height. The old fixed
+           * `h={400}` clamped to 400 px even on a 1440 p display — the
+           * inner ScrollArea ran out of room AND the drawer's outer
+           * scroll couldn't reach past it, so on a tall list the bottom
+           * notifications were unreachable.
+           */}
+          <ScrollArea.Autosize mah="calc(100vh - 220px)">
             {allNotifications.length === 0 ? (
               <Text c="dimmed" size="sm" ta="center" py="xl">
                 No notifications
@@ -213,7 +222,7 @@ const NotificationCenter: React.FC<NotificationCenterProps> = ({ isOpen, onClose
                 ))}
               </Stack>
             )}
-          </ScrollArea>
+          </ScrollArea.Autosize>
         </div>
       </Stack>
     </Drawer>


### PR DESCRIPTION
## Summary

You couldn't scroll the notifications tab — the bottom rows were unreachable. Root cause: \`NotificationCenter\` wrapped the backend-notifications list in \`<ScrollArea h={400}>\`. On a tall viewport the inner ScrollArea clamped to 400 px and the outer Drawer's natural scroll couldn't reach past it, so once you had more than ~5 notifications the rest dropped below the fold.

Fix: switch to \`<ScrollArea.Autosize mah="calc(100vh - 220px)">\`. The list grows with content but caps at the viewport, so the drawer stays usable at every screen height and the scrollbar is always reachable.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npx vitest run NotificationBadge NotificationBanner\` — 12 passing (no NotificationCenter tests existed; sibling components verify no regressions in the surrounding patterns)
- [x] \`pre-commit run --files frontend/src/components/NotificationCenter.tsx\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)