### PR TITLE
test(frontend): resilience states for electrical forms + ForgeKey gating (oms-f7cky)

### DIFF
--- a/frontend/src/__tests__/pages/BreakerFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/BreakerFormPage.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Resilience tests for BreakerFormPage (#457 R6, oms-f7cky).
+ *
+ * The page previously had no test. These cover the journey-resilience states
+ * required by AC-18 (protected actions / forbidden) and AC-19 (loading,
+ * save-failure, and duplicate-submit states render a consistent, accessible
+ * surface rather than a blank screen or raw exception).
+ *
+ * Edit mode is used to exercise the save path: loading an existing breaker
+ * pre-fills the location + required fields, so the submit reaches the API
+ * without driving the Mantine `Select` (interaction covered in the e2e suite).
+ */
+import { MantineProvider } from '@mantine/core';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import BreakerFormPage from '../../pages/BreakerFormPage';
+import * as api from '../../services/api';
+import { networkError } from '../helpers/offline';
+
+vi.mock('../../services/api');
+
+const breaker = {
+  id: 5,
+  location: 1,
+  panel: 'A',
+  breaker_number: '12',
+  amperage: 20,
+  voltage: 120,
+  poles: 1,
+  description: 'Wood shop dust collector',
+  notes: '',
+  is_active: true,
+};
+
+const renderEdit = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={['/facilities/electrical/breakers/5/edit']}>
+        <Routes>
+          <Route
+            path="/facilities/electrical/breakers/:id/edit"
+            element={<BreakerFormPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('BreakerFormPage resilience states', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (api.inventoryAPI.listLocations as jest.Mock).mockResolvedValue({
+      data: { results: [{ id: 1, name: 'Electrical Room' }] },
+    });
+  });
+
+  it('shows a loading state while the breaker loads (AC-19)', async () => {
+    // Never-resolving fetch keeps the page in its loading branch.
+    (api.electricalCircuitsAPI.getBreaker as jest.Mock).mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    renderEdit();
+
+    expect(await screen.findByText(/loading breaker/i)).toBeInTheDocument();
+  });
+
+  it('renders a forbidden message when the API denies the save (AC-18)', async () => {
+    (api.electricalCircuitsAPI.getBreaker as jest.Mock).mockResolvedValue({
+      data: breaker,
+    });
+    (api.electricalCircuitsAPI.updateBreaker as jest.Mock).mockRejectedValue({
+      response: {
+        status: 403,
+        data: { detail: 'You do not have permission to perform this action.' },
+      },
+    });
+
+    renderEdit();
+
+    await screen.findByDisplayValue('A');
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(
+      await screen.findByText('You do not have permission to perform this action.'),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces a save-failure message when the request errors (AC-19)', async () => {
+    (api.electricalCircuitsAPI.getBreaker as jest.Mock).mockResolvedValue({
+      data: breaker,
+    });
+    // Offline / no-response error falls through to the generic save fallback.
+    (api.electricalCircuitsAPI.updateBreaker as jest.Mock).mockRejectedValue(
+      networkError(),
+    );
+
+    renderEdit();
+
+    await screen.findByDisplayValue('A');
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(await screen.findByText('Failed to save breaker')).toBeInTheDocument();
+  });
+
+  it('disables the submit button in flight so the save cannot double-fire (AC-19)', async () => {
+    let resolveSave: () => void = () => {};
+    (api.electricalCircuitsAPI.getBreaker as jest.Mock).mockResolvedValue({
+      data: breaker,
+    });
+    (api.electricalCircuitsAPI.updateBreaker as jest.Mock).mockReturnValue(
+      new Promise<{ data: unknown }>((resolve) => {
+        resolveSave = () => resolve({ data: {} });
+      }),
+    );
+
+    renderEdit();
+
+    await screen.findByDisplayValue('A');
+    const submit = screen.getByRole('button', { name: /save changes/i });
+
+    fireEvent.click(submit);
+
+    await waitFor(() =>
+      expect(api.electricalCircuitsAPI.updateBreaker).toHaveBeenCalledTimes(1),
+    );
+    expect(submit).toBeDisabled();
+
+    // A second click while the first request is in flight is a no-op.
+    fireEvent.click(submit);
+    expect(api.electricalCircuitsAPI.updateBreaker).toHaveBeenCalledTimes(1);
+
+    // Let the in-flight request settle so pending state updates flush.
+    await act(async () => {
+      resolveSave();
+    });
+  });
+});

