### PR TITLE
fix(backups): install postgresql-client-18 so pg_dump matches the server

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,14 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
 # Install system dependencies
+#   postgresql-client-18:
+#                  the backup task (backups.tasks.daily_postgres_backup)
+#                  shells out to `pg_dump -Fc` against the prod postgres
+#                  18 server. Debian's default postgresql-client package
+#                  ships v15 on bookworm-slim, and pg_dump <= server
+#                  refuses to dump (custom-format archive version skew),
+#                  which is what BACKEND-A in Sentry was catching. Install
+#                  v18 explicitly from the PostgreSQL APT repo.
 #   libzbar0:      runtime for pyzbar (QR-code fallback in
 #                  inventory.services.work_order_ingest). Without it pyzbar
 #                  errors on import and the work-order PDF QR extraction
@@ -16,13 +24,20 @@ WORKDIR /app
 #                  runtime libs opencv-python-headless dlopen()s for
 #                  image decode. The wheel bundles most things but on
 #                  python:slim it still needs these from the OS.
-RUN apt-get update && apt-get install -y \
-    postgresql-client \
-    build-essential \
-    libpq-dev \
-    libzbar0 \
-    libgl1 \
-    libglib2.0-0 \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg \
+    && install -d /usr/share/postgresql-common/pgdg \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+       -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+    && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
+       > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        postgresql-client-18 \
+        build-essential \
+        libpq-dev \
+        libzbar0 \
+        libgl1 \
+        libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -9,6 +9,14 @@ ENV DJANGO_SETTINGS_MODULE=config.settings
 WORKDIR /app
 
 # Install system dependencies
+#   postgresql-client-18:
+#                  the backup task (backups.tasks.daily_postgres_backup)
+#                  shells out to `pg_dump -Fc` against the prod postgres
+#                  18 server. Debian's default postgresql-client package
+#                  ships v15 on bookworm-slim, and pg_dump <= server
+#                  refuses to dump (custom-format archive version skew),
+#                  which is what BACKEND-A in Sentry was catching. Install
+#                  v18 explicitly from the PostgreSQL APT repo.
 #   libzbar0:      runtime for pyzbar (QR-code fallback in
 #                  inventory.services.work_order_ingest). Without it pyzbar
 #                  errors on import and the work-order PDF QR extraction
@@ -17,14 +25,20 @@ WORKDIR /app
 #                  runtime libs opencv-python-headless dlopen()s for
 #                  image decode. The wheel bundles most things but on
 #                  python:slim it still needs these from the OS.
-RUN apt-get update && apt-get install -y \
-    postgresql-client \
-    build-essential \
-    libpq-dev \
-    libzbar0 \
-    libgl1 \
-    libglib2.0-0 \
-    curl \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg \
+    && install -d /usr/share/postgresql-common/pgdg \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+       -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+    && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo "$VERSION_CODENAME")-pgdg main" \
+       > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        postgresql-client-18 \
+        build-essential \
+        libpq-dev \
+        libzbar0 \
+        libgl1 \
+        libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies


### PR DESCRIPTION
## Summary

The daily backup task (`backups.tasks.daily_postgres_backup`) shells out to `pg_dump -Fc` against the prod postgres 18 server. The backend image installed Debian's default `postgresql-client`, which on bookworm-slim is v15. `pg_dump` refuses to dump a server that's newer than the client (custom-format archive version skew), so the backup has been failing every night at 02:00 UTC ever since the prod postgres 18 image came online.

This is **Sentry backend issue #15** — 15 occurrences since 2026-05-30, last 2026-06-15T02:00:00Z, fully aligned with the prod postgres 18 deployment window.

Switches both `Dockerfile` and `Dockerfile.prod` to install `postgresql-client-18` from the official PostgreSQL APT repo. Verified locally: `docker build` succeeds and the resulting image reports `pg_dump (PostgreSQL) 18.4`.

The firmware-builder image (`Dockerfile.firmware-builder`) is intentionally left alone — it doesn't run `pg_dump`.

## Test plan

- [x] `docker build -f backend/Dockerfile -t test backend/` — clean build (31s)
- [x] `docker run --rm test pg_dump --version` → `pg_dump (PostgreSQL) 18.4 (Debian 18.4-1.pgdg13+1)`
- [ ] After deploy: confirm tonight's backup at 02:00 UTC actually writes the dump file, and resolve Sentry #15.

## Triage notes for the other 6 backend Sentry issues

Closed without PRs:
- **Postmark 401** (#25) — server token rotation needed on prod, not code.
- **MQTT not authorized** (#6, 178x reconnect storm) — broker creds in the worker env don't match the broker.
- **4 `manage.py shell` typos** (#23 / #31 / #32 / #33) — interactive shell session on release `cf3e951`; same server, same breadcrumb signature; no production code path is broken.

Each one has a comment + ignore set; will auto-surface if a fresh occurrence shows a different root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)