### PR TITLE
Close out #453 reactive workflows: PO receive-items tests, un-skip mark-delivered, docs

### DIFF
--- a/docs/FRONTEND_JOURNEY_INVENTORY.md
+++ b/docs/FRONTEND_JOURNEY_INVENTORY.md
@@ -92,7 +92,7 @@ Staff create purchase orders, receive deliveries, and track supplier relationshi
 | --- | --- | --- | --- |
 | Browse purchase orders | `/purchasing/orders` (`PurchaseOrderListPage.tsx`) | staff | Filter by status; loading + empty states |
 | Create purchase order | `/purchasing/orders/new` (`PurchaseOrderFormPage.tsx`) | staff | Multi-supplier; line-item duplicate guard |
-| View / approve / receive purchase order | `/purchasing/orders/:orderId` (`PurchaseOrderPage.tsx`) | staff/admin | Receipt action gated by permission; auth expiration returns to PO |
+| View / approve / receive purchase order | `/purchasing/orders/:orderId` (`PurchaseOrderPage.tsx`) | staff/admin | `mark-delivered` and `receive` (per-line-item) patch the page from the response (no reload through the loading placeholder); receipt action gated by permission; auth expiration returns to PO |
 | Purchasing report (CSV / charts) | `/reports/purchasing` (`PurchasingReportPage.tsx`) | staff | Empty-state when no data |
 | Browse / edit suppliers | `/inventory/suppliers`, `/inventory/suppliers/:id`, `/inventory/suppliers/:id/edit` (`SupplierListPage.tsx`, `SupplierDetailPage.tsx`, `SupplierFormPage.tsx`) | staff | Lead-time and price-trend charts have empty-state |
 
@@ -251,7 +251,7 @@ state, scope failures, non-disruptive reconciliation) and the inventory
 of refresh-y workflows still to migrate live in
 [`REACTIVE_MUTATIONS.md`](REACTIVE_MUTATIONS.md). Reference implementations:
 purchase receiving (`AdminDashboard.tsx`, `PurchaseOrderPage.tsx`
-`mark-delivered`) and location problem resolution
+`mark-delivered` and `receive`) and location problem resolution
 (`LocationProblemDetailPage.tsx`).
 
 ---

--- a/docs/REACTIVE_MUTATIONS.md
+++ b/docs/REACTIVE_MUTATIONS.md
@@ -113,6 +113,16 @@ Behavior:
 - The "Mark as Delivered" submit button is disabled while in flight.
 - On failure the delivery panel stays open with its inputs intact so the
   operator can correct and retry.
+- `receive` (per-line-item receipt) patches the order from the API
+  response via `setOrder`, so the status and per-line received / pending
+  quantities update without a follow-up GET. The page does not flip back
+  to its initial "Loading purchase order…" state, and the receive panel
+  closes once the receipt succeeds.
+- Both the "Confirm Receipt" submit button and the per-line quantity
+  inputs are disabled while in flight, so a double click cannot resubmit
+  the same receipt.
+- On failure the receive panel stays open with the entered quantities
+  intact so the operator can correct and retry.
 
 ---
 
@@ -144,7 +154,7 @@ Each row lists the file, the mutation, and the loader being called.
 | Status | File | Mutation | Currently calls |
 | --- | --- | --- | --- |
 | ✅ migrated | `pages/AdminDashboard.tsx` | reorder approve / mark ordered / mark received / cancel / update tracking | (now patches row from response) |
-| ✅ migrated | `pages/PurchaseOrderPage.tsx` | `mark-delivered` | (now patches order from response) |
+| ✅ migrated | `pages/PurchaseOrderPage.tsx` | `mark-delivered` / `receive` (per-line-item) | (now patches order from response) |
 | ✅ migrated | `pages/LocationProblemDetailPage.tsx` | resolve / promote-standard / promote-third-party | (now patches problem from response) |
 | refresh-y | `pages/WorkOrderPage.tsx` | work-order status transition + save | `loadWorkOrder()` |
 | refresh-y | `pages/ChecklistCompletionPage.tsx` | submit checklist item | `loadData()` |

--- a/frontend/src/__tests__/pages/PurchaseOrderPage.test.tsx
+++ b/frontend/src/__tests__/pages/PurchaseOrderPage.test.tsx
@@ -132,10 +132,7 @@ describe('PurchaseOrderPage mark-delivered reactive contract (gh-453)', () => {
     localStorage.setItem('is_staff', 'true');
   });
 
