### PR TITLE
feat(reorder): add Receive items UI to PO page (oms-s0hj4)

### DIFF
--- a/frontend/src/__tests__/pages/PurchaseOrderPage.test.tsx
+++ b/frontend/src/__tests__/pages/PurchaseOrderPage.test.tsx
@@ -10,6 +10,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import PurchaseOrderPage from '../../pages/PurchaseOrderPage';
 import * as api from '../../services/api';
+import { showError } from '../../utils/dialogs';
 
 vi.mock('../../services/api');
 
@@ -347,5 +348,214 @@ describe('PurchaseOrderPage line item rendering', () => {
     expect(screen.getByText('Forklift 7')).toBeInTheDocument();
     expect(screen.queryByText('Unknown Item')).not.toBeInTheDocument();
     expect(screen.queryByText('Unknown Asset')).not.toBeInTheDocument();
+  });
+});
+
+describe('PurchaseOrderPage receive items (oms-s0hj4)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem('token', 'test-token');
+    localStorage.setItem('is_staff', 'true');
+  });
+
+  // A partially-received PO mixing receivable, fully-received and voided lines.
+  const makeReceiveOrder = () => ({
+    id: 'po-1',
+    po_number: 'PO-2026-0042',
+    supplier_details: 'Acme Supplies',
+    status: 'partially_received',
+    status_label: 'Partially Received',
+    order_date: '2026-04-01T00:00:00Z',
+    expected_delivery_date: '2026-05-15',
+    supplier_order_number: '',
+    sales_order_number: '',
+    estimated_total: '100.00',
+    voided_at: null,
+    voided_by_username: null,
+    void_reason: '',
+    attachments: [],
+    items: [
+      {
+        id: 101,
+        item_type: 'inventory_item',
+        description: null,
+        item_details: { name: 'Stocked Bolt', sku: 'BOLT-1' },
+        asset_details: null,
+        quantity_ordered: 10,
+        quantity_received: 3,
+        quantity_pending: 7,
+        is_fully_received: false,
+        unit_cost_ordered: '1.00',
+        unit_cost_actual: null,
+        estimated_cost: '10.00',
+        actual_cost: null,
+        expected_shipment_date: null,
+        notes: '',
+        is_voided: false,
+        voided_at: null,
+        void_reason: '',
+      },
+      {
+        id: 102,
+        item_type: 'inventory_item',
+        description: null,
+        item_details: { name: 'Done Widget', sku: 'DONE-1' },
+        asset_details: null,
+        quantity_ordered: 5,
+        quantity_received: 5,
+        quantity_pending: 0,
+        is_fully_received: true,
+        unit_cost_ordered: '2.00',
+        unit_cost_actual: null,
+        estimated_cost: '10.00',
+        actual_cost: null,
+        expected_shipment_date: null,
+        notes: '',
+        is_voided: false,
+        voided_at: null,
+        void_reason: '',
+      },
+      {
+        id: 103,
+        item_type: 'inventory_item',
+        description: null,
+        item_details: { name: 'Voided Thing', sku: 'VOID-1' },
+        asset_details: null,
+        quantity_ordered: 4,
+        quantity_received: 0,
+        quantity_pending: 4,
+        is_fully_received: false,
+        unit_cost_ordered: '3.00',
+        unit_cost_actual: null,
+        estimated_cost: '12.00',
+        actual_cost: null,
+        expected_shipment_date: null,
+        notes: '',
+        is_voided: true,
+        voided_at: '2026-04-10T00:00:00Z',
+        void_reason: 'discontinued',
+      },
+      {
+        id: 104,
+        item_type: 'freeform',
+        description: 'Custom Panel',
+        item_details: null,
+        asset_details: null,
+        quantity_ordered: 6,
+        quantity_received: 0,
+        quantity_pending: 6,
+        is_fully_received: false,
+        unit_cost_ordered: '8.00',
+        unit_cost_actual: null,
+        estimated_cost: '48.00',
+        actual_cost: null,
+        expected_shipment_date: null,
+        notes: '',
+        is_voided: false,
+        voided_at: null,
+        void_reason: '',
+      },
+    ],
+  });
+
+  test('opens a panel with qty inputs only for non-voided, not-fully-received items, defaulted to pending', async () => {
+    (api.purchaseOrderAPI.getOrder as jest.Mock).mockResolvedValue({ data: makeReceiveOrder() });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /^receive items$/i }));
+
+    // Receivable lines get an input pre-filled with their pending quantity.
+    expect((screen.getByLabelText('Receive quantity for Stocked Bolt') as HTMLInputElement).value).toBe('7');
+    expect((screen.getByLabelText('Receive quantity for Custom Panel') as HTMLInputElement).value).toBe('6');
+
+    // Fully-received and voided lines are excluded from the receive panel.
+    expect(screen.queryByLabelText('Receive quantity for Done Widget')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Receive quantity for Voided Thing')).not.toBeInTheDocument();
+  });
+
+  test('submits entered quantities to receiveItems and patches the page from the response', async () => {
+    (api.purchaseOrderAPI.getOrder as jest.Mock).mockResolvedValue({ data: makeReceiveOrder() });
+    const receivedOrder = {
+      ...makeReceiveOrder(),
+      status: 'received',
+      status_label: 'Received',
+    };
+    (api.purchaseOrderAPI.receiveItems as jest.Mock).mockResolvedValue({ data: receivedOrder });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /^receive items$/i }));
+
+    // Override the default delivery date so the assertion is deterministic.
+    fireEvent.change(screen.getByLabelText(/delivery date/i), { target: { value: '2026-06-10' } });
+    // Receive a partial quantity for the bolt; leave the panel at its default for the freeform line.
+    fireEvent.change(screen.getByLabelText('Receive quantity for Stocked Bolt'), {
+      target: { value: '2' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm receipt/i }));
+
+    await waitFor(() => {
+      expect(api.purchaseOrderAPI.receiveItems).toHaveBeenCalledWith('po-1', {
+        items: [
+          { purchase_order_item: 101, quantity_received: 2 },
+          { purchase_order_item: 104, quantity_received: 6 },
+        ],
+        delivery_date: '2026-06-10',
+        receipt_notes: undefined,
+      });
+    });
+
+    // The page is patched from the response (status flips, panel closes) — no follow-up GET.
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /confirm receipt/i })).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('Received')).toBeInTheDocument();
+    expect(api.purchaseOrderAPI.getOrder).toHaveBeenCalledTimes(1);
+  });
+
+  test('errors and does not call the API when no quantities are entered', async () => {
+    (api.purchaseOrderAPI.getOrder as jest.Mock).mockResolvedValue({ data: makeReceiveOrder() });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /^receive items$/i }));
+
+    // Zero out both receivable lines.
+    fireEvent.change(screen.getByLabelText('Receive quantity for Stocked Bolt'), {
+      target: { value: '0' },
+    });
+    fireEvent.change(screen.getByLabelText('Receive quantity for Custom Panel'), {
+      target: { value: '0' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm receipt/i }));
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith(expect.stringMatching(/at least one item/i));
+    });
+    expect(api.purchaseOrderAPI.receiveItems).not.toHaveBeenCalled();
+  });
+
+  test('rejects an over-receive that exceeds the pending quantity', async () => {
+    (api.purchaseOrderAPI.getOrder as jest.Mock).mockResolvedValue({ data: makeReceiveOrder() });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /^receive items$/i }));
+
+    // Bolt only has 7 pending; ask for more.
+    fireEvent.change(screen.getByLabelText('Receive quantity for Stocked Bolt'), {
+      target: { value: '99' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm receipt/i }));
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith(expect.stringMatching(/only 7 pending/i));
+    });
+    expect(api.purchaseOrderAPI.receiveItems).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/PurchaseOrderPage.tsx
+++ b/frontend/src/pages/PurchaseOrderPage.tsx
@@ -8,7 +8,7 @@
  * successful mark-delivered submit must never flip the page back into
  * that state.
  */
