### PR TITLE
feat(frontend): resilience test harnesses + core component tests (oms-1cx4f)

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -21,7 +21,7 @@ export default [
       'src/__tests__/**',
       'src/__mocks__/**',
       'src/setupTests.ts',
-      'src/vite-env.d.ts',
+      '**/*.d.ts',
     ],
   },
   js.configs.recommended,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -59,6 +59,7 @@
         "husky": "^9.0.0",
         "iconv-lite": "^0.7.0",
         "identity-obj-proxy": "^3.0.0",
+        "jest-axe": "^10.0.0",
         "jsdom": "^29.0.0",
         "patch-package": "^8.0.1",
         "playwright": "^1.56.1",
@@ -2219,6 +2220,19 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "dev": true,
@@ -3315,6 +3329,13 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "license": "MIT"
@@ -4287,6 +4308,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
+      "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/axios": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
@@ -5027,6 +5058,16 @@
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "license": "MIT"
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -6837,6 +6878,134 @@
         "node": ">=10"
       }
     },
+    "node_modules/jest-axe": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-10.0.0.tgz",
+      "integrity": "sha512-9QR0M7//o5UVRnEUUm68IsGapHrcKGakYy9dKWWMX79LmeUKguDI6DREyljC5I13j78OUmtKLF5My6ccffLFBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axe-core": "4.10.2",
+        "chalk": "4.1.2",
+        "jest-matcher-utils": "29.2.2",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.2.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.2.2.tgz",
+      "integrity": "sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.2.1",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "dev": true,
@@ -7327,6 +7496,13 @@
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
     "husky": "^9.0.0",
     "iconv-lite": "^0.7.0",
     "identity-obj-proxy": "^3.0.0",
+    "jest-axe": "^10.0.0",
     "jsdom": "^29.0.0",
     "patch-package": "^8.0.1",
     "playwright": "^1.56.1",

