### PR TITLE
test(frontend): purchasing/reorder/inventory resilience coverage (oms-bye0t)

### DIFF
--- a/frontend/src/__tests__/pages/AdminDashboard.test.tsx
+++ b/frontend/src/__tests__/pages/AdminDashboard.test.tsx
@@ -20,6 +20,7 @@ import React from 'react';
 import AdminDashboard from '../../pages/AdminDashboard';
 import { assetsAPI, inventoryAPI, reorderAPI } from '../../services/api';
 import { ReorderRequest } from '../../types';
+import { networkError } from '../helpers/offline';
 
 vi.mock('../../services/api', () => ({
   assetsAPI: {
@@ -409,5 +410,52 @@ describe('AdminDashboard — update tracking flow', () => {
     });
 
     expect(await screen.findByText('Tracking information updated')).toBeInTheDocument();
+  });
+});
+
+describe('AdminDashboard — reorder-triage resilience (#457 R3)', () => {
+  it('shows the empty state when there are no pending requests', async () => {
+    mockReorderAPI.getPendingRequests.mockResolvedValue({ data: [] } as any);
+
+    renderDashboard();
+
+    // The triage table renders its empty-state row once the load settles.
+    expect(await screen.findByText('No requests found')).toBeInTheDocument();
+    expect(screen.queryByText(/loading requests/i)).not.toBeInTheDocument();
+  });
+
+  it('surfaces an error notification and does not hang when the load is forbidden (403)', async () => {
+    mockReorderAPI.getPendingRequests.mockRejectedValue({
+      response: { status: 403, data: { detail: 'You do not have permission.' } },
+    } as any);
+
+    renderDashboard();
+
+    // No per-403 messaging exists; the page degrades to its generic load error
+    // toast and never gets stuck on the loading placeholder.
+    expect(
+      await screen.findByText('Failed to load requests. Please log in.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/loading requests/i)).not.toBeInTheDocument();
+  });
+
+  it('keeps the row and re-enables the action when a mutation hits a network error (offline)', async () => {
+    const pending = buildRequest({ id: 77, status: 'pending' });
+    mockReorderAPI.getPendingRequests.mockResolvedValue({ data: [pending] } as any);
+    // Offline signature: code ERR_NETWORK, request set, no response.
+    mockReorderAPI.approveRequest.mockRejectedValue(networkError('Network Error'));
+
+    renderDashboard();
+
+    const approveBtn = await screen.findByTitle('Approve');
+    fireEvent.click(approveBtn);
+
+    expect(await screen.findByText('Failed to approve request')).toBeInTheDocument();
+    // The row survives the failed mutation and the action re-enables for retry.
+    expect(screen.getByText(pending.item_details.name)).toBeInTheDocument();
+    expect(screen.getByText('pending')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(approveBtn).not.toBeDisabled();
+    });
   });
 });

--- a/frontend/src/__tests__/pages/InventoryItemDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemDetailPage.test.tsx
@@ -2,13 +2,21 @@
  * Tests for InventoryItemDetailPage component
  */
 import { MantineProvider } from '@mantine/core';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import SessionExpiredBanner, {
+  consumePendingReturnTo,
+} from '../../components/SessionExpiredBanner';
 import InventoryItemDetailPage from '../../pages/InventoryItemDetailPage';
 import * as api from '../../services/api';
+import { showError } from '../../utils/dialogs';
 
 // Mock the API
 vi.mock('../../services/api');
+
+vi.mock('../../utils/dialogs', async () => ({
+  showError: vi.fn(),
+}));
 
 // Mock qrcode.react
 vi.mock('qrcode.react', async () => ({
@@ -307,5 +315,95 @@ describe('InventoryItemDetailPage', () => {
     await waitFor(() => {
       expect(api.inventoryAPI.generateQR).toHaveBeenCalledWith('test-id');
     });
+  });
+
+  // ---- #457 R3 resilience ----
+
+  it('renders empty-state copy for each history tab when there is no activity', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item')).toBeInTheDocument();
+    });
+
+    // Each history tab shows its own empty-state copy once activated.
+    fireEvent.click(screen.getByRole('tab', { name: /Reorder History/i }));
+    expect(
+      await screen.findByText('No reorder history available.')
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: /Usage Logs/i }));
+    expect(await screen.findByText('No usage logs available.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: /Linked Assets/i }));
+    expect(
+      await screen.findByText('No assets linked to this inventory item.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the not-found state when the item load is forbidden (403)', async () => {
+    (api.inventoryAPI.getItem as jest.Mock).mockRejectedValue({
+      response: { status: 403, data: { detail: 'You do not have permission.' } },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Item not found/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error when QR generation fails and keeps the item view intact', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (api.inventoryAPI.generateQR as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText(/Generate QR/i));
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith(
+        'Failed to generate QR code. Please try again.'
+      );
+    });
+    // The page still shows the item — a failed action is not a crash.
+    expect(screen.getByText('Test Item')).toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
+  it('shows the re-login banner with a return path on session expiry, keeping the item', async () => {
+    sessionStorage.clear();
+    render(
+      <MantineProvider>
+        <MemoryRouter initialEntries={['/inventory/items/test-id']}>
+          <SessionExpiredBanner />
+          <Routes>
+            <Route path="/inventory/items/:id" element={<InventoryItemDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </MantineProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item')).toBeInTheDocument();
+    });
+
+    // The API client raises this on a 401 once token refresh fails.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('oms:session-expired', {
+          detail: { pathname: '/inventory/items/test-id' },
+        })
+      );
+    });
+
+    expect(screen.getByTestId('session-expired-banner')).toBeInTheDocument();
+    expect(screen.getByText(/where you left off/i)).toBeInTheDocument();
+    expect(consumePendingReturnTo()).toBe('/inventory/items/test-id');
+    expect(screen.getByText('Test Item')).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/pages/InventoryItemFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemFormPage.test.tsx
@@ -2,8 +2,11 @@
  * Tests for InventoryItemFormPage component
  */
 import { MantineProvider } from '@mantine/core';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import SessionExpiredBanner, {
+  consumePendingReturnTo,
+} from '../../components/SessionExpiredBanner';
 import InventoryItemFormPage from '../../pages/InventoryItemFormPage';
 import * as api from '../../services/api';
 import { showError } from '../../utils/dialogs';
@@ -369,5 +372,133 @@ describe('InventoryItemFormPage', () => {
     await waitFor(() => {
       expect(screen.getByText(/Validation error/)).toBeInTheDocument();
     }, { timeout: 3000 });
+  });
+
+  // ---- #457 R3 resilience ----
+
+  // Fill the minimum required fields so onSubmit reaches the API call.
+  const fillRequiredFields = () => {
+    const nameInputs = screen.getAllByLabelText(/Name/i);
+    fireEvent.change(nameInputs[0], { target: { value: 'New Item' } });
+    const currentStockInputs = screen.getAllByLabelText(/Current Stock/i);
+    if (currentStockInputs.length > 0) {
+      fireEvent.change(currentStockInputs[0], { target: { value: '10' } });
+    }
+    const minStockInputs = screen.getAllByLabelText(/Minimum Stock/i);
+    if (minStockInputs.length > 0) {
+      fireEvent.change(minStockInputs[0], { target: { value: '5' } });
+    }
+    const reorderInputs = screen.getAllByLabelText(/Reorder Quantity/i);
+    if (reorderInputs.length > 0) {
+      fireEvent.change(reorderInputs[0], { target: { value: '20' } });
+    }
+  };
+
+  it('shows an error alert when the item fails to load in edit mode', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (api.inventoryAPI.getItem as jest.Mock).mockRejectedValue({
+      response: { status: 404, data: { detail: 'Not found' } },
+    });
+
+    render(
+      <MantineProvider>
+        <MemoryRouter initialEntries={['/inventory/items/test-id/edit']}>
+          <Routes>
+            <Route
+              path="/inventory/items/:id/edit"
+              element={<InventoryItemFormPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </MantineProvider>
+    );
+
+    expect(
+      await screen.findByText('Failed to load item. Please try again.')
+    ).toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
+  it('falls back to a generic save error when the create has no detail', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (api.inventoryAPI.createItem as jest.Mock).mockRejectedValue({
+      response: { status: 500, data: {} },
+    });
+
+    renderCreatePage();
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(/Name/i).length).toBeGreaterThan(0);
+    });
+    fillRequiredFields();
+    fireEvent.click(screen.getByText('Create Item'));
+
+    expect(
+      await screen.findByText('Failed to save item. Please try again.')
+    ).toBeInTheDocument();
+    // The form stays open so the user can retry without re-entering everything.
+    expect(screen.getByText('Create Item')).toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
+  it('surfaces the permission message when the create is forbidden (403)', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (api.inventoryAPI.createItem as jest.Mock).mockRejectedValue({
+      response: {
+        status: 403,
+        data: { detail: 'You do not have permission to create inventory items.' },
+      },
+    });
+
+    renderCreatePage();
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(/Name/i).length).toBeGreaterThan(0);
+    });
+    fillRequiredFields();
+    fireEvent.click(screen.getByText('Create Item'));
+
+    expect(
+      await screen.findByText('You do not have permission to create inventory items.')
+    ).toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
+  it('shows the re-login banner with a return path on session expiry, keeping the form', async () => {
+    sessionStorage.clear();
+    (api.inventoryAPI.getItem as jest.Mock).mockResolvedValue({ data: mockItem });
+
+    render(
+      <MantineProvider>
+        <MemoryRouter initialEntries={['/inventory/items/test-id/edit']}>
+          <SessionExpiredBanner />
+          <Routes>
+            <Route
+              path="/inventory/items/:id/edit"
+              element={<InventoryItemFormPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </MantineProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Test Item')).toBeInTheDocument();
+    });
+
+    // The API client raises this on a 401 once token refresh fails.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('oms:session-expired', {
+          detail: { pathname: '/inventory/items/test-id/edit' },
+        })
+      );
+    });
+
+    expect(screen.getByTestId('session-expired-banner')).toBeInTheDocument();
+    expect(screen.getByText(/where you left off/i)).toBeInTheDocument();
+    expect(consumePendingReturnTo()).toBe('/inventory/items/test-id/edit');
+    // The in-progress form is untouched behind the banner.
+    expect(screen.getByDisplayValue('Test Item')).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/pages/InventoryListPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryListPage.test.tsx
@@ -4,6 +4,9 @@
 import { MantineProvider } from '@mantine/core';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import SessionExpiredBanner, {
+  consumePendingReturnTo,
+} from '../../components/SessionExpiredBanner';
 import InventoryListPage from '../../pages/InventoryListPage';
 import * as api from '../../services/api';
 import { showError, showInfo, showSuccess } from '../../utils/dialogs';
