### PR TITLE
test(frontend): offline + dependency-failure readable states for logistics/kiosk (oms-djvxt)

### DIFF
--- a/frontend/src/__tests__/pages/KioskDisplayPage.test.tsx
+++ b/frontend/src/__tests__/pages/KioskDisplayPage.test.tsx
@@ -1,10 +1,11 @@
 /**
  * Tests for KioskDisplayPage
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import KioskDisplayPage from '../../pages/KioskDisplayPage';
 import * as api from '../../services/api';
+import { networkError } from '../helpers/offline';
 
 vi.mock('../../services/api');
 
@@ -146,5 +147,50 @@ describe('KioskDisplayPage', () => {
     await waitFor(() => {
       expect(screen.getByTestId('kiosk-error')).toBeInTheDocument();
     });
+  });
+
+  it('shows a readable offline fallback when the network is unavailable', async () => {
+    // AC-16: a dropped connection surfaces a readable state, not a blank screen.
+    (api.kioskAPI.fetchPayload as jest.Mock).mockRejectedValue(networkError());
+    renderKiosk('lobby', 'secret');
+    const errorEl = await screen.findByTestId('kiosk-error');
+    expect(errorEl).toHaveTextContent('Unable to load screen payload.');
+  });
+
+  it('auto-refreshes on its interval and picks up updated content', async () => {
+    // AC-16/19: the unattended kiosk re-polls and recovers fresh content
+    // without manual intervention. refresh_interval_seconds defaults to 60.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      (api.kioskAPI.fetchPayload as jest.Mock)
+        .mockResolvedValueOnce({
+          data: makePayload({
+            content_blocks: [
+              { id: 'b1', block_type: 'custom_text', title: 'Welcome', body: 'First', config: {}, order: 0 },
+            ],
+          }),
+        })
+        .mockResolvedValue({
+          data: makePayload({
+            content_blocks: [
+              { id: 'b1', block_type: 'custom_text', title: 'Welcome', body: 'Second', config: {}, order: 0 },
+            ],
+          }),
+        });
+      renderKiosk('lobby', 'secret');
+
+      expect(await screen.findByText('First')).toBeInTheDocument();
+      expect(api.kioskAPI.fetchPayload).toHaveBeenCalledTimes(1);
+
+      // Fire the 60s refresh interval.
+      await act(async () => {
+        vi.advanceTimersByTime(60000);
+      });
+
+      expect(await screen.findByText('Second')).toBeInTheDocument();
+      expect((api.kioskAPI.fetchPayload as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/__tests__/pages/LogisticsDashboard.test.tsx
+++ b/frontend/src/__tests__/pages/LogisticsDashboard.test.tsx
@@ -1,13 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import LogisticsDashboard from '../../pages/LogisticsDashboard';
-import { analyticsAPI } from '../../services/api';
+import { analyticsAPI, locationCheckinAPI } from '../../services/api';
+import { networkError } from '../helpers/offline';
 
-vi.mock('../../services/api', () => ({
-  analyticsAPI: {
-    getLogisticsDashboard: jest.fn(),
-  },
-}));
+vi.mock('../../services/api');
 
 const mockDashboardData = {
   open_item_requests: 2,
@@ -97,5 +94,47 @@ describe('LogisticsDashboard', () => {
     await screen.findByText('Open Item Requests');
     expect(screen.queryByRole('alert')).toBeNull();
     expect(container.querySelector('.logistics-dashboard--alert')).toBeNull();
+  });
+
+  it('renders a readable offline state when the dashboard API is unreachable', async () => {
+    // AC-16: a network failure surfaces an actionable card with retry guidance,
+    // not a blank screen or a raw exception.
+    (analyticsAPI.getLogisticsDashboard as jest.Mock).mockRejectedValue(networkError());
+
+    render(<LogisticsDashboard />);
+
+    expect(await screen.findByText(/Unable to load logistics data/i)).toBeInTheDocument();
+    expect(screen.getByText(/Ensure the backend is reachable/i)).toBeInTheDocument();
+  });
+
+  it('shows per-panel empty states without crashing when there is no data', async () => {
+    // AC-19: each panel renders a readable empty state rather than a blank.
+    (analyticsAPI.getLogisticsDashboard as jest.Mock).mockResolvedValue({
+      data: {
+        open_item_requests: 0,
+        open_locations_with_problems: 0,
+        urgent_location_problems: 0,
+        alert_active: false,
+        assets_overdue_maintenance: 0,
+        pm_overdue: 0,
+        pm_due_this_week: 0,
+        qr_scans_total: 0,
+        qr_scans_by_day: [],
+        last_updated: '2024-02-01T19:45:00Z',
+      },
+    });
+    (locationCheckinAPI.getTopLocations as jest.Mock).mockResolvedValue({
+      data: { results: [] },
+    });
+
+    const { container } = render(<LogisticsDashboard />);
+
+    // Top-locations panel: readable empty message.
+    expect(await screen.findByText('No traffic recorded')).toBeInTheDocument();
+    // QR panel: an empty 7-day series renders no sparkline rather than crashing.
+    expect(container.querySelector('.sparkline')).toBeNull();
+    // Headline panels still render their labels.
+    expect(screen.getByText('QR Scans (Last 7 Days)')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).toBeNull();
   });
 });

--- a/frontend/src/__tests__/pages/ScreenEditPage.test.tsx
+++ b/frontend/src/__tests__/pages/ScreenEditPage.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Resilience tests for the Screen edit page (#457 R5, AC-19).
+ *
+ * Committee/SIG leaders configure kiosk screens here, so each non-happy state
+ * must render a readable, recoverable surface rather than a blank screen or a
+ * raw exception:
+ *  - loading while the screen is fetched;
+ *  - a readable error + recovery action when the screen can't be loaded
+ *    (missing / forbidden / network);
+ *  - a clear alert when saving fails;
+ *  - content blocks rendered in their configured order (reorder mechanism).
+ *
+ * NOTE: ScreenEditPage reorders content blocks via each row's "Order" field
+ * (the table re-sorts by `order`); there is no drag-and-drop widget, so the
+ * reorder coverage exercises that order field rather than a DnD interaction.
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ScreenEditPage from '../../pages/ScreenEditPage';
+import { screensAPI } from '../../services/api';
+import { Screen, ScreenContentBlock } from '../../types';
+
+vi.mock('../../services/api');
+
+const mockScreensAPI = screensAPI as jest.Mocked<typeof screensAPI>;
+
+const buildBlock = (overrides: Partial<ScreenContentBlock> = {}): ScreenContentBlock => ({
+  id: 'block-1',
+  screen: 'screen-1',
+  block_type: 'custom_text',
+  block_type_display: 'Custom Text',
+  title: 'Block',
+  body: '',
+  config: {},
+  order: 0,
+  is_enabled: true,
+  ...overrides,
+});
+
+const buildScreen = (overrides: Partial<Screen> = {}): Screen => ({
+  id: 'screen-1',
+  slug: 'lobby',
+  name: 'Lobby Screen',
+  description: '',
+  is_active: true,
+  rotation_interval_seconds: 15,
+  refresh_interval_seconds: 60,
+  access_token: 'secret-token',
+  is_online: true,
+  content_blocks: [],
+  ...overrides,
+});
+
+const renderPage = (slug = 'lobby') =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[`/facilities/screens/${slug}`]}>
+        <Routes>
+          <Route path="/facilities/screens/:slug" element={<ScreenEditPage />} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('ScreenEditPage resilience', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows a readable loading state while the screen is fetched', () => {
+    mockScreensAPI.getScreen.mockReturnValue(new Promise(() => {}) as never);
+    renderPage();
+
+    expect(screen.getByText('Loading screen…')).toBeInTheDocument();
+  });
+
+  it('shows a readable error state with a recovery action when the screen fails to load', async () => {
+    mockScreensAPI.getScreen.mockRejectedValue(new Error('500'));
+    renderPage();
+
+    expect(await screen.findByText('Unable to load screen.')).toBeInTheDocument();
+    // AC-19: a recovery path, not a dead end.
+    expect(screen.getByRole('button', { name: 'Back to Screens' })).toBeInTheDocument();
+  });
+
+  it('alerts the user when saving metadata fails instead of throwing', async () => {
+    const user = userEvent.setup();
+    mockScreensAPI.getScreen.mockResolvedValue({ data: buildScreen() } as never);
+    mockScreensAPI.updateScreen.mockRejectedValue(new Error('403'));
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+    renderPage();
+
+    const saveButton = await screen.findByRole('button', { name: 'Save' });
+    await user.click(saveButton);
+
+    await waitFor(() =>
+      expect(alertSpy).toHaveBeenCalledWith('Unable to save. Check permissions.'),
+    );
+    alertSpy.mockRestore();
+  });
+
+  it('shows a readable empty state when the screen has no content blocks', async () => {
+    mockScreensAPI.getScreen.mockResolvedValue({ data: buildScreen({ content_blocks: [] }) } as never);
+    renderPage();
+
+    expect(
+      await screen.findByText(/This screen has no content blocks yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders content block rows sorted by their order field', async () => {
+    mockScreensAPI.getScreen.mockResolvedValue({
+      data: buildScreen({
+        content_blocks: [
+          // Array order (Alpha, Bravo) deliberately differs from display order.
+          buildBlock({ id: 'a', title: 'Alpha', order: 1 }),
+          buildBlock({ id: 'b', title: 'Bravo', order: 0 }),
+        ],
+      }),
+    } as never);
+
+    renderPage();
+
+    await screen.findByTestId('block-row-a');
+    const rows = screen.getAllByTestId(/^block-row-/);
+    // Bravo (order 0) renders before Alpha (order 1) regardless of array order.
+    expect(rows.map((r) => r.getAttribute('data-testid'))).toEqual([
+      'block-row-b',
+      'block-row-a',
+    ]);
+
+    // The per-row "Order" field is the reorder control and reflects each value.
+    expect(within(rows[0]).getByDisplayValue('0')).toBeInTheDocument();
+    expect(within(rows[1]).getByDisplayValue('1')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/TVDashboard.test.tsx
+++ b/frontend/src/__tests__/pages/TVDashboard.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Resilience tests for the TV Dashboard (#457 R5, AC-16/19/20).
+ *
+ * The TV Dashboard is an unattended Chromecast/TV display, so it must:
+ *  - render a readable dependency-failure state (not a blank screen or raw
+ *    exception) when the backend is unreachable — AC-16/19;
+ *  - keep polling on its 30-second auto-refresh and recover once the backend
+ *    comes back — AC-16;
+ *  - expose accessible, readable kiosk states — AC-20.
+ *
+ * The page builds its own auth-less axios instance via `axios.create()` at
+ * module load, so we hoist a single mocked instance whose `get` we drive per
+ * test. `../services/api` is stubbed down to `resolveApiBaseUrl` and the site
+ * settings hook is stubbed so the test exercises only the dashboard.
+ */
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { InventoryItem } from '../../types';
+import { expectNoA11yViolations } from '../helpers/axe';
+
+const { tvGet } = vi.hoisted(() => ({ tvGet: vi.fn() }));
+
+vi.mock('axios', () => ({
+  default: { create: () => ({ get: tvGet }) },
+}));
+
+vi.mock('../../services/api', () => ({
+  resolveApiBaseUrl: () => 'http://test.local/api',
+}));
+
+vi.mock('../../hooks/useSiteSettings', () => ({
+  useSiteSettings: () => ({ settings: null, loading: false, error: null }),
+}));
+
+// eslint-disable-next-line import/first
+import TVDashboard from '../../pages/TVDashboard';
+
+const buildItem = (overrides: Partial<InventoryItem> = {}): InventoryItem =>
+  ({
+    id: 'item-1',
+    name: 'Widget',
+    description: '',
+    sku: 'WIDGET-1',
+    image: null,
+    thumbnail: null,
+    category: null,
+    category_name: '',
+    location: 'Main Workshop',
+    reorder_quantity: 5,
+    current_stock: 1,
+    minimum_stock: 10,
+    use_case_based_reorder: false,
+    minimum_cases: 0,
+    reorder_cases: 0,
+    current_cases: 0,
+    supplier: null,
+    supplier_name: '',
+    supplier_sku: '',
+    supplier_url: '',
+    unit_cost: null,
+    average_lead_time: 0,
+    qr_code: null,
+    is_active: true,
+    notes: '',
+    needs_reorder: true,
+    total_value: '0',
+    created_at: '',
+    updated_at: '',
+    ownership_type: 'space',
+    owning_user: null,
+    owning_group: null,
+    reorder_status: 'pending',
+    has_pending_reorder: true,
+    expected_delivery_date: null,
+    active_reorder_request: null,
+    is_hazardous: false,
+    msds_url: null,
+    nfpa_health_hazard: null,
+    nfpa_fire_hazard: null,
+    nfpa_instability_hazard: null,
+    nfpa_special_hazards: '',
+    nfpa_fire_diamond_display: '',
+    hazmat_compliance_status: '',
+    has_complete_nfpa_data: false,
+    ...overrides,
+  }) as InventoryItem;
+
+const renderTV = () =>
+  render(
+    <MemoryRouter>
+      <TVDashboard />
+    </MemoryRouter>,
+  );
+
+describe('TVDashboard resilience', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows a readable, accessible loading state before data arrives', async () => {
+    // Never resolves: the dashboard stays in its loading state.
+    tvGet.mockReturnValue(new Promise(() => {}));
+    const { container } = renderTV();
+
+    expect(screen.getByText('Loading Inventory Dashboard...')).toBeInTheDocument();
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+    await expectNoA11yViolations(container);
+  });
+
+  it('shows a readable backend-error state when the server returns 5xx', async () => {
+    tvGet.mockRejectedValue({ response: { status: 503, statusText: 'Service Unavailable' } });
+    renderTV();
+
+    expect(await screen.findByText('Connection Error')).toBeInTheDocument();
+    expect(
+      screen.getByText('Backend server error - Check if the server is running'),
+    ).toBeInTheDocument();
+    // The unattended display tells the viewer it will recover on its own.
+    expect(screen.getByText('Retrying automatically...')).toBeInTheDocument();
+  });
+
+  it('shows a readable network-error state when the backend is unreachable', async () => {
+    tvGet.mockRejectedValue({ code: 'ERR_NETWORK', message: 'Network Error' });
+    renderTV();
+
+    expect(
+      await screen.findByText('Network error - Cannot connect to backend server'),
+    ).toBeInTheDocument();
+  });
+
+  it('has no accessibility violations in the dependency-failure state', async () => {
+    tvGet.mockRejectedValue({ code: 'ERR_NETWORK', message: 'Network Error' });
+    const { container } = renderTV();
+
+    await screen.findByText('Connection Error');
+    await expectNoA11yViolations(container);
+  });
+
+  it('renders a readable empty state when nothing is on order', async () => {
+    tvGet.mockResolvedValue({ data: [] });
+    renderTV();
+
+    expect(await screen.findByText('No Items on Order')).toBeInTheDocument();
+  });
+
+  it('auto-refreshes every 30s and recovers content after a transient failure', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      tvGet
+        .mockRejectedValueOnce({ code: 'ERR_NETWORK', message: 'Network Error' })
+        .mockResolvedValue({ data: [buildItem({ id: 'i1', name: 'Recovered Widget' })] });
+
+      renderTV();
+
+      // Initial fetch (called once, from the mount effect) fails: the display
+      // shows the readable connection-error state, not a blank screen.
+      expect(await screen.findByText('Connection Error')).toBeInTheDocument();
+      expect(tvGet).toHaveBeenCalledTimes(1);
+
+      // After 30s the auto-refresh fires again and the backend is back.
+      await act(async () => {
+        vi.advanceTimersByTime(30000);
+      });
+      expect(await screen.findByText('Recovered Widget')).toBeInTheDocument();
+      expect(tvGet.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+      // It keeps polling on the same 30s cadence.
+      const callsSoFar = tvGet.mock.calls.length;
+      await act(async () => {
+        vi.advanceTimersByTime(30000);
+      });
+      await waitFor(() => {
+        expect(tvGet.mock.calls.length).toBeGreaterThan(callsSoFar);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Lands work bead **oms-djvxt** — #457 R5 (P2 logistics/kiosk), AC-16/19/20. Part of #457 series; no Closes keyword.

## Scope (TEST-ONLY frontend; ff-clean on current main d552545)
- frontend resilience tests for unattended displays (offline + dependency-failure readable states)
- new: TVDashboard, ScreenEditPage test suites; extended: KioskDisplayPage (+offline/auto-refresh), LogisticsDashboard
- No production code, no deps, no migrations (reuses R1 offline/axe helpers already on main)

## Refinery gates
- CI-gated: Frontend Tests + Lint + Build must go green.

Bead strategy direct; main is PR-only, landed by refinery via squash once CI is green. — oms/gastown.refinery