### PR TITLE
feat(frontend): indicator binding, room mode, and live-preview UI

### DIFF
--- a/frontend/src/__tests__/components/IndicatorManagementCard.test.tsx
+++ b/frontend/src/__tests__/components/IndicatorManagementCard.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * Tests for IndicatorManagementCard (epic ga-72l): gating to indicator devices,
+ * rendering a binding, the bind / unbind / sync / test actions firing the right
+ * API calls, and the live-preview legend.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import IndicatorManagementCard from '../../components/IndicatorManagementCard';
+import { assetsAPI, forgekeyAPI, inventoryAPI } from '../../services/api';
+
+vi.mock('../../utils/dialogs', async () => ({
+  showError: jest.fn(),
+  showSuccess: jest.fn(),
+  // Auto-confirm so the unbind path runs in tests.
+  confirmAction: (_t: string, _m: string, onConfirm: () => void) => onConfirm(),
+}));
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    forgekeyAPI: {
+      ...(actual as any).forgekeyAPI,
+      listDeviceTypes: jest.fn(),
+      listIndicatorBindings: jest.fn(),
+      createIndicatorBinding: jest.fn(),
+      deleteIndicatorBinding: jest.fn(),
+      indicatorSync: jest.fn(),
+      indicatorTest: jest.fn(),
+    },
+    assetsAPI: {
+      ...(actual as any).assetsAPI,
+      listAssets: jest.fn(),
+    },
+    inventoryAPI: {
+      ...(actual as any).inventoryAPI,
+      listLocations: jest.fn(),
+    },
+  };
+});
+
+const mockApi = forgekeyAPI as jest.Mocked<typeof forgekeyAPI>;
+const mockAssets = assetsAPI as jest.Mocked<typeof assetsAPI>;
+const mockInventory = inventoryAPI as jest.Mocked<typeof inventoryAPI>;
+
+const INDICATOR_TYPE = { id: 9, name: 'Indicator/Status Light', code: 'indicator' };
+
+const buildDevice = (overrides: Partial<any> = {}) => ({
+  id: 'ind-1',
+  mac_address: 'AA:BB:CC:DD:EE:01',
+  device_type: 9,
+  device_type_name: 'Indicator/Status Light',
+  name: 'Bay light',
+  description: '',
+  firmware_version: '1.0.0',
+  last_seen: '2026-06-01T00:00:00Z',
+  is_online: true,
+  is_active: true,
+  location: null,
+  enrollment_photo: null,
+  last_photo: null,
+  boot_count: 1,
+  free_heap: null,
+  ip: null,
+  capabilities: [],
+  capabilities_announced_at: null,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-06-01T00:00:00Z',
+  ...overrides,
+});
+
+const buildBinding = (overrides: Partial<any> = {}) => ({
+  id: 'bind-1',
+  device: 'ind-1',
+  device_mac_address: 'AA:BB:CC:DD:EE:01',
+  device_name: 'Bay light',
+  asset: 'asset-1',
+  asset_name: 'Table Saw',
+  location: null,
+  location_name: null,
+  last_status: 'in_use',
+  last_presentation: { cmd: 'set_indicator', color: 'green', brightness: 'high', pattern: 'solid' },
+  last_synced_at: '2026-06-02T00:00:00Z',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-06-02T00:00:00Z',
+  ...overrides,
+});
+
+const renderCard = (device = buildDevice()) =>
+  render(
+    <MantineProvider>
+      <IndicatorManagementCard device={device as any} />
+    </MantineProvider>,
+  );
+
+describe('IndicatorManagementCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApi.listDeviceTypes.mockResolvedValue({ data: [INDICATOR_TYPE] } as any);
+    mockApi.listIndicatorBindings.mockResolvedValue({ data: [] } as any);
+    mockAssets.listAssets.mockResolvedValue({
+      data: { count: 1, next: null, previous: null, results: [
+        { id: 'asset-1', name: 'Table Saw', asset_tag: 'TS-1' },
+      ] },
+    } as any);
+    mockInventory.listLocations.mockResolvedValue({
+      data: [{ id: 5, name: 'Wood Shop' }],
+    } as any);
+  });
+
+  it('renders nothing for a non-indicator device', async () => {
+    const device = buildDevice({ device_type: 1, device_type_name: 'people_counter' });
+    renderCard(device);
+    await waitFor(() => expect(mockApi.listDeviceTypes).toHaveBeenCalled());
+    expect(screen.queryByTestId('indicator-management')).not.toBeInTheDocument();
+  });
+
+  it('renders the current binding with its derived light state', async () => {
+    mockApi.listIndicatorBindings.mockResolvedValue({ data: [buildBinding()] } as any);
+    renderCard();
+
+    await screen.findByTestId('indicator-binding');
+    expect(screen.getByTestId('indicator-target-name')).toHaveTextContent('Table Saw');
+    expect(screen.getByTestId('indicator-current-status')).toHaveTextContent('In use');
+    expect(screen.getByTestId('indicator-current-swatch')).toBeInTheDocument();
+    // Legend is always shown.
+    expect(screen.getByTestId('indicator-legend')).toBeInTheDocument();
+  });
+
+  it('syncs the bound indicator', async () => {
+    mockApi.listIndicatorBindings.mockResolvedValue({ data: [buildBinding()] } as any);
+    mockApi.indicatorSync.mockResolvedValue({
+      data: { status: 'available', presentation: {}, command_id: 'cmd-9' },
+    } as any);
+    renderCard();
+
+    fireEvent.click(await screen.findByTestId('indicator-sync-btn'));
+    await waitFor(() => expect(mockApi.indicatorSync).toHaveBeenCalledWith('bind-1'));
+  });
+
+  it('unbinds the indicator after confirm', async () => {
+    mockApi.listIndicatorBindings.mockResolvedValue({ data: [buildBinding()] } as any);
+    mockApi.deleteIndicatorBinding.mockResolvedValue({} as any);
+    renderCard();
+
+    fireEvent.click(await screen.findByTestId('indicator-unbind-btn'));
+    await waitFor(() => expect(mockApi.deleteIndicatorBinding).toHaveBeenCalledWith('bind-1'));
+  });
+
+  it('binds the indicator to an asset', async () => {
+    mockApi.createIndicatorBinding.mockResolvedValue({} as any);
+    renderCard();
+
+    await screen.findByTestId('indicator-bind-form');
+    fireEvent.click(screen.getByPlaceholderText('Pick an asset'));
+    fireEvent.click(await screen.findByRole('option', { name: 'Table Saw (TS-1)' }));
+    fireEvent.click(screen.getByTestId('indicator-bind-btn'));
+
+    await waitFor(() =>
+      expect(mockApi.createIndicatorBinding).toHaveBeenCalledWith({
+        device: 'ind-1',
+        asset: 'asset-1',
+      }),
+    );
+  });
+
+  it('binds the indicator to a room', async () => {
+    mockApi.createIndicatorBinding.mockResolvedValue({} as any);
+    renderCard();
+
+    await screen.findByTestId('indicator-bind-form');
+    fireEvent.click(screen.getByText('Room'));
+    fireEvent.click(screen.getByPlaceholderText('Pick a room'));
+    fireEvent.click(await screen.findByRole('option', { name: 'Wood Shop' }));
+    fireEvent.click(screen.getByTestId('indicator-bind-btn'));
+
+    await waitFor(() =>
+      expect(mockApi.createIndicatorBinding).toHaveBeenCalledWith({
+        device: 'ind-1',
+        location: 5,
+      }),
+    );
+  });
+
+  it('sends a manual test with the chosen presentation', async () => {
+    mockApi.indicatorTest.mockResolvedValue({
+      data: { status: 'sent', device: 'AA:BB:CC:DD:EE:01', command_id: 'cmd-1', payload: { pattern: 'solid' } },
+    } as any);
+    renderCard();
+
+    fireEvent.click(await screen.findByTestId('indicator-test-btn'));
+    await waitFor(() =>
+      expect(mockApi.indicatorTest).toHaveBeenCalledWith('ind-1', {
+        brightness: 'high',
+        pattern: 'solid',
+        color: 'green',
+      }),
+    );
+  });
+});