@@ -432,5 +435,89 @@ describe('InventoryListPage', () => {
     await waitFor(() => {
       expect(screen.getByText('15')).toBeInTheDocument();
     });
+  });
+
+  // ---- #457 R3 resilience ----
+
+  it('shows the empty state when no items match the filters', async () => {
+    (api.inventoryAPI.listItems as jest.Mock).mockResolvedValue(fullPage([]));
+
+    renderPage();
+
+    expect(
+      await screen.findByText('No items found matching your filters.')
+    ).toBeInTheDocument();
+  });
+
+  it('degrades to the empty state without crashing when the load is forbidden (403)', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (api.inventoryAPI.listItems as jest.Mock).mockRejectedValue({
+      response: { status: 403, data: { detail: 'You do not have permission.' } },
+    });
+
+    renderPage();
+
+    // The list has no error banner; a forbidden load logs and leaves it empty.
+    expect(
+      await screen.findByText('No items found matching your filters.')
+    ).toBeInTheDocument();
+    // The page chrome is still interactive — this is graceful, not a crash.
+    expect(screen.getByPlaceholderText(/Search by name/)).toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
+  it('surfaces an error and keeps the inline editor open when a stock save fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (api.inventoryAPI.updateStock as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item 1')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('10'));
+    await screen.findByText('Save');
+    fireEvent.change(screen.getByDisplayValue('10'), { target: { value: '15' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith('Failed to update stock. Please try again.');
+    });
+    // The editor stays open with the entered value so the user can retry.
+    expect(screen.getByText('Save')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('15')).toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
+  it('shows the re-login banner with a return path on session expiry, keeping the list', async () => {
+    sessionStorage.clear();
+    render(
+      <MantineProvider>
+        <MemoryRouter>
+          <SessionExpiredBanner />
+          <InventoryListPage />
+        </MemoryRouter>
+      </MantineProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item 1')).toBeInTheDocument();
+    });
+
+    // The API client raises this on a 401 once token refresh fails.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('oms:session-expired', {
+          detail: { pathname: '/inventory/items' },
+        })
+      );
+    });
+
+    expect(screen.getByTestId('session-expired-banner')).toBeInTheDocument();
+    expect(screen.getByText(/where you left off/i)).toBeInTheDocument();
+    expect(consumePendingReturnTo()).toBe('/inventory/items');
+    // The list survived the interruption.
+    expect(screen.getByText('Test Item 1')).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/pages/InventoryReconciliationPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryReconciliationPage.test.tsx
@@ -2,11 +2,16 @@
  * Tests for InventoryReconciliationPage (oms-90k)
  */
 import { MantineProvider } from '@mantine/core';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Notifications } from '@mantine/notifications';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import SessionExpiredBanner, {
+  consumePendingReturnTo,
+} from '../../components/SessionExpiredBanner';
 import { NotificationProvider } from '../../contexts/NotificationContext';
 import InventoryReconciliationPage from '../../pages/InventoryReconciliationPage';
 import * as api from '../../services/api';