-import { Button, Paper, Text } from '@mantine/core';
+import { Button, Group, Paper, Text } from '@mantine/core';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import WorkspacePage from '../components/landing/WorkspacePage';
@@ -34,6 +34,8 @@ interface PurchaseOrderItem {
   } | null;
   quantity_ordered: number;
   quantity_received: number;
+  quantity_pending: number;
+  is_fully_received: boolean;
   unit_cost_ordered: string;
   unit_cost_actual: string | null;
   estimated_cost: string;
@@ -74,6 +76,22 @@ interface PurchaseOrder {
   void_reason: string;
 }
 
+const getItemNameAndSku = (item: PurchaseOrderItem): { itemName: string; itemSku: string } => {
+  if (item.item_type === 'asset') {
+    return {
+      itemName: item.asset_details?.name || 'Unknown Asset',
+      itemSku: item.asset_details?.asset_tag || '—',
+    };
+  }
+  if (item.item_type === 'freeform') {
+    return { itemName: item.description || 'Unknown Item', itemSku: '—' };
+  }
+  return {
+    itemName: item.item_details?.name || 'Unknown Item',
+    itemSku: item.item_details?.sku || '—',
+  };
+};
+
 const PurchaseOrderPage: React.FC = () => {
   const { orderId } = useParams<{ orderId: string }>();
   const [order, setOrder] = useState<PurchaseOrder | null>(null);
@@ -92,6 +110,10 @@ const PurchaseOrderPage: React.FC = () => {
   const [deliveryDate, setDeliveryDate] = useState<string>('');
   const [deliveryTracking, setDeliveryTracking] = useState<string>('');
   const [deliveryCarrier, setDeliveryCarrier] = useState<string>('');
+  const [receivingItems, setReceivingItems] = useState(false);
+  const [receiveQuantities, setReceiveQuantities] = useState<Record<string, string>>({});
+  const [receiveDeliveryDate, setReceiveDeliveryDate] = useState<string>('');
+  const [receiveNotes, setReceiveNotes] = useState<string>('');
   const [editingMetadata, setEditingMetadata] = useState(false);
   const [metadataSupplierOrderNumber, setMetadataSupplierOrderNumber] = useState('');
   const [metadataSalesOrderNumber, setMetadataSalesOrderNumber] = useState('');
@@ -301,6 +323,79 @@ const PurchaseOrderPage: React.FC = () => {
   const canMarkDelivered = (po: PurchaseOrder) =>
     isAuthenticated && ['sent', 'confirmed', 'partially_received'].includes(po.status);
 
+  const canReceiveItems = (po: PurchaseOrder) =>
+    isAuthenticated && ['sent', 'confirmed', 'partially_received'].includes(po.status);
+
+  const getReceivableItems = (po: PurchaseOrder) =>
+    po.items.filter((item) => !item.is_voided && !item.is_fully_received);
+
+  const handleOpenReceiveItems = () => {
+    if (!order) return;
+    const initialQuantities: Record<string, string> = {};
+    getReceivableItems(order).forEach((item) => {
+      initialQuantities[item.id] = String(item.quantity_pending);
+    });
+    setReceiveQuantities(initialQuantities);
+    setReceiveDeliveryDate(formatYmd(new Date()));
+    setReceiveNotes('');
+    setReceivingItems(true);
+  };
+
+  const handleCancelReceiveItems = () => {
+    setReceivingItems(false);
+    setReceiveQuantities({});
+    setReceiveDeliveryDate('');
+    setReceiveNotes('');
+  };
+
+  const handleReceiveQuantityChange = (itemId: string, value: string) => {
+    setReceiveQuantities((prev) => ({ ...prev, [itemId]: value }));
+  };
+
+  const handleSubmitReceiveItems = async () => {
+    if (!order || saving) return;
+
+    const lines: { purchase_order_item: number; quantity_received: number }[] = [];
+    for (const item of getReceivableItems(order)) {
+      const raw = receiveQuantities[item.id];
+      if (raw === undefined || raw.trim() === '') continue;
+      const quantity = Number.parseInt(raw, 10);
+      if (Number.isNaN(quantity) || quantity <= 0) continue;
+      if (quantity > item.quantity_pending) {
+        showError(
+          `Cannot receive ${quantity} of ${getItemNameAndSku(item).itemName}; ` +
+            `only ${item.quantity_pending} pending`,
+        );
+        return;
+      }
+      lines.push({ purchase_order_item: Number(item.id), quantity_received: quantity });
+    }
+
+    if (lines.length === 0) {
+      showError('Enter a quantity for at least one item to receive');
+      return;
+    }
+
+    try {
+      setSaving(true);
+      const response = await purchaseOrderAPI.receiveItems(orderId!, {
+        items: lines,
+        delivery_date: receiveDeliveryDate || undefined,
+        receipt_notes: receiveNotes || undefined,
+      });
+      if (response.data && typeof response.data === 'object' && response.data.id) {
+        setOrder(response.data as PurchaseOrder);
+      }
+      handleCancelReceiveItems();
+      showSuccess('Items received');
+    } catch (err: any) {
+      showError(extractErrorMessage(err, 'Failed to receive items'));
+      console.error('Error receiving items:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const handleStartEditMetadata = () => {
     if (!order) return;
     setMetadataSupplierOrderNumber(order.supplier_order_number || '');
@@ -421,6 +516,8 @@ const PurchaseOrderPage: React.FC = () => {
     );
   }
 
+  const receivableItems = getReceivableItems(order);
+
   return (
     <WorkspacePage
       testId="purchase-order-page"
@@ -428,9 +525,15 @@ const PurchaseOrderPage: React.FC = () => {
         eyebrow: `Purchasing · ${order.supplier_details}`,
         title: `PO ${order.po_number}`,
         description: order.status_label,
-        action: canMarkDelivered(order) && !markingDelivered ? (
-          <Button onClick={handleOpenMarkDelivered}>Mark as delivered</Button>
-        ) : undefined,
+        action:
+          canReceiveItems(order) && !markingDelivered && !receivingItems ? (
+            <Group gap="sm">
+              <Button onClick={handleOpenReceiveItems}>Receive items</Button>
+              <Button variant="default" onClick={handleOpenMarkDelivered}>
+                Mark as delivered
+              </Button>
+            </Group>
+          ) : undefined,
       }}
     >
       <div className="purchase-order-page">
@@ -512,6 +615,90 @@ const PurchaseOrderPage: React.FC = () => {
               type="button"
               className="btn-secondary"
               onClick={handleCancelMarkDelivered}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+          </div>
+        </section>
+      )}
+
+      {receivingItems && (
+        <section className="receive-items-panel" aria-label="Receive purchase order items">
+          <h2>Receive Items</h2>
+          <div className="receive-items-fields">
+            <label htmlFor="receive-delivery-date">
+              Delivery Date (optional)
+              <input
+                id="receive-delivery-date"
+                type="date"
+                value={receiveDeliveryDate}
+                onChange={(e) => setReceiveDeliveryDate(e.target.value)}
+              />
+            </label>
+            <label htmlFor="receive-notes">
+              Receipt Notes (optional)
+              <input
+                id="receive-notes"
+                type="text"
+                value={receiveNotes}
+                onChange={(e) => setReceiveNotes(e.target.value)}
+                placeholder="e.g. Partial shipment, backorder to follow"
+              />
+            </label>
+          </div>
+          {receivableItems.length === 0 ? (
+            <p className="no-data">All line items have already been received.</p>
+          ) : (
+            <table className="items-table receive-items-table">
+              <thead>
+                <tr>
+                  <th>Item</th>
+                  <th>SKU</th>
+                  <th>Pending</th>
+                  <th>Receive Qty</th>
+                </tr>
+              </thead>
+              <tbody>
+                {receivableItems.map((item) => {
+                  const { itemName, itemSku } = getItemNameAndSku(item);
+                  return (
+                    <tr key={item.id}>
+                      <td>{itemName}</td>
+                      <td>{itemSku}</td>
+                      <td>{item.quantity_pending}</td>
+                      <td>
+                        <input
+                          type="number"
+                          min="0"
+                          max={item.quantity_pending}
+                          step="1"
+                          className="receive-items-qty-input"
+                          value={receiveQuantities[item.id] ?? ''}
+                          onChange={(e) => handleReceiveQuantityChange(item.id, e.target.value)}
+                          disabled={saving}
+                          aria-label={`Receive quantity for ${itemName}`}
+                        />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+          <div className="receive-items-actions">
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={handleSubmitReceiveItems}
+              disabled={saving || receivableItems.length === 0}
+            >
+              {saving ? 'Saving…' : 'Confirm Receipt'}
+            </button>
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={handleCancelReceiveItems}
               disabled={saving}
             >
               Cancel
@@ -720,19 +907,8 @@ const PurchaseOrderPage: React.FC = () => {
               </tr>
             ) : (
               order.items.map((item) => {
-                let itemName: string;
-                let itemSku: string;
-                if (item.item_type === 'asset') {
-                  itemName = item.asset_details?.name || 'Unknown Asset';
-                  itemSku = item.asset_details?.asset_tag || '—';
-                } else if (item.item_type === 'freeform') {
-                  itemName = item.description || 'Unknown Item';
-                  itemSku = '—';
-                } else {
-                  itemName = item.item_details?.name || 'Unknown Item';
-                  itemSku = item.item_details?.sku || '—';
-                }
-                
+                const { itemName, itemSku } = getItemNameAndSku(item);
+
                 return (
                 <tr key={item.id} className={item.is_voided ? 'voided-item' : ''}>
                   <td>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1191,6 +1191,16 @@ export const purchaseOrderAPI = {
     orderId: string,
     data: { delivery_date: string; tracking_number?: string; carrier?: string; receipt_notes?: string },
   ) => api.post<any>(`/reorders/purchase-orders/${orderId}/mark-delivered/`, data),
+  receiveItems: (
+    orderId: string,
+    data: {
+      items: { purchase_order_item: number; quantity_received: number }[];
+      delivery_date?: string;
+      tracking_number?: string;
+      carrier?: string;
+      receipt_notes?: string;
+    },
+  ) => api.post<any>(`/reorders/purchase-orders/${orderId}/receive/`, data),
   updateOrder: (
     orderId: string,
     data: {

--- a/frontend/src/styles/PurchaseOrderPage.css
+++ b/frontend/src/styles/PurchaseOrderPage.css
@@ -351,6 +351,59 @@
   min-width: 300px;
 }
 
+.receive-items-panel {
+  background-color: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-left: 4px solid #667eea;
+  padding: 1rem 1.25rem;
+  border-radius: 0.5rem;
+  margin: 1rem 0;
+}
+
+.receive-items-panel h2 {
+  margin: 0 0 1rem;
+  font-size: 1.25rem;
+  color: #1e293b;
+}
+
+.receive-items-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.receive-items-fields label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: #475569;
+}
+
+.receive-items-fields input {
+  padding: 0.5rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 400;
+}
+
+.receive-items-qty-input {
+  width: 6rem;
+  padding: 0.5rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+}
+
+.receive-items-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
 .void-item-form textarea {
   padding: 0.5rem;
   border: 1px solid #cbd5e1;


### PR DESCRIPTION
Lands work bead **oms-s0hj4** — frontend UI for the per-line-item PO receive flow (consumes the receive endpoint landed in #760 / oms-tyzfv).

## Scope (frontend-only, based on current main 81745a6)
- `frontend/src/pages/PurchaseOrderPage.tsx` (+210/-17) — Receive items UI (per-line qty)
- `frontend/src/services/api.ts` (+10) — receive endpoint client
- `frontend/src/styles/PurchaseOrderPage.css` (+53)
- `frontend/src/__tests__/pages/PurchaseOrderPage.test.tsx` (+210) — component tests

## Refinery gates (re-run locally on the branch @ b36271b)
- `npm run test:ci`: **108 files / 775 passed** (1 skipped) — green
- `npm run lint`: **0 errors** (4 pre-existing warnings) — green
- `npm run build` (vite): **green**
- e2e (Playwright) not runnable locally → **CI-gated**: required checks incl E2E must go green before merge (no bypass).

Bead strategy was `direct`; `main` is PR-only (ruleset No-Commit-To-Main), so landed by refinery via squash-merge once CI is green. Branch ff-clean on main (no rebase). Landed by oms/gastown.refinery.