### PR TITLE
feat(frontend): sortable Purchase Orders table (oms-xwo8n)

### DIFF
--- a/frontend/src/__tests__/pages/PurchaseOrderListPage.test.tsx
+++ b/frontend/src/__tests__/pages/PurchaseOrderListPage.test.tsx
@@ -9,7 +9,8 @@
  *  - plus an a11y audit of the populated table (AC-20).
  */
 import { MantineProvider } from '@mantine/core';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import PurchaseOrderListPage from '../../pages/PurchaseOrderListPage';
 import * as api from '../../services/api';
@@ -128,5 +129,125 @@ describe('PurchaseOrderListPage', () => {
       expect(screen.getByText('PO-2026-001')).toBeInTheDocument();
     });
     await expectNoA11yViolations(container);
+  });
+});
+
+describe('PurchaseOrderListPage sorting', () => {
+  const baseOrder = {
+    id: 'po-1',
+    po_number: 'PO-2026-001',
+    supplier_details: 'Acme Supplies',
+    status: 'sent',
+    status_label: 'Sent to Supplier',
+    order_date: '2026-01-15',
+    expected_delivery_date: '2026-01-25',
+    estimated_total: '1250.00',
+    actual_total: '1000.00',
+    total_items: 3,
+    total_quantity: 12,
+    is_fully_received: false,
+  };
+
+  // Three orders chosen so each sortable column yields a distinct ordering.
+  const orders = [
+    {
+      ...baseOrder,
+      id: 'po-1',
+      po_number: 'PO-2026-001',
+      order_date: '2026-01-15',
+      estimated_total: '1250.00',
+      actual_total: '1000.00',
+    },
+    {
+      ...baseOrder,
+      id: 'po-2',
+      po_number: 'PO-2026-002',
+      order_date: '2026-03-10',
+      estimated_total: '300.00',
+      actual_total: null,
+    },
+    {
+      ...baseOrder,
+      id: 'po-3',
+      po_number: 'PO-2026-003',
+      order_date: '2026-02-01',
+      estimated_total: '9999.00',
+      actual_total: '50.00',
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    (api.purchaseOrderAPI.listOrders as jest.Mock).mockResolvedValue({
+      data: { results: orders },
+    });
+  });
+
+  // PO numbers in render order (the first body cell of each non-header row).
+  const renderedPoNumbers = () =>
+    screen
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => within(row).getAllByRole('cell')[0].textContent);
+
+  const loadPage = async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('PO-2026-001')).toBeInTheDocument();
+    });
+  };
+
+  it('defaults to Order Date descending (newest first)', async () => {
+    await loadPage();
+
+    expect(renderedPoNumbers()).toEqual(['PO-2026-002', 'PO-2026-003', 'PO-2026-001']);
+    expect(screen.getByRole('columnheader', { name: 'Order Date' })).toHaveAttribute(
+      'aria-sort',
+      'descending'
+    );
+    // Inactive sortable columns advertise themselves via aria-sort="none".
+    expect(screen.getByRole('columnheader', { name: 'PO Number' })).toHaveAttribute(
+      'aria-sort',
+      'none'
+    );
+  });
+
+  it('sorts by PO Number ascending on click, then toggles to descending', async () => {
+    await loadPage();
+
+    await userEvent.click(screen.getByRole('button', { name: 'PO Number' }));
+    expect(renderedPoNumbers()).toEqual(['PO-2026-001', 'PO-2026-002', 'PO-2026-003']);
+    expect(screen.getByRole('columnheader', { name: 'PO Number' })).toHaveAttribute(
+      'aria-sort',
+      'ascending'
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'PO Number' }));
+    expect(renderedPoNumbers()).toEqual(['PO-2026-003', 'PO-2026-002', 'PO-2026-001']);
+    expect(screen.getByRole('columnheader', { name: 'PO Number' })).toHaveAttribute(
+      'aria-sort',
+      'descending'
+    );
+  });
+
+  it('sorts Estimated Total numerically rather than lexically', async () => {
+    await loadPage();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Estimated Total' }));
+    // 300 < 1250 < 9999 — a string sort would place '1250' before '300'.
+    expect(renderedPoNumbers()).toEqual(['PO-2026-002', 'PO-2026-001', 'PO-2026-003']);
+  });
+
+  it('keeps blank Actual Total rows last in both sort directions', async () => {
+    await loadPage();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Actual Total' }));
+    // asc: 50, 1000, then the null (po-2) sorted last.
+    expect(renderedPoNumbers()).toEqual(['PO-2026-003', 'PO-2026-001', 'PO-2026-002']);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Actual Total' }));
+    // desc: 1000, 50, with the null (po-2) still last.
+    expect(renderedPoNumbers()).toEqual(['PO-2026-001', 'PO-2026-003', 'PO-2026-002']);
   });
 });