+import { networkError } from '../helpers/offline';
 
 vi.mock('../../services/api');
 
@@ -36,6 +41,52 @@ const renderPage = () =>
       </NotificationProvider>
     </MantineProvider>,
   );
+
+// Variant that also mounts the global re-login banner (normally in the layout)
+// so a session-expiry can be exercised against the live page.
+const renderWithBanner = () =>
+  render(
+    <MantineProvider>
+      <NotificationProvider>
+        <MemoryRouter initialEntries={['/inventory/locations/1/reconcile']}>
+          <SessionExpiredBanner />
+          <Routes>
+            <Route
+              path="/inventory/locations/:id/reconcile"
+              element={<InventoryReconciliationPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </NotificationProvider>
+    </MantineProvider>,
+  );
+
+// Variant that mounts the Mantine notifications outlet so toast text is asserted.
+const renderWithToasts = () =>
+  render(
+    <MantineProvider>
+      <Notifications />
+      <NotificationProvider>
+        <MemoryRouter initialEntries={['/inventory/locations/1/reconcile']}>
+          <Routes>
+            <Route
+              path="/inventory/locations/:id/reconcile"
+              element={<InventoryReconciliationPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </NotificationProvider>
+    </MantineProvider>,
+  );
+
+// The API client dispatches this event on a 401 once token refresh fails.
+const dispatchSessionExpired = (pathname: string) => {
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent('oms:session-expired', { detail: { pathname } }),
+    );
+  });
+};
 
 const gridItems = [
   {
@@ -150,5 +201,58 @@ describe('InventoryReconciliationPage', () => {
     const payload = (api.inventoryAPI.submitReconciliationBatch as jest.Mock).mock
       .calls[0][0];
     expect(payload[0].skip_reorder).toBe(true);
+  });
+
+  it('preserves in-progress counts and shows the re-login banner when the session expires', async () => {
+    sessionStorage.clear();
+    renderWithBanner();
+    expect(await screen.findByText('Widget A')).toBeInTheDocument();
+
+    // Operator is mid-count when their session lapses.
+    fireEvent.change(screen.getByLabelText('Actual count for Widget A'), {
+      target: { value: '18' },
+    });
+    fireEvent.change(screen.getByLabelText('Actual count for Widget B'), {
+      target: { value: '5' },
+    });
+
+    dispatchSessionExpired('/inventory/locations/1/reconcile');
+
+    // The recovery banner appears and offers to return here after re-login.
+    expect(screen.getByTestId('session-expired-banner')).toBeInTheDocument();
+    expect(screen.getByText(/your session expired/i)).toBeInTheDocument();
+    expect(screen.getByText(/where you left off/i)).toBeInTheDocument();
+    expect(consumePendingReturnTo()).toBe('/inventory/locations/1/reconcile');
+
+    // Crucially, the half-finished counts are not lost.
+    expect(
+      (screen.getByLabelText('Actual count for Widget A') as HTMLInputElement).value,
+    ).toBe('18');
+    expect(
+      (screen.getByLabelText('Actual count for Widget B') as HTMLInputElement).value,
+    ).toBe('5');
+  });
+
+  it('surfaces an error and keeps counts when the submit fails offline', async () => {
+    (api.inventoryAPI.submitReconciliationBatch as jest.Mock).mockRejectedValue(
+      networkError('Network Error'),
+    );
+
+    renderWithToasts();
+    expect(await screen.findByText('Widget A')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Actual count for Widget A'), {
+      target: { value: '18' },
+    });
+    fireEvent.click(screen.getByTestId('submit-reconciliation'));
+
+    // A network failure has no response.data.detail, so the generic copy shows.
+    expect(await screen.findByText('Failed to submit reconciliation')).toBeInTheDocument();
+
+    // The entered count survives so the operator can retry once back online.
+    expect(
+      (screen.getByLabelText('Actual count for Widget A') as HTMLInputElement).value,
+    ).toBe('18');
+    expect(screen.getByTestId('submit-reconciliation')).not.toBeDisabled();
   });
 });

