### PR TITLE
fix(membership): guard is_valid() against None expires_at (BACKEND-P)

### DIFF
--- a/backend/membership/models.py
+++ b/backend/membership/models.py
@@ -380,7 +380,10 @@ class UserRegistrationToken(models.Model):
         """Check if token is valid (not used and not expired)."""
         if self.used:
             return False
-        if timezone.now() > self.expires_at:
+        # A token with no expiry set (e.g. an unsaved instance rendered by the
+        # admin add page) is not valid. Guards against comparing a datetime to
+        # None, which raised TypeError on /admin/.../userregistrationtoken/add/.
+        if self.expires_at is None or timezone.now() > self.expires_at:
             return False
         return True
 

--- a/backend/membership/tests/test_registration_token.py
+++ b/backend/membership/tests/test_registration_token.py
@@ -86,6 +86,18 @@ class TestUserRegistrationToken:
 
         assert token.is_valid() is False
 
+    def test_token_is_invalid_when_no_expiry(self):
+        """Regression (BACKEND-P): an unsaved token has expires_at=None.
+
+        The Django admin add page renders the is_valid()-based readonly
+        display methods (qr_code_preview, is_valid_display, qr_code_link)
+        against an empty instance. is_valid() must return False, not raise
+        TypeError comparing timezone.now() to None.
+        """
+        token = UserRegistrationToken()
+
+        assert token.is_valid() is False
+
     def test_token_registration_url(self):
         """Test registration URL generation."""
         user = User.objects.create_user(


### PR DESCRIPTION
## Problem
`/admin/membership/userregistrationtoken/add/` returns 500 (Sentry **BACKEND-P**):
`TypeError: '>' not supported between instances of 'datetime.datetime' and 'NoneType'`.

## Root cause
`UserRegistrationToken.is_valid()` does `timezone.now() > self.expires_at`. The admin **add** page renders the `is_valid()`-based readonly display methods (`qr_code_preview`, `is_valid_display`, `qr_code_link`) against an **unsaved** instance whose `expires_at` is `None` → TypeError.

## Fix
Guard `is_valid()`: a token with no expiry set is not valid (covers all three callers). Adds a regression test (`test_token_is_invalid_when_no_expiry`).

No schema change. Fixes Sentry BACKEND-P.