--- a/frontend/src/__tests__/pages/BreakerTracePage.test.tsx
+++ b/frontend/src/__tests__/pages/BreakerTracePage.test.tsx
@@ -6,6 +6,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import BreakerTracePage from '../../pages/BreakerTracePage';
 import * as api from '../../services/api';
+import { expectNoA11yViolations } from '../helpers/axe';
 
 vi.mock('../../services/api');
 
@@ -107,5 +108,25 @@ describe('BreakerTracePage', () => {
     });
     renderAt('/facilities/electrical/breakers/999/trace');
     expect(await screen.findByText('Not found')).toBeInTheDocument();
+  });
+
+  // AC-19: the trace renders a consistent loading state while the breaker and
+  // its fed loads resolve, rather than a blank screen.
+  it('shows a loading state while the trace loads (AC-19)', async () => {
+    (api.electricalCircuitsAPI.getBreaker as jest.Mock).mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    renderAt('/facilities/electrical/breakers/5/trace');
+
+    expect(await screen.findByText(/loading breaker trace/i)).toBeInTheDocument();
+  });
+
+  // AC-20: the loaded trace view must be free of WCAG A/AA violations.
+  it('has no accessibility violations once loaded (AC-20)', async () => {
+    const { container } = renderAt('/facilities/electrical/breakers/5/trace');
+
+    expect(await screen.findByText(/Trace: A \/ 12/)).toBeInTheDocument();
+    await expectNoA11yViolations(container);
   });
 });

--- a/frontend/src/__tests__/pages/ElectricalCircuitsPage.test.tsx
+++ b/frontend/src/__tests__/pages/ElectricalCircuitsPage.test.tsx
@@ -7,6 +7,7 @@ import { MemoryRouter } from 'react-router-dom';
 import ElectricalCircuitsPage from '../../pages/ElectricalCircuitsPage';
 import * as api from '../../services/api';
 import { confirmDelete, showError } from '../../utils/dialogs';
+import { expectNoA11yViolations } from '../helpers/axe';
 
 vi.mock('../../services/api');
 
@@ -116,5 +117,27 @@ describe('ElectricalCircuitsPage', () => {
     await waitFor(() => {
       expect(showError).toHaveBeenCalledWith('Outlets still depend on it');
     });
+  });
+
+  // AC-19: while the active tab is fetching, the table renders a consistent
+  // loading row rather than a premature "No breakers found" empty state.
+  it('shows a loading state in the breakers table before data resolves (AC-19)', async () => {
+    (api.electricalCircuitsAPI.listBreakers as jest.Mock).mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText('Loading…')).toBeInTheDocument();
+    expect(screen.queryByText('No breakers found')).not.toBeInTheDocument();
+  });
+
+  // AC-20: the loaded circuits table (tabs, filter select, action controls)
+  // must be free of WCAG A/AA violations.
+  it('has no accessibility violations once loaded (AC-20)', async () => {
+    const { container } = renderPage();
+
+    expect(await screen.findByText('A / 12')).toBeInTheDocument();
+    await expectNoA11yViolations(container);
   });
 });

--- a/frontend/src/__tests__/pages/ForgeKeyDevicesPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyDevicesPage.test.tsx
@@ -13,6 +13,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import ForgeKeyDevicesPage from '../../pages/ForgeKeyDevicesPage';
 import { forgekeyAPI, inventoryAPI } from '../../services/api';
