### PR TITLE
feat(notifications): email staff on new-device sign-in via Celery (oms-1crmp)

### DIFF
--- a/backend/config/tests/test_new_device_alert_email.py
+++ b/backend/config/tests/test_new_device_alert_email.py
@@ -1,0 +1,173 @@
+"""
+Tests for the new-device sign-in *email* alert (oms-1crmp, FP2).
+
+FP1 (oms-bwcdb) records a ``KnownDevice`` and raises an in-app alert on a new
+staff/privileged sign-in. FP2 adds the email companion: a Celery task
+(``notifications.tasks.send_new_device_alert_email``) fired via
+``transaction.on_commit`` from the same new-device branch.
+
+Coverage:
+
+* the task renders + sends one email to the signing-in user, with the device's
+  User-Agent, IP, and the ``/account/devices`` link in the body;
+* a new-device staff login enqueues exactly one email (on_commit -> eager task);
+* the security alert is sent even when the user opted out of email (the default);
+* with the opt-out exemption disabled, ``email_enabled=False`` suppresses it;
+* missing user/device rows and a user without an email address are clean no-ops.
+
+Email is captured via pytest-django's ``mailoutbox`` (locmem backend); Celery
+runs eagerly under the suite's autouse ``configure_celery_for_tests`` fixture.
+"""
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+import pytest
+
+from notifications.models import KnownDevice, NotificationPreference
+from notifications.tasks import send_new_device_alert_email
+
+User = get_user_model()
+
+
+@pytest.fixture
+def staff_user(db):
+    """Staff user — in scope for new-device alerting."""
+    return User.objects.create_user(
+        username="staffer",
+        email="staff@example.com",
+        password="staff-secret-42",
+        is_staff=True,
+    )
+
+
+def _device_for(user, **overrides):
+    fields = {
+        "device_token": "tok-abc123",
+        "user_agent": "Mozilla/5.0 (TestBrowser)",
+        "ip_address": "203.0.113.7",
+    }
+    fields.update(overrides)
+    return KnownDevice.objects.create(user=user, **fields)
+
+
+def _login(client, username, password):
+    return client.post(
+        reverse("login"),
+        {"username": username, "password": password},
+        format="json",
+    )
+
+
+class TestSendNewDeviceAlertEmailTask:
+    def test_sends_email_with_device_details(self, staff_user, mailoutbox):
+        device = _device_for(staff_user)
+
+        result = send_new_device_alert_email(staff_user.id, device.id)
+
+        assert result["sent"] == 1
+        assert len(mailoutbox) == 1
+        msg = mailoutbox[0]
+        assert msg.to == ["staff@example.com"]
+        assert "New device sign-in" in msg.subject
+        # UA, IP, and the devices link all appear in the plain-text body.
+        assert "Mozilla/5.0 (TestBrowser)" in msg.body
+        assert "203.0.113.7" in msg.body
+        assert "/account/devices" in msg.body
+        # An HTML alternative is attached alongside the text body.
+        assert any(mimetype == "text/html" for _, mimetype in msg.alternatives)
+
+    def test_security_alert_sent_despite_email_opt_out(self, staff_user, mailoutbox):
+        # The user disabled routine email notifications...
+        NotificationPreference.objects.create(user=staff_user, email_enabled=False)
+        device = _device_for(staff_user)
+
+        result = send_new_device_alert_email(staff_user.id, device.id)
+
+        # ...but a new-device alert is a security signal, sent by default.
+        assert result["sent"] == 1
+        assert len(mailoutbox) == 1
+
+    def test_respects_email_enabled_when_exemption_disabled(
+        self, staff_user, mailoutbox, monkeypatch
+    ):
+        monkeypatch.setattr("notifications.tasks.NEW_DEVICE_ALERT_BYPASS_EMAIL_OPT_OUT", False)
+        NotificationPreference.objects.create(user=staff_user, email_enabled=False)
+        device = _device_for(staff_user)
+
+        result = send_new_device_alert_email(staff_user.id, device.id)
+
+        assert result["sent"] == 0
+        assert len(mailoutbox) == 0
+
+    def test_no_email_address_is_noop(self, db, mailoutbox):
+        user = User.objects.create_user(
+            username="noemail", email="", password="x-secret-99", is_staff=True
+        )
+        device = _device_for(user)
+
+        result = send_new_device_alert_email(user.id, device.id)
+
+        assert result["sent"] == 0
+        assert len(mailoutbox) == 0
+
+    def test_email_backend_failure_is_swallowed(self, staff_user, mailoutbox, monkeypatch):
+        """A blow-up in the email backend must not fail the task."""
+        device = _device_for(staff_user)
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("smtp down")
+
+        monkeypatch.setattr("django.core.mail.EmailMultiAlternatives.send", boom)
+
+        result = send_new_device_alert_email(staff_user.id, device.id)
+
+        assert result["sent"] == 0
+        assert len(mailoutbox) == 0
+
+    def test_missing_device_is_noop(self, staff_user, mailoutbox):
+        result = send_new_device_alert_email(staff_user.id, 999999)
+
+        assert result == {"sent": 0, "reason": "device-not-found"}
+        assert len(mailoutbox) == 0
+
+    def test_missing_user_is_noop(self, db, mailoutbox):
+        result = send_new_device_alert_email(999999, 1)
+
+        assert result == {"sent": 0, "reason": "user-not-found"}
+        assert len(mailoutbox) == 0
+
+
+class TestLoginEnqueuesEmail:
+    def test_new_device_login_sends_one_email(
+        self, api_client, staff_user, mailoutbox, django_capture_on_commit_callbacks
+    ):
+        with django_capture_on_commit_callbacks(execute=True) as callbacks:
+            response = _login(api_client, "staffer", "staff-secret-42")
+
+        assert response.status_code == 200
+        # Exactly one on_commit callback (the email dispatch) was registered.
+        assert len(callbacks) == 1
+        assert KnownDevice.objects.filter(user=staff_user).count() == 1
+        assert len(mailoutbox) == 1
+        assert mailoutbox[0].to == ["staff@example.com"]
+
+    def test_known_device_login_sends_no_email(
+        self, api_client, staff_user, mailoutbox, django_capture_on_commit_callbacks
+    ):
+        from notifications.device_login import DEVICE_COOKIE_NAME
+
+        with django_capture_on_commit_callbacks(execute=True):
+            first = _login(api_client, "staffer", "staff-secret-42")
+        assert first.status_code == 200
+        assert len(mailoutbox) == 1
+        cookie_value = first.cookies[DEVICE_COOKIE_NAME].value
+
+        # Replay the signed device cookie: a returning device must not re-email.
+        api_client.cookies[DEVICE_COOKIE_NAME] = cookie_value
+        with django_capture_on_commit_callbacks(execute=True) as callbacks:
+            second = _login(api_client, "staffer", "staff-secret-42")
+
+        assert second.status_code == 200
+        assert callbacks == []
+        assert len(mailoutbox) == 1  # still just the first sign-in's email

