### PR TITLE
test(frontend): resilience coverage for P0 public scan journeys (oms-sr1l4)

### DIFF
--- a/frontend/src/__tests__/pages/AssetScanPage.test.tsx
+++ b/frontend/src/__tests__/pages/AssetScanPage.test.tsx
@@ -11,6 +11,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import AssetScanPage from '../../pages/AssetScanPage';
 import * as api from '../../services/api';
+import { networkError } from '../helpers/offline';
 
 vi.mock('../../services/api');
 
@@ -237,5 +238,107 @@ describe('AssetScanPage — modal flows', () => {
 
     expect(api.checklistsAPI.startChecklist).not.toHaveBeenCalled();
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  // --- R2 resilience (oms-sr1l4): asset scan journey ----------------------
+  // The asset page is reached via the QR-encoded URL (/scan/asset/:assetId),
+  // so it needs no in-page camera. These pin AC-19 loading/empty surfaces,
+  // AC-16 offline/dependency-failure actionable states, and the AC-15
+  // duplicate-submit guard on the report-problem form.
+
+  test('AC-19: shows a loading state while the asset is fetched', async () => {
+    (api.assetsAPI.scanAsset as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+    renderPage();
+
+    expect(await screen.findByText(/loading asset details/i)).toBeInTheDocument();
+  });
+
+  test('AC-16: an offline asset load shows an actionable error with a way home', async () => {
+    (api.assetsAPI.scanAsset as jest.Mock).mockRejectedValue(networkError());
+
+    renderPage();
+
+    expect(await screen.findByText(/failed to load asset/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /go home/i })).toBeInTheDocument();
+  });
+
+  test('AC-19: renders an empty "asset not found" state when the scan returns no asset', async () => {
+    (api.assetsAPI.scanAsset as jest.Mock).mockResolvedValue({ data: null });
+
+    renderPage();
+
+    expect(await screen.findByText(/asset not found/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /go home/i })).toBeInTheDocument();
+  });
+
+  test('AC-16: a report-problem submitted offline surfaces an actionable error', async () => {
+    localStorage.setItem('token', 'fake-token');
+    (api.assetsAPI.reportProblem as jest.Mock).mockRejectedValue(networkError());
+
+    renderPage();
+
+    const textarea = await screen.findByPlaceholderText(/describe the problem/i);
+    fireEvent.change(textarea, { target: { value: 'Belt is frayed' } });
+    fireEvent.click(screen.getByRole('button', { name: /^report problem$/i }));
+
+    expect(await screen.findByText(/failed to report problem/i)).toBeInTheDocument();
+  });
+
+  test('AC-15: a rapid double-tap on Report Problem only files one report', async () => {
+    localStorage.setItem('token', 'fake-token');
+    // Never resolves: holds the submitting state so the disabled guard shows.
+    (api.assetsAPI.reportProblem as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+    renderPage();
+
+    const textarea = await screen.findByPlaceholderText(/describe the problem/i);
+    fireEvent.change(textarea, { target: { value: 'Belt is frayed' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^report problem$/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /submitting/i })).toBeDisabled()
+    );
+    fireEvent.click(screen.getByRole('button', { name: /submitting/i }));
+
+    expect(api.assetsAPI.reportProblem).toHaveBeenCalledTimes(1);
+  });
+
+  test('AC-16: an offline photo upload still saves the report and flags the photo', async () => {
+    localStorage.setItem('token', 'fake-token');
+    const createObjectURL = jest.fn().mockReturnValue('blob:preview');
+    const revokeObjectURL = jest.fn();
+    Object.defineProperty(window.URL, 'createObjectURL', {
+      value: createObjectURL,
+      configurable: true,
+    });
+    Object.defineProperty(window.URL, 'revokeObjectURL', {
+      value: revokeObjectURL,
+      configurable: true,
+    });
+
+    (api.assetsAPI.reportProblem as jest.Mock).mockResolvedValue({ data: { id: 'prob-1' } });
+    (api.assetProblemsAPI.uploadPhoto as jest.Mock).mockRejectedValue(networkError());
+
+    const { container } = renderPage();
+
+    const textarea = await screen.findByPlaceholderText(/describe the problem/i);
+    fireEvent.change(textarea, { target: { value: 'Cracked housing' } });
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['img'], 'broken.png', { type: 'image/png' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    // The preview registers (Remove control appears) before we submit.
+    await screen.findByRole('button', { name: /^remove$/i });
+    fireEvent.click(screen.getByRole('button', { name: /^report problem$/i }));
+
+    // The problem report is created even though the photo upload is offline…
+    await waitFor(() =>
+      expect(api.assetsAPI.reportProblem).toHaveBeenCalledWith('asset-1', 'Cracked housing')
+    );
+    await waitFor(() => expect(api.assetProblemsAPI.uploadPhoto).toHaveBeenCalled());
+    // …and the offline photo is surfaced as a non-fatal, actionable failure.
+    expect(await screen.findByText(/photo 1 failed to upload/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/pages/ChecklistCompletionPage.test.tsx
+++ b/frontend/src/__tests__/pages/ChecklistCompletionPage.test.tsx
@@ -9,9 +9,41 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { NotificationProvider } from '../../contexts/NotificationContext';
 import ChecklistCompletionPage from '../../pages/ChecklistCompletionPage';
 import * as api from '../../services/api';
+import { networkError } from '../helpers/offline';
 
 // Mock the API
 vi.mock('../../services/api');
+
+// Stub the QR scanner: html5-qrcode needs a real camera/WASM (covered by
+// QRScanner.test.tsx). Here we only need to drive the page's onScanError /
+// onScanSuccess handlers to assert how the page reacts (AC-14).
+vi.mock('../../components/QRScanner', () => ({
+  default: (props: {
+    onScanSuccess: (text: string) => void;
+    onScanError: (error: { kind: string; message: string }) => void;
+    onClose: () => void;
+  }) => (
+    <div data-testid="qr-scanner-stub">
+      <button
+        type="button"
+        onClick={() =>
+          props.onScanError({
+            kind: 'permission-denied',
+            message: 'Enable camera access or enter the code manually.',
+          })
+        }
+      >
+        simulate camera denied
+      </button>
+      <button type="button" onClick={() => props.onScanSuccess('SCAN-CODE')}>
+        simulate scan
+      </button>
+      <button type="button" onClick={props.onClose}>
+        close scanner
+      </button>
+    </div>
+  ),
+}));
 
 const mockNavigate = jest.fn();
 vi.mock('react-router-dom', async () => ({
@@ -290,6 +322,59 @@ describe('ChecklistCompletionPage', () => {
     const pageHeading = headings.find(h => h.tagName === 'H3');
     expect(pageHeading).toBeInTheDocument();
     expect(pageHeading).toHaveTextContent(/✓ checklist completed/i);
+  });
+
+  // --- R2 resilience (oms-sr1l4): long-form checklist journey -------------
+  // This is the one public scan page with a live camera (QRScanner), so it
+  // anchors AC-14 camera-denied handling; plus AC-16 offline survival and the
+  // AC-15 duplicate-submit guard on completion.
+
+  test('AC-14: a camera-permission denial surfaces an actionable, code-entry hint', async () => {
+    (api.checklistsAPI.getChecklist as jest.Mock).mockResolvedValue({ data: mockChecklist });
+    (api.checklistsAPI.getCompletion as jest.Mock).mockResolvedValue({ data: mockCompletion });
+
+    await renderWithRouter();
+    await screen.findByText('Monthly Safety Walk');
+
+    fireEvent.click(screen.getByRole('button', { name: /scan qr code/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /simulate camera denied/i }));
+
+    expect(await screen.findByText(/camera access denied/i)).toBeInTheDocument();
+    expect(screen.getByText(/enter the code manually/i)).toBeInTheDocument();
+  });
+
+  test('AC-16: an offline checklist load shows an actionable error with a way home', async () => {
+    (api.checklistsAPI.getChecklist as jest.Mock).mockRejectedValue(networkError());
+    (api.checklistsAPI.getCompletion as jest.Mock).mockResolvedValue({ data: mockCompletion });
+
+    await renderWithRouter();
+
+    expect(await screen.findByText(/failed to load checklist/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /go home/i })).toBeInTheDocument();
+  });
+
+  test('AC-15: a completed checklist disables Complete so it cannot be submitted twice', async () => {
+    const completed = {
+      ...mockCompletion,
+      status: 'completed',
+      completed_at: '2024-01-02T00:00:00Z',
+      completed_steps_count: 2,
+      required_steps_completed: 2,
+      required_steps_total: 2,
+      step_completions: [
+        { id: 'sc-1', step: 'step-1', scanned_at: '2024-01-01T00:00:00Z' },
+        { id: 'sc-2', step: 'step-2', scanned_at: '2024-01-01T00:00:00Z' },
+      ],
+    };
+    (api.checklistsAPI.getChecklist as jest.Mock).mockResolvedValue({ data: mockChecklist });
+    (api.checklistsAPI.getCompletion as jest.Mock).mockResolvedValue({ data: completed });
+
+    await renderWithRouter();
+    await screen.findByText('Monthly Safety Walk');
+
+    const completeButton = await screen.findByRole('button', { name: /^completed$/i });
+    expect(completeButton).toBeDisabled();
+    expect(api.checklistsAPI.completeChecklist).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/__tests__/pages/DonationItemScanPage.test.tsx
+++ b/frontend/src/__tests__/pages/DonationItemScanPage.test.tsx
@@ -13,6 +13,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import DonationItemScanPage from '../../pages/DonationItemScanPage';
 import * as api from '../../services/api';
+import { networkError } from '../helpers/offline';
 
 vi.mock('../../services/api');
 
@@ -142,5 +143,16 @@ describe('DonationItemScanPage', () => {
       );
     });
     await screen.findByText(/disposition recorded successfully/i);
+  });
+
+  // R2 resilience (oms-sr1l4): AC-16 — a true network failure (offline) must
+  // degrade to the same actionable error surface, not a blank screen.
+  test('AC-16: an offline item load shows an actionable error with a recovery action', async () => {
+    (api.donationsAPI.getDonationItem as jest.Mock).mockRejectedValue(networkError());
+
+    renderPage();
+
+    await screen.findByText(/failed to load donation item/i);
+    expect(screen.getByRole('button', { name: /go home/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/pages/LocationScanPage.test.tsx
+++ b/frontend/src/__tests__/pages/LocationScanPage.test.tsx
@@ -9,6 +9,7 @@ import { NotificationProvider } from '../../contexts/NotificationContext';
 import LocationScanPage from '../../pages/LocationScanPage';
 import * as api from '../../services/api';
 import { promptInput, showError } from '../../utils/dialogs';
+import { networkError } from '../helpers/offline';
 
 // Mock the API
 vi.mock('../../services/api');
@@ -308,6 +309,76 @@ describe('LocationScanPage', () => {
         })
       );
     });
+  });
+
+  // --- R2 resilience (oms-sr1l4): public location scan journey -------------
+  // AC-16 offline actionable error, AC-15 duplicate-submit guard + clear
+  // final state, and anonymous-vs-member gating.
+
+  test('AC-16: an offline location load shows an actionable error with a way home', async () => {
+    (api.inventoryAPI.getLocation as jest.Mock).mockRejectedValue(networkError());
+
+    await renderWithRouter();
+
+    await screen.findByText(/failed to load location/i);
+    expect(screen.getByRole('button', { name: /go home/i })).toBeInTheDocument();
+  });
+
+  test('AC-15: a rapid double-tap on Submit Report only files one report', async () => {
+    (api.inventoryAPI.getLocation as jest.Mock).mockResolvedValue({ data: mockLocation });
+    // Never resolves: keeps the page in its submitting state so the disabled
+    // guard is observable and a second tap is a no-op.
+    (api.locationCheckinAPI.reportSecurity as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+    await renderWithRouter();
+    await screen.findByText('Test Location');
+
+    fireEvent.click(screen.getByRole('button', { name: /report issue/i }));
+    fireEvent.click(await screen.findByText(/needs cleaning/i));
+    fireEvent.click(await screen.findByRole('button', { name: /submit report/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /submitting/i })).toBeDisabled()
+    );
+    fireEvent.click(screen.getByRole('button', { name: /submitting/i }));
+
+    expect(api.locationCheckinAPI.reportSecurity).toHaveBeenCalledTimes(1);
+  });
+
+  test('AC-15: a successful check-in shows a clear final-state confirmation', async () => {
+    (api.inventoryAPI.getLocation as jest.Mock).mockResolvedValue({ data: mockLocation });
+    (api.locationCheckinAPI.checkin as jest.Mock).mockResolvedValue({ data: { id: 'c-1' } });
+
+    await renderWithRouter();
+    await screen.findByText('Test Location');
+
+    const notes = screen.getByPlaceholderText(/any notes about your check-in/i);
+    fireEvent.change(notes, { target: { value: 'Here for the laser class' } });
+    fireEvent.submit(notes.closest('form')!);
+
+    await screen.findByText(/thank you! your submission has been recorded/i);
+  });
+
+  test('anonymous visitor does not see member-only check-in type or Tasks tab', async () => {
+    (api.inventoryAPI.getLocation as jest.Mock).mockResolvedValue({ data: mockLocation });
+
+    await renderWithRouter();
+    await screen.findByText('Test Location');
+
+    expect(screen.queryByText(/check-in type/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^tasks$/i })).not.toBeInTheDocument();
+  });
+
+  test('authenticated member sees the check-in type selector and the Tasks tab', async () => {
+    localStorage.setItem('token', 'member-token');
+    (api.inventoryAPI.getLocation as jest.Mock).mockResolvedValue({ data: mockLocation });
+    (api.locationCheckinAPI.getTasks as jest.Mock).mockResolvedValue({ data: { results: [] } });
+
+    await renderWithRouter();
+    await screen.findByText('Test Location');
+
+    expect(screen.getByText(/check-in type/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^tasks$/i })).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/__tests__/pages/MakerBoxScanPage.test.tsx
+++ b/frontend/src/__tests__/pages/MakerBoxScanPage.test.tsx
@@ -13,6 +13,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 import MakerBoxScanPage from '../../pages/MakerBoxScanPage';
 import * as api from '../../services/api';
+import { networkError } from '../helpers/offline';
 
 vi.mock('../../services/api');
 
@@ -142,5 +143,19 @@ describe('MakerBoxScanPage', () => {
     expect(screen.queryByTestId('scan-result')).not.toBeInTheDocument();
     expect(screen.getByLabelText(/bin id/i)).toHaveValue('');
     expect(screen.getByLabelText(/username/i)).toHaveValue('');
+  });
+
+  // R2 resilience (oms-sr1l4): AC-16 — when the scan request fails with a bare
+  // network error (offline, no response body), the page still shows the
+  // fallback "Scan failed." alert rather than crashing or going blank.
+  test('AC-16: a scan made offline shows the fallback "Scan failed." alert', async () => {
+    (api.makerBoxesAPI.scan as jest.Mock).mockRejectedValue(networkError());
+
+    render(<MakerBoxScanPage />);
+    fillAndSubmit();
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/scan failed/i);
+    expect(screen.queryByTestId('scan-result')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/pages/ScanPage.test.tsx
+++ b/frontend/src/__tests__/pages/ScanPage.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import ScanPage from '../../pages/ScanPage';
 import * as api from '../../services/api';
+import { networkError } from '../helpers/offline';
 
 // Mock the API
 vi.mock('../../services/api');
@@ -209,5 +210,70 @@ describe('ScanPage', () => {
     await renderWithRouter();
 
     await screen.findByText(/item not found/i);
+  });
+
+  // --- R2 resilience (oms-sr1l4): public scan journey ---------------------
+  // ScanPage is reached via the QR's encoded URL (/scan/:itemId); there is no
+  // in-page camera, so AC-14 "mobile resilience" here means the journey
+  // completes from the URL alone, AC-15 prevents duplicate auto-submits, and
+  // AC-16 surfaces an actionable state when the network drops.
+
+  test('AC-16: an offline item load shows an actionable error, not a blank screen', async () => {
+    (api.inventoryAPI.getItem as jest.Mock).mockRejectedValue(networkError());
+
+    await renderWithRouter();
+
+    await screen.findByText(/failed to load item/i);
+    expect(screen.getByRole('button', { name: /go home/i })).toBeInTheDocument();
+    // A lost network must never silently fire an auto-submitted reorder.
+    expect(api.reorderAPI.createRequest).not.toHaveBeenCalled();
+  });
+
+  test('AC-15: the anonymous auto-submit fires exactly once (no duplicate reorder)', async () => {
+    const itemWithoutPending = { ...mockItem, has_pending_reorder: false };
+    (api.inventoryAPI.getItem as jest.Mock).mockResolvedValue({ data: itemWithoutPending });
+    (api.reorderAPI.createRequest as jest.Mock).mockResolvedValue({ data: { id: 1 } });
+
+    await renderWithRouter();
+
+    // The (!submitting && !submitted) guard keeps the effect's re-runs from
+    // re-submitting, so the request lands exactly once.
+    await waitFor(() => {
+      expect(api.reorderAPI.createRequest).toHaveBeenCalledTimes(1);
+    });
+    expect(api.reorderAPI.createRequest).toHaveBeenCalledTimes(1);
+  });
+
+  test('AC-14: completes the reorder from the scanned URL with no camera step', async () => {
+    const itemWithoutPending = { ...mockItem, has_pending_reorder: false };
+    (api.inventoryAPI.getItem as jest.Mock).mockResolvedValue({ data: itemWithoutPending });
+    (api.reorderAPI.createRequest as jest.Mock).mockResolvedValue({ data: { id: 1 } });
+
+    await renderWithRouter();
+
+    // Reaching /thanks proves the journey is driven entirely by the
+    // QR-encoded :itemId — the camera-free, code-entry-by-URL path.
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/thanks');
+    });
+  });
+
+  test('AC-15: an existing pending reorder is not duplicated and shows a clear final state', async () => {
+    const pendingItem = {
+      ...mockItem,
+      has_pending_reorder: true,
+      active_reorder_request: {
+        status: 'pending',
+        quantity: 25,
+        requested_at: '2024-01-01T00:00:00Z',
+        requested_by: 'Anonymous',
+      },
+    };
+    (api.inventoryAPI.getItem as jest.Mock).mockResolvedValue({ data: pendingItem });
+
+    await renderWithRouter();
+
+    await screen.findByText(/reorder already requested/i);
+    expect(api.reorderAPI.createRequest).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/pages/TaxReceiptLookupPage.test.tsx
+++ b/frontend/src/__tests__/pages/TaxReceiptLookupPage.test.tsx
@@ -13,6 +13,7 @@ import { MemoryRouter } from 'react-router-dom';
 
 import TaxReceiptLookupPage from '../../pages/TaxReceiptLookupPage';
 import * as api from '../../services/api';
+import { networkError } from '../helpers/offline';
 
 vi.mock('../../services/api');
 
@@ -142,5 +143,22 @@ describe('TaxReceiptLookupPage', () => {
     });
     expect(createObjectURL).toHaveBeenCalled();
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake-url');
+  });
+
+  // R2 resilience (oms-sr1l4): AC-16 — a lookup that fails offline (bare
+  // network error, no response body) still shows the actionable not-found
+  // state and re-enables the form so the donor can retry once back online.
+  test('AC-16: a lookup made offline shows an actionable state and re-enables retry', async () => {
+    (api.donationsAPI.lookupTaxReceipt as jest.Mock).mockRejectedValue(networkError());
+
+    renderPage();
+
+    fireEvent.change(screen.getByLabelText(/serial number/i), {
+      target: { value: 'RCP-OFFLINE' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /lookup receipt/i }));
+
+    await screen.findByText(/tax receipt not found/i);
+    expect(screen.getByRole('button', { name: /lookup receipt/i })).not.toBeDisabled();
   });
 });

--- a/frontend/src/__tests__/pages/TransparencyPage.test.tsx
+++ b/frontend/src/__tests__/pages/TransparencyPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import TransparencyPage from '../../pages/TransparencyPage';
 import { analyticsAPI } from '../../services/api';
+import { networkError } from '../helpers/offline';
 
 vi.mock('../../services/api', () => ({
   analyticsAPI: {
@@ -89,5 +90,23 @@ describe('TransparencyPage', () => {
     expect(screen.getAllByText(/\$200\.00/).length).toBeGreaterThan(0);
     expect(screen.getByText(/Order #ORD-2024-001/)).toBeInTheDocument();
     expect(screen.getByText(/Invoice #INV-2024-001/)).toBeInTheDocument();
+  });
+
+  // R2 resilience (oms-sr1l4): AC-16 — when the public ledger can't load
+  // (offline / dependency failure), the page shows an actionable error with a
+  // retry action instead of a blank screen.
+  it('AC-16: shows an actionable error with a retry action when the report fails to load offline', async () => {
+    const getTransparencyLedgerMock = analyticsAPI.getTransparencyLedger as jest.Mock;
+    getTransparencyLedgerMock.mockRejectedValue(networkError());
+
+    render(
+      <MantineProvider><MemoryRouter>
+        <TransparencyPage />
+      </MemoryRouter></MantineProvider>
+    );
+
+    const messages = await screen.findAllByText(/unable to load transparency data/i);
+    expect(messages.length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Lands work bead **oms-sr1l4** — #457 R2 (P0 public scan): camera-fallback + offline + duplicate-guard. Part of #457 series; no Closes keyword.

## Scope (TEST-ONLY frontend; independent of R3/R6 — different pages)
- resilience coverage for P0 public scan journeys (TaxReceiptLookupPage, TransparencyPage, scan pages): camera-fallback, offline, duplicate-guard
- No production code, no deps, no migrations (reuses R1 helpers already on main)

## Refinery gates
- CI-gated: Frontend Tests + Lint + Build must go green.

Bead strategy direct; main is PR-only, landed by refinery via squash once CI is green. — oms/gastown.refinery