### PR TITLE
fix(frontend): clear leaked Mantine notification autoClose timers in tests (oms-ltzrn.1)

### DIFF
--- a/frontend/src/__tests__/notificationsTimerLeak.test.tsx
+++ b/frontend/src/__tests__/notificationsTimerLeak.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Regression guard for the @mantine/notifications (v9) auto-close timer leak
+ * that reddened the frontend CI suite (gh-660 / oms-ltzrn).
+ *
+ * NotificationContainer schedules its auto-close `setTimeout(handleHide, …)`
+ * from two effects sharing one `autoCloseTimeout` ref, so the first timer's id
+ * is orphaned and survives unmount. Left alone, it fires after the test file's
+ * jsdom is torn down and throws "window is not defined", failing the whole run
+ * (flaky — passes in isolation, fails in the full suite).
+ *
+ * `setupTests.ts` clears leaked long-lived timers in a global afterEach. This
+ * test proves it works: a notification's auto-close timer must NOT survive into
+ * the next test. If the afterEach guard is removed, the orphaned timer fires
+ * during the second test's wait and flips `closedAfterTeardown` — turning this
+ * test deterministically red instead of letting the leak flake the suite.
+ */
+import { MantineProvider } from '@mantine/core';
+import { Notifications, notifications } from '@mantine/notifications';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+// Survives across the two tests (module scope). Set if a notification's
+// auto-close timer fires after its test ended — i.e. it leaked.
+let closedAfterTeardown = false;
+const AUTO_CLOSE_MS = 1200; // >= setupTests' leaked-timer threshold (1000ms)
+
+describe('@mantine/notifications auto-close timer leak guard', () => {
+  it('shows a notification, scheduling an auto-close timer', async () => {
+    render(
+      <MantineProvider>
+        <Notifications />
+      </MantineProvider>,
+    );
+    notifications.show({
+      message: 'leak-guard',
+      autoClose: AUTO_CLOSE_MS,
+      onClose: () => {
+        // Reached only if the auto-close timer actually fires. By the time the
+        // next test runs, this test is over, so any firing here is a leak.
+        closedAfterTeardown = true;
+      },
+    });
+    expect(await screen.findByText('leak-guard')).toBeInTheDocument();
+    // Test ends well before AUTO_CLOSE_MS; the global afterEach must clear the
+    // pending auto-close timer.
+  });
+
+  it('does not let the previous auto-close timer fire after teardown', async () => {
+    // Wait past the auto-close delay. If the timer leaked, it fires in here.
+    await new Promise((resolve) => setTimeout(resolve, AUTO_CLOSE_MS + 600));
+    expect(closedAfterTeardown).toBe(false);
+  });
+});

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,6 +1,6 @@
 // jest-dom adds custom matchers for asserting on DOM nodes.
 import '@testing-library/jest-dom/vitest';
-import { vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
 
 // Shim: existing test files reference `jest.fn` / `jest.mock` etc.
 // Vitest's `vi` is API-compatible for the operations used here, so
@@ -110,3 +110,48 @@ if (typeof document !== 'undefined' && !(document as Document & { fonts?: unknow
     },
   });
 }
+
+// ---------------------------------------------------------------------------
+// Clear leaked long-lived timers after every test (e.g. @mantine/notifications
+// auto-close timers).
+//
+// Mantine v9's NotificationContainer schedules its auto-close
+// `window.setTimeout(handleHide, …)` from two separate effects that share a
+// single `autoCloseTimeout` ref, so the first timer's id is overwritten and
+// orphaned. On unmount Mantine cancels only the tracked (second) timer; the
+// orphaned one survives, then fires a few seconds later — after vitest has torn
+// down this file's jsdom environment — and runs `window.clearTimeout(...)`,
+// throwing "window is not defined". Under vitest v4's stricter unhandled-error
+// handling that reddens the whole run. It is flaky because it depends on
+// teardown-vs-timer timing: a file passes in isolation but fails in the full
+// suite (observed first on AdminDashboard.test.tsx, gh-660).
+//
+// Fix (test-only, no production impact): track timers with a delay at or above
+// the threshold and clear any still pending after each test, so no notification
+// auto-close timer (autoClose is 3–5s in this app) can outlive the test that
+// scheduled it. The threshold leaves sub-second timers (Testing Library
+// polling, Mantine transitions, React scheduling) untouched to keep the blast
+// radius minimal.
+// ---------------------------------------------------------------------------
+const LEAKED_TIMER_THRESHOLD_MS = 1000;
+const longLivedTimers = new Set<unknown>();
+const nativeSetTimeout = window.setTimeout.bind(window);
+const nativeClearTimeout = window.clearTimeout.bind(window);
+
+window.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+  const id = nativeSetTimeout(handler as never, timeout as never, ...(args as never[]));
+  if (typeof timeout === 'number' && timeout >= LEAKED_TIMER_THRESHOLD_MS) {
+    longLivedTimers.add(id);
+  }
+  return id;
+}) as typeof window.setTimeout;
+
+window.clearTimeout = ((id?: unknown) => {
+  longLivedTimers.delete(id);
+  return nativeClearTimeout(id as never);
+}) as typeof window.clearTimeout;
+
+afterEach(() => {
+  longLivedTimers.forEach((id) => nativeClearTimeout(id as never));
+  longLivedTimers.clear();
+});


### PR DESCRIPTION
Lands work bead **oms-ltzrn.1** (child of OMS major dep upgrade epic oms-ltzrn).

## What
Test-only fix: clear leaked @mantine/notifications v9 autoClose timers via a global afterEach in setupTests.ts; adds a deterministic regression guard (notificationsTimerLeak.test.tsx). The orphaned autoClose timer was firing after jsdom teardown -> "window is not defined" under vitest v4, flakily reddening the frontend suite (first seen on AdminDashboard.test.tsx).

## Refinery gates (re-run on this branch @ 100c7ec; base = current main fc48aad)
- frontend `npm run test:ci`: **108 files / 771 passed** (1 skipped) — green
- frontend `npm run lint`: **0 errors** (29 pre-existing warnings, none in changed files) — green
- Diff is test-only: `frontend/src/setupTests.ts` (+47/-1), `frontend/src/__tests__/notificationsTimerLeak.test.tsx` (+53)

## Merge mechanism
Bead merge_strategy was `direct`, but `main` is PR-only (ruleset No-Commit-To-Main). Landed by the refinery via squash-merge (required_linear_history compliant) as the rig-intended equivalent of a direct land (0 required approvals; admin bypass).

Landed by oms/gastown.refinery.