### PR TITLE
feat(sidebar): surface Maker Boxes under Facilities

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -120,6 +120,8 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed = false, isMobileOpen = f
         { path: '/facilities/forgekey-rollouts', label: 'Firmware Rollouts', icon: '🚀', requiresStaff: true },
         { path: '/facilities/forgekey-certificates', label: 'Certificates (PKI)', icon: '🔐', requiresStaff: true },
         { path: '/facilities/lockers', label: 'Lockers', icon: '🔒', requiresStaff: true },
+        { path: '/facilities/maker-boxes', label: 'Maker Boxes', icon: '🗃️', requiresStaff: true },
+        { path: '/facilities/maker-boxes/scan', label: 'Maker Box scan', icon: '🔍', requiresStaff: true },
         { path: '/facilities/electrical', label: 'Electrical & Network', icon: '⚡', requiresStaff: true },
         { path: '/facilities/project-storage/queue', label: 'Project Storage', icon: '📦', requiresStaff: true },
         { path: '/facilities/storage-vision', label: 'Storage Vision', icon: '📸', requiresStaff: true },

--- a/frontend/src/navigation/routeMap.ts
+++ b/frontend/src/navigation/routeMap.ts
@@ -53,6 +53,7 @@ const ENTRIES: RouteEntry[] = [
   { path: 'facilities/checklist', label: 'Checklist' },
   { path: 'facilities/screens', label: 'Screens' },
   { path: 'facilities/maker-boxes', label: 'Maker Boxes' },
+  { path: 'facilities/maker-boxes/scan', label: 'Maker Box scan' },
   { path: 'facilities/project-storage', label: 'Project Storage' },
   { path: 'facilities/project-storage/queue', label: 'Queue' },
   { path: 'facilities/electrical', label: 'Electrical' },


### PR DESCRIPTION
## Summary

You couldn't get to Maker Boxes from the sidebar — the admin + scan pages and the routeMap entry already existed, but the sidebar didn't list them. So the only way in was the Facilities overview tile (or typing the URL).

Adds two staff-gated entries under Facilities (between Lockers and Electrical):

- 🗃️ **Maker Boxes** → \`/facilities/maker-boxes\` (admin)
- 🔍 **Maker Box scan** → \`/facilities/maker-boxes/scan\` (on-floor scan flow that hits \`/api/maker-boxes/scan/\`)

Also adds the scan path to \`routeMap.ts\` so the breadcrumb renders the right label there.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npx vitest run src/__tests__/components/Sidebar.test.tsx\` — 7 passing
- [x] \`pre-commit run --files Sidebar.tsx routeMap.ts\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)