### PR TITLE
fix(forgekey/epaper): use FRONTEND_URL for the panel QR so https:// renders

### DIFF
--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -2398,13 +2398,27 @@ class ForgeKeyCertificateRevocationListView(APIView):
 def epaper_service_url(request, display_pk) -> str:
     """Front-end "log service" page a maintainer lands on from a panel QR.
 
-    This is a React-Router route (mirrors the bind page's
-    ``/forgekey/epaper/...`` path), not a Django view, so it is built as a
-    plain path rather than reversed. Front-end and API share the origin
-    behind nginx in prod, so deriving it from the request host keeps the
-    QR correct across dev/staging/prod without a hardcoded domain.
+    Prefer the configured ``FRONTEND_URL`` over ``request.build_absolute_uri``.
+    The firmware fetches the panel image over plain HTTP from inside the
+    network (the device has no kernel-level cert store), so
+    ``request.scheme`` is ``"http"`` on that GET — which used to leak into
+    the QR target and the operator's phone landed on http://, relying on
+    the prod SECURE_SSL_REDIRECT to bounce to HTTPS. That worked but
+    showed up as "no https://" in QR scanners and decoders.
+
+    ``FRONTEND_URL`` is set per-environment in .env (e.g.
+    https://dms.openmakersuite.net in prod) and is the canonical address
+    the maintainer's phone would visit, so it's what the QR should point
+    at. Falls back to ``request.build_absolute_uri`` when the setting is
+    missing or empty so dev (no .env) still works.
     """
-    return request.build_absolute_uri(f"/forgekey/epaper/service?did={display_pk}")
+    from django.conf import settings
+
+    base = (getattr(settings, "FRONTEND_URL", "") or "").strip().rstrip("/")
+    path = f"/forgekey/epaper/service?did={display_pk}"
+    if base:
+        return f"{base}{path}"
+    return request.build_absolute_uri(path)
 
 
 class EPaperDisplayImageView(APIView):


### PR DESCRIPTION
## Summary

**Not by design** — fixing it. The Seeed Studio panel QR was missing \`https://\` because \`epaper_service_url\` used \`request.build_absolute_uri\` to derive the target. The firmware fetches the panel image over plain HTTP from inside the network (the ESP32-S3 has no kernel-level cert store for this firmware class), so \`request.scheme\` is \`"http"\` on that GET — that leaked into the QR.

In prod the operator's phone still ended up on HTTPS because \`SECURE_SSL_REDIRECT\` bounced it, but QR decoders / clipboard shows the raw \`http://…\` (or just hostname depending on which scanner) — which is what you noticed.

Switch \`epaper_service_url\` to prefer the canonical \`FRONTEND_URL\` setting (already \`https://dms.openmakersuite.net\` in prod and staging). Falls back to \`build_absolute_uri\` when \`FRONTEND_URL\` is empty so dev quickstarts still work.

## Test plan

- [x] \`pytest forgekey/tests -k epaper\` — 97 passing (panel render, service-URL, OTA, rollout)
- [x] \`pre-commit run --files backend/forgekey/views.py\` — clean

Once this merges + deploys, the next panel re-render will encode the full \`https://dms.openmakersuite.net/forgekey/epaper/service?did=N\` in the QR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)