--- a/frontend/src/__tests__/components/CommandPalette.test.tsx
+++ b/frontend/src/__tests__/components/CommandPalette.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * CommandPalette Component Tests
+ *
+ * Closes the biggest single AC-20 (a11y) gap for the #457 resilience program:
+ * open-focus, keyboard navigation (Arrow/Enter/Escape), query-filtered results,
+ * the searchbox role, and a clean axe audit.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { CommandPalette } from '../../components/CommandPalette';
+import {
+  getRecentSearches,
+  saveRecentSearch,
+  searchGlobal,
+} from '../../services/searchService';
+import { SearchResult } from '../../types';
+import { expectNoA11yViolations } from '../helpers/axe';
+
+vi.mock('../../services/searchService', () => ({
+  // Pass-through debounce so a typed query triggers search synchronously.
+  debounce: (fn: (...args: unknown[]) => unknown) => fn,
+  searchGlobal: vi.fn(),
+  getRecentSearches: vi.fn(),
+  saveRecentSearch: vi.fn(),
+}));
+
+const mockedSearchGlobal = vi.mocked(searchGlobal);
+const mockedGetRecent = vi.mocked(getRecentSearches);
+const mockedSaveRecent = vi.mocked(saveRecentSearch);
+
+const makeResult = (overrides: Partial<SearchResult> = {}): SearchResult => ({
+  id: '1',
+  type: 'inventory',
+  title: 'Widget',
+  subtitle: 'SKU-1',
+  url: '/inventory/items/1',
+  ...overrides,
+});
+
+const renderPalette = () => {
+  const onClose = vi.fn();
+  const utils = render(
+    <MantineProvider>
+      <MemoryRouter>
+        <CommandPalette isOpen onClose={onClose} />
+      </MemoryRouter>
+    </MantineProvider>
+  );
+  return { onClose, ...utils };
+};
+
+describe('CommandPalette', () => {
+  beforeEach(() => {
+    mockedSearchGlobal.mockResolvedValue([]);
+    mockedGetRecent.mockResolvedValue([]);
+    mockedSaveRecent.mockResolvedValue(undefined);
+  });
+
+  it('exposes the input as a named searchbox and focuses it when opened', async () => {
+    renderPalette();
+    const searchbox = await screen.findByRole('searchbox', { name: /search/i });
+    await waitFor(() => expect(searchbox).toHaveFocus());
+  });
+
+  it('filters quick actions by the typed query', async () => {
+    renderPalette();
+    const searchbox = await screen.findByRole('searchbox');
+
+    fireEvent.change(searchbox, { target: { value: 'asset' } });
+
+    expect(await screen.findByText('Go to Assets')).toBeInTheDocument();
+    expect(screen.getByText('Create Asset')).toBeInTheDocument();
+    // An unrelated action must not leak into the filtered results.
+    expect(screen.queryByText('Go to Locations')).not.toBeInTheDocument();
+  });
+
+  it('closes when Escape is pressed', async () => {
+    const { onClose } = renderPalette();
+    const searchbox = await screen.findByRole('searchbox');
+
+    fireEvent.keyDown(searchbox, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('moves the selection with the down arrow key', async () => {
+    mockedSearchGlobal.mockResolvedValue([
+      makeResult({ id: 'a', title: 'Result A', url: '/a' }),
+      makeResult({ id: 'b', title: 'Result B', url: '/b' }),
+    ]);
+    // Modal content portals to document.body, so query baseElement, not container.
+    const { baseElement } = renderPalette();
+    const searchbox = await screen.findByRole('searchbox');
+
+    // 'zzz' matches no quick actions, so only the two search results render.
+    fireEvent.change(searchbox, { target: { value: 'zzz' } });
+    await screen.findByText('Result A');
+
+    // First result is selected on load.
+    await waitFor(() =>
+      expect(baseElement.querySelector('.command-palette-item.selected')).toHaveTextContent(
+        'Result A'
+      )
+    );
+
+    fireEvent.keyDown(searchbox, { key: 'ArrowDown' });
+    await waitFor(() =>
+      expect(baseElement.querySelector('.command-palette-item.selected')).toHaveTextContent(
+        'Result B'
+      )
+    );
+  });
+
+  it('selects the highlighted result on Enter', async () => {
+    mockedSearchGlobal.mockResolvedValue([
+      makeResult({ id: 'a', title: 'Result A', url: '/a' }),
+    ]);
+    const { onClose } = renderPalette();
+    const searchbox = await screen.findByRole('searchbox');
+
+    fireEvent.change(searchbox, { target: { value: 'zzz' } });
+    await screen.findByText('Result A');
+
+    fireEvent.keyDown(searchbox, { key: 'Enter' });
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(mockedSaveRecent).toHaveBeenCalled();
+  });
+
+  it('has no accessibility violations when open', async () => {
+    const { baseElement } = renderPalette();
+    await screen.findByRole('searchbox');
+    await expectNoA11yViolations(baseElement);
+  });
+});

--- a/frontend/src/__tests__/components/ErrorFallback.test.tsx
+++ b/frontend/src/__tests__/components/ErrorFallback.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * ErrorFallback Component Tests
+ *
+ * Covers the error-recovery surface for the #457 resilience program:
+ * render-on-catch, the recovery action, the alert role, focus management, and
+ * a clean axe audit.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import ErrorFallback from '../../components/ErrorFallback';
+import { expectNoA11yViolations } from '../helpers/axe';
+
+/** Minimal boundary that renders ErrorFallback when a child throws. */
+class TestErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { error: Error | null }
+> {
+  state: { error: Error | null } = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <ErrorFallback
+          error={this.state.error}
+          resetError={() => this.setState({ error: null })}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}
+
+describe('ErrorFallback', () => {
+  it('renders the error UI with an alert role', () => {
+    render(<ErrorFallback error={new Error('boom')} resetError={vi.fn()} />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+  });
+
+  it('invokes the recovery action when "Try Again" is clicked', async () => {
+    const resetError = vi.fn();
+    const user = userEvent.setup();
+    render(<ErrorFallback error={new Error('boom')} resetError={resetError} />);
+
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+    expect(resetError).toHaveBeenCalledTimes(1);
+  });
+
+  it('moves focus to the recovery button on mount', () => {
+    render(<ErrorFallback error={new Error('boom')} resetError={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /try again/i })).toHaveFocus();
+  });
+
+  it('renders as the fallback when a child component throws', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const Boom = () => {
+      throw new Error('kaboom');
+    };
+
+    render(
+      <TestErrorBoundary>
+        <Boom />
+      </TestErrorBoundary>
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <ErrorFallback error={new Error('boom')} resetError={vi.fn()} />
+    );
+    await expectNoA11yViolations(container);
+  });
+});

--- a/frontend/src/__tests__/components/NotificationCenter.test.tsx
+++ b/frontend/src/__tests__/components/NotificationCenter.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * NotificationCenter Component Tests
+ *
+ * Covers the notification drawer for the #457 resilience program: the drawer's
+ * modal focus-trap, keyboard dismissal, the empty state, and rendering of an
+ * error-type notification.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import NotificationCenter from '../../components/NotificationCenter';
+import type { BannerNotification, Notification } from '../../contexts/NotificationContext';
+
+interface HookValue {
+  banners: BannerNotification[];
+  backendNotifications: Notification[];
+  unreadCount: number;
+  loadNotifications: ReturnType<typeof vi.fn>;
+  markAsRead: ReturnType<typeof vi.fn>;
+  markAllAsRead: ReturnType<typeof vi.fn>;
+  deleteNotification: ReturnType<typeof vi.fn>;
+  dismissBanner: ReturnType<typeof vi.fn>;
+  clearBanners: ReturnType<typeof vi.fn>;
+}
+
+let hookValue: HookValue;
+
+vi.mock('../../hooks/useNotifications', () => ({
+  useNotifications: () => hookValue,
+}));
+
+const makeNotification = (overrides: Partial<Notification> = {}): Notification => ({
+  id: '1',
+  type: 'info',
+  title: 'Title',
+  message: 'Message',
+  read: false,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  ...overrides,
+});
+
+beforeEach(() => {
+  hookValue = {
+    banners: [],
+    backendNotifications: [],
+    unreadCount: 0,
+    loadNotifications: vi.fn(),
+    markAsRead: vi.fn(),
+    markAllAsRead: vi.fn(),
+    deleteNotification: vi.fn(),
+    dismissBanner: vi.fn(),
+    clearBanners: vi.fn(),
+  };
+});
+
+const renderCenter = (isOpen = true) => {
+  const onClose = vi.fn();
+  const utils = render(
+    <MantineProvider>
+      <MemoryRouter>
+        <NotificationCenter isOpen={isOpen} onClose={onClose} />
+      </MemoryRouter>
+    </MantineProvider>
+  );
+  return { onClose, ...utils };
+};
+
+describe('NotificationCenter', () => {
+  it('renders a modal drawer and loads notifications when opened', () => {
+    renderCenter(true);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    // aria-modal marks the drawer as a focus-trapping modal surface.
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(hookValue.loadNotifications).toHaveBeenCalled();
+  });
+
+  it('does not render the drawer when closed', () => {
+    renderCenter(false);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('traps focus inside the drawer when open', async () => {
+    renderCenter(true);
+    const dialog = screen.getByRole('dialog');
+    await waitFor(() =>
+      expect(dialog).toContainElement(document.activeElement as HTMLElement)
+    );
+  });
+
+  it('closes on Escape (keyboard dismissal)', () => {
+    const { onClose } = renderCenter(true);
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows the empty state when there are no notifications', () => {
+    renderCenter(true);
+    expect(screen.getByText(/no notifications/i)).toBeInTheDocument();
+  });
+
+  it('renders an error-type notification', () => {
+    hookValue.backendNotifications = [
+      makeNotification({
+        id: 'e1',
+        type: 'error',
+        title: 'Sync failed',
+        message: 'Could not reach server',
+        read: false,
+      }),
+    ];
+    hookValue.unreadCount = 1;
+
+    renderCenter(true);
+
+    expect(screen.getByText('Sync failed')).toBeInTheDocument();
+    expect(screen.getByText('Could not reach server')).toBeInTheDocument();
+    expect(screen.getByText('✕')).toBeInTheDocument();
+  });
+
+  it('invokes markAllAsRead from the header action', async () => {
+    hookValue.backendNotifications = [makeNotification({ read: false })];
+    hookValue.unreadCount = 1;
+    const user = userEvent.setup();
+
+    renderCenter(true);
+    await user.click(screen.getByRole('button', { name: /mark all read/i }));
+
+    expect(hookValue.markAllAsRead).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/components/OfflineIndicator.test.tsx
+++ b/frontend/src/__tests__/components/OfflineIndicator.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * OfflineIndicator Component Tests
+ *
+ * Anchors AC-16 (offline coverage) for the #457 resilience program: the
+ * indicator is hidden while online and visible while offline, driven by the
+ * shared offline helper (navigator.onLine + online/offline events).
+ */
+import { MantineProvider } from '@mantine/core';
+import { act, render, screen } from '@testing-library/react';
+import OfflineIndicator from '../../components/OfflineIndicator';
+import { expectNoA11yViolations } from '../helpers/axe';
+import { goOffline, goOnline } from '../helpers/offline';
+
+const renderIndicator = () =>
+  render(
+    <MantineProvider>
+      <OfflineIndicator />
+    </MantineProvider>
+  );
+
+describe('OfflineIndicator', () => {
+  it('renders nothing while online', () => {
+    renderIndicator();
+    expect(screen.queryByText(/you're offline/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the offline alert when offline at mount', () => {
+    goOffline();
+    renderIndicator();
+    expect(screen.getByText(/you're offline/i)).toBeInTheDocument();
+    expect(screen.getByText(/some features may be limited/i)).toBeInTheDocument();
+  });
+
+  it('appears and disappears as connectivity toggles', () => {
+    renderIndicator();
+    expect(screen.queryByText(/you're offline/i)).not.toBeInTheDocument();
+
+    act(() => goOffline());
+    expect(screen.getByText(/you're offline/i)).toBeInTheDocument();
+
+    act(() => goOnline());
+    expect(screen.queryByText(/you're offline/i)).not.toBeInTheDocument();
+  });
+
+  it('has no accessibility violations while offline', async () => {
+    goOffline();
+    const { container } = renderIndicator();
+    await expectNoA11yViolations(container);
+  });
+});

--- a/frontend/src/__tests__/helpers/README.md
+++ b/frontend/src/__tests__/helpers/README.md
@@ -1,0 +1,71 @@
+# Frontend test helpers
+
+Reusable test harnesses for the `#457` frontend journey-resilience program.
+Slice **R1** added these so the journey slices (**R2..R7**) share one a11y audit
+and one offline-simulation pattern instead of re-rolling them per test.
+
+## `axe.ts` — accessibility assertions
+
+Wraps [`jest-axe`](https://github.com/nickcolley/jest-axe). The
+`toHaveNoViolations` matcher is registered globally in `src/setupTests.ts`, so
+you only import the helper:
+
+```ts
+import { render } from '@testing-library/react';
+import { expectNoA11yViolations } from '../helpers/axe';
+
+it('has no accessibility violations', async () => {
+  const { container } = render(<MyComponent />);
+  await expectNoA11yViolations(container);
+});
+```
+
+For components that **portal** their content (Mantine `Modal`, `Drawer`,
+`Menu`, tooltips), audit `baseElement` (defaults to `document.body`) instead of
+`container`, otherwise the portaled DOM is not included:
+
+```ts
+const { baseElement } = render(<CommandPalette isOpen onClose={vi.fn()} />);
+await expectNoA11yViolations(baseElement);
+```
+
+Defaults are tuned for component-level testing in jsdom: only **WCAG 2.0/2.1 A
+& AA** rules run (page-level best-practice rules like `region`/`landmark` would
+false-positive on a fragment), and `color-contrast` is disabled (jsdom does no
+layout, so the ratio is never computable). Pass an axe options object as the
+second argument to override.
+
+## `offline.ts` — offline / poor-network simulation
+
+The app detects connectivity loss two ways; the helper covers both.
+
+**1. `navigator.onLine` + window events** (drives `useOnlineStatus`,
+`<OfflineIndicator />`):
+
+```ts
+import { goOffline, goOnline } from '../helpers/offline';
+
+it('shows the offline indicator', () => {
+  goOffline();                 // set before render to seed the initial state
+  render(<OfflineIndicator />);
+  expect(screen.getByText(/offline/i)).toBeInTheDocument();
+});
+
+// Toggle live (wrap in act() when it triggers React state updates):
+act(() => goOnline());
+```
+
+`navigator.onLine` is reset to `true` automatically in an `afterEach`, so
+offline state never leaks between tests. Call `resetOnlineStatus()` manually if
+you need to reset mid-test.
+
+**2. axios network-failure error** (drives retry/offline branches in data
+fetching):
+
+```ts
+import { networkError } from '../helpers/offline';
+
+vi.mocked(api.get).mockRejectedValue(networkError());
+// error.request is set, error.response is undefined, code === 'ERR_NETWORK',
+// and axios.isAxiosError(error) === true — the real offline signature.
+```

--- a/frontend/src/__tests__/helpers/axe.ts
+++ b/frontend/src/__tests__/helpers/axe.ts
@@ -1,0 +1,65 @@
+/**
+ * Accessibility (a11y) test helper.
+ *
+ * Wraps `jest-axe` so journey slices can assert a rendered subtree has no
+ * accessibility violations with a single call:
+ *
+ *   const { container } = render(<Foo />);
+ *   await expectNoA11yViolations(container);
+ *
+ * The `toHaveNoViolations` matcher is registered globally in
+ * `src/setupTests.ts`; this helper centralises the `axe(...)` call plus the
+ * jsdom-friendly default configuration so every slice runs the same audit.
+ */
+import { axe } from 'jest-axe';
+import { expect } from 'vitest';
+
+// Augment Vitest's matcher interface with the jest-axe matcher registered in
+// setupTests.ts so `expect(results).toHaveNoViolations()` type-checks.
+declare module 'vitest' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  interface Assertion<T = any> {
+    toHaveNoViolations(): T;
+  }
+  interface AsymmetricMatchersContaining {
+    toHaveNoViolations(): unknown;
+  }
+}
+
+type AxeOptions = Parameters<typeof axe>[1];
+
+/**
+ * Default axe configuration tuned for component-level testing in jsdom:
+ *
+ *  - Restrict to WCAG 2.0/2.1 A & AA rules. Best-practice rules (landmark /
+ *    region / heading-order / dialog-name) assume a full page and produce false
+ *    positives when auditing an isolated component fragment.
+ *  - Disable `color-contrast`: jsdom performs no layout, so axe cannot compute a
+ *    contrast ratio and the rule can only ever return an inconclusive result.
+ */
+const DEFAULT_OPTIONS: AxeOptions = {
+  runOnly: {
+    type: 'tag',
+    values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
+  },
+  rules: {
+    'color-contrast': { enabled: false },
+  },
+};
+
+/**
+ * Assert that `container` has no WCAG A/AA accessibility violations.
+ *
+ * @param container  A rendered element (e.g. `container` or `baseElement` from
+ *                   `@testing-library/react`'s `render`). Use `baseElement`
+ *                   (the default `document.body`) for components that portal
+ *                   their content, such as Mantine `Modal`/`Drawer`.
+ * @param options    Optional axe overrides merged over the defaults.
+ */
+export async function expectNoA11yViolations(
+  container: Element,
+  options: AxeOptions = {}
+): Promise<void> {
+  const results = await axe(container, { ...DEFAULT_OPTIONS, ...options });
+  expect(results).toHaveNoViolations();
+}

--- a/frontend/src/__tests__/helpers/offline.ts
+++ b/frontend/src/__tests__/helpers/offline.ts
@@ -1,0 +1,80 @@
+/**
+ * Offline / poor-network test helpers.
+ *
+ * Journey slices (R2..R7 of #457) reuse these to drive the two ways the app
+ * detects connectivity loss:
+ *
+ *  1. The `navigator.onLine` flag plus the `online`/`offline` window events
+ *     that `useOnlineStatus` (and therefore `<OfflineIndicator />`) listens to.
+ *  2. An axios error shaped like a real network failure — `error.request` set,
+ *     `error.response` undefined, `code === 'ERR_NETWORK'` — which is how axios
+ *     reports a request that left the browser but got no reply (offline, DNS
+ *     failure, timeout). Components branch on this to show retry/offline UI.
+ *
+ * Example:
+ *
+ *   import { goOffline, networkError } from '../helpers/offline';
+ *
+ *   it('shows the offline banner', () => {
+ *     goOffline();
+ *     render(<OfflineIndicator />);
+ *     expect(screen.getByText(/offline/i)).toBeInTheDocument();
+ *   });
+ *
+ *   it('surfaces a retry on network failure', async () => {
+ *     vi.mocked(api.get).mockRejectedValue(networkError());
+ *     // ...assert the component renders its offline/retry affordance
+ *   });
+ *
+ * `navigator.onLine` is reset to `true` automatically after every test (see the
+ * `afterEach` below), so a test that calls `goOffline()` cannot leak its state
+ * into the next one.
+ */
+import { AxiosError } from 'axios';
+import { afterEach } from 'vitest';
+
+let patched = false;
+
+const setNavigatorOnLine = (value: boolean): void => {
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    get: () => value,
+  });
+  patched = true;
+};
+
+/** Mark the browser offline and fire the `offline` event. */
+export const goOffline = (): void => {
+  setNavigatorOnLine(false);
+  window.dispatchEvent(new Event('offline'));
+};
+
+/** Mark the browser online and fire the `online` event. */
+export const goOnline = (): void => {
+  setNavigatorOnLine(true);
+  window.dispatchEvent(new Event('online'));
+};
+
+/** Restore the default (`navigator.onLine === true`) without firing an event. */
+export const resetOnlineStatus = (): void => {
+  if (!patched) {
+    return;
+  }
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    get: () => true,
+  });
+  patched = false;
+};
+
+/**
+ * Build an axios network-failure error (offline signature: `request` set,
+ * `response` undefined, `code === 'ERR_NETWORK'`, `isAxiosError === true`).
+ */
+export const networkError = (message = 'Network Error'): AxiosError =>
+  new AxiosError(message, AxiosError.ERR_NETWORK, undefined, {});
+
+// Auto-reset so an offline state set by one test never bleeds into the next.
+afterEach(() => {
+  resetOnlineStatus();
+});

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -299,6 +299,8 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose 
         <Box p="md">
           <TextInput
             ref={inputRef}
+            type="search"
+            aria-label="Search inventory, assets, POs, suppliers, locations"
             placeholder="Search inventory, assets, POs, suppliers, locations..."
             value={query}
             onChange={(e) => setQuery(e.currentTarget.value)}

--- a/frontend/src/components/ErrorFallback.tsx
+++ b/frontend/src/components/ErrorFallback.tsx
@@ -11,13 +11,21 @@ interface ErrorFallbackProps {
 }
 
 const ErrorFallback: React.FC<ErrorFallbackProps> = ({ error, resetError }) => {
+  const tryAgainRef = React.useRef<HTMLButtonElement>(null);
+
   React.useEffect(() => {
     // eslint-disable-next-line no-console
     console.error('Error caught by ErrorFallback:', error);
   }, [error]);
 
+  React.useEffect(() => {
+    // Move focus to the primary recovery action so keyboard and screen-reader
+    // users land on something actionable when the fallback replaces the page.
+    tryAgainRef.current?.focus();
+  }, []);
+
   return (
-    <div className="error-fallback">
+    <div className="error-fallback" role="alert">
       <div className="error-fallback-content">
         <h1>Something went wrong</h1>
         <p className="error-message">
@@ -33,7 +41,7 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({ error, resetError }) => {
         )}
 
         <div className="error-actions">
-          <button onClick={resetError} className="btn-try-again">
+          <button ref={tryAgainRef} onClick={resetError} className="btn-try-again">
             Try Again
           </button>
           <button onClick={() => window.location.href = '/'} className="btn-go-home">

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,6 +1,12 @@
 // jest-dom adds custom matchers for asserting on DOM nodes.
 import '@testing-library/jest-dom/vitest';
-import { afterEach, vi } from 'vitest';
+import { toHaveNoViolations } from 'jest-axe';
+import { afterEach, expect, vi } from 'vitest';
+
+// Register the jest-axe accessibility matcher globally so `toHaveNoViolations`
+// (and the `expectNoA11yViolations` helper that wraps it) is available in every
+// test without per-file setup. See src/__tests__/helpers/axe.ts.
+expect.extend(toHaveNoViolations);
 
 // Shim: existing test files reference `jest.fn` / `jest.mock` etc.
 // Vitest's `vi` is API-compatible for the operations used here, so

--- a/frontend/src/types/jest-axe.d.ts
+++ b/frontend/src/types/jest-axe.d.ts
@@ -1,0 +1,30 @@
+/**
+ * Ambient type declarations for `jest-axe` (v10 ships no types of its own).
+ *
+ * Only the surface this codebase consumes is declared. The typed entry point
+ * tests should use is the helper in `src/__tests__/helpers/axe.ts`; this
+ * declaration exists so `tsc` resolves the bare `jest-axe` import without
+ * pulling Jest's global type definitions (this project runs on Vitest).
+ */
+declare module 'jest-axe' {
+  import type AxeCore from 'axe-core';
+
+  export type JestAxeConfigureOptions = AxeCore.RunOptions & {
+    globalOptions?: AxeCore.Spec;
+  };
+
+  export function axe(
+    html: AxeCore.ElementContext,
+    options?: JestAxeConfigureOptions
+  ): Promise<AxeCore.AxeResults>;
+
+  export function configureAxe(
+    options?: JestAxeConfigureOptions
+  ): typeof axe;
+
+  /** Matcher object passed to `expect.extend(...)`. */
+  export const toHaveNoViolations: Record<
+    string,
+    (results: AxeCore.AxeResults) => { pass: boolean; message(): string }
+  >;
+}


### PR DESCRIPTION
Lands work bead **oms-1cx4f** — #457 R1: resilience harnesses. R1 of a series (R2..R7 to follow); no Closes keyword (does not close epic #457 on merge).

## Scope (frontend; ff-clean on current main a7d57d8)
- jest-axe a11y helper (expectNoA11yViolations) + offline helper (goOffline/goOnline/networkError) under src/__tests__/helpers/ (+README for R2..R7)
- component tests: OfflineIndicator (AC-16), CommandPalette (AC-20 +axe), ErrorFallback, NotificationCenter
- adds jest-axe dependency (package.json + package-lock.json) + type defs; eslint/setupTests wiring
- minor a11y fixes: CommandPalette.tsx, ErrorFallback.tsx

## Refinery gates
- CI-gated (new dependency + production component changes): Frontend Tests (fresh install incl jest-axe) + Frontend Lint + Build + E2E must go green before merge.

Bead strategy direct; main is PR-only, landed by refinery via squash once CI is green. — oms/gastown.refinery