--- a/frontend/src/__tests__/pages/PurchaseOrderListPage.test.tsx
+++ b/frontend/src/__tests__/pages/PurchaseOrderListPage.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Resilience tests for PurchaseOrderListPage (#457 R3).
+ *
+ * Covers the four states a transparency-facing list must survive:
+ *  - loading (request in flight),
+ *  - empty (no orders match the filter),
+ *  - forbidden (403 — surfaced in the error banner, page does not crash),
+ *  - error (server failure — falls back to the generic message),
+ *  - plus an a11y audit of the populated table (AC-20).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import PurchaseOrderListPage from '../../pages/PurchaseOrderListPage';
+import * as api from '../../services/api';
+import { expectNoA11yViolations } from '../helpers/axe';
+
+vi.mock('../../services/api');
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <PurchaseOrderListPage />
+      </MemoryRouter>
+    </MantineProvider>
+  );
+
+describe('PurchaseOrderListPage', () => {
+  const mockOrder = {
+    id: 'po-1',
+    po_number: 'PO-2026-001',
+    supplier_details: 'Acme Supplies',
+    status: 'sent',
+    status_label: 'Sent to Supplier',
+    order_date: '2026-01-15',
+    expected_delivery_date: '2026-01-25',
+    estimated_total: '1250.00',
+    actual_total: null,
+    total_items: 3,
+    total_quantity: 12,
+    is_fully_received: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // The page logs failures to console.error; keep the test output clean.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('shows the loading state while orders are in flight', () => {
+    // A promise that never settles keeps the page in its loading state.
+    (api.purchaseOrderAPI.listOrders as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+    renderPage();
+
+    expect(screen.getByText(/Loading purchase orders/)).toBeInTheDocument();
+  });
+
+  it('shows the empty state when no orders match', async () => {
+    (api.purchaseOrderAPI.listOrders as jest.Mock).mockResolvedValue({
+      data: { results: [] },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Loading purchase orders/)).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(/No purchase orders found/)).toBeInTheDocument();
+  });
+
+  it('renders the orders table once loaded', async () => {
+    (api.purchaseOrderAPI.listOrders as jest.Mock).mockResolvedValue({
+      data: { results: [mockOrder] },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('PO-2026-001')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Acme Supplies')).toBeInTheDocument();
+    // 'Sent to Supplier' is also a filter <option>; scope to the status badge.
+    expect(screen.getByText('Sent to Supplier', { selector: '.status-badge' })).toBeInTheDocument();
+    expect(screen.getByText('View Details →')).toBeInTheDocument();
+  });
+
+  it('surfaces a forbidden (403) response in the error banner', async () => {
+    (api.purchaseOrderAPI.listOrders as jest.Mock).mockRejectedValue({
+      response: {
+        status: 403,
+        data: { detail: 'You do not have permission to view purchase orders.' },
+      },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('You do not have permission to view purchase orders.')
+      ).toBeInTheDocument();
+    });
+    // The page degrades gracefully rather than rendering a table.
+    expect(screen.getByText(/No purchase orders found/)).toBeInTheDocument();
+  });
+
+  it('falls back to a generic message on a server error', async () => {
+    (api.purchaseOrderAPI.listOrders as jest.Mock).mockRejectedValue({
+      response: { status: 500, data: {} },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load purchase orders')).toBeInTheDocument();
+    });
+  });
+
+  it('has no accessibility violations with orders loaded', async () => {
+    (api.purchaseOrderAPI.listOrders as jest.Mock).mockResolvedValue({
+      data: { results: [mockOrder] },
+    });
+
+    const { container } = renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('PO-2026-001')).toBeInTheDocument();
+    });
+    await expectNoA11yViolations(container);
+  });
+});