-  // TODO(vite-migration): under vitest the optimistic patch doesn't surface
-  // before the assertion timeout; needs an act() wrap around the modal-close
-  // dispatch. Re-enable after PR #565 lands.
-  test.skip('patches the page from the mark-delivered response without a follow-up GET', async () => {
+  test('patches the page from the mark-delivered response without a follow-up GET', async () => {
     const sentOrder = {
       ...baseOrder,
       status: 'sent',
@@ -174,9 +171,11 @@ describe('PurchaseOrderPage mark-delivered reactive contract (gh-453)', () => {
       });
     });
 
-    // Status flips to "Received" from the response — no follow-up GET.
+    // Status flips to "Received" from the response — no follow-up GET. Match the
+    // exact status label so we don't collide with the "Quantity Received" column
+    // header (a loose /Received/ regex matches both and throws on multiple nodes).
     await waitFor(() => {
-      expect(screen.getByText(/Received/)).toBeInTheDocument();
+      expect(screen.getByText('Received')).toBeInTheDocument();
     });
     expect(api.purchaseOrderAPI.getOrder).toHaveBeenCalledTimes(1);
     expect(screen.queryByText(/loading purchase order/i)).not.toBeInTheDocument();
@@ -514,6 +513,89 @@ describe('PurchaseOrderPage receive items (oms-s0hj4)', () => {
     });
     expect(screen.getByText('Received')).toBeInTheDocument();
     expect(api.purchaseOrderAPI.getOrder).toHaveBeenCalledTimes(1);
+    // The patch never flips the page back into the initial loading placeholder.
+    expect(screen.queryByText(/loading purchase order/i)).not.toBeInTheDocument();
+  });
+
+  test('disables Confirm Receipt while in-flight and ignores duplicate submits', async () => {
+    (api.purchaseOrderAPI.getOrder as jest.Mock).mockResolvedValue({ data: makeReceiveOrder() });
+    const receivedOrder = {
+      ...makeReceiveOrder(),
+      status: 'received',
+      status_label: 'Received',
+    };
+
+    // Hold the receive request in-flight so we can observe the pending state.
+    let resolveReceive: (value: any) => void = () => undefined;
+    (api.purchaseOrderAPI.receiveItems as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveReceive = resolve;
+        }),
+    );
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /^receive items$/i }));
+    fireEvent.change(screen.getByLabelText('Receive quantity for Stocked Bolt'), {
+      target: { value: '2' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm receipt/i }));
+
+    // While the request is pending the submit button reflects the saving state
+    // and is disabled — and the page does not fall back to the loading placeholder.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled();
+    });
+    expect(screen.queryByText(/loading purchase order/i)).not.toBeInTheDocument();
+
+    // A second click while pending must not dispatch another receiveItems call.
+    fireEvent.click(screen.getByRole('button', { name: /saving/i }));
+    expect(api.purchaseOrderAPI.receiveItems).toHaveBeenCalledTimes(1);
+
+    // Let the in-flight request settle so the success path patches and closes.
+    resolveReceive({ data: receivedOrder });
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /confirm receipt/i })).not.toBeInTheDocument();
+    });
+  });
+
+  test('keeps the panel and entered quantities on failure, re-enabling Confirm Receipt', async () => {
+    (api.purchaseOrderAPI.getOrder as jest.Mock).mockResolvedValue({ data: makeReceiveOrder() });
+
+    let rejectReceive: (err: any) => void = () => undefined;
+    (api.purchaseOrderAPI.receiveItems as jest.Mock).mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectReceive = reject;
+        }),
+    );
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /^receive items$/i }));
+    fireEvent.change(screen.getByLabelText('Receive quantity for Stocked Bolt'), {
+      target: { value: '2' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm receipt/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled();
+    });
+
+    // Reject — the panel stays mounted with the entered quantity intact so the
+    // user can retry without re-typing, and Confirm Receipt re-enables.
+    rejectReceive(new Error('boom'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /confirm receipt/i })).not.toBeDisabled();
+    });
+    expect(
+      (screen.getByLabelText('Receive quantity for Stocked Bolt') as HTMLInputElement).value,
+    ).toBe('2');
+    expect(screen.queryByText(/loading purchase order/i)).not.toBeInTheDocument();
   });
 
   test('errors and does not call the API when no quantities are entered', async () => {


### PR DESCRIPTION
Closes #453

Final AC-8 closeout for the #453 reactive-workflow transitions. PRs #469 (mark-delivered pilot) and #761 (receive-items UI) did the bulk of the work; this fills the remaining test + docs gaps the audit found. Broad cross-app rollout stays out of scope per `.criteria/reactive-workflow-transitions.md`.

Neither #469 nor #761 put `Closes #453` in their body (only a `gh-453` title tag, which does not auto-close), so this wrap-up PR carries it.

## Changes

### Tests — `PurchaseOrderPage` (AC-8: patch-from-response, scoped pending, scoped failure)
`handleSubmitReceiveItems` was already compliant; this is coverage only.
- **receive-items success**: assert the patch never flips the page back to the "Loading purchase order…" placeholder.
- **receive-items pending / duplicate-submit**: while in flight, Confirm Receipt shows "Saving…" and is disabled, and a second click dispatches no second `receiveItems` call.
- **receive-items failure**: the panel stays mounted with the entered quantity intact and Confirm Receipt re-enabled.
- **mark-delivered**: re-enabled the skipped "patches the page from the mark-delivered response without a follow-up GET" test. Root cause was **not** the `act()` wrap the TODO guessed — a loose `/Received/` regex matched both the patched hero status **and** the "Quantity Received" column header, so `getByText` threw on multiple nodes until `waitFor` timed out. Fixed with the exact `'Received'` matcher (the approach the receive-items success test already uses).

### Docs (AC-8 documentation; #761 touched no docs)
- `docs/REACTIVE_MUTATIONS.md`: document PO `receive` (per-line-item) behavior (patches from response, disabled submit + per-line qty inputs while in flight, panel-preserved-on-failure) and mark the receive path migrated in the high-impact inventory row.
- `docs/FRONTEND_JOURNEY_INVENTORY.md`: name mark-delivered + receive as patch-from-response in the Purchasing journey row and the reactive-mutation-contract reference.

## Validation
- `vitest run src/__tests__/pages/PurchaseOrderPage.test.tsx` — 12/12, green 4× (no flakiness on the re-enabled test).
- Full frontend suite — 778/778.
- `npm run build` (vite) and `npm run lint` (eslint) — clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)