--- a/frontend/src/__tests__/components/RoomOperationalModeControl.test.tsx
+++ b/frontend/src/__tests__/components/RoomOperationalModeControl.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Tests for RoomOperationalModeControl (epic ga-72l): rendering the current
+ * room mode + legend, creating a mode when none exists, updating an existing
+ * one, and the staff-only gating.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import RoomOperationalModeControl from '../../components/RoomOperationalModeControl';
+import { forgekeyAPI } from '../../services/api';
+
+vi.mock('../../utils/dialogs', async () => ({
+  showError: jest.fn(),
+  showSuccess: jest.fn(),
+}));
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    forgekeyAPI: {
+      ...(actual as any).forgekeyAPI,
+      listRoomOperationalModes: jest.fn(),
+      createRoomOperationalMode: jest.fn(),
+      setRoomOperationalMode: jest.fn(),
+    },
+  };
+});
+
+const mockApi = forgekeyAPI as jest.Mocked<typeof forgekeyAPI>;
+
+const buildMode = (overrides: Partial<any> = {}) => ({
+  id: 7,
+  location: 5,
+  location_name: 'Wood Shop',
+  mode: 'available',
+  updated_by: 2,
+  updated_by_username: 'bob',
+  updated_at: '2026-06-01T00:00:00Z',
+  ...overrides,
+});
+
+const renderControl = () =>
+  render(
+    <MantineProvider>
+      <RoomOperationalModeControl locationId={5} locationName="Wood Shop" />
+    </MantineProvider>,
+  );
+
+const pickMode = async (label: string) => {
+  fireEvent.click(screen.getByLabelText('Set mode'));
+  fireEvent.click(await screen.findByRole('option', { name: label }));
+};
+
+describe('RoomOperationalModeControl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.setItem('is_staff', 'true');
+  });
+
+  afterEach(() => {
+    localStorage.removeItem('is_staff');
+    localStorage.removeItem('is_superuser');
+  });
+
+  it('renders the current mode and the legend', async () => {
+    mockApi.listRoomOperationalModes.mockResolvedValue({
+      data: [buildMode({ mode: 'locked_out' })],
+    } as any);
+    renderControl();
+
+    await screen.findByTestId('room-operational-mode');
+    expect(screen.getByTestId('room-mode-current')).toHaveTextContent('Locked out');
+    expect(screen.getByTestId('room-mode-swatch')).toBeInTheDocument();
+    expect(screen.getByTestId('indicator-legend')).toBeInTheDocument();
+  });
+
+  it('creates a room mode when none exists yet', async () => {
+    mockApi.listRoomOperationalModes.mockResolvedValue({ data: [] } as any);
+    mockApi.createRoomOperationalMode.mockResolvedValue({} as any);
+    renderControl();
+
+    await screen.findByTestId('room-operational-mode');
+    await pickMode('In use');
+    fireEvent.click(screen.getByTestId('room-mode-save'));
+
+    await waitFor(() =>
+      expect(mockApi.createRoomOperationalMode).toHaveBeenCalledWith({
+        location: 5,
+        mode: 'in_use',
+      }),
+    );
+  });
+
+  it('updates an existing room mode', async () => {
+    mockApi.listRoomOperationalModes.mockResolvedValue({ data: [buildMode()] } as any);
+    mockApi.setRoomOperationalMode.mockResolvedValue({} as any);
+    renderControl();
+
+    await screen.findByTestId('room-operational-mode');
+    await pickMode('In use for a class');
+    fireEvent.click(screen.getByTestId('room-mode-save'));
+
+    await waitFor(() =>
+      expect(mockApi.setRoomOperationalMode).toHaveBeenCalledWith(7, 'classroom'),
+    );
+  });
+
+  it('disables editing for non-staff users', async () => {
+    localStorage.removeItem('is_staff');
+    mockApi.listRoomOperationalModes.mockResolvedValue({ data: [buildMode()] } as any);
+    renderControl();
+
+    await screen.findByTestId('room-operational-mode');
+    expect(screen.getByTestId('room-mode-save')).toBeDisabled();
+    expect(
+      screen.getByText('Staff access is required to change the room mode.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/ForgeKeyDeviceDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyDeviceDetailPage.test.tsx
@@ -28,6 +28,10 @@ vi.mock('../../services/api', async () => {
       ping: jest.fn(),
       identify: jest.fn(),
       recentCommands: jest.fn(),
+      // IndicatorManagementCard (mounted for indicator devices) probes these on
+      // load; the test device is a people_counter, so it renders nothing.
+      listDeviceTypes: jest.fn(),
+      listIndicatorBindings: jest.fn(),
     },
   };
 });
@@ -111,6 +115,9 @@ describe('ForgeKeyDeviceDetailPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.setItem('is_staff', 'true');
+    // Default: no indicator device type, so IndicatorManagementCard is inert.
+    mockApi.listDeviceTypes.mockResolvedValue({ data: [] } as any);
+    mockApi.listIndicatorBindings.mockResolvedValue({ data: [] } as any);
   });
 
   afterEach(() => {

--- a/frontend/src/__tests__/utils/indicatorPresentation.test.ts
+++ b/frontend/src/__tests__/utils/indicatorPresentation.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the indicator presentation policy (epic ga-72l). These lock
+ * the frontend mirror to the backend ``PRESENTATIONS`` table so the on-screen
+ * swatch/legend can't silently drift from what firmware actually renders.
+ */
+import {
+  INDICATOR_PRESENTATIONS,
+  INDICATOR_STATUS_ORDER,
+  brightnessOpacity,
+  isBlinkPattern,
+  resolveColorHex,
+  statusLabel,
+  swatchVisualForPresentation,
+  swatchVisualForStatus,
+} from '../../utils/indicatorPresentation';
+
+describe('indicatorPresentation', () => {
+  it('mirrors the canonical ga-72l status → presentation mapping', () => {
+    expect(INDICATOR_PRESENTATIONS.available).toEqual({
+      color: 'green',
+      brightness: 'low',
+      pattern: 'solid',
+      period_ms: null,
+    });
+    expect(INDICATOR_PRESENTATIONS.in_use).toEqual({
+      color: 'green',
+      brightness: 'high',
+      pattern: 'solid',
+      period_ms: null,
+    });
+    expect(INDICATOR_PRESENTATIONS.unavailable).toEqual({
+      color: 'red',
+      brightness: 'low',
+      pattern: 'solid',
+      period_ms: null,
+    });
+    expect(INDICATOR_PRESENTATIONS.locked_out).toEqual({
+      color: null,
+      brightness: null,
+      pattern: 'off',
+      period_ms: null,
+    });
+    expect(INDICATOR_PRESENTATIONS.classroom).toEqual({
+      color: 'purple',
+      brightness: 'high',
+      pattern: 'slow_blink',
+      period_ms: 1500,
+    });
+  });
+
+  it('orders the five statuses for the legend', () => {
+    expect(INDICATOR_STATUS_ORDER).toEqual([
+      'available',
+      'in_use',
+      'unavailable',
+      'locked_out',
+      'classroom',
+    ]);
+  });
+
+  it('derives swatch visuals from a status', () => {
+    const available = swatchVisualForStatus('available');
+    const inUse = swatchVisualForStatus('in_use');
+    expect(available.isOff).toBe(false);
+    expect(available.blink).toBe(false);
+    // Low brightness is dimmer than high.
+    expect(available.opacity).toBeLessThan(inUse.opacity);
+
+    expect(swatchVisualForStatus('classroom').blink).toBe(true);
+
+    const lockedOut = swatchVisualForStatus('locked_out');
+    expect(lockedOut.isOff).toBe(true);
+    expect(lockedOut.blink).toBe(false);
+  });
+
+  it('derives swatch visuals from an explicit presentation', () => {
+    expect(swatchVisualForPresentation({ pattern: 'off' }).isOff).toBe(true);
+    const preview = swatchVisualForPresentation({
+      color: 'green',
+      brightness: 'high',
+      pattern: 'solid',
+    });
+    expect(preview.isOff).toBe(false);
+    expect(preview.blink).toBe(false);
+    expect(preview.background).toBe('#2f9e44');
+    expect(swatchVisualForPresentation(null).isOff).toBe(true);
+  });
+
+  it('resolves firmware colors to CSS', () => {
+    expect(resolveColorHex('green')).toBe('#2f9e44');
+    expect(resolveColorHex('#abcdef')).toBe('#abcdef');
+    expect(resolveColorHex([1, 2, 3])).toBe('rgb(1, 2, 3)');
+    expect(resolveColorHex(null)).toBeNull();
+    expect(resolveColorHex([1, 2])).toBeNull();
+  });
+
+  it('maps brightness to opacity', () => {
+    expect(brightnessOpacity('high')).toBe(1);
+    expect(brightnessOpacity('low')).toBeLessThan(1);
+    expect(brightnessOpacity(255)).toBe(1);
+    expect(brightnessOpacity(null)).toBe(1);
+  });
+
+  it('recognises animating patterns', () => {
+    expect(isBlinkPattern('slow_blink')).toBe(true);
+    expect(isBlinkPattern('blink')).toBe(true);
+    expect(isBlinkPattern('breathe')).toBe(true);
+    expect(isBlinkPattern('solid')).toBe(false);
+    expect(isBlinkPattern('off')).toBe(false);
+    expect(isBlinkPattern(null)).toBe(false);
+  });
+
+  it('labels statuses, including the pre-sync empty value', () => {
+    expect(statusLabel('')).toBe('Not yet synced');
+    expect(statusLabel('available')).toBe('Available');
+    expect(statusLabel('in_use')).toBe('In use');
+    expect(statusLabel('classroom')).toBe('In use for a class');
+  });
+});

--- a/frontend/src/components/IndicatorManagementCard.tsx
+++ b/frontend/src/components/IndicatorManagementCard.tsx
@@ -1,0 +1,445 @@
+/**
+ * IndicatorManagementCard
+ *
+ * Device-detail panel for a ForgeKey *indicator* device (epic ga-72l). Lets an
+ * admin:
+ *   - bind the light to an asset XOR a room (and unbind),
+ *   - see the derived / last-pushed light state and re-sync it ("Sync now"),
+ *   - send an explicit color/brightness/pattern preview ("Test light"),
+ *   - read the color/pattern legend.
+ *
+ * Renders nothing for non-indicator devices, so the device-detail page can
+ * mount it unconditionally.
+ */
+import {
+  Badge,
+  Button,
+  Card,
+  Group,
+  NumberInput,
+  SegmentedControl,
+  Select,
+  Stack,
+  Text,
+} from '@mantine/core';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import IndicatorStatusLegend from './IndicatorStatusLegend';
+import IndicatorSwatch from './IndicatorSwatch';
+import {
+  ForgeKeyDevice,
+  ForgeKeyDeviceType,
+  ForgeKeyIndicatorBinding,
+  ForgeKeyIndicatorSyncResponse,
+  ForgeKeyIndicatorTestResponse,
+  assetsAPI,
+  forgekeyAPI,
+  inventoryAPI,
+} from '../services/api';
+import { Asset, Location } from '../types';
+import { confirmAction, showError, showSuccess } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+import { isBlinkPattern, statusLabel } from '../utils/indicatorPresentation';
+
+interface Props {
+  device: ForgeKeyDevice;
+  onChanged?: () => void;
+}
+
+// Default name the indicator DeviceType ships with; used as a fallback when the
+// device-types lookup can't resolve the stable ``indicator`` code.
+const INDICATOR_TYPE_NAME = 'Indicator/Status Light';
+
+const STATUS_BADGE_COLORS: Record<string, string> = {
+  available: 'green',
+  in_use: 'teal',
+  unavailable: 'red',
+  locked_out: 'dark',
+  classroom: 'grape',
+};
+
+const TEST_COLORS = ['green', 'red', 'purple', 'blue', 'yellow', 'white'];
+const TEST_BRIGHTNESS = ['low', 'high'];
+const TEST_PATTERNS = ['solid', 'blink', 'slow_blink', 'breathe', 'off'];
+
+function unwrap<T>(data: { results?: T[] } | T[]): T[] {
+  if (Array.isArray(data)) return data;
+  return data.results ?? [];
+}
+
+function titleCase(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1).replace(/_/g, ' ');
+}
+
+export default function IndicatorManagementCard({ device, onChanged }: Props) {
+  const [loading, setLoading] = useState(true);
+  const [isIndicator, setIsIndicator] = useState(false);
+  const [binding, setBinding] = useState<ForgeKeyIndicatorBinding | null>(null);
+  const [assets, setAssets] = useState<Asset[]>([]);
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const [targetKind, setTargetKind] = useState<'asset' | 'room'>('asset');
+  const [targetAsset, setTargetAsset] = useState<string | null>(null);
+  const [targetRoom, setTargetRoom] = useState<string | null>(null);
+
+  const [testColor, setTestColor] = useState<string>('green');
+  const [testBrightness, setTestBrightness] = useState<string>('high');
+  const [testPattern, setTestPattern] = useState<string>('solid');
+  const [testPeriod, setTestPeriod] = useState<number | string>(1500);
+
+  const [syncResult, setSyncResult] = useState<ForgeKeyIndicatorSyncResponse | null>(null);
+  const [testResult, setTestResult] = useState<ForgeKeyIndicatorTestResponse | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const typesRes = await forgekeyAPI.listDeviceTypes();
+      const types = unwrap<ForgeKeyDeviceType>(typesRes.data);
+      const indicatorType = types.find((t) => t.code === 'indicator');
+      const indicator =
+        (indicatorType != null && device.device_type === indicatorType.id) ||
+        device.device_type_name === INDICATOR_TYPE_NAME;
+      setIsIndicator(indicator);
+      if (!indicator) {
+        setBinding(null);
+        return;
+      }
+      const bindRes = await forgekeyAPI.listIndicatorBindings({ device: device.id });
+      const existing = unwrap<ForgeKeyIndicatorBinding>(bindRes.data)[0] ?? null;
+      setBinding(existing);
+      if (!existing) {
+        const [assetRes, locRes] = await Promise.all([
+          assetsAPI.listAssets({ page_size: 200, ordering: 'name' }),
+          inventoryAPI.listLocations(),
+        ]);
+        setAssets(assetRes.data.results ?? []);
+        setLocations(unwrap<Location>(locRes.data));
+      }
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Failed to load indicator settings.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [device.id, device.device_type, device.device_type_name]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const reload = useCallback(async () => {
+    await load();
+    onChanged?.();
+  }, [load, onChanged]);
+
+  const assetOptions = useMemo(
+    () =>
+      assets.map((a) => ({
+        value: a.id,
+        label: a.asset_tag ? `${a.name} (${a.asset_tag})` : a.name,
+      })),
+    [assets],
+  );
+  const roomOptions = useMemo(
+    () => locations.map((l) => ({ value: String(l.id), label: l.name })),
+    [locations],
+  );
+
+  const onBind = async () => {
+    const body =
+      targetKind === 'asset'
+        ? targetAsset && { device: device.id, asset: targetAsset }
+        : targetRoom && { device: device.id, location: Number(targetRoom) };
+    if (!body) {
+      showError('Pick an asset or a room to bind to.');
+      return;
+    }
+    setBusy('bind');
+    try {
+      await forgekeyAPI.createIndicatorBinding(body);
+      showSuccess('Indicator bound.');
+      setTargetAsset(null);
+      setTargetRoom(null);
+      await reload();
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Bind failed.'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onSync = async () => {
+    if (!binding) return;
+    setBusy('sync');
+    try {
+      const res = await forgekeyAPI.indicatorSync(binding.id);
+      setSyncResult(res.data);
+      showSuccess('Indicator re-synced.');
+      await reload();
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Sync failed.'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onUnbind = () => {
+    if (!binding) return;
+    const label = binding.asset_name ?? binding.location_name ?? 'its target';
+    confirmAction(
+      'Unbind indicator',
+      `Unbind this light from ${label}?`,
+      async () => {
+        setBusy('unbind');
+        try {
+          await forgekeyAPI.deleteIndicatorBinding(binding.id);
+          showSuccess('Indicator unbound.');
+          setSyncResult(null);
+          await reload();
+        } catch (err) {
+          showError(extractErrorMessage(err, 'Unbind failed.'));
+        } finally {
+          setBusy(null);
+        }
+      },
+      { color: 'red' },
+    );
+  };
+
+  const onTest = async () => {
+    setBusy('test');
+    try {
+      const body: {
+        color?: string;
+        brightness?: string;
+        pattern?: string;
+        period_ms?: number;
+      } = { brightness: testBrightness, pattern: testPattern };
+      if (testPattern !== 'off') body.color = testColor;
+      if (isBlinkPattern(testPattern) && testPeriod) body.period_ms = Number(testPeriod);
+      const res = await forgekeyAPI.indicatorTest(device.id, body);
+      setTestResult(res.data);
+      showSuccess('Test command sent.');
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Test failed.'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (loading || !isIndicator) return null;
+
+  const previewPresentation = {
+    color: testPattern === 'off' ? null : testColor,
+    brightness: testBrightness,
+    pattern: testPattern,
+  };
+
+  return (
+    <Card withBorder radius="md" p="md" data-testid="indicator-management">
+      <Text fw={600}>Indicator light</Text>
+      <Text size="xs" c="dimmed" mb="md">
+        Bind this light to an asset or room, preview it, and re-sync its state.
+      </Text>
+
+      <Stack gap="lg">
+        {binding ? (
+          <div data-testid="indicator-binding">
+            <Group gap="xs" mb="xs">
+              <Text size="sm" fw={500}>
+                Bound to
+              </Text>
+              <Badge variant="light" color={binding.asset ? 'blue' : 'grape'}>
+                {binding.asset ? 'Asset' : 'Room'}
+              </Badge>
+              <Text size="sm" data-testid="indicator-target-name">
+                {binding.asset_name ?? binding.location_name ?? '—'}
+              </Text>
+            </Group>
+
+            <Group gap="xs" mb="xs">
+              <Text size="sm" fw={500}>
+                Current light
+              </Text>
+              {binding.last_status ? (
+                <>
+                  <IndicatorSwatch
+                    status={binding.last_status}
+                    testId="indicator-current-swatch"
+                  />
+                  <Badge
+                    color={STATUS_BADGE_COLORS[binding.last_status] ?? 'gray'}
+                    data-testid="indicator-current-status"
+                  >
+                    {statusLabel(binding.last_status)}
+                  </Badge>
+                </>
+              ) : (
+                <Text size="sm" c="dimmed" data-testid="indicator-current-status">
+                  Not yet synced
+                </Text>
+              )}
+              {binding.last_synced_at && (
+                <Text size="xs" c="dimmed">
+                  last synced {new Date(binding.last_synced_at).toLocaleString()}
+                </Text>
+              )}
+            </Group>
+
+            {syncResult && (
+              <Text size="xs" c="dimmed" mb="xs" data-testid="indicator-sync-result">
+                Synced: {statusLabel(syncResult.status)}
+                {syncResult.command_id ? ` · command ${syncResult.command_id}` : ''}
+              </Text>
+            )}
+
+            <Group gap="xs">
+              <Button
+                size="xs"
+                variant="light"
+                loading={busy === 'sync'}
+                onClick={onSync}
+                data-testid="indicator-sync-btn"
+              >
+                Sync now
+              </Button>
+              <Button
+                size="xs"
+                variant="light"
+                color="red"
+                loading={busy === 'unbind'}
+                onClick={onUnbind}
+                data-testid="indicator-unbind-btn"
+              >
+                Unbind
+              </Button>
+            </Group>
+          </div>
+        ) : (
+          <div data-testid="indicator-bind-form">
+            <Text size="sm" fw={500} mb="xs">
+              Not bound — bind this light to a target
+            </Text>
+            <Stack gap="xs">
+              <SegmentedControl
+                value={targetKind}
+                onChange={(v) => setTargetKind(v as 'asset' | 'room')}
+                data={[
+                  { label: 'Asset', value: 'asset' },
+                  { label: 'Room', value: 'room' },
+                ]}
+                data-testid="indicator-target-kind"
+              />
+              {targetKind === 'asset' ? (
+                <Select
+                  label="Asset"
+                  placeholder="Pick an asset"
+                  searchable
+                  data={assetOptions}
+                  value={targetAsset}
+                  onChange={setTargetAsset}
+                  aria-label="Asset"
+                  data-testid="indicator-asset-select"
+                />
+              ) : (
+                <Select
+                  label="Room"
+                  placeholder="Pick a room"
+                  searchable
+                  data={roomOptions}
+                  value={targetRoom}
+                  onChange={setTargetRoom}
+                  aria-label="Room"
+                  data-testid="indicator-room-select"
+                />
+              )}
+              <Group>
+                <Button
+                  size="xs"
+                  loading={busy === 'bind'}
+                  onClick={onBind}
+                  data-testid="indicator-bind-btn"
+                >
+                  Bind
+                </Button>
+              </Group>
+            </Stack>
+          </div>
+        )}
+
+        <div data-testid="indicator-test">
+          <Text size="sm" fw={500} mb="xs">
+            Test light
+          </Text>
+          <Group align="flex-end" gap="sm" wrap="wrap">
+            <Select
+              label="Color"
+              data={TEST_COLORS.map((c) => ({ value: c, label: titleCase(c) }))}
+              value={testColor}
+              onChange={(v) => setTestColor(v ?? 'green')}
+              w={120}
+              aria-label="Color"
+              data-testid="indicator-test-color"
+            />
+            <Select
+              label="Brightness"
+              data={TEST_BRIGHTNESS.map((b) => ({ value: b, label: titleCase(b) }))}
+              value={testBrightness}
+              onChange={(v) => setTestBrightness(v ?? 'high')}
+              w={120}
+              aria-label="Brightness"
+              data-testid="indicator-test-brightness"
+            />
+            <Select
+              label="Pattern"
+              data={TEST_PATTERNS.map((p) => ({ value: p, label: titleCase(p) }))}
+              value={testPattern}
+              onChange={(v) => setTestPattern(v ?? 'solid')}
+              w={130}
+              aria-label="Pattern"
+              data-testid="indicator-test-pattern"
+            />
+            {isBlinkPattern(testPattern) && (
+              <NumberInput
+                label="Period (ms)"
+                min={1}
+                max={60000}
+                value={testPeriod}
+                onChange={setTestPeriod}
+                w={120}
+                aria-label="Period (ms)"
+                data-testid="indicator-test-period"
+              />
+            )}
+            <Group gap="xs" pb={4}>
+              <Text size="xs" c="dimmed">
+                Preview
+              </Text>
+              <IndicatorSwatch
+                presentation={previewPresentation}
+                size={20}
+                testId="indicator-test-preview"
+              />
+            </Group>
+          </Group>
+          <Button
+            size="xs"
+            mt="sm"
+            variant="light"
+            loading={busy === 'test'}
+            onClick={onTest}
+            data-testid="indicator-test-btn"
+          >
+            Send test
+          </Button>
+          {testResult && (
+            <Text size="xs" c="dimmed" mt="xs" data-testid="indicator-test-result">
+              Sent {testResult.payload.pattern ?? ''} · command {testResult.command_id}
+            </Text>
+          )}
+        </div>
+
+        <IndicatorStatusLegend />
+      </Stack>
+    </Card>
+  );
+}

--- a/frontend/src/components/IndicatorStatusLegend.tsx
+++ b/frontend/src/components/IndicatorStatusLegend.tsx
@@ -1,0 +1,39 @@
+/**
+ * The indicator color/pattern legend — one row per operational status with a
+ * live swatch, label and plain-language description. Mirrors the ga-72l spec
+ * mapping so admins can map a light they see in the room to its meaning.
+ */
+import { Group, Stack, Text } from '@mantine/core';
+import IndicatorSwatch from './IndicatorSwatch';
+import {
+  INDICATOR_STATUS_DESCRIPTIONS,
+  INDICATOR_STATUS_LABELS,
+  INDICATOR_STATUS_ORDER,
+} from '../utils/indicatorPresentation';
+
+interface Props {
+  title?: string;
+}
+
+export default function IndicatorStatusLegend({ title = 'Light legend' }: Props) {
+  return (
+    <div data-testid="indicator-legend">
+      <Text size="sm" fw={500} mb="xs">
+        {title}
+      </Text>
+      <Stack gap={6}>
+        {INDICATOR_STATUS_ORDER.map((status) => (
+          <Group key={status} gap="xs" wrap="nowrap" data-testid={`legend-row-${status}`}>
+            <IndicatorSwatch status={status} testId={`legend-swatch-${status}`} />
+            <Text size="sm" fw={500}>
+              {INDICATOR_STATUS_LABELS[status]}
+            </Text>
+            <Text size="xs" c="dimmed">
+              — {INDICATOR_STATUS_DESCRIPTIONS[status]}
+            </Text>
+          </Group>
+        ))}
+      </Stack>
+    </div>
+  );
+}

--- a/frontend/src/components/IndicatorSwatch.css
+++ b/frontend/src/components/IndicatorSwatch.css
@@ -1,0 +1,21 @@
+.indicator-swatch {
+  display: inline-block;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  box-sizing: border-box;
+  flex: none;
+}
+
+.indicator-swatch--blink {
+  animation: indicator-swatch-blink 1.5s ease-in-out infinite;
+}
+
+@keyframes indicator-swatch-blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.2;
+  }
+}

--- a/frontend/src/components/IndicatorSwatch.tsx
+++ b/frontend/src/components/IndicatorSwatch.tsx
@@ -1,0 +1,52 @@
+/**
+ * A small colored dot that mirrors what a bound indicator light shows for a
+ * given status or presentation. Color, dimness (brightness) and a pulsing
+ * animation (blink patterns) follow the shared ga-72l presentation policy.
+ */
+import './IndicatorSwatch.css';
+import { ForgeKeyIndicatorPresentation, IndicatorStatusValue } from '../services/api';
+import {
+  IndicatorPresentationSpec,
+  swatchVisualForPresentation,
+  swatchVisualForStatus,
+} from '../utils/indicatorPresentation';
+
+interface Props {
+  /** Render the canonical presentation for this status… */
+  status?: IndicatorStatusValue;
+  /** …or an explicit presentation (derived/last-pushed or a manual preview). */
+  presentation?: ForgeKeyIndicatorPresentation | IndicatorPresentationSpec | null;
+  /** Diameter in px (default 16). */
+  size?: number;
+  title?: string;
+  testId?: string;
+}
+
+export default function IndicatorSwatch({
+  status,
+  presentation,
+  size = 16,
+  title,
+  testId,
+}: Props) {
+  const visual = status
+    ? swatchVisualForStatus(status)
+    : swatchVisualForPresentation(presentation);
+
+  return (
+    <span
+      className={`indicator-swatch${visual.blink ? ' indicator-swatch--blink' : ''}`}
+      data-testid={testId}
+      data-off={visual.isOff ? 'true' : 'false'}
+      data-blink={visual.blink ? 'true' : 'false'}
+      title={title}
+      aria-hidden="true"
+      style={{
+        width: size,
+        height: size,
+        background: visual.background,
+        opacity: visual.blink ? undefined : visual.opacity,
+      }}
+    />
+  );
+}

--- a/frontend/src/components/RoomOperationalModeControl.tsx
+++ b/frontend/src/components/RoomOperationalModeControl.tsx
@@ -1,0 +1,162 @@
+/**
+ * RoomOperationalModeControl
+ *
+ * Lets an admin set a room's manual operational mode (epic ga-72l). The chosen
+ * mode drives every indicator light bound to the room, so the control shows the
+ * current state with a swatch and the full color/pattern legend.
+ *
+ * Rooms have no derived status — the mode is set directly here. Read access is
+ * open; the editable control + save are staff-only (the API enforces the same).
+ */
+import { Badge, Button, Card, Group, Select, Stack, Text } from '@mantine/core';
+import { useCallback, useEffect, useState } from 'react';
+import IndicatorStatusLegend from './IndicatorStatusLegend';
+import IndicatorSwatch from './IndicatorSwatch';
+import {
+  ForgeKeyRoomOperationalMode,
+  IndicatorStatusValue,
+  forgekeyAPI,
+} from '../services/api';
+import { showError, showSuccess } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+import {
+  INDICATOR_STATUS_LABELS,
+  INDICATOR_STATUS_ORDER,
+  statusLabel,
+} from '../utils/indicatorPresentation';
+
+interface Props {
+  locationId: number;
+  locationName?: string;
+}
+
+const STATUS_BADGE_COLORS: Record<string, string> = {
+  available: 'green',
+  in_use: 'teal',
+  unavailable: 'red',
+  locked_out: 'dark',
+  classroom: 'grape',
+};
+
+function unwrap<T>(data: { results?: T[] } | T[]): T[] {
+  if (Array.isArray(data)) return data;
+  return data.results ?? [];
+}
+
+export default function RoomOperationalModeControl({ locationId, locationName }: Props) {
+  const isStaff =
+    typeof window !== 'undefined' &&
+    (localStorage.getItem('is_staff') === 'true' ||
+      localStorage.getItem('is_superuser') === 'true');
+
+  const [mode, setMode] = useState<ForgeKeyRoomOperationalMode | null>(null);
+  const [selected, setSelected] = useState<IndicatorStatusValue>('available');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await forgekeyAPI.listRoomOperationalModes({ location: locationId });
+      const existing = unwrap<ForgeKeyRoomOperationalMode>(res.data)[0] ?? null;
+      setMode(existing);
+      setSelected(existing?.mode ?? 'available');
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Failed to load room mode.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [locationId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const onSave = async () => {
+    setSaving(true);
+    try {
+      if (mode) {
+        await forgekeyAPI.setRoomOperationalMode(mode.id, selected);
+      } else {
+        await forgekeyAPI.createRoomOperationalMode({ location: locationId, mode: selected });
+      }
+      showSuccess('Room mode updated.');
+      await load();
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Failed to update room mode.'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return null;
+
+  const currentMode: IndicatorStatusValue = mode?.mode ?? 'available';
+
+  return (
+    <Card withBorder radius="md" p="md" data-testid="room-operational-mode">
+      <Text fw={600}>Room operational mode</Text>
+      <Text size="xs" c="dimmed" mb="md">
+        Drives the indicator lights bound to {locationName ? `“${locationName}”` : 'this room'}.
+      </Text>
+
+      <Stack gap="md">
+        <Group gap="xs">
+          <Text size="sm" fw={500}>
+            Current
+          </Text>
+          <IndicatorSwatch status={currentMode} testId="room-mode-swatch" />
+          <Badge
+            color={STATUS_BADGE_COLORS[currentMode] ?? 'gray'}
+            data-testid="room-mode-current"
+          >
+            {statusLabel(currentMode)}
+          </Badge>
+          {!mode && (
+            <Text size="xs" c="dimmed">
+              (default — not set)
+            </Text>
+          )}
+          {mode?.updated_by_username && (
+            <Text size="xs" c="dimmed">
+              set by {mode.updated_by_username}
+            </Text>
+          )}
+        </Group>
+
+        <Group align="flex-end" gap="sm">
+          <Select
+            label="Set mode"
+            data={INDICATOR_STATUS_ORDER.map((s) => ({
+              value: s,
+              label: INDICATOR_STATUS_LABELS[s],
+            }))}
+            value={selected}
+            onChange={(v) => setSelected((v as IndicatorStatusValue) ?? 'available')}
+            disabled={!isStaff}
+            w={220}
+            aria-label="Set mode"
+            data-testid="room-mode-select"
+          />
+          <Button
+            size="sm"
+            loading={saving}
+            disabled={!isStaff || selected === currentMode}
+            onClick={onSave}
+            data-testid="room-mode-save"
+          >
+            Save
+          </Button>
+        </Group>
+
+        {!isStaff && (
+          <Text size="xs" c="dimmed">
+            Staff access is required to change the room mode.
+          </Text>
+        )}
+
+        <IndicatorStatusLegend />
+      </Stack>
+    </Card>
+  );
+}

--- a/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
+++ b/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
@@ -11,6 +11,7 @@ import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import DeviceControlsCard from '../components/DeviceControlsCard';
 import DeviceLifecycleCard from '../components/DeviceLifecycleCard';
+import IndicatorManagementCard from '../components/IndicatorManagementCard';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import {
   ForgeKeyCommandResponse,
@@ -268,6 +269,8 @@ const ForgeKeyDeviceDetailPage: React.FC = () => {
           )}
 
           <DeviceControlsCard device={device} />
+
+          <IndicatorManagementCard device={device} onChanged={loadAll} />
 
           <DeviceLifecycleCard
             device={device}

--- a/frontend/src/pages/LocationDetailPage.tsx
+++ b/frontend/src/pages/LocationDetailPage.tsx
@@ -11,6 +11,7 @@ import LocationFixturesList from '../components/LocationFixturesList';
 import LocationProblemsPanel from '../components/LocationProblemsPanel';
 import LocationTrafficPanel from '../components/LocationTrafficPanel';
 import ReportLocationProblemModal from '../components/ReportLocationProblemModal';
+import RoomOperationalModeControl from '../components/RoomOperationalModeControl';
 import { climateAPI, inventoryAPI, Thermostat } from '../services/api';
 import '../styles/LocationDetailPage.css';
 import { Location } from '../types';
@@ -256,6 +257,11 @@ const LocationDetailPage: React.FC = () => {
         <div className="detail-section">
           <h2>Traffic</h2>
           <LocationTrafficPanel locationId={location.id} />
+        </div>
+
+        <div className="detail-section" data-testid="location-indicator-mode-section">
+          <h2>Indicator light status</h2>
+          <RoomOperationalModeControl locationId={location.id} locationName={location.name} />
         </div>
 
         <div className="detail-section" data-testid="location-thermostats-section">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2132,6 +2132,68 @@ export interface ForgeKeyDeviceLockout {
   is_active: boolean;
 }
 
+// Indicator-light status management (epic ga-72l). The canonical operational
+// statuses an indicator can reflect — must match backend ``IndicatorStatus``.
+export type IndicatorStatusValue =
+  | 'available'
+  | 'in_use'
+  | 'unavailable'
+  | 'locked_out'
+  | 'classroom';
+
+// The ``set_indicator`` payload the backend derives/pushes. Colors may be a
+// named string, a hex string, or an [r, g, b] triple; brightness may be a
+// 'low'/'high' word or a 0-255 int. Fields are omitted when not applicable
+// (e.g. an off pattern carries no color/brightness).
+export interface ForgeKeyIndicatorPresentation {
+  cmd?: string;
+  color?: string | number[] | null;
+  brightness?: string | number | null;
+  pattern?: string;
+  period_ms?: number;
+  duration_s?: number;
+}
+
+export interface ForgeKeyIndicatorBinding {
+  id: string;
+  device: string;
+  device_mac_address: string;
+  device_name: string;
+  asset: string | null;
+  asset_name: string | null;
+  location: number | null;
+  location_name: string | null;
+  // '' before the first sync; otherwise the last pushed status.
+  last_status: IndicatorStatusValue | '';
+  last_presentation: ForgeKeyIndicatorPresentation | null;
+  last_synced_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ForgeKeyRoomOperationalMode {
+  id: number;
+  location: number;
+  location_name: string;
+  mode: IndicatorStatusValue;
+  updated_by: number | null;
+  updated_by_username: string | null;
+  updated_at: string;
+}
+
+export interface ForgeKeyIndicatorSyncResponse {
+  status: IndicatorStatusValue | '';
+  presentation: ForgeKeyIndicatorPresentation | null;
+  command_id: string | null;
+}
+
+export interface ForgeKeyIndicatorTestResponse {
+  status: string;
+  device: string;
+  command_id: string;
+  payload: ForgeKeyIndicatorPresentation;
+}
+
 export const forgekeyAPI = {
   listDevices: (opts: { capability?: string } = {}) =>
     api.get<{ results?: ForgeKeyDevice[] } | ForgeKeyDevice[]>('/forgekey/devices/', {
@@ -2220,6 +2282,59 @@ export const forgekeyAPI = {
     api.get<ForgeKeyRecentCommandsResponse>(
       `/forgekey/devices/${id}/recent-commands/`,
       { params: { limit } },
+    ),
+  // Indicator lights (epic ga-72l): bind an indicator device to an asset XOR a
+  // room, drive a room's manual mode, and preview/sync the light.
+  listIndicatorBindings: (
+    opts: { device?: string; asset?: string; location?: number } = {},
+  ) =>
+    api.get<{ results?: ForgeKeyIndicatorBinding[] } | ForgeKeyIndicatorBinding[]>(
+      '/forgekey/indicator-bindings/',
+      {
+        params: {
+          ...(opts.device ? { device: opts.device } : {}),
+          ...(opts.asset ? { asset: opts.asset } : {}),
+          ...(opts.location != null ? { location: opts.location } : {}),
+        },
+      },
+    ),
+  createIndicatorBinding: (
+    body: { device: string; asset: string } | { device: string; location: number },
+  ) => api.post<ForgeKeyIndicatorBinding>('/forgekey/indicator-bindings/', body),
+  deleteIndicatorBinding: (id: string) =>
+    api.delete(`/forgekey/indicator-bindings/${id}/`),
+  // Recompute the bound target's status and push it to the device now.
+  indicatorSync: (bindingId: string) =>
+    api.post<ForgeKeyIndicatorSyncResponse>(
+      `/forgekey/indicator-bindings/${bindingId}/sync/`,
+    ),
+  listRoomOperationalModes: (opts: { location?: number } = {}) =>
+    api.get<{ results?: ForgeKeyRoomOperationalMode[] } | ForgeKeyRoomOperationalMode[]>(
+      '/forgekey/room-operational-modes/',
+      { params: opts.location != null ? { location: opts.location } : undefined },
+    ),
+  createRoomOperationalMode: (body: { location: number; mode: IndicatorStatusValue }) =>
+    api.post<ForgeKeyRoomOperationalMode>('/forgekey/room-operational-modes/', body),
+  setRoomOperationalMode: (id: number, mode: IndicatorStatusValue) =>
+    api.patch<ForgeKeyRoomOperationalMode>(
+      `/forgekey/room-operational-modes/${id}/`,
+      { mode },
+    ),
+  // Explicit color/brightness/pattern preview to an indicator device — bypasses
+  // status derivation for a live hardware check.
+  indicatorTest: (
+    deviceId: string,
+    body: {
+      color?: string | number[];
+      brightness?: string | number;
+      pattern?: string;
+      period_ms?: number;
+      duration_s?: number;
+    },
+  ) =>
+    api.post<ForgeKeyIndicatorTestResponse>(
+      `/forgekey/devices/${deviceId}/indicator/test/`,
+      body,
     ),
   bindEPaper: (displayId: string, assetId: string) =>
     api.post<{ display_id: string; asset_id: string; asset_name: string }>(

--- a/frontend/src/utils/indicatorPresentation.ts
+++ b/frontend/src/utils/indicatorPresentation.ts
@@ -1,0 +1,150 @@
+/**
+ * Indicator-light presentation policy (frontend mirror of epic ga-72l).
+ *
+ * The backend (`forgekey/services/indicator.py`) is the source of truth for the
+ * status → (color, brightness, pattern) mapping it pushes to firmware. This
+ * module mirrors that table so the management UI can render an on-screen swatch
+ * and legend that match what an admin will actually see on the hardware, and so
+ * a live "test light" preview can be rendered from an arbitrary presentation.
+ */
+import { ForgeKeyIndicatorPresentation, IndicatorStatusValue } from '../services/api';
+
+// Display order for the legend (matches backend IndicatorStatus.CHOICES).
+export const INDICATOR_STATUS_ORDER: IndicatorStatusValue[] = [
+  'available',
+  'in_use',
+  'unavailable',
+  'locked_out',
+  'classroom',
+];
+
+// Human labels — match the backend ``IndicatorStatus.CHOICES`` display text.
+export const INDICATOR_STATUS_LABELS: Record<IndicatorStatusValue, string> = {
+  available: 'Available',
+  in_use: 'In use',
+  unavailable: 'Unavailable',
+  locked_out: 'Locked out',
+  classroom: 'In use for a class',
+};
+
+// Short plain-language description of the light each status produces.
+export const INDICATOR_STATUS_DESCRIPTIONS: Record<IndicatorStatusValue, string> = {
+  available: 'Low green',
+  in_use: 'Bright green',
+  unavailable: 'Low red',
+  locked_out: 'Off',
+  classroom: 'Purple slow blink',
+};
+
+export interface IndicatorPresentationSpec {
+  color: string | null;
+  brightness: 'low' | 'high' | null;
+  pattern: 'solid' | 'slow_blink' | 'off';
+  period_ms: number | null;
+}
+
+// Canonical ga-72l mapping — mirrors backend ``PRESENTATIONS``.
+export const INDICATOR_PRESENTATIONS: Record<IndicatorStatusValue, IndicatorPresentationSpec> = {
+  available: { color: 'green', brightness: 'low', pattern: 'solid', period_ms: null },
+  in_use: { color: 'green', brightness: 'high', pattern: 'solid', period_ms: null },
+  unavailable: { color: 'red', brightness: 'low', pattern: 'solid', period_ms: null },
+  locked_out: { color: null, brightness: null, pattern: 'off', period_ms: null },
+  classroom: { color: 'purple', brightness: 'high', pattern: 'slow_blink', period_ms: 1500 },
+};
+
+// Named firmware colors → CSS hex for the on-screen swatch.
+const NAMED_COLOR_HEX: Record<string, string> = {
+  green: '#2f9e44',
+  red: '#e03131',
+  purple: '#9c36b5',
+  blue: '#1971c2',
+  yellow: '#f08c00',
+  orange: '#e8590c',
+  white: '#f1f3f5',
+  off: '#212529',
+};
+
+const OFF_BACKGROUND = NAMED_COLOR_HEX.off;
+
+// Patterns that animate on the hardware (and so the swatch should pulse).
+const BLINK_PATTERNS = new Set(['blink', 'slow_blink', 'breathe']);
+
+export interface SwatchVisual {
+  /** CSS color for the swatch background. */
+  background: string;
+  /** 0-1 opacity derived from brightness (dimmer for 'low'). */
+  opacity: number;
+  /** True when the pattern animates — the swatch pulses. */
+  blink: boolean;
+  /** True when the light is off (locked out / off pattern). */
+  isOff: boolean;
+}
+
+function clamp(value: number, lo: number, hi: number): number {
+  return Math.min(Math.max(value, lo), hi);
+}
+
+/** Resolve a firmware color (name / hex / [r,g,b]) to a CSS color string. */
+export function resolveColorHex(
+  color: string | number[] | null | undefined,
+): string | null {
+  if (color == null) return null;
+  if (Array.isArray(color)) {
+    if (color.length !== 3) return null;
+    return `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+  }
+  const text = String(color).trim().toLowerCase();
+  if (!text) return null;
+  if (text.startsWith('#') || text.startsWith('rgb')) return text;
+  // Fall back to the raw token — the browser may understand it (e.g. 'cyan').
+  return NAMED_COLOR_HEX[text] ?? text;
+}
+
+/** Map a brightness word/int to a swatch opacity. */
+export function brightnessOpacity(
+  brightness: string | number | null | undefined,
+): number {
+  if (brightness == null || brightness === '') return 1;
+  if (typeof brightness === 'number') return clamp(brightness / 255, 0.2, 1);
+  const word = String(brightness).trim().toLowerCase();
+  if (word === 'low') return 0.45;
+  if (word === 'high') return 1;
+  const numeric = Number(word);
+  if (!Number.isNaN(numeric)) return clamp(numeric / 255, 0.2, 1);
+  return 1;
+}
+
+export function isBlinkPattern(pattern: string | null | undefined): boolean {
+  return pattern != null && BLINK_PATTERNS.has(pattern);
+}
+
+/**
+ * Build the visual treatment for a swatch from an arbitrary presentation
+ * (the derived/last-pushed state, or a manual test preview).
+ */
+export function swatchVisualForPresentation(
+  presentation: ForgeKeyIndicatorPresentation | IndicatorPresentationSpec | null | undefined,
+): SwatchVisual {
+  const pattern = presentation?.pattern ?? null;
+  const hex = resolveColorHex(presentation?.color);
+  const isOff =
+    pattern === 'off' ||
+    (presentation?.color == null && presentation?.brightness == null && hex == null);
+  return {
+    background: isOff || hex == null ? OFF_BACKGROUND : hex,
+    opacity: isOff ? 1 : brightnessOpacity(presentation?.brightness),
+    blink: !isOff && isBlinkPattern(pattern),
+    isOff,
+  };
+}
+
+/** Swatch treatment for a canonical operational status. */
+export function swatchVisualForStatus(status: IndicatorStatusValue): SwatchVisual {
+  return swatchVisualForPresentation(INDICATOR_PRESENTATIONS[status]);
+}
+
+/** Human label for a status, tolerant of the empty pre-sync value. */
+export function statusLabel(status: IndicatorStatusValue | '' | null | undefined): string {
+  if (!status) return 'Not yet synced';
+  return INDICATOR_STATUS_LABELS[status] ?? status;
+}


### PR DESCRIPTION
Work bead: **op-3a7** — Indicator management UI: bind device to asset/room, room mode, live preview

Published by the openmakersuite refinery as the `mr`-mode merge handoff for op-3a7. The branch was already current with `main` (0 commits behind `63785db`, which includes the merged backend counterpart op-1n8 / #793), so no rebase was needed.

## Change
`feat(frontend): indicator binding, room mode, and live-preview UI`

Frontend-only (13 files): `IndicatorManagementCard`, `IndicatorStatusLegend`, `IndicatorSwatch`, `RoomOperationalModeControl`, `ForgeKeyDeviceDetailPage`, `LocationDetailPage`, `services/api.ts`, `utils/indicatorPresentation.ts`, plus their tests.

Landing is gated on the repo's required checks (CI Complete + Semgrep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)