+import { networkError } from '../helpers/offline';
 
 vi.mock('../../services/api', async () => {
   const actual = await vi.importActual('../../services/api');
@@ -126,5 +127,38 @@ describe('ForgeKeyDevicesPage', () => {
     });
 
     expect((screen.getByLabelText(/Location for Front door counter/i) as HTMLSelectElement).value).toBe('10');
+  });
+
+  // AC-18: the page authorizes on `is_staff` OR `is_superuser`. The existing
+  // "non-staff users are redirected" test covers the revoke/denial half (both
+  // flags false); this covers the authorize half via a superuser who is not
+  // staff, so neither branch of the gate can silently regress.
+  test('authorizes a superuser who is not staff (AC-18)', async () => {
+    localStorage.setItem('is_staff', 'false');
+    localStorage.setItem('is_superuser', 'true');
+
+    const device = buildDevice();
+    mockForgekey.listDevices.mockResolvedValue({ data: { results: [device] } } as any);
+    mockInventory.listLocations.mockResolvedValue({ data: { results: [] } } as any);
+
+    renderPage();
+
+    expect(await screen.findByText('Front door counter')).toBeInTheDocument();
+    expect(mockForgekey.listDevices).toHaveBeenCalled();
+  });
+
+  // AC-16: a dependency/network failure must surface an actionable state, not
+  // a blank table or an unhandled rejection.
+  test('shows an actionable error when the device list fails offline (AC-16)', async () => {
+    localStorage.setItem('is_staff', 'true');
+
+    mockForgekey.listDevices.mockRejectedValue(networkError());
+    mockInventory.listLocations.mockResolvedValue({ data: { results: [] } } as any);
+
+    renderPage();
+
+    expect(
+      await screen.findByText('Failed to load ForgeKey devices.'),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/pages/LightSwitchFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/LightSwitchFormPage.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Resilience tests for LightSwitchFormPage (#457 R6, oms-f7cky).
+ *
+ * Previously untested. Covers AC-18 (forbidden save) and AC-19 (loading,
+ * save-failure, and duplicate-submit states). Edit mode pre-fills the
+ * location + identifier so the submit reaches the API without driving the
+ * Mantine `Select` (covered in the e2e suite).
+ */
+import { MantineProvider } from '@mantine/core';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import LightSwitchFormPage from '../../pages/LightSwitchFormPage';
+import * as api from '../../services/api';
+import { networkError } from '../helpers/offline';
+
+vi.mock('../../services/api');
+
+const lightSwitch = {
+  id: 9,
+  location: 1,
+  identifier: 'door-east',
+  controls_location: null,
+  breaker: null,
+  description: 'Bay overhead lights',
+  notes: '',
+  is_active: true,
+};
+
+const renderEdit = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={['/facilities/electrical/switches/9/edit']}>
+        <Routes>
+          <Route
+            path="/facilities/electrical/switches/:id/edit"
+            element={<LightSwitchFormPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('LightSwitchFormPage resilience states', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (api.inventoryAPI.listLocations as jest.Mock).mockResolvedValue({
+      data: { results: [{ id: 1, name: 'Electrical Room' }] },
+    });
+    (api.electricalCircuitsAPI.listBreakers as jest.Mock).mockResolvedValue({
+      data: { results: [] },
+    });
+  });
+
+  it('shows a loading state while the light switch loads (AC-19)', async () => {
+    (api.electricalCircuitsAPI.getLightSwitch as jest.Mock).mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    renderEdit();
+
+    expect(await screen.findByText(/loading light switch/i)).toBeInTheDocument();
+  });
+
+  it('renders a forbidden message when the API denies the save (AC-18)', async () => {
+    (api.electricalCircuitsAPI.getLightSwitch as jest.Mock).mockResolvedValue({
+      data: lightSwitch,
+    });
+    (api.electricalCircuitsAPI.updateLightSwitch as jest.Mock).mockRejectedValue({
+      response: {
+        status: 403,
+        data: { detail: 'You do not have permission to perform this action.' },
+      },
+    });
+
+    renderEdit();
+
+    await screen.findByDisplayValue('door-east');
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(
+      await screen.findByText('You do not have permission to perform this action.'),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces a save-failure message when the request errors (AC-19)', async () => {
+    (api.electricalCircuitsAPI.getLightSwitch as jest.Mock).mockResolvedValue({
+      data: lightSwitch,
+    });
+    (api.electricalCircuitsAPI.updateLightSwitch as jest.Mock).mockRejectedValue(
+      networkError(),
+    );
+
+    renderEdit();
+
+    await screen.findByDisplayValue('door-east');
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(
+      await screen.findByText('Failed to save light switch'),
+    ).toBeInTheDocument();
+  });
+
+  it('disables the submit button in flight so the save cannot double-fire (AC-19)', async () => {
+    let resolveSave: () => void = () => {};
+    (api.electricalCircuitsAPI.getLightSwitch as jest.Mock).mockResolvedValue({
+      data: lightSwitch,
+    });
+    (api.electricalCircuitsAPI.updateLightSwitch as jest.Mock).mockReturnValue(
+      new Promise<{ data: unknown }>((resolve) => {
+        resolveSave = () => resolve({ data: {} });
+      }),
+    );
+
+    renderEdit();
+
+    await screen.findByDisplayValue('door-east');
+    const submit = screen.getByRole('button', { name: /save changes/i });
+
+    fireEvent.click(submit);
+
+    await waitFor(() =>
+      expect(api.electricalCircuitsAPI.updateLightSwitch).toHaveBeenCalledTimes(1),
+    );
+    expect(submit).toBeDisabled();
+
+    fireEvent.click(submit);
+    expect(api.electricalCircuitsAPI.updateLightSwitch).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSave();
+    });
+  });
+});

--- a/frontend/src/__tests__/pages/NetworkDropFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/NetworkDropFormPage.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Resilience tests for NetworkDropFormPage (#457 R6, oms-f7cky).
+ *
+ * Previously untested. Covers AC-18 (forbidden save) and AC-19 (loading,
+ * save-failure, and duplicate-submit states). Edit mode pre-fills the
+ * location + identifier so the submit reaches the API without driving the
+ * Mantine `Select` (covered in the e2e suite).
+ */
+import { MantineProvider } from '@mantine/core';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import NetworkDropFormPage from '../../pages/NetworkDropFormPage';
+import * as api from '../../services/api';
+import { networkError } from '../helpers/offline';
+
+vi.mock('../../services/api');
+
+const networkDrop = {
+  id: 3,
+  location: 1,
+  identifier: 'drop-1',
+  drop_type: 'data',
+  patch_panel: 'PP-1',
+  patch_port: '7',
+  mac_address: '',
+  ip_address: '',
+  description: 'Office uplink',
+  notes: '',
+  photo: null,
+  is_active: true,
+};
+
+const renderEdit = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={['/facilities/electrical/drops/3/edit']}>
+        <Routes>
+          <Route
+            path="/facilities/electrical/drops/:id/edit"
+            element={<NetworkDropFormPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('NetworkDropFormPage resilience states', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (api.inventoryAPI.listLocations as jest.Mock).mockResolvedValue({
+      data: { results: [{ id: 1, name: 'Electrical Room' }] },
+    });
+  });
+
+  it('shows a loading state while the network drop loads (AC-19)', async () => {
+    (api.electricalCircuitsAPI.getNetworkDrop as jest.Mock).mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    renderEdit();
+
+    expect(await screen.findByText(/loading network drop/i)).toBeInTheDocument();
+  });
+
+  it('renders a forbidden message when the API denies the save (AC-18)', async () => {
+    (api.electricalCircuitsAPI.getNetworkDrop as jest.Mock).mockResolvedValue({
+      data: networkDrop,
+    });
+    (api.electricalCircuitsAPI.updateNetworkDrop as jest.Mock).mockRejectedValue({
+      response: {
+        status: 403,
+        data: { detail: 'You do not have permission to perform this action.' },
+      },
+    });
+
+    renderEdit();
+
+    await screen.findByDisplayValue('drop-1');
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(
+      await screen.findByText('You do not have permission to perform this action.'),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces a save-failure message when the request errors (AC-19)', async () => {
+    (api.electricalCircuitsAPI.getNetworkDrop as jest.Mock).mockResolvedValue({
+      data: networkDrop,
+    });
+    (api.electricalCircuitsAPI.updateNetworkDrop as jest.Mock).mockRejectedValue(
+      networkError(),
+    );
+
+    renderEdit();
+
+    await screen.findByDisplayValue('drop-1');
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(
+      await screen.findByText('Failed to save network drop'),
+    ).toBeInTheDocument();
+  });
+
+  it('disables the submit button in flight so the save cannot double-fire (AC-19)', async () => {
+    let resolveSave: () => void = () => {};
+    (api.electricalCircuitsAPI.getNetworkDrop as jest.Mock).mockResolvedValue({
+      data: networkDrop,
+    });
+    (api.electricalCircuitsAPI.updateNetworkDrop as jest.Mock).mockReturnValue(
+      new Promise<{ data: unknown }>((resolve) => {
+        resolveSave = () => resolve({ data: {} });
+      }),
+    );
+
+    renderEdit();
+
+    await screen.findByDisplayValue('drop-1');
+    const submit = screen.getByRole('button', { name: /save changes/i });
+
+    fireEvent.click(submit);
+
+    await waitFor(() =>
+      expect(api.electricalCircuitsAPI.updateNetworkDrop).toHaveBeenCalledTimes(1),
+    );
+    expect(submit).toBeDisabled();
+
+    fireEvent.click(submit);
+    expect(api.electricalCircuitsAPI.updateNetworkDrop).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSave();
+    });
+  });
+});

