### PR TITLE
chore(beads): untrack vestigial .beads/redirect (oms-4tc7y)

### DIFF
--- a/.beads/redirect
+++ b/.beads/redirect
@@ -1,1 +1,0 @@
-../../../mayor/rig/.beads

--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,6 @@ Thumbs.db
 .runtime/
 .claude/
 .beads/*
-!.beads/redirect
 !.beads/routes.jsonl
 
 # Per-developer overrides (CLAUDE.md itself is committed — project conventions)


### PR DESCRIPTION
Untracks the canonical `.beads/redirect` runtime file (bead **oms-4tc7y**). It was force-tracked via `!.beads/redirect` in .gitignore with a bad relative value (`../../../mayor/rig/.beads`) that resolves nowhere — trips `bd doctor` and risks a silent merge-queue hijack if that path ever exists.

**Verified safe to untrack:** `worktree-setup.sh:158` provisions a correct per-worktree redirect (`echo $RIG_ROOT/.beads > $WT/.beads/redirect`) at setup and git-excludes it, so the git-tracked copy is vestigial — new worktrees get their redirect from the setup script, not from git. Local canonical mitigation already applied; this is the durable repo fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)