### PR TITLE
test(settings): cover settings/webhook page resilience states (oms-065g5)

### DIFF
--- a/frontend/src/__tests__/pages/SiteSettingsPage.test.tsx
+++ b/frontend/src/__tests__/pages/SiteSettingsPage.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Tests for SiteSettingsPage.
+ *
+ * Covers the superuser permission gate (AC-18: a protected frontend action
+ * matches the backend permission and offers a recovery path) and the
+ * loading / save-failed / duplicate-submit resilience states (AC-19: a
+ * consistent, accessible state instead of a blank screen or raw exception).
+ * Part of #457 R7 (settings/webhooks coverage).
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SiteSettingsPage from '../../pages/SiteSettingsPage';
+import { customizationAPI } from '../../services/api';
+
+vi.mock('../../services/api', () => ({
+  customizationAPI: {
+    getSiteSettings: jest.fn(),
+    updateSiteSettings: jest.fn(),
+  },
+}));
+
+const mockNavigate = jest.fn();
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockSettings = {
+  site_name: 'Test Makerspace',
+  site_tagline: 'Make all the things',
+  logo_url: null,
+  logo_alt_text: '',
+  favicon_url: null,
+  primary_color: '#007cba',
+  secondary_color: '#417690',
+  footer_text: '',
+  contact_email: 'hello@example.com',
+  contact_phone: '555-1234',
+  website_url: 'https://example.com',
+  dashboard_title: '',
+  dashboard_subtitle: '',
+  show_logo_on_dashboard: true,
+};
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <SiteSettingsPage />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('SiteSettingsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    (customizationAPI.getSiteSettings as jest.Mock).mockResolvedValue({ data: mockSettings });
+    (customizationAPI.updateSiteSettings as jest.Mock).mockResolvedValue({ data: mockSettings });
+  });
+
+  // AC-18: a non-superuser lacks permission for this settings page, so the
+  // page must redirect them out (recovery path) and never call the API.
+  it('redirects a non-superuser to home and never loads settings', async () => {
+    // is_superuser is absent from localStorage → not permitted.
+    renderPage();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+    expect(customizationAPI.getSiteSettings).not.toHaveBeenCalled();
+  });
+
+  // AC-19: while settings load, a superuser sees a consistent loading state
+  // rather than a blank screen.
+  it('shows a loading state for a superuser while settings load', () => {
+    localStorage.setItem('is_superuser', 'true');
+    (customizationAPI.getSiteSettings as jest.Mock).mockImplementation(
+      () => new Promise(() => {}), // never resolves: hold the loading state
+    );
+
+    renderPage();
+
+    expect(screen.getByText(/loading site settings/i)).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  // AC-19: a failed save surfaces a consistent error alert, not a raw
+  // exception or a silently swallowed failure.
+  it('surfaces an error alert when saving settings fails', async () => {
+    localStorage.setItem('is_superuser', 'true');
+    (customizationAPI.updateSiteSettings as jest.Mock).mockRejectedValue({
+      response: { data: { detail: 'Save blocked by server' } },
+    });
+
+    renderPage();
+
+    const saveButton = await screen.findByRole('button', { name: /save settings/i });
+    fireEvent.click(saveButton);
+
+    expect(await screen.findByText('Save blocked by server')).toBeInTheDocument();
+  });
+
+  // AC-15/AC-19: the save button disables while a save is in flight so the
+  // user cannot fire a duplicate submission, then re-enables on completion.
+  it('disables the save button while a save is in flight', async () => {
+    localStorage.setItem('is_superuser', 'true');
+    let resolveSave: (value: unknown) => void = () => {};
+    (customizationAPI.updateSiteSettings as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+
+    renderPage();
+
+    const saveButton = await screen.findByRole('button', { name: /save settings/i });
+    expect(saveButton).not.toBeDisabled();
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(saveButton).toBeDisabled();
+    });
+    // A second click on the disabled button cannot trigger another request.
+    fireEvent.click(saveButton);
+    expect(customizationAPI.updateSiteSettings).toHaveBeenCalledTimes(1);
+
+    // Resolve the pending save so nothing leaks past the test.
+    resolveSave({ data: mockSettings });
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/__tests__/pages/UserProfilePage.test.tsx
+++ b/frontend/src/__tests__/pages/UserProfilePage.test.tsx
@@ -253,5 +253,90 @@ describe('UserProfilePage', () => {
       expect(notificationsAPI.updatePreferences).toHaveBeenCalledWith({ email_enabled: false });
     });
   });
+
+  // AC-17/AC-19 (#457 R7): an expired session (401 on profile load) surfaces a
+  // recovery message instead of leaving the page stuck on the loading state.
+  // The global token-refresh interceptor lives in services/api and is mocked
+  // away here, so this asserts the page-level fallback behavior.
+  it('surfaces an error and is not stuck loading when the session has expired', async () => {
+    (notificationsAPI.getPreferences as jest.Mock).mockResolvedValue({ data: mockPreferences });
+    (userAPI.getProfile as jest.Mock).mockRejectedValueOnce({
+      response: { status: 401, data: { detail: 'Authentication credentials were not provided.' } },
+    });
+
+    render(
+      <MantineProvider>
+        <BrowserRouter>
+          <UserProfilePage />
+        </BrowserRouter>
+      </MantineProvider>
+    );
+
+    expect(
+      await screen.findByText('Authentication credentials were not provided.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Loading profile/)).not.toBeInTheDocument();
+  });
+
+  // AC-19 (#457 R7): a missing profile (404 with no error body) falls back to a
+  // consistent message rather than a blank screen or a raw exception.
+  it('surfaces a fallback error when the profile is missing', async () => {
+    (notificationsAPI.getPreferences as jest.Mock).mockResolvedValue({ data: mockPreferences });
+    (userAPI.getProfile as jest.Mock).mockRejectedValueOnce({
+      response: { status: 404, data: {} },
+    });
+
+    render(
+      <MantineProvider>
+        <BrowserRouter>
+          <UserProfilePage />
+        </BrowserRouter>
+      </MantineProvider>
+    );
+
+    expect(await screen.findByText('Failed to load profile')).toBeInTheDocument();
+    expect(screen.queryByText(/Loading profile/)).not.toBeInTheDocument();
+  });
+
+  // AC-15/AC-19 (#457 R7): the profile save button disables while a save is in
+  // flight, preventing a duplicate submission, then re-enables on completion.
+  it('disables the profile save button while a save is in flight', async () => {
+    (notificationsAPI.getPreferences as jest.Mock).mockResolvedValue({ data: mockPreferences });
+    let resolveUpdate: (value: unknown) => void = () => {};
+    (userAPI.updateProfile as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveUpdate = resolve;
+        })
+    );
+
+    render(
+      <MantineProvider>
+        <BrowserRouter>
+          <UserProfilePage />
+        </BrowserRouter>
+      </MantineProvider>
+    );
+
+    // The profile tab is active by default; its save button appears once the
+    // profile finishes loading and the form is populated with valid values.
+    const saveButton = await screen.findByRole('button', { name: /save changes/i });
+    expect(saveButton).not.toBeDisabled();
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(saveButton).toBeDisabled();
+    });
+    // A second click on the disabled button cannot fire another request.
+    fireEvent.click(saveButton);
+    expect(userAPI.updateProfile).toHaveBeenCalledTimes(1);
+
+    // Resolve the pending save so nothing leaks past the test.
+    resolveUpdate({ data: mockProfile });
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled();
+    });
+  });
 });
 