--- a/frontend/src/__tests__/pages/OutletFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/OutletFormPage.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Resilience tests for OutletFormPage (#457 R6, oms-f7cky).
+ *
+ * Previously untested. Covers AC-18 (forbidden save) and AC-19 (loading,
+ * save-failure, and duplicate-submit states). Edit mode pre-fills the
+ * location + identifier so the submit reaches the API without driving the
+ * Mantine `Select` (covered in the e2e suite).
+ */
+import { MantineProvider } from '@mantine/core';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import OutletFormPage from '../../pages/OutletFormPage';
+import * as api from '../../services/api';
+import { networkError } from '../helpers/offline';
+
+vi.mock('../../services/api');
+
+const outlet = {
+  id: 7,
+  location: 1,
+  identifier: 'bench-1',
+  breaker: null,
+  outlet_type: 'standard',
+  description: 'Table saw',
+  plugged_in_notes: '',
+  photo: null,
+  is_active: true,
+};
+
+const renderEdit = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={['/facilities/electrical/outlets/7/edit']}>
+        <Routes>
+          <Route
+            path="/facilities/electrical/outlets/:id/edit"
+            element={<OutletFormPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('OutletFormPage resilience states', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (api.inventoryAPI.listLocations as jest.Mock).mockResolvedValue({
+      data: { results: [{ id: 1, name: 'Electrical Room' }] },
+    });
+    (api.electricalCircuitsAPI.listBreakers as jest.Mock).mockResolvedValue({
+      data: { results: [] },
+    });
+  });
+
+  it('shows a loading state while the outlet loads (AC-19)', async () => {
+    (api.electricalCircuitsAPI.getOutlet as jest.Mock).mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    renderEdit();
+
+    expect(await screen.findByText(/loading outlet/i)).toBeInTheDocument();
+  });
+
+  it('renders a forbidden message when the API denies the save (AC-18)', async () => {
+    (api.electricalCircuitsAPI.getOutlet as jest.Mock).mockResolvedValue({
+      data: outlet,
+    });
+    (api.electricalCircuitsAPI.updateOutlet as jest.Mock).mockRejectedValue({
+      response: {
+        status: 403,
+        data: { detail: 'You do not have permission to perform this action.' },
+      },
+    });
+
+    renderEdit();
+
+    await screen.findByDisplayValue('bench-1');
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(
+      await screen.findByText('You do not have permission to perform this action.'),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces a save-failure message when the request errors (AC-19)', async () => {
+    (api.electricalCircuitsAPI.getOutlet as jest.Mock).mockResolvedValue({
+      data: outlet,
+    });
+    (api.electricalCircuitsAPI.updateOutlet as jest.Mock).mockRejectedValue(
+      networkError(),
+    );
+
+    renderEdit();
+
+    await screen.findByDisplayValue('bench-1');
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(await screen.findByText('Failed to save outlet')).toBeInTheDocument();
+  });
+
+  it('disables the submit button in flight so the save cannot double-fire (AC-19)', async () => {
+    let resolveSave: () => void = () => {};
+    (api.electricalCircuitsAPI.getOutlet as jest.Mock).mockResolvedValue({
+      data: outlet,
+    });
+    (api.electricalCircuitsAPI.updateOutlet as jest.Mock).mockReturnValue(
+      new Promise<{ data: unknown }>((resolve) => {
+        resolveSave = () => resolve({ data: {} });
+      }),
+    );
+
+    renderEdit();
+
+    await screen.findByDisplayValue('bench-1');
+    const submit = screen.getByRole('button', { name: /save changes/i });
+
+    fireEvent.click(submit);
+
+    await waitFor(() =>
+      expect(api.electricalCircuitsAPI.updateOutlet).toHaveBeenCalledTimes(1),
+    );
+    expect(submit).toBeDisabled();
+
+    fireEvent.click(submit);
+    expect(api.electricalCircuitsAPI.updateOutlet).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSave();
+    });
+  });
+});