--- a/frontend/src/pages/PurchaseOrderListPage.tsx
+++ b/frontend/src/pages/PurchaseOrderListPage.tsx
@@ -3,7 +3,7 @@
  * Shows all active and settled purchase orders for transparency
  */
 import { Button, Group, Paper, Text } from '@mantine/core';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import { purchaseOrderAPI } from '../services/api';
@@ -26,11 +26,87 @@ interface PurchaseOrder {
   is_fully_received: boolean;
 }
 
+type SortDirection = 'asc' | 'desc';
+type SortType = 'string' | 'number' | 'date';
+
+interface SortableColumn {
+  key: string;
+  label: string;
+  type: SortType;
+  getValue: (order: PurchaseOrder) => string | number | null;
+}
+
+// Sortable header cells, in display order. The non-sortable "Actions" column is
+// rendered separately after this list. The list loads every order up front, so
+// sorting happens entirely client-side over the in-memory array.
+const SORTABLE_COLUMNS: SortableColumn[] = [
+  { key: 'po_number', label: 'PO Number', type: 'string', getValue: (order) => order.po_number },
+  { key: 'supplier', label: 'Supplier', type: 'string', getValue: (order) => order.supplier_details },
+  { key: 'status', label: 'Status', type: 'string', getValue: (order) => order.status_label },
+  { key: 'order_date', label: 'Order Date', type: 'date', getValue: (order) => order.order_date },
+  {
+    key: 'expected_delivery',
+    label: 'Expected Delivery',
+    type: 'date',
+    getValue: (order) => order.expected_delivery_date,
+  },
+  { key: 'items', label: 'Items', type: 'number', getValue: (order) => order.total_items },
+  {
+    key: 'estimated_total',
+    label: 'Estimated Total',
+    type: 'number',
+    getValue: (order) => order.estimated_total,
+  },
+  { key: 'actual_total', label: 'Actual Total', type: 'number', getValue: (order) => order.actual_total },
+];
+
+// Normalise a column's raw value for comparison. Missing values (null/empty
+// string) and unparseable numbers/dates collapse to null so they can always be
+// ordered last, regardless of sort direction.
+const toComparable = (order: PurchaseOrder, column: SortableColumn): number | string | null => {
+  const raw = column.getValue(order);
+  if (raw === null || raw === undefined || raw === '') return null;
+  if (column.type === 'number') {
+    const num = parseFloat(String(raw));
+    return Number.isNaN(num) ? null : num;
+  }
+  if (column.type === 'date') {
+    const time = new Date(String(raw)).getTime();
+    return Number.isNaN(time) ? null : time;
+  }
+  return String(raw);
+};
+
+// Compare two orders by a single column + direction. Empty values always sort
+// last so blank rows never jump to the top when the direction is reversed.
+const compareByColumn = (
+  a: PurchaseOrder,
+  b: PurchaseOrder,
+  column: SortableColumn,
+  direction: SortDirection
+): number => {
+  const va = toComparable(a, column);
+  const vb = toComparable(b, column);
+  if (va === null && vb === null) return 0;
+  if (va === null) return 1;
+  if (vb === null) return -1;
+  let result: number;
+  if (typeof va === 'number' && typeof vb === 'number') {
+    result = va - vb;
+  } else {
+    result = String(va).localeCompare(String(vb));
+  }
+  return direction === 'asc' ? result : -result;
+};
+
 const PurchaseOrderListPage: React.FC = () => {
   const [orders, setOrders] = useState<PurchaseOrder[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<string>('');
+  // Default to newest-first by order date; click a header to re-sort.
+  const [sortColumn, setSortColumn] = useState<string>('order_date');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
 
   const loadOrders = useCallback(async () => {
     try {
@@ -85,6 +161,23 @@ const PurchaseOrderListPage: React.FC = () => {
     };
     return statusMap[status] || 'status-default';
   };
+
+  // Clicking the active column toggles direction; a new column starts ascending.
+  const handleSort = (key: string) => {
+    if (sortColumn === key) {
+      setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortColumn(key);
+      setSortDirection('asc');
+    }
+  };
+
+  // Sort a copy of the loaded orders; never mutate state or refetch.
+  const sortedOrders = useMemo(() => {
+    const column = SORTABLE_COLUMNS.find((c) => c.key === sortColumn);
+    if (!column) return orders;
+    return [...orders].sort((a, b) => compareByColumn(a, b, column, sortDirection));
+  }, [orders, sortColumn, sortDirection]);
 
   return (
     <WorkspacePage
@@ -172,19 +265,38 @@ const PurchaseOrderListPage: React.FC = () => {
           <table className="orders-table">
             <thead>
               <tr>
-                <th>PO Number</th>
-                <th>Supplier</th>
-                <th>Status</th>
-                <th>Order Date</th>
-                <th>Expected Delivery</th>
-                <th>Items</th>
-                <th>Estimated Total</th>
-                <th>Actual Total</th>
-                <th>Actions</th>
+                {SORTABLE_COLUMNS.map((column) => {
+                  const active = sortColumn === column.key;
+                  const ariaSort: 'ascending' | 'descending' | 'none' = active
+                    ? sortDirection === 'asc'
+                      ? 'ascending'
+                      : 'descending'
+                    : 'none';
+                  return (
+                    <th key={column.key} scope="col" aria-sort={ariaSort}>
+                      <button
+                        type="button"
+                        className="po-sort-header"
+                        onClick={() => handleSort(column.key)}
+                      >
+                        <span>{column.label}</span>
+                        <span
+                          className={`po-sort-indicator${
+                            active ? '' : ' po-sort-indicator-inactive'
+                          }`}
+                          aria-hidden="true"
+                        >
+                          {active ? (sortDirection === 'asc' ? '▲' : '▼') : '↕'}
+                        </span>
+                      </button>
+                    </th>
+                  );
+                })}
+                <th scope="col">Actions</th>
               </tr>
             </thead>
             <tbody>
-              {orders.map((order) => (
+              {sortedOrders.map((order) => (
                 <tr key={order.id}>
                   <td className="po-number">{order.po_number}</td>
                   <td>{order.supplier_details}</td>

--- a/frontend/src/styles/PurchaseOrderListPage.css
+++ b/frontend/src/styles/PurchaseOrderListPage.css
@@ -144,6 +144,42 @@
   letter-spacing: 0.05em;
 }
 
+/* Sortable headers render a borderless button that inherits the th's type
+   styling, so the column looks unchanged until you hover/focus it. */
+.po-sort-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  color: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  cursor: pointer;
+}
+
+.po-sort-header:hover {
+  color: #1e293b;
+}
+
+.po-sort-header:focus-visible {
+  outline: 2px solid #667eea;
+  outline-offset: 2px;
+  border-radius: 0.25rem;
+}
+
+.po-sort-indicator {
+  font-size: 0.7rem;
+  line-height: 1;
+  color: #667eea;
+}
+
+.po-sort-indicator-inactive {
+  color: #cbd5e1;
+}
+
 .orders-table td {
   padding: 1rem;
   border-top: 1px solid #e2e8f0;


### PR DESCRIPTION
Lands work bead **oms-xwo8n** — Sortable Purchase Orders table (click column headers to sort: PO#, Order Date, Total).

## Scope (frontend feature; integrates cleanly on current main 35275a8)
- PurchaseOrderListPage.tsx: client-side sortable table — per-type comparators (string/date/number), null/empty sort-last, keyboard-accessible <button> headers with aria-sort, default Order Date desc
- PurchaseOrderListPage.css + component tests
- No deps, no migrations (built on R3 PO-list tests already on main)

## Refinery gates
- CI-gated (production UI change): Frontend Tests + E2E + Lint + Build must go green.

Bead strategy direct; main is PR-only, landed by refinery via squash once CI is green. — oms/gastown.refinery