--- a/frontend/src/__tests__/pages/WebhookDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/WebhookDetailPage.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Tests for WebhookDetailPage.
+ *
+ * Covers the loading state, the test-send transient-error surface (a failed
+ * "Test" delivery is reported in the result modal rather than swallowed), and
+ * a forbidden (admin-only) load degrading gracefully to the not-found state.
+ * Maps to AC-18 (a denied action stays consistent, no raw exception) and
+ * AC-19 (loading / error / missing states are consistent). Part of #457 R7.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { networkError } from '../helpers/offline';
+import WebhookDetailPage from '../../pages/WebhookDetailPage';
+import { webhooksAPI } from '../../services/api';
+
+vi.mock('../../services/api', () => ({
+  webhooksAPI: {
+    getWebhook: jest.fn(),
+    testWebhook: jest.fn(),
+    getTestStatus: jest.fn(),
+    deleteWebhook: jest.fn(),
+  },
+}));
+
+const mockNavigate = jest.fn();
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ id: '5' }),
+}));
+
+const mockWebhook = {
+  id: 5,
+  name: 'Existing Hook',
+  description: 'Sends reorder events',
+  url: 'https://example.com/hook',
+  event_type: 'reorder_request_created',
+  event_type_display: 'Reorder Request Created',
+  is_active: true,
+  headers: null,
+  last_triggered_at: null,
+  success_count: 0,
+  failure_count: 0,
+  success_rate: null,
+  total_triggers: 0,
+  last_error: '',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+};
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <WebhookDetailPage />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('WebhookDetailPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (webhooksAPI.getWebhook as jest.Mock).mockResolvedValue({ data: mockWebhook });
+    (webhooksAPI.testWebhook as jest.Mock).mockResolvedValue({
+      data: { webhook_id: 5, success: true, tested_at: '2024-01-01T00:00:00Z' },
+    });
+  });
+
+  // AC-19: a consistent loading state renders while the webhook loads.
+  it('shows a loading state while the webhook loads', () => {
+    (webhooksAPI.getWebhook as jest.Mock).mockImplementation(
+      () => new Promise(() => {}), // never resolves: hold the loading state
+    );
+
+    renderPage();
+
+    expect(screen.getByText(/loading webhook/i)).toBeInTheDocument();
+  });
+
+  // AC-19: a transient failure of the "Test" send is surfaced in the result
+  // modal instead of being swallowed or crashing the page.
+  it('surfaces a transient error when the test send fails', async () => {
+    (webhooksAPI.testWebhook as jest.Mock).mockRejectedValue(networkError());
+
+    renderPage();
+
+    const testButton = await screen.findByRole('button', { name: /^test$/i });
+    fireEvent.click(testButton);
+
+    expect(await screen.findByText('Test Failed')).toBeInTheDocument();
+    // The fallback message is rendered (network error carries no response body).
+    expect(screen.getAllByText('Failed to test webhook').length).toBeGreaterThan(0);
+  });
+
+  // AC-18/AC-19: when the backend denies the load (e.g. a non-admin viewer),
+  // the page degrades to a consistent not-found state rather than a blank
+  // screen or a thrown exception.
+  it('renders a consistent not-found state when the load is denied', async () => {
+    (webhooksAPI.getWebhook as jest.Mock).mockRejectedValue({
+      response: {
+        status: 403,
+        data: { detail: 'You do not have permission to perform this action.' },
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Webhook not found.')).toBeInTheDocument();
+    expect(screen.queryByText(/loading webhook/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/WebhookFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/WebhookFormPage.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Tests for WebhookFormPage.
+ *
+ * Covers the edit-mode loading state, a failed save, and forbidden
+ * (admin-only) API responses on both the edit-mode load and the create-mode
+ * save. Maps to AC-18 (a denied action is surfaced with a recovery path and
+ * the user is not navigated away) and AC-19 (loading / error states stay
+ * consistent). Part of #457 R7 (settings/webhooks coverage).
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import WebhookFormPage from '../../pages/WebhookFormPage';
+import { webhooksAPI } from '../../services/api';
+
+vi.mock('../../services/api', () => ({
+  webhooksAPI: {
+    getWebhook: jest.fn(),
+    createWebhook: jest.fn(),
+    updateWebhook: jest.fn(),
+  },
+}));
+
+const mockUseParams = vi.fn((): { id?: string } => ({}));
+const mockNavigate = jest.fn();
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useParams: () => mockUseParams(),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockWebhook = {
+  id: 5,
+  name: 'Existing Hook',
+  description: 'Sends reorder events',
+  url: 'https://example.com/hook',
+  event_type: 'reorder_request_created',
+  event_type_display: 'Reorder Request Created',
+  is_active: true,
+  headers: null,
+  last_triggered_at: null,
+  success_count: 0,
+  failure_count: 0,
+  success_rate: null,
+  total_triggers: 0,
+  last_error: '',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+};
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <WebhookFormPage />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('WebhookFormPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseParams.mockReturnValue({});
+    (webhooksAPI.getWebhook as jest.Mock).mockResolvedValue({ data: mockWebhook });
+    (webhooksAPI.createWebhook as jest.Mock).mockResolvedValue({ data: mockWebhook });
+    (webhooksAPI.updateWebhook as jest.Mock).mockResolvedValue({ data: mockWebhook });
+  });
+
+  // AC-19: in edit mode the page shows a loading state while the webhook
+  // loads rather than flashing an empty form.
+  it('shows a loading state while the webhook loads in edit mode', () => {
+    mockUseParams.mockReturnValue({ id: '5' });
+    (webhooksAPI.getWebhook as jest.Mock).mockImplementation(
+      () => new Promise(() => {}), // never resolves: hold the loading state
+    );
+
+    renderPage();
+
+    expect(screen.getByText(/loading webhook/i)).toBeInTheDocument();
+  });
+
+  // AC-19: a failed save surfaces an error alert and keeps the user on the
+  // form instead of navigating away or throwing.
+  it('surfaces an error and stays on the form when saving fails', async () => {
+    mockUseParams.mockReturnValue({ id: '5' });
+    (webhooksAPI.updateWebhook as jest.Mock).mockRejectedValue({
+      response: { data: { detail: 'Upstream rejected the webhook' } },
+    });
+
+    renderPage();
+
+    // The form is pre-filled from the loaded webhook, so it is already valid.
+    const saveButton = await screen.findByRole('button', { name: /save changes/i });
+    fireEvent.click(saveButton);
+
+    expect(await screen.findByText('Upstream rejected the webhook')).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalledWith('/settings/webhooks');
+  });
+
+  // AC-18/AC-19: a forbidden load (non-admin) surfaces a recovery message and
+  // does not leave the page stuck on the loading state.
+  it('surfaces a forbidden error when loading is denied', async () => {
+    mockUseParams.mockReturnValue({ id: '5' });
+    (webhooksAPI.getWebhook as jest.Mock).mockRejectedValue({
+      response: {
+        status: 403,
+        data: { detail: 'You do not have permission to perform this action.' },
+      },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText('You do not have permission to perform this action.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/loading webhook/i)).not.toBeInTheDocument();
+  });
+
+  // AC-18: a forbidden create (non-admin) is surfaced rather than silently
+  // failing, and the user is not navigated away on the denied action.
+  it('surfaces a forbidden error when creating is denied', async () => {
+    mockUseParams.mockReturnValue({}); // create mode
+    (webhooksAPI.createWebhook as jest.Mock).mockRejectedValue({
+      response: { status: 403, data: { detail: 'Admin access required' } },
+    });
+
+    renderPage();
+
+    fireEvent.change(await screen.findByLabelText(/^name/i), {
+      target: { value: 'New Hook' },
+    });
+    fireEvent.change(screen.getByLabelText(/webhook url/i), {
+      target: { value: 'https://example.com/new-hook' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create webhook/i }));
+
+    expect(await screen.findByText('Admin access required')).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalledWith('/settings/webhooks');
+  });
+});

--- a/frontend/src/__tests__/pages/WebhookListPage.test.tsx
+++ b/frontend/src/__tests__/pages/WebhookListPage.test.tsx
@@ -90,3 +90,50 @@ describe('WebhookListPage delete flow', () => {
     });
   });
 });
+
+/**
+ * Resilience states (#457 R7, AC-18/AC-19): the list must render a consistent
+ * loading state and degrade gracefully when the backend denies the request
+ * (e.g. a non-admin viewer) instead of showing a blank screen or throwing.
+ */
+describe('WebhookListPage resilience states', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderPage = () =>
+    render(
+      <MantineProvider>
+        <MemoryRouter>
+          <WebhookListPage />
+        </MemoryRouter>
+      </MantineProvider>,
+    );
+
+  // AC-19: a consistent loading state renders while webhooks load.
+  it('shows a loading state while webhooks load', () => {
+    (api.webhooksAPI.listWebhooks as jest.Mock).mockImplementation(
+      () => new Promise(() => {}), // never resolves: hold the loading state
+    );
+
+    renderPage();
+
+    expect(screen.getByText(/loading webhooks/i)).toBeInTheDocument();
+  });
+
+  // AC-18/AC-19: a denied list request degrades to the consistent empty state
+  // rather than a blank screen or an unhandled exception.
+  it('renders a consistent empty state when the list request is denied', async () => {
+    (api.webhooksAPI.listWebhooks as jest.Mock).mockRejectedValue({
+      response: {
+        status: 403,
+        data: { detail: 'You do not have permission to perform this action.' },
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('No webhooks found')).toBeInTheDocument();
+    expect(screen.queryByText(/loading webhooks/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Lands work bead **oms-065g5** — #457 R7 (P2 settings/webhooks), AC-18/AC-19. Part of #457 series; no Closes keyword (does not close epic #457 on merge).

## Scope (TEST-ONLY frontend; ff-clean on current main d552545)
- 16 frontend tests covering previously-untested settings/webhook pages
- new: SiteSettingsPage, WebhookFormPage, WebhookDetailPage test suites
- extended: WebhookListPage (+loading,+denied-empty), UserProfilePage (+session-expired,+missing,+duplicate-submit)
- No production code, no new deps, no migrations (uses R1 jest-axe/offline helpers, already on main)

## Refinery gates
- CI-gated: Frontend Tests must go green (fresh install has jest-axe from R1); Frontend Lint + Build run too.

Bead strategy direct; main is PR-only, landed by refinery via squash once CI is green. — oms/gastown.refinery