### PR TITLE
feat(maker_boxes): pre-conversion queue endpoints + UI (PR2/3)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -1951,10 +1951,19 @@ views:
       list:
         permission_classes:
         - IsAuthenticated
+      lookup:
+        permission_classes:
+        - IsAuthenticated
       manual_label:
         permission_classes:
         - IsAuthenticated
       partial_update:
+        permission_classes:
+        - IsAuthenticated
+      pre_conversion_queue:
+        permission_classes:
+        - IsAuthenticated
+      pre_convert:
         permission_classes:
         - IsAuthenticated
       print_sheet:

--- a/backend/maker_boxes/serializers.py
+++ b/backend/maker_boxes/serializers.py
@@ -24,6 +24,8 @@ class MakerBoxSerializer(serializers.ModelSerializer):
             "expires_at",
             "last_verified_at",
             "status",
+            "identity_source",
+            "conversion_completed_at",
             "paid_at",
             "notes",
             "created_at",
@@ -52,3 +54,41 @@ class ManualLabelRequestSerializer(serializers.Serializer):
     username = serializers.CharField(max_length=64)
     first_name = serializers.CharField(max_length=64, allow_blank=True, required=False, default="")
     last_name = serializers.CharField(max_length=64, allow_blank=True, required=False, default="")
+
+
+# ---------------------------------------------------------------------------
+# Pre-conversion (PR 2)
+# ---------------------------------------------------------------------------
+
+# The pre-conversion screen accepts either a badge number (digits) or a
+# WHMCS username (alphanumeric). The resolver decides which backend to
+# call — the request shape is the same for both, hence ``query`` rather
+# than ``username`` / ``badge``.
+
+
+class LookupRequestSerializer(serializers.Serializer):
+    query = serializers.CharField(max_length=64)
+
+
+class LookupResponseSerializer(serializers.Serializer):
+    """Result of an identity-only lookup (no DB write).
+
+    ``found`` is false when neither backend matched the query. In that
+    case the other fields are empty / null but still present so the
+    frontend can render a single shape.
+    """
+
+    found = serializers.BooleanField()
+    identity_source = serializers.CharField(allow_blank=True)
+    username = serializers.CharField(allow_blank=True)
+    first_name = serializers.CharField(allow_blank=True)
+    last_name = serializers.CharField(allow_blank=True)
+    email = serializers.EmailField(allow_blank=True)
+    membership_status = serializers.CharField(allow_blank=True)
+    expires_at = serializers.DateTimeField(allow_null=True)
+    days_remaining = serializers.IntegerField(allow_null=True)
+
+
+class PreConvertRequestSerializer(serializers.Serializer):
+    query = serializers.CharField(max_length=64)
+    notes = serializers.CharField(max_length=2000, allow_blank=True, required=False, default="")