--- a/frontend/src/__tests__/pages/PurchaseOrderPage.test.tsx
+++ b/frontend/src/__tests__/pages/PurchaseOrderPage.test.tsx
@@ -6,8 +6,11 @@
  *    flipping back into the initial "Loading purchase order…" placeholder.
  */
 import { MantineProvider } from '@mantine/core';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import SessionExpiredBanner, {
+  consumePendingReturnTo,
+} from '../../components/SessionExpiredBanner';
 import PurchaseOrderPage from '../../pages/PurchaseOrderPage';
 import * as api from '../../services/api';
 import { showError } from '../../utils/dialogs';
@@ -221,6 +224,29 @@ describe('PurchaseOrderPage mark-delivered reactive contract (gh-453)', () => {
     });
     expect((screen.getByLabelText(/delivery date/i) as HTMLInputElement).value).toBe('2026-05-10');
     expect((screen.getByLabelText(/tracking number/i) as HTMLInputElement).value).toBe('TRK-99');
+  });
+
+  test('surfaces the error and keeps the panel when the mark-delivered save fails (#457 R3)', async () => {
+    (api.purchaseOrderAPI.getOrder as jest.Mock).mockResolvedValue({
+      data: { ...baseOrder, status: 'sent', items: [], attachments: [] },
+    });
+    // No detail on the error → the page falls back to its generic save message.
+    (api.purchaseOrderAPI.markDelivered as jest.Mock).mockRejectedValue({
+      response: { status: 500, data: {} },
+    });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /^mark as delivered$/i }));
+    fireEvent.change(screen.getByLabelText(/delivery date/i), { target: { value: '2026-05-10' } });
+    fireEvent.click(screen.getByRole('button', { name: /confirm delivery/i }));
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith('Failed to mark purchase order as delivered');
+    });
+    // The panel stays mounted with the typed date so the user can retry.
+    expect(screen.getByRole('button', { name: /confirm delivery/i })).toBeInTheDocument();
+    expect((screen.getByLabelText(/delivery date/i) as HTMLInputElement).value).toBe('2026-05-10');
   });
 });
 