--- a/backend/notifications/device_login.py
+++ b/backend/notifications/device_login.py
@@ -27,10 +27,12 @@ import secrets
 
 from django.conf import settings
 from django.core import signing
+from django.db import transaction
 from django.utils import timezone
 
 from .models import KnownDevice
 from .services import create_notification
+from .tasks import send_new_device_alert_email
 
 logger = logging.getLogger(__name__)
 
@@ -138,13 +140,17 @@ def track_device_login(request, user):
         # treat as a NEW device. Reuse the presented token when available so a
         # shared browser is not issued a fresh cookie on every account.
         device_token = token or _mint_device_token()
-        KnownDevice.objects.create(
+        device = KnownDevice.objects.create(
             user=user,
             device_token=device_token,
             ip_address=ip_address,
             user_agent=user_agent,
         )
         _notify_new_device(user, ip_address, user_agent, device_token)
+        # Email companion to the in-app alert (oms-1crmp, FP2). Defer the
+        # dispatch to on_commit so the worker never races the device row it
+        # looks up; in request autocommit (no ATOMIC_REQUESTS) it fires at once.
+        transaction.on_commit(lambda: send_new_device_alert_email.delay(user.id, device.id))
         return device_token
     except Exception:  # never let device tracking break a login
         logger.exception(

--- a/backend/notifications/tasks.py
+++ b/backend/notifications/tasks.py
@@ -1,0 +1,137 @@
+"""
+Celery tasks for the notifications app.
+
+Hosts the new-device sign-in *email* alert (oms-1crmp, FP2) — the email
+companion to the in-app alert raised inline by ``notifications.device_login``
+(oms-bwcdb, FP1). FP1's login hook records a :class:`KnownDevice` and schedules
+:func:`send_new_device_alert_email` via ``transaction.on_commit`` so the email
+is only dispatched once the device row is durably committed.
+
+The send path mirrors ``reorder_queue.tasks.send_reorder_request_notification_email``
++ ``reorder_queue.notifications``: a thin ``@shared_task`` that resolves the row
+ids and delegates to a helper which renders the templated email and sends it via
+``EmailMultiAlternatives`` (Postmark via django-anymail in prod).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.mail import EmailMultiAlternatives
+from django.template.loader import render_to_string
+from django.utils import timezone
+
+from celery import shared_task
+
+logger = logging.getLogger(__name__)
+
+# A new-device sign-in is a security signal, so by default we email the alert
+# even to users who have turned off routine email notifications
+# (NotificationPreference.email_enabled=False). Flip to False to honor that
+# opt-out for new-device alerts too.
+NEW_DEVICE_ALERT_BYPASS_EMAIL_OPT_OUT = True
+
+# Defensive cap so a hostile/oversized User-Agent can't bloat the email body.
+_UA_MESSAGE_MAX = 256
+
+
+def _email_opted_out(user) -> bool:
+    """
+    Return ``True`` when ``user`` has disabled email notifications *and* the
+    security-alert exemption is off. With the exemption on (the default) this
+    always returns ``False`` so the alert is sent regardless of preference.
+    """
+    if NEW_DEVICE_ALERT_BYPASS_EMAIL_OPT_OUT:
+        return False
+
+    from .models import NotificationPreference
+
+    pref = NotificationPreference.objects.filter(user=user).first()
+    return pref is not None and not pref.email_enabled
+
+
+def _build_context(user, device) -> dict:
+    """Template context for the new-device alert email."""
+    frontend_url = getattr(settings, "FRONTEND_URL", "").rstrip("/")
+    seen_dt = device.first_seen or timezone.now()
+    return {
+        "username": user.get_username(),
+        # UA / IP / time mirror the in-app alert in device_login._notify_new_device.
+        "user_agent": (device.user_agent or "an unrecognized browser")[:_UA_MESSAGE_MAX],
+        "ip_address": device.ip_address or "an unknown location",
+        "seen_at": seen_dt.strftime("%Y-%m-%d %H:%M UTC"),
+        "devices_url": (f"{frontend_url}/account/devices" if frontend_url else "/account/devices"),
+    }
+
+
+def send_new_device_alert(user, device) -> Optional[int]:
+    """
+    Render and send the new-device alert email to ``user``.
+
+    Returns the count of messages sent (Django's ``EmailMessage.send()`` return
+    value), or ``None`` when there is nothing to send (no email address on the
+    account, opted out, or the email backend errored).
+
+    Email-backend exceptions are logged but never raised — a provider hiccup
+    must not fail the Celery task (and so trigger a misleading retry/error).
+    """
+    if not user.email:
+        logger.info("new-device alert: user %s has no email address; skipping", user.pk)
+        return None
+
+    if _email_opted_out(user):
+        logger.info("new-device alert: user %s opted out of email; skipping", user.pk)
+        return None
+
+    ctx = _build_context(user, device)
+    subject = "New device sign-in to your account"
+    text_body = render_to_string("emails/new_device_alert.txt", ctx)
+    html_body = render_to_string("emails/new_device_alert.html", ctx)
+
+    try:
+        message = EmailMultiAlternatives(
+            subject=subject,
+            body=text_body,
+            from_email=getattr(settings, "DEFAULT_FROM_EMAIL", None),
+            to=[user.email],
+        )
+        message.attach_alternative(html_body, "text/html")
+        sent = message.send(fail_silently=False)
+        logger.info("Sent new-device alert email to user %s", user.pk)
+        return sent
+    except Exception:  # noqa: BLE001 — email failure must not fail the task
+        logger.exception("Failed to send new-device alert email to user %s", user.pk)
+        return None
+
+
+@shared_task
+def send_new_device_alert_email(user_id: int, device_id: int) -> Dict[str, Any]:
+    """
+    Celery task: email a staff/privileged user that a new device signed in.
+
+    Looks up the ``User`` and ``KnownDevice`` by id and delegates to
+    :func:`send_new_device_alert`. A missing row (user or device deleted before
+    the task runs) is swallowed with a logged warning and a ``{"sent": 0, ...}``
+    result rather than raising, so a benign race never errors the task.
+    """
+    from .models import KnownDevice
+
+    User = get_user_model()
+
+    try:
+        user = User.objects.get(pk=user_id)
+    except User.DoesNotExist:
+        logger.warning("send_new_device_alert_email: user %s not found", user_id)
+        return {"sent": 0, "reason": "user-not-found"}
+
+    try:
+        device = KnownDevice.objects.get(pk=device_id)
+    except KnownDevice.DoesNotExist:
+        logger.warning("send_new_device_alert_email: device %s not found", device_id)
+        return {"sent": 0, "reason": "device-not-found"}
+
+    sent = send_new_device_alert(user, device)
+    return {"sent": sent or 0, "user_id": user_id, "device_id": device_id}

--- a/backend/notifications/templates/emails/new_device_alert.html
+++ b/backend/notifications/templates/emails/new_device_alert.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>New device sign-in</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; color: #222; line-height: 1.5;">
+  <h2 style="margin-bottom: 0.25em;">New device sign-in to your account</h2>
+  <p style="margin-top: 0; color: #555;">
+    Hi {{ username }}, we noticed a new sign-in to your account from a device we have not seen before.
+  </p>
+
+  <table cellpadding="6" cellspacing="0" style="border-collapse: collapse; margin: 1em 0;">
+    <tr><td style="color:#666;">Device</td><td><strong>{{ user_agent }}</strong></td></tr>
+    <tr><td style="color:#666;">Location</td><td>{{ ip_address }}</td></tr>
+    <tr><td style="color:#666;">When</td><td>{{ seen_at }}</td></tr>
+  </table>
+
+  <p>If this was you, no action is needed.</p>
+  <p style="color:#555;">
+    If you do not recognize this sign-in, secure your account by changing your
+    password and reviewing the devices on your account.
+  </p>
+
+  <p>
+    <a href="{{ devices_url }}" style="background:#2563eb; color:#fff; padding:10px 16px; text-decoration:none; border-radius:4px; display:inline-block;">
+      Review your devices
+    </a>
+  </p>
+  <p style="color:#888; font-size: 12px;">Or paste this URL into your browser: {{ devices_url }}</p>
+
+  {# FP3 (revoke / "this wasn't me") will add a one-click revoke link here. #}
+
+  <hr style="border: none; border-top: 1px solid #eee; margin-top: 2em;">
+  <p style="color:#888; font-size: 12px;">Sent by OpenMakerSuite. You are receiving this security alert because a new device signed in to your account.</p>
+</body>
+</html>

--- a/backend/notifications/templates/emails/new_device_alert.txt
+++ b/backend/notifications/templates/emails/new_device_alert.txt
@@ -1,0 +1,19 @@
+New device sign-in to your account
+===================================
+
+Hi {{ username }},
+
+We noticed a new sign-in to your account from a device we have not seen before:
+
+Device:    {{ user_agent }}
+Location:  {{ ip_address }}
+When:      {{ seen_at }}
+
+If this was you, no action is needed.
+
+If you do not recognize this sign-in, secure your account by changing your
+password and reviewing the devices on your account:
+{{ devices_url }}
+
+{# FP3 (revoke / "this wasn't me") will add a one-click revoke link here. #}
+— OpenMakerSuite

--- a/docs/CELERY_TASKS.md
+++ b/docs/CELERY_TASKS.md
@@ -83,6 +83,12 @@ operator surface for inspecting status, args, and tracebacks
 | `reorder_queue.tasks.send_asset_problem_webhook` | `.delay()` from `AssetProblem` create | Builds payload, hands off to `send_webhook_notification` | None at this layer; downstream task retries | 30 min global | **Duplicate-safe** | Re-call with the same `problem_id`. |
 | `reorder_queue.tasks.send_location_problem_webhook` | `.delay()` from `Location.report_problem` action | Builds payload, hands off to `send_webhook_notification` | None at this layer; downstream task retries | 30 min global | **Duplicate-safe** | Re-call with the same `problem_id`. |
 
+### notifications
+
+| Task | Trigger | Side effects | Retries | Timeout | Idempotency | Recovery |
+| --- | --- | --- | --- | --- | --- | --- |
+| `notifications.tasks.send_new_device_alert_email` | `transaction.on_commit` from the new-device branch of `notifications.device_login.track_device_login` — fires when a staff/privileged account signs in from an unrecognized device (oms-1crmp, FP2; email companion to FP1's in-app alert) | Sends one templated email (Postmark via django-anymail in prod) to the signing-in user with the new device's User-Agent, approximate IP, time, and a link to `/account/devices`. Honors `NotificationPreference.email_enabled` only when the module constant `NEW_DEVICE_ALERT_BYPASS_EMAIL_OPT_OUT=False`; by default this security alert is sent regardless of the email opt-out. | None (`@shared_task` defaults) | 30 min global | **Duplicate-safe** — re-running for the same `(user_id, device_id)` re-sends the same alert; a deleted user/device returns `{"sent": 0, "reason": ...}` rather than raising | Re-call `send_new_device_alert_email.delay(user_id, device_id)` from a shell. |
+
 ### location_checkins
 
 | Task | Trigger | Side effects | Retries | Timeout | Idempotency | Recovery |


### PR DESCRIPTION
Lands work bead **oms-1crmp** — New-device login alert FP2 (templated email via Celery). Part of the new-device-alert series; no Closes keyword (no parent epic closed on merge).

## Scope (backend, NO migration; ff-clean on current main 5a5a898 = FP1)
- notifications/tasks.py: send_new_device_alert_email Celery task (+ docs/CELERY_TASKS.md)
- new_device_alert email templates (.html/.txt)
- notifications/device_login.py: fire task via transaction.on_commit from the new-device branch; honors email_enabled via NEW_DEVICE_ALERT_BYPASS_EMAIL_OPT_OUT (default send)
- tests: config/tests/test_new_device_alert_email.py

## Refinery gates
- CI-gated (backend feature, no refinery venv): Backend Tests + Backend Lint + Docker Build must go green before merge.

Bead strategy direct; main is PR-only, landed by refinery via squash once CI is green. — oms/gastown.refinery