--- a/backend/maker_boxes/tests/test_preconversion.py
+++ b/backend/maker_boxes/tests/test_preconversion.py
@@ -1,0 +1,234 @@
+"""Tests for the PR2 pre-conversion endpoints.
+
+Covers:
+
+* ``POST /lookup/`` — identity-only lookup hit / miss / staff gate.
+* ``POST /pre-convert/`` — creates a queue row, idempotent on resolved
+  username, refuses to clobber an already-converted row.
+* ``GET /pre-conversion-queue/`` — lists only ``pre_conversion`` rows.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.urls import reverse
+from django.utils import timezone
+
+import pytest
+from rest_framework.test import APIClient
+
+from maker_boxes.models import MakerBox
+from maker_boxes.services.whmcs_client import MemberLookup
+
+User = get_user_model()
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def staff_client():
+    user = User.objects.create_user(username="staff", password="x", is_staff=True)
+    Group.objects.get_or_create(name="Logistics")
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def member_client():
+    user = User.objects.create_user(username="rando", password="x")
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _hit(username="ada", *, status_="valid", expires_days=30):
+    expires = timezone.now() + timedelta(days=expires_days)
+    return MemberLookup(
+        status=status_,
+        username=username,
+        first_name="Ada",
+        last_name="Lovelace",
+        email="ada@example.org",
+        expires_at=expires,
+        days_remaining=expires_days,
+    )
+
+
+# ---------------------------------------------------------------------------
+# /lookup/
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_hit_returns_identity(staff_client):
+    with patch("maker_boxes.views.resolve_identity", return_value=(_hit(), "whmcs")):
+        resp = staff_client.post(reverse("maker-box-lookup"), {"query": "ada"}, format="json")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["found"] is True
+    assert body["identity_source"] == "whmcs"
+    assert body["username"] == "ada"
+    assert body["first_name"] == "Ada"
+    assert body["membership_status"] == "valid"
+    # No DB write — the lookup endpoint is read-only.
+    assert MakerBox.objects.count() == 0
+
+
+def test_lookup_miss_returns_found_false(staff_client):
+    with patch("maker_boxes.views.resolve_identity", return_value=(None, "")):
+        resp = staff_client.post(reverse("maker-box-lookup"), {"query": "ghost"}, format="json")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["found"] is False
+    assert body["username"] == ""
+    assert body["membership_status"] == ""
+    assert body["expires_at"] is None
+
+
+def test_lookup_rejects_non_staff(member_client):
+    resp = member_client.post(reverse("maker-box-lookup"), {"query": "ada"}, format="json")
+    assert resp.status_code == 403
+
+
+def test_lookup_anonymous_rejected():
+    client = APIClient()
+    resp = client.post(reverse("maker-box-lookup"), {"query": "ada"}, format="json")
+    assert resp.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# /pre-convert/
+# ---------------------------------------------------------------------------
+
+
+def test_pre_convert_creates_pre_conversion_row(staff_client):
+    with patch("maker_boxes.views.resolve_identity", return_value=(_hit(), "whmcs")):
+        resp = staff_client.post(reverse("maker-box-pre-convert"), {"query": "ada"}, format="json")
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["assigned_username"] == "ada"
+    assert body["status"] == "pre_conversion"
+    assert body["bin_id"] is None
+    assert body["identity_source"] == "whmcs"
+    assert body["first_name"] == "Ada"
+
+    row = MakerBox.objects.get(assigned_username="ada")
+    assert row.status == MakerBox.STATUS_PRE_CONVERSION
+    assert row.bin_id is None
+    assert row.last_verified_at is not None
+
+
+def test_pre_convert_idempotent_returns_200_and_refreshes_identity(staff_client):
+    # First call creates.
+    with patch("maker_boxes.views.resolve_identity", return_value=(_hit(), "whmcs")):
+        first = staff_client.post(reverse("maker-box-pre-convert"), {"query": "ada"}, format="json")
+    assert first.status_code == 201
+
+    # Second call returns the existing row with refreshed identity.
+    refreshed = _hit()
+    refreshed.first_name = "Augusta"  # WHMCS now has the formal name.
+    refreshed.email = "ada+new@example.org"
+    with patch("maker_boxes.views.resolve_identity", return_value=(refreshed, "whmcs")):
+        second = staff_client.post(
+            reverse("maker-box-pre-convert"), {"query": "ada"}, format="json"
+        )
+
+    assert second.status_code == 200
+    body = second.json()
+    assert body["first_name"] == "Augusta"
+    assert body["email"] == "ada+new@example.org"
+    assert MakerBox.objects.filter(assigned_username="ada").count() == 1
+
+
+def test_pre_convert_appends_notes(staff_client):
+    with patch("maker_boxes.views.resolve_identity", return_value=(_hit(), "whmcs")):
+        staff_client.post(
+            reverse("maker-box-pre-convert"),
+            {"query": "ada", "notes": "wants the small bin"},
+            format="json",
+        )
+        staff_client.post(
+            reverse("maker-box-pre-convert"),
+            {"query": "ada", "notes": "also: dropped off keys"},
+            format="json",
+        )
+    row = MakerBox.objects.get(assigned_username="ada")
+    assert "wants the small bin" in row.notes
+    assert "dropped off keys" in row.notes
+
+
+def test_pre_convert_miss_returns_404(staff_client):
+    with patch("maker_boxes.views.resolve_identity", return_value=(None, "")):
+        resp = staff_client.post(
+            reverse("maker-box-pre-convert"), {"query": "ghost"}, format="json"
+        )
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "not_found"
+    assert MakerBox.objects.count() == 0
+
+
+def test_pre_convert_rejects_already_converted_user(staff_client):
+    # User has a bin_id and a real status — they're past PR3.
+    MakerBox.objects.create(
+        bin_id="MBX-007",
+        assigned_username="ada",
+        status=MakerBox.STATUS_VALID,
+        first_name="Ada",
+    )
+    with patch("maker_boxes.views.resolve_identity", return_value=(_hit(), "whmcs")):
+        resp = staff_client.post(reverse("maker-box-pre-convert"), {"query": "ada"}, format="json")
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["code"] == "already_converted"
+    assert body["bin_id"] == "MBX-007"
+
+
+def test_pre_convert_rejects_non_staff(member_client):
+    resp = member_client.post(reverse("maker-box-pre-convert"), {"query": "ada"}, format="json")
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# /pre-conversion-queue/
+# ---------------------------------------------------------------------------
+
+
+def test_pre_conversion_queue_lists_only_pre_conversion_rows(staff_client):
+    MakerBox.objects.create(
+        assigned_username="ada",
+        status=MakerBox.STATUS_PRE_CONVERSION,
+        first_name="Ada",
+    )
+    MakerBox.objects.create(
+        assigned_username="bob",
+        status=MakerBox.STATUS_PRE_CONVERSION,
+        first_name="Bob",
+    )
+    # Already-converted: should NOT appear.
+    MakerBox.objects.create(
+        bin_id="MBX-001",
+        assigned_username="carol",
+        status=MakerBox.STATUS_VALID,
+        first_name="Carol",
+    )
+    # Unassigned legacy row: also should NOT appear.
+    MakerBox.objects.create(
+        bin_id="MBX-002",
+        status=MakerBox.STATUS_UNASSIGNED,
+    )
+
+    resp = staff_client.get(reverse("maker-box-pre-conversion-queue"))
+    assert resp.status_code == 200
+    body = resp.json()
+    usernames = sorted(row["assigned_username"] for row in body)
+    assert usernames == ["ada", "bob"]
+
+
+def test_pre_conversion_queue_rejects_non_staff(member_client):
+    resp = member_client.get(reverse("maker-box-pre-conversion-queue"))
+    assert resp.status_code == 403

--- a/backend/maker_boxes/views.py
+++ b/backend/maker_boxes/views.py
@@ -15,12 +15,16 @@ from membership.utils import is_logistics_member
 
 from .models import MakerBox
 from .serializers import (
+    LookupRequestSerializer,
+    LookupResponseSerializer,
     MakerBoxSerializer,
     ManualLabelRequestSerializer,
+    PreConvertRequestSerializer,
     ScanRequestSerializer,
     ScanResponseSerializer,
 )
 from .services.email_service import send_pickup_notification
+from .services.identity_resolver import resolve as resolve_identity
 from .services.label_service import render_box_label
 from .services.sheet_service import CARDS_PER_SHEET, render_avery_5371_sheet
 from .services.whmcs_client import WhmcsNotConfigured, lookup_member
@@ -212,6 +216,137 @@ class MakerBoxViewSet(viewsets.ModelViewSet):
         response = HttpResponse(png, content_type="image/png")
         response["Content-Disposition"] = 'inline; filename="maker-box-manual.png"'
         return response
+
+    # ------------------------------------------------------------------
+    # Pre-conversion (PR 2)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _lookup_payload(lookup, source):
+        """Serializer-shaped dict for an identity hit or miss."""
+        if lookup is None:
+            return {
+                "found": False,
+                "identity_source": "",
+                "username": "",
+                "first_name": "",
+                "last_name": "",
+                "email": "",
+                "membership_status": "",
+                "expires_at": None,
+                "days_remaining": None,
+            }
+        return {
+            "found": True,
+            "identity_source": source,
+            "username": lookup.username,
+            "first_name": lookup.first_name,
+            "last_name": lookup.last_name,
+            "email": lookup.email,
+            "membership_status": lookup.status,
+            "expires_at": lookup.expires_at,
+            "days_remaining": lookup.days_remaining,
+        }
+
+    @action(detail=False, methods=["post"], url_path="lookup")
+    def lookup(self, request):
+        """Identity-only lookup: run the cascade, return what we found.
+
+        No DB write. The frontend uses this for live preview as a
+        staffer types or scans a badge/username — the actual queue
+        insert happens in ``pre_convert`` when they hit "Add".
+        """
+        denied = self._check_staff(request)
+        if denied is not None:
+            return denied
+
+        serializer = LookupRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        query = serializer.validated_data["query"]
+
+        lookup, source = resolve_identity(query)
+        payload = self._lookup_payload(lookup, source)
+        return Response(LookupResponseSerializer(payload).data)
+
+    @action(detail=False, methods=["post"], url_path="pre-convert")
+    def pre_convert(self, request):
+        """Resolve identity and put the user on the pre-conversion queue.
+
+        Idempotent on resolved username: if a pre-conversion row
+        already exists, we update its identity fields (in case the
+        member's name/email changed) and return it. If the user has
+        already been converted (status != pre_conversion AND bin_id is
+        set), we return 409 — the queue is for users without a bin
+        yet, and reopening a converted row would silently undo PR3's
+        work.
+        """
+        denied = self._check_staff(request)
+        if denied is not None:
+            return denied
+
+        serializer = PreConvertRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        query = serializer.validated_data["query"]
+        notes = serializer.validated_data.get("notes", "")
+
+        lookup, source = resolve_identity(query)
+        if lookup is None:
+            return Response(
+                {
+                    "detail": (
+                        "No identity matched that badge or username. "
+                        "Check the spelling, or have the member scan their badge."
+                    ),
+                    "code": "not_found",
+                },
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        existing = MakerBox.objects.filter(assigned_username=lookup.username).first()
+        if existing and existing.bin_id and existing.status != MakerBox.STATUS_PRE_CONVERSION:
+            return Response(
+                {
+                    "detail": (
+                        f"{lookup.username} is already assigned bin {existing.bin_id}. "
+                        "Use the scan screen instead of the pre-conversion queue."
+                    ),
+                    "code": "already_converted",
+                    "bin_id": existing.bin_id,
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        box = existing or MakerBox(assigned_username=lookup.username, bin_id=None)
+        box.assigned_username = lookup.username
+        box.first_name = lookup.first_name
+        box.last_name = lookup.last_name
+        box.email = lookup.email
+        box.expires_at = lookup.expires_at
+        box.status = MakerBox.STATUS_PRE_CONVERSION
+        box.identity_source = source
+        box.last_verified_at = timezone.now()
+        if notes:
+            # Append rather than overwrite so an earlier staffer's note
+            # isn't lost when a second staffer re-runs the lookup.
+            existing_notes = box.notes or ""
+            box.notes = (existing_notes + ("\n" if existing_notes else "") + notes).strip()
+        box.save()
+
+        return Response(
+            MakerBoxSerializer(box).data,
+            status=status.HTTP_200_OK if existing else status.HTTP_201_CREATED,
+        )
+
+    @action(detail=False, methods=["get"], url_path="pre-conversion-queue")
+    def pre_conversion_queue(self, request):
+        """List the rows waiting for bin allocation, newest first."""
+        denied = self._check_staff(request)
+        if denied is not None:
+            return denied
+        queue = MakerBox.objects.filter(status=MakerBox.STATUS_PRE_CONVERSION).order_by(
+            "-created_at"
+        )
+        return Response(MakerBoxSerializer(queue, many=True).data)
 
     @action(detail=True, methods=["post"], url_path="email-pickup")
     def email_pickup(self, request, pk=None):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,6 +75,7 @@ import LocationProblemsListPage from './pages/LocationProblemsListPage';
 import LocationScanPage from './pages/LocationScanPage';
 import LogisticsDashboard from './pages/LogisticsDashboard';
 import MakerBoxAdminPage from './pages/MakerBoxAdminPage';
+import MakerBoxPreConversionPage from './pages/MakerBoxPreConversionPage';
 import MakerBoxScanPage from './pages/MakerBoxScanPage';
 import MaintenanceDashboard from './pages/MaintenanceDashboard';
 import MaintenanceDashboardPage from './pages/MaintenanceDashboardPage';
@@ -294,6 +295,7 @@ function AppContent() {
           <Route path="/facilities/screens/:slug" element={<WorkspaceLayout><ScreenEditPage /></WorkspaceLayout>} />
           <Route path="/kiosk/:slug" element={<KioskDisplayPage />} />
           <Route path="/facilities/logistics" element={<LogisticsDashboard />} />
+          <Route path="/facilities/maker-boxes/pre-conversion" element={<WorkspaceLayout><MakerBoxPreConversionPage /></WorkspaceLayout>} />
           <Route path="/facilities/maker-boxes/scan" element={<WorkspaceLayout><MakerBoxScanPage /></WorkspaceLayout>} />
           <Route path="/facilities/maker-boxes" element={<WorkspaceLayout><MakerBoxAdminPage /></WorkspaceLayout>} />
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -121,6 +121,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed = false, isMobileOpen = f
         { path: '/facilities/forgekey-certificates', label: 'Certificates (PKI)', icon: '🔐', requiresStaff: true },
         { path: '/facilities/lockers', label: 'Lockers', icon: '🔒', requiresStaff: true },
         { path: '/facilities/maker-boxes', label: 'Maker Boxes', icon: '🗃️', requiresStaff: true },
+        { path: '/facilities/maker-boxes/pre-conversion', label: 'Maker Box pre-conversion', icon: '📥', requiresStaff: true },
         { path: '/facilities/maker-boxes/scan', label: 'Maker Box scan', icon: '🔍', requiresStaff: true },
         { path: '/facilities/electrical', label: 'Electrical & Network', icon: '⚡', requiresStaff: true },
         { path: '/facilities/project-storage/queue', label: 'Project Storage', icon: '📦', requiresStaff: true },

--- a/frontend/src/navigation/routeMap.ts
+++ b/frontend/src/navigation/routeMap.ts
@@ -53,6 +53,7 @@ const ENTRIES: RouteEntry[] = [
   { path: 'facilities/checklist', label: 'Checklist' },
   { path: 'facilities/screens', label: 'Screens' },
   { path: 'facilities/maker-boxes', label: 'Maker Boxes' },
+  { path: 'facilities/maker-boxes/pre-conversion', label: 'Maker Box pre-conversion' },
   { path: 'facilities/maker-boxes/scan', label: 'Maker Box scan' },
   { path: 'facilities/project-storage', label: 'Project Storage' },
   { path: 'facilities/project-storage/queue', label: 'Queue' },

--- a/frontend/src/pages/MakerBoxPreConversionPage.tsx
+++ b/frontend/src/pages/MakerBoxPreConversionPage.tsx
@@ -1,0 +1,262 @@
+/**
+ * Maker Box Pre-Conversion Page
+ *
+ * Phase 1 of the three-phase maker-box conversion workflow:
+ *
+ *   1. Pre-conversion (this page) — staff scans a badge or types a
+ *      WHMCS username; the cascade resolves identity from Common API
+ *      and/or WHMCS; the row is queued for bin allocation later.
+ *   2. Conversion (PR 3) — staff allocates ``MBX-NNN`` and prints the
+ *      label.
+ *   3. Post-conversion — the existing scan screen verifies status.
+ *
+ * The "Add to queue" button hits ``/pre-convert/``, which is
+ * idempotent on resolved username: re-scanning the same member just
+ * refreshes their identity row rather than producing duplicates.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  makerBoxesAPI,
+  MakerBox,
+  MakerBoxLookupResult,
+} from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+const IDENTITY_SOURCE_LABEL: Record<string, string> = {
+  whmcs: 'WHMCS',
+  common_api: 'Common API (badge / AD)',
+  manual: 'Manual admin entry',
+  '': 'Unknown',
+};
+
+const MakerBoxPreConversionPage: React.FC = () => {
+  const [query, setQuery] = useState('');
+  const [notes, setNotes] = useState('');
+  const [preview, setPreview] = useState<MakerBoxLookupResult | null>(null);
+  const [previewQuery, setPreviewQuery] = useState('');
+  const [previewing, setPreviewing] = useState(false);
+  const [adding, setAdding] = useState(false);
+  const [queue, setQueue] = useState<MakerBox[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmation, setConfirmation] = useState<string | null>(null);
+
+  const refreshQueue = useCallback(async () => {
+    try {
+      const response = await makerBoxesAPI.preConversionQueue();
+      setQueue(response.data);
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to load queue.'));
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshQueue();
+  }, [refreshQueue]);
+
+  const runLookup = useCallback(async () => {
+    const cleaned = query.trim();
+    if (!cleaned) return;
+    setPreviewing(true);
+    setError(null);
+    setConfirmation(null);
+    try {
+      const response = await makerBoxesAPI.lookup(cleaned);
+      setPreview(response.data);
+      setPreviewQuery(cleaned);
+    } catch (err) {
+      setPreview(null);
+      setError(extractErrorMessage(err, 'Lookup failed.'));
+    } finally {
+      setPreviewing(false);
+    }
+  }, [query]);
+
+  const handleLookupSubmit = useCallback(
+    (event: React.FormEvent) => {
+      event.preventDefault();
+      runLookup();
+    },
+    [runLookup],
+  );
+
+  const handleAddToQueue = useCallback(async () => {
+    const cleaned = (previewQuery || query).trim();
+    if (!cleaned) return;
+    setAdding(true);
+    setError(null);
+    setConfirmation(null);
+    try {
+      const response = await makerBoxesAPI.preConvert(cleaned, notes.trim() || undefined);
+      const row = response.data;
+      setConfirmation(
+        `${row.display_name || row.assigned_username} queued for bin allocation.`,
+      );
+      setQuery('');
+      setNotes('');
+      setPreview(null);
+      setPreviewQuery('');
+      await refreshQueue();
+    } catch (err: any) {
+      setError(extractErrorMessage(err, 'Failed to add to queue.'));
+    } finally {
+      setAdding(false);
+    }
+  }, [previewQuery, query, notes, refreshQueue]);
+
+  const previewIsFresh = preview && previewQuery === query.trim();
+
+  return (
+    <div style={{ padding: '1.5rem', maxWidth: '880px', margin: '0 auto' }}>
+      <h1>Maker Box — Pre-Conversion Queue</h1>
+      <p>
+        Scan a badge or type a WHMCS username. We'll look up the member
+        and queue them for bin allocation. Bin IDs (<code>MBX-NNN</code>)
+        are assigned in the next phase.
+      </p>
+
+      <form
+        onSubmit={handleLookupSubmit}
+        style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', marginBottom: '1rem' }}
+      >
+        <label>
+          Badge or username
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="12345678 or ada.lovelace"
+            required
+            autoFocus
+            style={{ width: '100%', padding: '0.5rem', fontSize: '1rem' }}
+          />
+        </label>
+        <label>
+          Notes (optional)
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="e.g. wants the small bin"
+            rows={2}
+            style={{ width: '100%', padding: '0.5rem', fontSize: '0.95rem' }}
+          />
+        </label>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <button
+            type="submit"
+            disabled={previewing || !query.trim()}
+            style={{ padding: '0.5rem 1rem' }}
+          >
+            {previewing ? 'Looking up…' : 'Look up'}
+          </button>
+          <button
+            type="button"
+            onClick={handleAddToQueue}
+            disabled={adding || !previewIsFresh || !preview?.found}
+            style={{ padding: '0.5rem 1rem' }}
+          >
+            {adding ? 'Adding…' : 'Add to queue'}
+          </button>
+        </div>
+      </form>
+
+      {error && (
+        <div
+          role="alert"
+          style={{
+            background: '#fdecea',
+            border: '1px solid #c0392b',
+            color: '#7a1f15',
+            padding: '0.75rem',
+            marginBottom: '1rem',
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {confirmation && (
+        <div
+          role="status"
+          style={{
+            background: '#eaf6ec',
+            border: '1px solid #1f8a3a',
+            color: '#0f5320',
+            padding: '0.75rem',
+            marginBottom: '1rem',
+          }}
+        >
+          {confirmation}
+        </div>
+      )}
+
+      {previewIsFresh && (
+        <div
+          data-testid="lookup-preview"
+          style={{
+            border: '1px solid #ccc',
+            padding: '0.75rem',
+            marginBottom: '1.5rem',
+            background: preview.found ? '#f5fbf6' : '#fef5f4',
+          }}
+        >
+          {preview.found ? (
+            <>
+              <div style={{ fontSize: '1.1rem', fontWeight: 600 }}>
+                {preview.first_name} {preview.last_name} ({preview.username})
+              </div>
+              <div>{preview.email || <em>no email on file</em>}</div>
+              <div style={{ marginTop: '0.25rem' }}>
+                Identity source: {IDENTITY_SOURCE_LABEL[preview.identity_source] || preview.identity_source}
+              </div>
+              <div>
+                Membership: {preview.membership_status || 'unknown'}
+                {preview.days_remaining !== null && ` (${preview.days_remaining} days remaining)`}
+              </div>
+            </>
+          ) : (
+            <div>
+              No match. If this is an add-on user, have them scan their badge so
+              the Common API can resolve their identity.
+            </div>
+          )}
+        </div>
+      )}
+
+      <h2>Queue ({queue.length})</h2>
+      {queue.length === 0 ? (
+        <p>
+          <em>No members are waiting for bin allocation.</em>
+        </p>
+      ) : (
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr style={{ background: '#f0f0f0', textAlign: 'left' }}>
+              <th style={{ padding: '0.5rem' }}>Username</th>
+              <th style={{ padding: '0.5rem' }}>Name</th>
+              <th style={{ padding: '0.5rem' }}>Source</th>
+              <th style={{ padding: '0.5rem' }}>Notes</th>
+              <th style={{ padding: '0.5rem' }}>Queued</th>
+            </tr>
+          </thead>
+          <tbody>
+            {queue.map((row) => (
+              <tr key={row.id} style={{ borderTop: '1px solid #eee' }}>
+                <td style={{ padding: '0.5rem' }}>{row.assigned_username}</td>
+                <td style={{ padding: '0.5rem' }}>{row.display_name}</td>
+                <td style={{ padding: '0.5rem' }}>
+                  {IDENTITY_SOURCE_LABEL[row.identity_source] || row.identity_source || '—'}
+                </td>
+                <td style={{ padding: '0.5rem', whiteSpace: 'pre-wrap' }}>{row.notes}</td>
+                <td style={{ padding: '0.5rem' }}>
+                  {row.created_at ? new Date(row.created_at).toLocaleString() : ''}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+
+export default MakerBoxPreConversionPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1753,7 +1753,7 @@ export const kioskAPI = {
 
 export interface MakerBox {
   id: number;
-  bin_id: string;
+  bin_id: string | null;
   assigned_username: string;
   first_name: string;
   last_name: string;
@@ -1762,7 +1762,15 @@ export interface MakerBox {
   assigned_at: string | null;
   expires_at: string | null;
   last_verified_at: string | null;
-  status: 'valid' | 'grace' | 'expired' | 'unassigned' | 'unknown';
+  status:
+    | 'valid'
+    | 'grace'
+    | 'expired'
+    | 'unassigned'
+    | 'unknown'
+    | 'pre_conversion';
+  identity_source: '' | 'whmcs' | 'common_api' | 'manual';
+  conversion_completed_at: string | null;
   paid_at: string | null;
   notes: string;
   created_at: string;
@@ -1776,6 +1784,18 @@ export interface MakerBoxScanResult {
   first_name: string;
   last_name: string;
   email: string;
+  expires_at: string | null;
+  days_remaining: number | null;
+}
+
+export interface MakerBoxLookupResult {
+  found: boolean;
+  identity_source: '' | 'whmcs' | 'common_api' | 'manual';
+  username: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  membership_status: '' | 'valid' | 'grace' | 'expired' | 'unknown';
   expires_at: string | null;
   days_remaining: number | null;
 }
@@ -2426,6 +2446,17 @@ export const makerBoxesAPI = {
   // or a new-tab preview.
   printSheet: (binIds: string[]) =>
     api.post<ArrayBuffer>('/maker-boxes/print-sheet/', { bin_ids: binIds }, { responseType: 'arraybuffer' }),
+  // PR2 — pre-conversion workflow. ``lookup`` is read-only and used for
+  // live preview as staff types or scans on the pre-conversion screen;
+  // ``preConvert`` puts the user on the queue (idempotent on resolved
+  // username); ``preConversionQueue`` lists the rows waiting for bin
+  // allocation.
+  lookup: (query: string) =>
+    api.post<MakerBoxLookupResult>('/maker-boxes/lookup/', { query }),
+  preConvert: (query: string, notes?: string) =>
+    api.post<MakerBox>('/maker-boxes/pre-convert/', notes ? { query, notes } : { query }),
+  preConversionQueue: () =>
+    api.get<MakerBox[]>('/maker-boxes/pre-conversion-queue/'),
 };
 
 export interface AssetWarrantyDto {


### PR DESCRIPTION
## Summary

PR 2 of the three-phase maker-box conversion workflow (PR 1 was #753). Wires the identity-lookup and pre-conversion-queue endpoints plus a staff queue UI. PR 3 will allocate `MBX-NNN`, reprint the label with the new QR, and ship the Pi-side `/resolve` listener.

### Backend
- `POST /api/maker-boxes/lookup/` — read-only identity probe via the cascade resolver (Common API + WHMCS). Returns the matched member or `found=false`. Used by the page for live preview before commit.
- `POST /api/maker-boxes/pre-convert/` — idempotent on resolved username: creates a `MakerBox` row with `status=pre_conversion` and `bin_id=null`, or refreshes the existing pre-conversion row. Returns **409** if the user is already converted (has a bin_id + non-`pre_conversion` status). Optional `notes` is appended rather than overwritten so multi-staffer notes don't get lost.
- `GET /api/maker-boxes/pre-conversion-queue/` — staff-only list, newest first.
- `MakerBoxSerializer` now exposes `identity_source` and `conversion_completed_at`.

### Frontend
New `/facilities/maker-boxes/pre-conversion` page: badge / username input, live identity preview, "Add to queue" button, queue table. Wired into sidebar, `routeMap`, and `App.tsx`.

### Companion: scantty
The `p` key on the maker-boxes screen will open a pre-conversion scan (badge OR username); successful inserts refresh the directory and show a green status line. Filed as a separate scantty PR (different repo).

## Test plan

- [x] `pytest maker_boxes/tests/test_preconversion.py` — 12 new tests pass (lookup hit / miss / staff gate; pre-convert create / idempotent / notes-append / 404 / 409 / staff gate; queue lists only `pre_conversion`).
- [x] `npm test src/__tests__/navigation` — 47 pass (entryPoints test still maps every clickable route to a real page).
- [x] `npm run build` — green.
- [x] `pre-commit` — green (black / isort / ruff / bandit / django-upgrade).
- [ ] Smoke-test the page in dev: type a username, see preview, hit "Add to queue", verify the row appears.

## Out of scope (PR 3)

- `POST /api/maker-boxes/convert/` that allocates `MBX-NNN`.
- Re-printed label with `/scan/makerbox/MBX-NNN/:username:` QR.
- Pi-side `/resolve` listener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)