--- a/frontend/src/pages/ElectricalCircuitsPage.tsx
+++ b/frontend/src/pages/ElectricalCircuitsPage.tsx
@@ -160,7 +160,7 @@ const ElectricalCircuitsPage: React.FC = () => {
   };
 
   const filterBar = (
-    <Paper p="md" withBorder>
+    <Paper p="md" withBorder mt="md">
       <Group>
         <Select
           label="Location"
@@ -541,14 +541,30 @@ const ElectricalCircuitsPage: React.FC = () => {
             Network drops
           </Tabs.Tab>
         </Tabs.List>
+
+        {filterBar}
+
+        {/*
+          Render every tab's panel (keepMounted) so each Tabs.Tab's
+          `aria-controls` resolves to a real tabpanel element — without
+          panels the generated ids dangle and axe flags
+          `aria-valid-attr-value`. Only the active tab's table actually
+          mounts (the `activeTab === …` guard), matching the prior behavior
+          and the single shared `loading` flag.
+        */}
+        <Tabs.Panel value="breakers" keepMounted pt="md">
+          {activeTab === 'breakers' && breakersTable}
+        </Tabs.Panel>
+        <Tabs.Panel value="outlets" keepMounted pt="md">
+          {activeTab === 'outlets' && outletsTable}
+        </Tabs.Panel>
+        <Tabs.Panel value="switches" keepMounted pt="md">
+          {activeTab === 'switches' && switchesTable}
+        </Tabs.Panel>
+        <Tabs.Panel value="drops" keepMounted pt="md">
+          {activeTab === 'drops' && dropsTable}
+        </Tabs.Panel>
       </Tabs>
-
-      {filterBar}
-
-      {activeTab === 'breakers' && breakersTable}
-      {activeTab === 'outlets' && outletsTable}
-      {activeTab === 'switches' && switchesTable}
-      {activeTab === 'drops' && dropsTable}
     </Stack>
   );
 };


### PR DESCRIPTION
Lands work bead **oms-f7cky** — #457 R6 (P2 ForgeKey/electrical), AC-18/19/20. Part of #457 series; no Closes keyword.

## Scope (frontend; ff-clean on current main d552545; independent of R5/R7)
- resilience tests: BreakerFormPage/OutletFormPage/LightSwitchFormPage/NetworkDropFormPage (loading/forbidden/save-fail/duplicate-submit) + BreakerTracePage, ElectricalCircuitsPage, ForgeKeyDevicesPage (superuser-authorize + offline)
- minor a11y fix: ElectricalCircuitsPage.tsx (production)
- No deps, no migrations (reuses R1 helpers already on main)

## Refinery gates
- CI-gated (production a11y change + tests): Frontend Tests + Lint + Build + E2E must go green.

Bead strategy direct; main is PR-only, landed by refinery via squash once CI is green. — oms/gastown.refinery