@@ -639,5 +665,82 @@ describe('PurchaseOrderPage receive items (oms-s0hj4)', () => {
       expect(showError).toHaveBeenCalledWith(expect.stringMatching(/only 7 pending/i));
     });
     expect(api.purchaseOrderAPI.receiveItems).not.toHaveBeenCalled();
+  });
+
+  test('surfaces a permission error and keeps the panel when receiving is forbidden (403) (#457 R3)', async () => {
+    (api.purchaseOrderAPI.getOrder as jest.Mock).mockResolvedValue({ data: makeReceiveOrder() });
+    // The receive permission is enforced by the backend (403); the page has no
+    // client-side gate, so it must surface the message and let the user recover.
+    (api.purchaseOrderAPI.receiveItems as jest.Mock).mockRejectedValue({
+      response: {
+        status: 403,
+        data: { detail: 'You do not have permission to receive items.' },
+      },
+    });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /^receive items$/i }));
+    fireEvent.change(screen.getByLabelText('Receive quantity for Stocked Bolt'), {
+      target: { value: '2' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /confirm receipt/i }));
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith('You do not have permission to receive items.');
+    });
+    // The panel stays open with the entered quantity so a permitted user can retry.
+    expect(
+      (screen.getByLabelText('Receive quantity for Stocked Bolt') as HTMLInputElement).value,
+    ).toBe('2');
+    expect(screen.getByRole('button', { name: /confirm receipt/i })).toBeInTheDocument();
+  });
+});
+
+describe('PurchaseOrderPage session-expiry return-to (#457 R3)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem('token', 'test-token');
+    localStorage.setItem('is_staff', 'true');
+    sessionStorage.clear();
+  });
+
+  // Mounts the global re-login banner (normally in WorkspaceLayout) next to the page.
+  const renderWithBanner = () =>
+    render(
+      <MantineProvider>
+        <MemoryRouter initialEntries={['/purchase-orders/po-1']}>
+          <SessionExpiredBanner />
+          <Routes>
+            <Route path="/purchase-orders/:orderId" element={<PurchaseOrderPage />} />
+          </Routes>
+        </MemoryRouter>
+      </MantineProvider>,
+    );
+
+  test('shows the re-login banner with a return path and keeps the order on screen', async () => {
+    (api.purchaseOrderAPI.getOrder as jest.Mock).mockResolvedValue({ data: baseOrder });
+
+    renderWithBanner();
+    await waitFor(() => {
+      expect(screen.getByText('PO-2026-0001', { exact: false })).toBeInTheDocument();
+    });
+
+    // The API client raises this on a 401; in production the detail page lives
+    // under the recoverable /purchasing/orders/:id route.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('oms:session-expired', {
+          detail: { pathname: '/purchasing/orders/po-1' },
+        }),
+      );
+    });
+
+    expect(screen.getByTestId('session-expired-banner')).toBeInTheDocument();
+    expect(screen.getByText(/where you left off/i)).toBeInTheDocument();
+    expect(consumePendingReturnTo()).toBe('/purchasing/orders/po-1');
+    // The page itself is untouched — the order is still rendered behind the banner.
+    expect(screen.getByText('PO-2026-0001', { exact: false })).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/pages/PurchasingReportPage.test.tsx
+++ b/frontend/src/__tests__/pages/PurchasingReportPage.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Resilience tests for PurchasingReportPage (#457 R3).
+ *
+ * The report page loads "spend by supplier" on mount. It has no dedicated
+ * error UI — a failed load is logged and leaves the table empty — so the
+ * resilience contract is: show a loading row while in flight, an empty row
+ * when there is no data, and never crash on a failed request.
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import PurchasingReportPage from '../../pages/PurchasingReportPage';
+import * as api from '../../services/api';
+import { expectNoA11yViolations } from '../helpers/axe';
+
+vi.mock('../../services/api');
+vi.mock('../../utils/csvExport', async () => ({
+  exportPurchasingReportToCSV: jest.fn(),
+}));
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <PurchasingReportPage />
+    </MantineProvider>
+  );
+
+describe('PurchasingReportPage', () => {
+  const mockSupplier = {
+    supplier_id: 1,
+    supplier_name: 'Acme Supplies',
+    total_orders: 5,
+    total_spend: 1234.56,
+    avg_order_value: 246.91,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  // Mantine Tabs keeps every panel mounted (keepMounted defaults to true), so
+  // "Loading..." / "No data available" render in all four (hidden) panels.
+  // Scope shared body text to the single visible tab panel.
+  const activePanel = () => screen.getByRole('tabpanel');
+
+  it('shows a loading row while the report is in flight', async () => {
+    (api.reportsAPI.getPurchasingSpendBySupplier as jest.Mock).mockReturnValue(
+      new Promise(() => {})
+    );
+
+    renderPage();
+
+    expect(screen.getByText('Purchasing Reports')).toBeInTheDocument();
+    expect(await within(activePanel()).findByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there is no spend data', async () => {
+    (api.reportsAPI.getPurchasingSpendBySupplier as jest.Mock).mockResolvedValue({
+      data: [],
+    });
+
+    renderPage();
+
+    expect(await within(activePanel()).findByText('No data available')).toBeInTheDocument();
+  });
+
+  it('renders supplier spend rows once loaded', async () => {
+    (api.reportsAPI.getPurchasingSpendBySupplier as jest.Mock).mockResolvedValue({
+      data: [mockSupplier],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Acme Supplies')).toBeInTheDocument();
+    expect(screen.getByText('$1234.56')).toBeInTheDocument();
+  });
+
+  it('degrades to the empty state without crashing on a failed load', async () => {
+    (api.reportsAPI.getPurchasingSpendBySupplier as jest.Mock).mockRejectedValue(
+      new Error('boom')
+    );
+
+    renderPage();
+
+    // No error banner exists; a failed load simply leaves the table empty.
+    expect(await within(activePanel()).findByText('No data available')).toBeInTheDocument();
+    expect(screen.getByText('Purchasing Reports')).toBeInTheDocument();
+  });
+
+  it('has no accessibility violations with data loaded', async () => {
+    (api.reportsAPI.getPurchasingSpendBySupplier as jest.Mock).mockResolvedValue({
+      data: [mockSupplier],
+    });
+
+    const { container } = renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Acme Supplies')).toBeInTheDocument();
+    });
+    await expectNoA11yViolations(container);
+  });
+});


### PR DESCRIPTION
Lands work bead **oms-bye0t** — #457 R3 (P1 purchasing/reorder): forbidden + auth-expiry + missing tests. Part of #457 series; no Closes keyword.

## Scope (TEST-ONLY frontend; independent of R5/R6/R7 — different pages)
- +31 frontend tests: forbidden + auth-expiry + offline coverage for purchasing/reorder/inventory pages; new PurchaseOrderListPage + PurchasingReportPage resilience tests
- No production code, no deps, no migrations (reuses R1 helpers already on main)

## Refinery gates
- CI-gated: Frontend Tests + Lint + Build must go green.

Bead strategy direct; main is PR-only, landed by refinery via squash once CI is green. — oms/gastown.refinery