### PR TITLE
feat(frontend): access authorization grant, badge enrollment, and access log UI (op-tup)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -2107,6 +2107,14 @@ views:
       update:
         permission_classes:
         - IsAuthenticated
+  membership.views.UserDirectoryViewSet:
+    actions:
+      list:
+        permission_classes:
+        - IsAdminUser
+      retrieve:
+        permission_classes:
+        - IsAdminUser
   membership.views.UserProfileViewSet:
     actions:
       me:

--- a/backend/forgekey/tests/test_asset_access_filtering.py
+++ b/backend/forgekey/tests/test_asset_access_filtering.py
@@ -68,6 +68,28 @@ class TestAuthorizationAssetFilter:
         assert results[0]["is_active"] is True
 
 
+class TestAuthorizationUserFilter:
+    def test_filters_by_user(self, client):
+        """``?user=<id>`` backs the per-member "assets I'm authorized for" view."""
+        target = AssetAuthorizationFactory(asset=AssetFactory(), is_active=True)
+        AssetAuthorizationFactory(asset=AssetFactory(), is_active=True)  # different user
+
+        resp = client.get(f"/api/forgekey/authorizations/?user={target.user_id}")
+        assert resp.status_code == 200, resp.data
+        results = _results(resp)
+        assert len(results) == 1
+        assert results[0]["user"] == target.user_id
+
+    def test_user_and_active_combine(self, client):
+        target_user = AssetAuthorizationFactory(asset=AssetFactory(), is_active=True).user
+        AssetAuthorizationFactory(asset=AssetFactory(), user=target_user, is_active=False)
+
+        resp = client.get(f"/api/forgekey/authorizations/?user={target_user.id}&is_active=true")
+        results = _results(resp)
+        assert len(results) == 1
+        assert results[0]["is_active"] is True
+
+
 class TestLockoutAssetFilter:
     def test_filters_by_asset_and_is_active(self, client):
         asset = AssetFactory()

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -1553,13 +1553,18 @@ class AssetAuthorizationViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticatedOrReadOnly]
 
     def get_queryset(self):
-        """Support ``?asset=<id>`` and ``?is_active=<bool>`` so the asset
-        detail page can list just that asset's authorizations (typically the
-        active ones)."""
+        """Support ``?asset=<id>``, ``?user=<id>`` and ``?is_active=<bool>``.
+
+        ``?asset=`` backs the asset detail page's authorized-users list;
+        ``?user=`` backs the per-member "assets I'm authorized for" view (op-tup);
+        ``?is_active=`` narrows either to the currently-active grants."""
         qs = super().get_queryset()
         asset_id = self.request.query_params.get("asset")
         if asset_id:
             qs = qs.filter(asset_id=asset_id)
+        user_id = self.request.query_params.get("user")
+        if user_id:
+            qs = qs.filter(user_id=user_id)
         is_active = self.request.query_params.get("is_active")
         if is_active is not None:
             qs = qs.filter(is_active=is_active.lower() in ("1", "true", "yes"))

--- a/backend/membership/serializers.py
+++ b/backend/membership/serializers.py
@@ -192,6 +192,36 @@ class UserSerializer(serializers.ModelSerializer):
         ]
 
 
+class UserDirectorySerializer(serializers.ModelSerializer):
+    """Lightweight, read-only user listing for staff access-control pickers (op-tup).
+
+    The access-control frontend needs to resolve a member when granting an asset
+    authorization or enrolling a badge, but no general user listing existed. This
+    exposes just enough to identify a member and show their current badge —
+    nothing sensitive — and is staff-gated at the view layer.
+    """
+
+    full_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = [
+            "id",
+            "username",
+            "first_name",
+            "last_name",
+            "full_name",
+            "email",
+            "badge_number",
+            "is_active",
+        ]
+        read_only_fields = fields
+
+    def get_full_name(self, obj):
+        """Display name for the picker, falling back to the username."""
+        return obj.get_full_name() or obj.username
+
+
 class UserProfileSerializer(serializers.ModelSerializer):
     """Serializer for user profile editing."""
 

--- a/backend/membership/tests/test_user_directory.py
+++ b/backend/membership/tests/test_user_directory.py
@@ -1,0 +1,72 @@
+"""Staff-only user directory endpoint for access-control pickers (op-tup).
+
+The access-control frontend (asset authorization grant, badge enrollment) needs
+to resolve a member to a user id and read their current badge. These tests cover
+the ``/api/membership/users/`` listing: staff-only access, ``?search=`` over
+name/username/email, and the ``?has_badge=`` filter.
+"""
+
+import pytest
+from rest_framework.test import APIClient
+
+from membership.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _results(response):
+    body = response.json()
+    return body["results"] if isinstance(body, dict) and "results" in body else body
+
+
+@pytest.fixture
+def staff_client():
+    api = APIClient()
+    api.force_authenticate(user=UserFactory(is_staff=True))
+    return api
+
+
+class TestUserDirectoryPermissions:
+    def test_non_staff_is_forbidden(self):
+        api = APIClient()
+        api.force_authenticate(user=UserFactory(is_staff=False))
+        resp = api.get("/api/membership/users/")
+        assert resp.status_code == 403
+
+    def test_anonymous_is_forbidden(self):
+        resp = APIClient().get("/api/membership/users/")
+        assert resp.status_code in (401, 403)
+
+
+class TestUserDirectoryListing:
+    def test_lists_users_with_badge_and_name(self, staff_client):
+        UserFactory(username="alice", first_name="Alice", last_name="Adams", badge_number="A1")
+        resp = staff_client.get("/api/membership/users/")
+        assert resp.status_code == 200, resp.data
+        rows = _results(resp)
+        alice = next(r for r in rows if r["username"] == "alice")
+        assert alice["badge_number"] == "A1"
+        assert alice["full_name"] == "Alice Adams"
+        assert "id" in alice
+
+    def test_search_matches_username_name_email(self, staff_client):
+        UserFactory(username="zoe_smith", first_name="Zoe", last_name="Smith", email="zoe@x.io")
+        UserFactory(username="other", first_name="Pat", last_name="Jones", email="pat@x.io")
+
+        by_name = _results(staff_client.get("/api/membership/users/?search=smith"))
+        assert {r["username"] for r in by_name} == {"zoe_smith"}
+
+        by_email = _results(staff_client.get("/api/membership/users/?search=pat@x.io"))
+        assert {r["username"] for r in by_email} == {"other"}
+
+    def test_has_badge_filter(self, staff_client):
+        UserFactory(username="hasbadge", badge_number="BDG123")
+        UserFactory(username="nobadge", badge_number=None)
+
+        with_badge = _results(staff_client.get("/api/membership/users/?has_badge=true"))
+        assert "hasbadge" in {r["username"] for r in with_badge}
+        assert "nobadge" not in {r["username"] for r in with_badge}
+
+        without_badge = _results(staff_client.get("/api/membership/users/?has_badge=false"))
+        assert "nobadge" in {r["username"] for r in without_badge}
+        assert "hasbadge" not in {r["username"] for r in without_badge}

--- a/backend/membership/urls.py
+++ b/backend/membership/urls.py
@@ -11,6 +11,7 @@ from .views import (
     SIGAdminViewSet,
     SIGMemberViewSet,
     SIGViewSet,
+    UserDirectoryViewSet,
     UserProfileViewSet,
     change_password,
     invite_code_preview,
@@ -24,6 +25,7 @@ router.register(r"sigs", SIGViewSet, basename="sig")
 router.register(r"sigs/(?P<sig_pk>\d+)/members", SIGMemberViewSet, basename="sig-member")
 router.register(r"sig-admins", SIGAdminViewSet, basename="sig-admin")
 router.register(r"profile", UserProfileViewSet, basename="profile")
+router.register(r"users", UserDirectoryViewSet, basename="user-directory")
 router.register(r"invite-codes", InviteCodeViewSet, basename="invite-code")
 
 urlpatterns = [

--- a/backend/membership/views.py
+++ b/backend/membership/views.py
@@ -4,11 +4,12 @@ Views for membership and SIG management API.
 
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import Group
+from django.db.models import Q
 
 from rest_framework import status, viewsets
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
 from .models import SIGAdmin, User, UserRegistrationToken
@@ -19,6 +20,7 @@ from .serializers import (
     SIGMemberSerializer,
     SIGSerializer,
     TokenValidationSerializer,
+    UserDirectorySerializer,
     UserProfileSerializer,
     UserRegistrationSerializer,
     UserSerializer,
@@ -300,6 +302,44 @@ class UserProfileViewSet(viewsets.ViewSet):
             serializer.save()
             return Response(serializer.data)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class UserDirectoryViewSet(viewsets.ReadOnlyModelViewSet):
+    """Read-only, staff-only directory of users for access-control pickers (op-tup).
+
+    The access-control frontend (asset authorization grant, badge enrollment)
+    needs to resolve a member to a user id and show their current badge, but no
+    general user listing existed. This provides a minimal one:
+
+    - ``?search=`` matches username / first / last name / email (case-insensitive);
+    - ``?has_badge=true`` (or ``false``) narrows to members with (or without) a
+      badge, for the badge-enrollment admin.
+
+    Results are ordered by username; the global PageNumberPagination bounds the
+    response so a large roster never returns unbounded.
+    """
+
+    serializer_class = UserDirectorySerializer
+    permission_classes = [IsAdminUser]
+
+    def get_queryset(self):
+        qs = User.objects.all().order_by("username")
+        params = self.request.query_params
+        search = (params.get("search") or "").strip()
+        if search:
+            qs = qs.filter(
+                Q(username__icontains=search)
+                | Q(first_name__icontains=search)
+                | Q(last_name__icontains=search)
+                | Q(email__icontains=search)
+            )
+        has_badge = params.get("has_badge")
+        if has_badge is not None:
+            if has_badge.lower() in ("1", "true", "yes"):
+                qs = qs.exclude(badge_number__isnull=True).exclude(badge_number="")
+            elif has_badge.lower() in ("0", "false", "no"):
+                qs = qs.filter(Q(badge_number__isnull=True) | Q(badge_number=""))
+        return qs
 
 
 @api_view(["POST"])

--- a/docs/API_PERMISSION_MATRIX.md
+++ b/docs/API_PERMISSION_MATRIX.md
@@ -106,6 +106,7 @@ below are public.
 | --- | --- | --- | --- |
 | any | `membership/profile/...` | member | `IsAuthenticated` — every authed user can hit the endpoint; the queryset filters to records the caller can see and writes go through `perform_*` checks. |
 | any | `membership/sigs/...`, `membership/sig-admins/...` | member | `IsAuthenticated` on `SIGViewSet`/`SIGAdminViewSet`/`SIGMemberViewSet`; staff-only writes are guarded inside `perform_*`. |
+| GET | `membership/users/...` | admin | `IsAdminUser` on `UserDirectoryViewSet` (read-only list/retrieve) — staff user lookup for the access-control badge-enrollment UI. |
 | POST | `membership/register/validate-token/` | public | Token validation for the registration QR flow (no `permission_classes` set; falls back to the per-environment default — `AllowAny` in dev, `IsAuthenticatedOrReadOnly` in prod, which still answers GET-style POSTs). |
 | POST | `membership/register/complete/` | public | Token-gated user registration; the token (carried in the body) gates access. |
 | POST | `membership/change-password/` | member | Password change for the authenticated user. |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,8 @@ import PowerPanelPrintPage from './pages/PowerPanelPrintPage';
 import PowerPanelDirectoryPage from './pages/PowerPanelDirectoryPage';
 import PowerPanelFormPage from './pages/PowerPanelFormPage';
 import FixtureScanPage from './pages/FixtureScanPage';
+import ForgeKeyAccessLogPage from './pages/ForgeKeyAccessLogPage';
+import ForgeKeyBadgeEnrollmentPage from './pages/ForgeKeyBadgeEnrollmentPage';
 import ForgeKeyCertificatesPage from './pages/ForgeKeyCertificatesPage';
 import ForgeKeyDashboardPage from './pages/ForgeKeyDashboardPage';
 import ForgeKeyDeviceDetailPage from './pages/ForgeKeyDeviceDetailPage';
@@ -253,6 +255,8 @@ function AppContent() {
           <Route path="/facilities/forgekey-rollouts" element={<WorkspaceLayout><ForgeKeyFirmwareRolloutsPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-certificates" element={<WorkspaceLayout><ForgeKeyCertificatesPage /></WorkspaceLayout>} />
           <Route path="/facilities/forgekey-device-types" element={<WorkspaceLayout><ForgeKeyDeviceTypesPage /></WorkspaceLayout>} />
+          <Route path="/facilities/forgekey-badges" element={<WorkspaceLayout><ForgeKeyBadgeEnrollmentPage /></WorkspaceLayout>} />
+          <Route path="/facilities/forgekey-access-log" element={<WorkspaceLayout><ForgeKeyAccessLogPage /></WorkspaceLayout>} />
           <Route path="/facilities/lockers" element={<WorkspaceLayout><LockersPage /></WorkspaceLayout>} />
           <Route path="/forgekey/epaper" element={<Navigate to="/facilities/forgekey-epaper" replace />} />
           <Route path="/forgekey/epaper/bind" element={<WorkspaceLayout><ForgeKeyEPaperBindPage /></WorkspaceLayout>} />

--- a/frontend/src/__tests__/components/AssetForgeKeyAccessCard.test.tsx
+++ b/frontend/src/__tests__/components/AssetForgeKeyAccessCard.test.tsx
@@ -6,7 +6,7 @@
 import { MantineProvider } from '@mantine/core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import AssetForgeKeyAccessCard from '../../components/AssetForgeKeyAccessCard';
-import { forgekeyAPI } from '../../services/api';
+import { forgekeyAPI, userAPI } from '../../services/api';
 
 vi.mock('../../utils/dialogs', async () => ({
   showError: jest.fn(),
@@ -28,11 +28,17 @@ vi.mock('../../services/api', async () => {
       disableClassroomMode: jest.fn(),
       revokeAuthorization: jest.fn(),
       unlockLockout: jest.fn(),
+      grantAuthorization: jest.fn(),
+    },
+    userAPI: {
+      ...(actual as any).userAPI,
+      listUsers: jest.fn(),
     },
   };
 });
 
 const mockApi = forgekeyAPI as jest.Mocked<typeof forgekeyAPI>;
+const mockUserApi = userAPI as jest.Mocked<typeof userAPI>;
 
 const buildMode = (overrides: Partial<any> = {}) => ({
   id: 1,
@@ -84,8 +90,23 @@ const renderCard = (assetId = 'a1') =>
     </MantineProvider>,
   );
 
+const buildUser = (overrides: Partial<any> = {}) => ({
+  id: 7,
+  username: 'dora',
+  first_name: 'Dora',
+  last_name: 'Diaz',
+  full_name: 'Dora Diaz',
+  email: 'dora@example.com',
+  badge_number: null,
+  is_active: true,
+  ...overrides,
+});
+
 describe('AssetForgeKeyAccessCard', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
 
   it('renders nothing for an asset with no ForgeKey data', async () => {
     mockApi.listOperationalModes.mockResolvedValue({ data: [] } as any);
@@ -132,5 +153,39 @@ describe('AssetForgeKeyAccessCard', () => {
     renderCard();
     fireEvent.click(await screen.findByText('Revoke'));
     await waitFor(() => expect(mockApi.revokeAuthorization).toHaveBeenCalledWith(10));
+  });
+
+  it('hides the grant control from non-staff', async () => {
+    mockApi.listOperationalModes.mockResolvedValue({ data: [buildMode()] } as any);
+    mockApi.listAuthorizations.mockResolvedValue({ data: [] } as any);
+    mockApi.listLockouts.mockResolvedValue({ data: [] } as any);
+
+    renderCard();
+    await screen.findByTestId('asset-forgekey-access');
+    expect(screen.queryByTestId('grant-open')).not.toBeInTheDocument();
+  });
+
+  it('grants access to a picked member (staff)', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockApi.listOperationalModes.mockResolvedValue({ data: [buildMode()] } as any);
+    mockApi.listAuthorizations.mockResolvedValue({ data: [] } as any);
+    mockApi.listLockouts.mockResolvedValue({ data: [] } as any);
+    mockApi.grantAuthorization.mockResolvedValue({ data: {} } as any);
+    mockUserApi.listUsers.mockResolvedValue({ data: [buildUser()] } as any);
+
+    renderCard();
+    fireEvent.click(await screen.findByTestId('grant-open'));
+    // Picker loads members, then we pick one and submit.
+    fireEvent.click(await screen.findByPlaceholderText('Search members…'));
+    fireEvent.click(await screen.findByRole('option', { name: 'Dora Diaz (dora)' }));
+    fireEvent.click(screen.getByTestId('grant-submit'));
+
+    await waitFor(() =>
+      expect(mockApi.grantAuthorization).toHaveBeenCalledWith({
+        asset: 'a1',
+        user: 7,
+        notes: undefined,
+      }),
+    );
   });
 });

--- a/frontend/src/__tests__/pages/ForgeKeyAccessLogPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyAccessLogPage.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Tests for the ForgeKey access log (op-tup): non-staff redirect, rendering
+ * grant/deny rows with their reason, and filtering by action.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ForgeKeyAccessLogPage from '../../pages/ForgeKeyAccessLogPage';
+import { forgekeyAPI } from '../../services/api';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    forgekeyAPI: {
+      ...(actual as any).forgekeyAPI,
+      listAccessLog: jest.fn(),
+    },
+  };
+});
+
+const mockForgekey = forgekeyAPI as jest.Mocked<typeof forgekeyAPI>;
+
+const grantedEvent = {
+  id: 'evt-1',
+  created_at: '2026-06-01T10:00:00Z',
+  action: 'access_granted',
+  action_display: 'Access granted',
+  actor: 5,
+  actor_username: 'alice',
+  asset: 'a1',
+  asset_name: 'Table Saw',
+  device: 'd1',
+  device_mac: 'AA:BB',
+  notes: '',
+  metadata: {},
+};
+
+const deniedEvent = {
+  id: 'evt-2',
+  created_at: '2026-06-01T11:00:00Z',
+  action: 'access_denied',
+  action_display: 'Access denied',
+  actor: null,
+  actor_username: null,
+  asset: 'a1',
+  asset_name: 'Table Saw',
+  device: 'd1',
+  device_mac: 'AA:BB',
+  notes: 'access denied: not authorized',
+  metadata: { reason: 'not_authorized' },
+};
+
+const renderPage = (initialEntry = '/facilities/forgekey-access-log') =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/facilities/forgekey-access-log" element={<ForgeKeyAccessLogPage />} />
+          <Route path="/" element={<div>HOME</div>} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('ForgeKeyAccessLogPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  test('non-staff users are redirected away', async () => {
+    localStorage.setItem('is_staff', 'false');
+    renderPage();
+    expect(await screen.findByText('HOME')).toBeInTheDocument();
+    expect(mockForgekey.listAccessLog).not.toHaveBeenCalled();
+  });
+
+  test('renders grant and deny rows with the deny reason', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockForgekey.listAccessLog.mockResolvedValue({ data: [grantedEvent, deniedEvent] } as any);
+
+    renderPage();
+    expect(await screen.findByTestId('access-log-row-evt-1')).toBeInTheDocument();
+    // Scope action labels to the table — the filter <Select> mounts the same
+    // labels as options in the DOM.
+    const table = screen.getByTestId('access-log-table');
+    expect(within(table).getByText('Access granted')).toBeInTheDocument();
+    expect(within(table).getByText('Access denied')).toBeInTheDocument();
+    expect(within(table).getByText('alice')).toBeInTheDocument();
+    // The deny reason is humanized from metadata.reason.
+    expect(within(table).getByText('Not authorized')).toBeInTheDocument();
+    expect(within(table).getByText('unknown card')).toBeInTheDocument();
+    // First load defaults to access-control events only.
+    expect(mockForgekey.listAccessLog).toHaveBeenCalledWith({ accessOnly: true, action: undefined });
+  });
+
+  test('filters by action', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockForgekey.listAccessLog.mockResolvedValue({ data: [grantedEvent, deniedEvent] } as any);
+
+    renderPage();
+    await screen.findByTestId('access-log-table');
+
+    fireEvent.click(screen.getByTestId('access-log-action-filter'));
+    fireEvent.click(await screen.findByRole('option', { name: 'Denied' }));
+
+    await waitFor(() =>
+      expect(mockForgekey.listAccessLog).toHaveBeenCalledWith({
+        accessOnly: true,
+        action: 'access_denied',
+      }),
+    );
+  });
+});

--- a/frontend/src/__tests__/pages/ForgeKeyBadgeEnrollmentPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyBadgeEnrollmentPage.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Tests for the ForgeKey badge enrollment admin (op-tup): non-staff redirect,
+ * member listing with current badge, manual set, and the armed → captured →
+ * saved enroll handshake.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ForgeKeyBadgeEnrollmentPage from '../../pages/ForgeKeyBadgeEnrollmentPage';
+import { forgekeyAPI, userAPI } from '../../services/api';
+
+vi.mock('../../utils/dialogs', async () => ({
+  showError: jest.fn(),
+  showSuccess: jest.fn(),
+  confirmAction: (_t: string, _m: string, onConfirm: () => void) => onConfirm(),
+}));
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    userAPI: {
+      ...(actual as any).userAPI,
+      listUsers: jest.fn(),
+    },
+    forgekeyAPI: {
+      ...(actual as any).forgekeyAPI,
+      armBadgeEnrollment: jest.fn(),
+      cancelBadgeEnrollment: jest.fn(),
+      getBadgeEnrollmentState: jest.fn(),
+      setBadge: jest.fn(),
+    },
+  };
+});
+
+const mockUserApi = userAPI as jest.Mocked<typeof userAPI>;
+const mockForgekey = forgekeyAPI as jest.Mocked<typeof forgekeyAPI>;
+
+const buildUser = (overrides: Partial<any> = {}) => ({
+  id: 1,
+  username: 'alice',
+  first_name: 'Alice',
+  last_name: 'Adams',
+  full_name: 'Alice Adams',
+  email: 'alice@example.com',
+  badge_number: null,
+  is_active: true,
+  ...overrides,
+});
+
+const renderPage = (initialEntry = '/facilities/forgekey-badges') =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/facilities/forgekey-badges" element={<ForgeKeyBadgeEnrollmentPage />} />
+          <Route path="/" element={<div>HOME</div>} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('ForgeKeyBadgeEnrollmentPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  test('non-staff users are redirected away', async () => {
+    localStorage.setItem('is_staff', 'false');
+    renderPage();
+    expect(await screen.findByText('HOME')).toBeInTheDocument();
+    expect(mockUserApi.listUsers).not.toHaveBeenCalled();
+  });
+
+  test('lists members with their current badge', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockUserApi.listUsers.mockResolvedValue({
+      data: [buildUser({ badge_number: 'A1' }), buildUser({ id: 2, username: 'bob', full_name: 'Bob Boyd' })],
+    } as any);
+
+    renderPage();
+    expect(await screen.findByTestId('user-row-1')).toBeInTheDocument();
+    expect(screen.getByTestId('badge-value-1')).toHaveTextContent('A1');
+    expect(screen.getByTestId('badge-value-2')).toHaveTextContent('none');
+  });
+
+  test('sets a badge manually', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockUserApi.listUsers.mockResolvedValue({ data: [buildUser()] } as any);
+    mockForgekey.setBadge.mockResolvedValue({ data: { user_id: 1, badge_number: 'MANUAL9' } } as any);
+
+    renderPage();
+    fireEvent.click(await screen.findByTestId('set-1'));
+    fireEvent.change(screen.getByTestId('manual-input'), { target: { value: 'MANUAL9' } });
+    fireEvent.click(screen.getByTestId('manual-save'));
+
+    await waitFor(() =>
+      expect(mockForgekey.setBadge).toHaveBeenCalledWith({ userId: 1, badgeNumber: 'MANUAL9' }),
+    );
+    await waitFor(() => expect(screen.getByTestId('badge-value-1')).toHaveTextContent('MANUAL9'));
+  });
+
+  test('enroll flow: armed then captured binds the scanned UID', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockUserApi.listUsers.mockResolvedValue({ data: [buildUser()] } as any);
+    mockForgekey.armBadgeEnrollment.mockResolvedValue({
+      data: { armed: true, user_id: 1, reader_id: null, ttl_seconds: 120 },
+    } as any);
+    mockForgekey.getBadgeEnrollmentState.mockResolvedValue({
+      data: {
+        armed: false,
+        armed_user_id: null,
+        reader_id: null,
+        captured: { user_id: 1, badge_number: 'SCAN7' },
+      },
+    } as any);
+
+    renderPage();
+    fireEvent.click(await screen.findByTestId('enroll-1'));
+
+    await waitFor(() =>
+      expect(mockForgekey.armBadgeEnrollment).toHaveBeenCalledWith({ userId: 1 }),
+    );
+    expect(await screen.findByText(/Captured badge SCAN7/)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('badge-value-1')).toHaveTextContent('SCAN7'));
+  });
+});

--- a/frontend/src/components/AssetForgeKeyAccessCard.tsx
+++ b/frontend/src/components/AssetForgeKeyAccessCard.tsx
@@ -4,7 +4,8 @@
  * Surfaces the ForgeKey access controls for a single inventory Asset on the
  * asset detail page (#7b):
  *  - Operational mode + classroom-mode toggle (enable / disable)
- *  - Authorized users, each revocable
+ *  - Authorized users, each revocable, with a staff grant flow (user picker)
+ *    (access-control interlock, op-tup)
  *  - Active device lockouts, each unlockable (server enforces the unlock
  *    permission hierarchy; a 403 surfaces as an error toast)
  *
@@ -12,13 +13,16 @@
  * operational mode, no active authorizations, no active lockouts), so it's a
  * no-op on ordinary inventory assets.
  */
-import { Badge, Button, Card, Group, Stack, Text } from '@mantine/core';
-import { useCallback, useEffect, useState } from 'react';
+import { Badge, Button, Card, Group, Select, Stack, Text, Textarea } from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  DirectoryUser,
   ForgeKeyAssetAuthorization,
   ForgeKeyDeviceLockout,
   ForgeKeyOperationalMode,
   forgekeyAPI,
+  userAPI,
 } from '../services/api';
 import { confirmAction, showError, showSuccess } from '../utils/dialogs';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
@@ -32,6 +36,21 @@ function unwrap<T>(data: { results?: T[] } | T[]): T[] {
   return data.results ?? [];
 }
 
+// Staff/superuser can grant/revoke; mirrors the gate used by the ForgeKey pages.
+function isStaffUser(): boolean {
+  if (typeof window === 'undefined') return false;
+  return (
+    localStorage.getItem('is_staff') === 'true' ||
+    localStorage.getItem('is_superuser') === 'true'
+  );
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return '';
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? '' : d.toLocaleDateString();
+}
+
 const MODE_COLORS: Record<string, string> = {
   available: 'green',
   classroom: 'blue',
@@ -40,11 +59,20 @@ const MODE_COLORS: Record<string, string> = {
 };
 
 export default function AssetForgeKeyAccessCard({ assetId }: Props) {
+  const isStaff = isStaffUser();
   const [mode, setMode] = useState<ForgeKeyOperationalMode | null>(null);
   const [auths, setAuths] = useState<ForgeKeyAssetAuthorization[]>([]);
   const [lockouts, setLockouts] = useState<ForgeKeyDeviceLockout[]>([]);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState<string | null>(null);
+
+  // Grant flow (staff only).
+  const [grantOpen, setGrantOpen] = useState(false);
+  const [userOptions, setUserOptions] = useState<DirectoryUser[]>([]);
+  const [userSearch, setUserSearch] = useState('');
+  const [debouncedSearch] = useDebouncedValue(userSearch, 250);
+  const [selectedUser, setSelectedUser] = useState<string | null>(null);
+  const [grantNotes, setGrantNotes] = useState('');
 
   const load = useCallback(async () => {
     try {
@@ -68,6 +96,24 @@ export default function AssetForgeKeyAccessCard({ assetId }: Props) {
     load();
   }, [load]);
 
+  // Lazily load members for the picker only once a staffer opens the grant
+  // panel; re-fetch (server-side search) as they type.
+  useEffect(() => {
+    if (!grantOpen) return undefined;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await userAPI.listUsers({ search: debouncedSearch || undefined });
+        if (!cancelled) setUserOptions(unwrap<DirectoryUser>(res.data));
+      } catch (err) {
+        if (!cancelled) showError(extractErrorMessage(err, 'Failed to load members.'));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [grantOpen, debouncedSearch]);
+
   const run = async (key: string, fn: () => Promise<unknown>, success: string) => {
     setBusy(key);
     try {
@@ -76,6 +122,44 @@ export default function AssetForgeKeyAccessCard({ assetId }: Props) {
       await load();
     } catch (err) {
       showError(extractErrorMessage(err, 'Action failed.'));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const userSelectData = useMemo(
+    () =>
+      userOptions.map((u) => ({
+        value: String(u.id),
+        label:
+          u.full_name && u.full_name !== u.username
+            ? `${u.full_name} (${u.username})`
+            : u.username,
+      })),
+    [userOptions],
+  );
+
+  const resetGrant = () => {
+    setGrantOpen(false);
+    setSelectedUser(null);
+    setGrantNotes('');
+    setUserSearch('');
+  };
+
+  const handleGrant = async () => {
+    if (!selectedUser) return;
+    setBusy('grant');
+    try {
+      await forgekeyAPI.grantAuthorization({
+        asset: assetId,
+        user: Number(selectedUser),
+        notes: grantNotes.trim() || undefined,
+      });
+      showSuccess('Access granted.');
+      resetGrant();
+      await load();
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Failed to grant access.'));
     } finally {
       setBusy(null);
     }
@@ -160,11 +244,10 @@ export default function AssetForgeKeyAccessCard({ assetId }: Props) {
                 <Group key={a.id} justify="space-between" wrap="nowrap">
                   <div>
                     <Text size="sm">{a.username}</Text>
-                    {a.authorized_by_username && (
-                      <Text size="xs" c="dimmed">
-                        by {a.authorized_by_username}
-                      </Text>
-                    )}
+                    <Text size="xs" c="dimmed">
+                      {a.authorized_by_username ? `by ${a.authorized_by_username}` : 'granted'}
+                      {formatDate(a.authorized_at) && ` · ${formatDate(a.authorized_at)}`}
+                    </Text>
                   </div>
                   <Button
                     size="xs"
@@ -190,6 +273,59 @@ export default function AssetForgeKeyAccessCard({ assetId }: Props) {
                 </Group>
               ))}
             </Stack>
+          )}
+
+          {isStaff && (
+            <div style={{ marginTop: 'var(--mantine-spacing-sm)' }}>
+              {!grantOpen ? (
+                <Button
+                  size="xs"
+                  variant="light"
+                  onClick={() => setGrantOpen(true)}
+                  data-testid="grant-open"
+                >
+                  Grant access
+                </Button>
+              ) : (
+                <Stack gap="xs" data-testid="grant-panel">
+                  <Select
+                    placeholder="Search members…"
+                    searchable
+                    data={userSelectData}
+                    value={selectedUser}
+                    onChange={setSelectedUser}
+                    searchValue={userSearch}
+                    onSearchChange={setUserSearch}
+                    filter={({ options }) => options}
+                    nothingFoundMessage="No members found"
+                    aria-label="Member"
+                    data-testid="grant-user-select"
+                  />
+                  <Textarea
+                    placeholder="Notes (optional)"
+                    autosize
+                    minRows={1}
+                    value={grantNotes}
+                    onChange={(e) => setGrantNotes(e.currentTarget.value)}
+                    data-testid="grant-notes"
+                  />
+                  <Group gap="xs">
+                    <Button
+                      size="xs"
+                      loading={busy === 'grant'}
+                      disabled={!selectedUser}
+                      onClick={handleGrant}
+                      data-testid="grant-submit"
+                    >
+                      Grant
+                    </Button>
+                    <Button size="xs" variant="subtle" onClick={resetGrant}>
+                      Cancel
+                    </Button>
+                  </Group>
+                </Stack>
+              )}
+            </div>
           )}
         </div>
 

--- a/frontend/src/pages/ForgeKeyAccessLogPage.tsx
+++ b/frontend/src/pages/ForgeKeyAccessLogPage.tsx
@@ -1,0 +1,194 @@
+/**
+ * ForgeKeyAccessLogPage — access / denial log (op-tup).
+ *
+ * A read-only view of recent access-control events from the ForgeKey audit log
+ * (op-vj9): grants, denials (with reason), session ends, and badge enrollments.
+ * Staff filter by action (e.g. just denials) and can widen to the full audit
+ * stream. Backs "staff can see who was denied and why".
+ */
+import {
+  Alert,
+  Badge,
+  Button,
+  Group,
+  Loader,
+  Select,
+  Switch,
+  Table,
+  Text,
+} from '@mantine/core';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
+import { ForgeKeyAuditEvent, forgekeyAPI } from '../services/api';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+function unwrap<T>(data: { results?: T[] } | T[]): T[] {
+  if (Array.isArray(data)) return data;
+  return data.results ?? [];
+}
+
+function isStaffUser(): boolean {
+  if (typeof window === 'undefined') return false;
+  return (
+    localStorage.getItem('is_staff') === 'true' ||
+    localStorage.getItem('is_superuser') === 'true'
+  );
+}
+
+const ACTION_OPTIONS = [
+  { value: 'all', label: 'All access events' },
+  { value: 'access_granted', label: 'Access granted' },
+  { value: 'access_denied', label: 'Denied' },
+  { value: 'session_ended', label: 'Session ended' },
+  { value: 'badge_enrolled', label: 'Badge enrolled' },
+];
+
+const ACTION_COLORS: Record<string, string> = {
+  access_granted: 'green',
+  access_denied: 'red',
+  session_ended: 'gray',
+  badge_enrolled: 'blue',
+};
+
+const DENY_REASON_LABELS: Record<string, string> = {
+  not_authorized: 'Not authorized',
+  in_use: 'In use by another member',
+  unknown_card: 'Unknown card',
+  unknown_device: 'Unknown device',
+  no_asset: 'No asset bound to device',
+  relay_error: 'Relay error',
+  malformed: 'Malformed request',
+  badge_in_use: 'Badge already assigned',
+};
+
+// The deny reason lives in ``metadata.reason``; fall back to the free-text note.
+function describeReason(event: ForgeKeyAuditEvent): string {
+  const reason = event.metadata && typeof event.metadata.reason === 'string'
+    ? (event.metadata.reason as string)
+    : '';
+  if (reason) return DENY_REASON_LABELS[reason] ?? reason;
+  return event.notes || '';
+}
+
+function formatTime(value: string): string {
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? value : d.toLocaleString();
+}
+
+const ForgeKeyAccessLogPage: React.FC = () => {
+  const isStaff = isStaffUser();
+
+  const [events, setEvents] = useState<ForgeKeyAuditEvent[]>([]);
+  const [action, setAction] = useState<string>('all');
+  const [accessOnly, setAccessOnly] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await forgekeyAPI.listAccessLog({
+        accessOnly,
+        action: action !== 'all' ? action : undefined,
+      });
+      setEvents(unwrap<ForgeKeyAuditEvent>(res.data));
+      setError(null);
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to load the access log.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [accessOnly, action]);
+
+  useEffect(() => {
+    if (isStaff) load();
+  }, [isStaff, load]);
+
+  if (!isStaff) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <WorkspacePage
+      testId="forgekey-access-log-page"
+      hero={{
+        eyebrow: 'Facilities · ForgeKey',
+        title: 'Access log',
+        description:
+          'Recent badge access grants, denials (with reason), session ends, and badge enrollments.',
+        action: (
+          <Button variant="default" onClick={load} data-testid="access-log-refresh">
+            Refresh
+          </Button>
+        ),
+      }}
+    >
+      <Group mb="md" gap="md" align="flex-end">
+        <Select
+          label="Action"
+          data={ACTION_OPTIONS}
+          value={action}
+          onChange={(v) => setAction(v ?? 'all')}
+          aria-label="Action"
+          data-testid="access-log-action-filter"
+          allowDeselect={false}
+          w={220}
+        />
+        <Switch
+          label="Access events only"
+          checked={accessOnly}
+          onChange={(e) => setAccessOnly(e.currentTarget.checked)}
+          data-testid="access-log-access-only"
+        />
+      </Group>
+
+      {error && (
+        <Alert color="red" variant="light" data-testid="access-log-error" mb="md">
+          {error}
+        </Alert>
+      )}
+
+      {loading && events.length === 0 ? (
+        <Group justify="center" p="xl">
+          <Loader />
+        </Group>
+      ) : events.length === 0 ? (
+        <Text c="dimmed" data-testid="access-log-empty">
+          No access events match these filters.
+        </Text>
+      ) : (
+        <Table.ScrollContainer minWidth={680}>
+          <Table striped highlightOnHover data-testid="access-log-table">
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Time</Table.Th>
+                <Table.Th>Action</Table.Th>
+                <Table.Th>Member</Table.Th>
+                <Table.Th>Asset</Table.Th>
+                <Table.Th>Reason / notes</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {events.map((e) => (
+                <Table.Tr key={e.id} data-testid={`access-log-row-${e.id}`}>
+                  <Table.Td>{formatTime(e.created_at)}</Table.Td>
+                  <Table.Td>
+                    <Badge color={ACTION_COLORS[e.action] ?? 'gray'} variant="light">
+                      {e.action_display}
+                    </Badge>
+                  </Table.Td>
+                  <Table.Td>{e.actor_username ?? <Text c="dimmed">unknown card</Text>}</Table.Td>
+                  <Table.Td>{e.asset_name ?? <Text c="dimmed">—</Text>}</Table.Td>
+                  <Table.Td>{describeReason(e) || <Text c="dimmed">—</Text>}</Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </Table.ScrollContainer>
+      )}
+    </WorkspacePage>
+  );
+};
+
+export default ForgeKeyAccessLogPage;

--- a/frontend/src/pages/ForgeKeyBadgeEnrollmentPage.tsx
+++ b/frontend/src/pages/ForgeKeyBadgeEnrollmentPage.tsx
@@ -1,0 +1,320 @@
+/**
+ * ForgeKeyBadgeEnrollmentPage — staff member/badge admin (op-tup).
+ *
+ * Lists members (staff-only directory) with their current access badge and
+ * lets staff:
+ *  - **Enroll a badge** by arming "enroll next scan" for a member and prompting
+ *    them to tap the reader; the access-control interlock binds the captured
+ *    UID and this page polls until it sees the capture.
+ *  - **Set a badge manually** (fallback when no reader is handy).
+ *  - **Clear a badge.**
+ *
+ * Staff-gated client-side (the backend enforces it too); non-staff are bounced
+ * to the home page like the other ForgeKey admin pages.
+ */
+import { Alert, Badge, Button, Card, Group, Loader, Stack, Text, TextInput } from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
+import { DirectoryUser, forgekeyAPI, userAPI } from '../services/api';
+import { confirmAction, showError, showSuccess } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+const POLL_MS = 2000;
+
+type EnrollStatus = 'waiting' | 'captured' | 'expired';
+
+function unwrap<T>(data: { results?: T[] } | T[]): T[] {
+  if (Array.isArray(data)) return data;
+  return data.results ?? [];
+}
+
+function isStaffUser(): boolean {
+  if (typeof window === 'undefined') return false;
+  return (
+    localStorage.getItem('is_staff') === 'true' ||
+    localStorage.getItem('is_superuser') === 'true'
+  );
+}
+
+const ForgeKeyBadgeEnrollmentPage: React.FC = () => {
+  const isStaff = isStaffUser();
+
+  const [users, setUsers] = useState<DirectoryUser[]>([]);
+  const [search, setSearch] = useState('');
+  const [debouncedSearch] = useDebouncedValue(search, 250);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [editingUserId, setEditingUserId] = useState<number | null>(null);
+  const [badgeDraft, setBadgeDraft] = useState('');
+
+  const [enrollUserId, setEnrollUserId] = useState<number | null>(null);
+  const [enrollStatus, setEnrollStatus] = useState<EnrollStatus | null>(null);
+  const [capturedBadge, setCapturedBadge] = useState<string | null>(null);
+
+  const loadUsers = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await userAPI.listUsers({ search: debouncedSearch || undefined });
+      setUsers(unwrap<DirectoryUser>(res.data));
+      setError(null);
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to load members.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [debouncedSearch]);
+
+  useEffect(() => {
+    if (isStaff) loadUsers();
+  }, [isStaff, loadUsers]);
+
+  const setBadgeOnRow = (userId: number, badge: string | null) =>
+    setUsers((prev) =>
+      prev.map((u) => (u.id === userId ? { ...u, badge_number: badge } : u)),
+    );
+
+  // Poll for a captured scan while an enrollment is armed. Recursive setTimeout
+  // (not setInterval) so we never schedule another poll after we stop.
+  useEffect(() => {
+    if (enrollUserId == null) return undefined;
+    let stopped = false;
+    let handle: number | undefined;
+    const tick = async () => {
+      if (stopped) return;
+      try {
+        const res = await forgekeyAPI.getBadgeEnrollmentState({ userId: enrollUserId });
+        if (stopped) return;
+        const state = res.data;
+        if (state.captured) {
+          stopped = true;
+          setCapturedBadge(state.captured.badge_number);
+          setEnrollStatus('captured');
+          setBadgeOnRow(enrollUserId, state.captured.badge_number);
+          showSuccess(`Badge ${state.captured.badge_number} enrolled.`);
+          return;
+        }
+        if (!state.armed) {
+          stopped = true;
+          setEnrollStatus('expired');
+          return;
+        }
+      } catch (err) {
+        stopped = true;
+        showError(extractErrorMessage(err, 'Enrollment check failed.'));
+        return;
+      }
+      handle = window.setTimeout(tick, POLL_MS);
+    };
+    tick();
+    return () => {
+      stopped = true;
+      if (handle) window.clearTimeout(handle);
+    };
+  }, [enrollUserId]);
+
+  if (!isStaff) {
+    return <Navigate to="/" replace />;
+  }
+
+  const startEnroll = async (userId: number) => {
+    setEditingUserId(null);
+    setCapturedBadge(null);
+    setEnrollStatus(null);
+    try {
+      await forgekeyAPI.armBadgeEnrollment({ userId });
+      setEnrollStatus('waiting');
+      setEnrollUserId(userId);
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Failed to arm enrollment.'));
+    }
+  };
+
+  const cancelEnroll = async () => {
+    setEnrollUserId(null);
+    setEnrollStatus(null);
+    setCapturedBadge(null);
+    try {
+      await forgekeyAPI.cancelBadgeEnrollment();
+    } catch {
+      /* best-effort disarm; the armed record TTL-expires on its own anyway */
+    }
+  };
+
+  const openManual = (user: DirectoryUser) => {
+    setEnrollUserId(null);
+    setEnrollStatus(null);
+    setEditingUserId(user.id);
+    setBadgeDraft(user.badge_number ?? '');
+  };
+
+  const saveManual = async (userId: number) => {
+    const value = badgeDraft.trim();
+    try {
+      const res = await forgekeyAPI.setBadge({ userId, badgeNumber: value || null });
+      setBadgeOnRow(userId, res.data.badge_number);
+      showSuccess(value ? `Badge set to ${value}.` : 'Badge cleared.');
+      setEditingUserId(null);
+    } catch (err) {
+      showError(extractErrorMessage(err, 'Failed to set badge.'));
+    }
+  };
+
+  const clearBadge = (userId: number) =>
+    confirmAction(
+      'Clear badge',
+      'Remove this member’s badge? They will no longer be able to scan in.',
+      async () => {
+        try {
+          await forgekeyAPI.setBadge({ userId, badgeNumber: null });
+          setBadgeOnRow(userId, null);
+          showSuccess('Badge cleared.');
+        } catch (err) {
+          showError(extractErrorMessage(err, 'Failed to clear badge.'));
+        }
+      },
+      { color: 'red' },
+    );
+
+  return (
+    <WorkspacePage
+      testId="forgekey-badge-enrollment-page"
+      hero={{
+        eyebrow: 'Facilities · ForgeKey',
+        title: 'Badge enrollment',
+        description:
+          'Assign access badges to members — arm a reader for the next tap, or enter a UID by hand.',
+      }}
+    >
+      <TextInput
+        placeholder="Search members by name, username, or email…"
+        value={search}
+        onChange={(e) => setSearch(e.currentTarget.value)}
+        data-testid="badge-user-search"
+        mb="md"
+      />
+
+      {error && (
+        <Alert color="red" variant="light" data-testid="badge-error" mb="md">
+          {error}
+        </Alert>
+      )}
+
+      {loading && users.length === 0 ? (
+        <Group justify="center" p="xl">
+          <Loader />
+        </Group>
+      ) : users.length === 0 ? (
+        <Text c="dimmed" data-testid="badge-empty">
+          No members found.
+        </Text>
+      ) : (
+        <Stack gap="sm">
+          {users.map((u) => (
+            <Card key={u.id} withBorder p="sm" radius="md" data-testid={`user-row-${u.id}`}>
+              <Group justify="space-between" wrap="nowrap" align="flex-start">
+                <div>
+                  <Text fw={500}>
+                    {u.full_name}{' '}
+                    <Text span c="dimmed" size="sm">
+                      ({u.username})
+                    </Text>
+                  </Text>
+                  <Group gap="xs" mt={4}>
+                    <Text size="sm">Badge:</Text>
+                    {u.badge_number ? (
+                      <Badge variant="light" data-testid={`badge-value-${u.id}`}>
+                        {u.badge_number}
+                      </Badge>
+                    ) : (
+                      <Text size="sm" c="dimmed" data-testid={`badge-value-${u.id}`}>
+                        none
+                      </Text>
+                    )}
+                  </Group>
+                </div>
+                <Group gap="xs" wrap="nowrap">
+                  {enrollUserId === u.id ? null : (
+                    <>
+                      <Button
+                        size="xs"
+                        onClick={() => startEnroll(u.id)}
+                        data-testid={`enroll-${u.id}`}
+                      >
+                        Enroll badge
+                      </Button>
+                      <Button
+                        size="xs"
+                        variant="light"
+                        onClick={() => openManual(u)}
+                        data-testid={`set-${u.id}`}
+                      >
+                        Set manually
+                      </Button>
+                      {u.badge_number && (
+                        <Button
+                          size="xs"
+                          variant="light"
+                          color="red"
+                          onClick={() => clearBadge(u.id)}
+                          data-testid={`clear-${u.id}`}
+                        >
+                          Clear
+                        </Button>
+                      )}
+                    </>
+                  )}
+                </Group>
+              </Group>
+
+              {editingUserId === u.id && (
+                <Group mt="sm" gap="xs" data-testid={`manual-${u.id}`}>
+                  <TextInput
+                    placeholder="Badge UID"
+                    value={badgeDraft}
+                    onChange={(e) => setBadgeDraft(e.currentTarget.value)}
+                    data-testid="manual-input"
+                    style={{ flex: 1 }}
+                  />
+                  <Button size="xs" onClick={() => saveManual(u.id)} data-testid="manual-save">
+                    Save
+                  </Button>
+                  <Button size="xs" variant="subtle" onClick={() => setEditingUserId(null)}>
+                    Cancel
+                  </Button>
+                </Group>
+              )}
+
+              {enrollUserId === u.id && (
+                <Group mt="sm" gap="xs" data-testid={`enroll-status-${u.id}`}>
+                  {enrollStatus === 'waiting' && (
+                    <Text size="sm" c="blue">
+                      Ask {u.full_name || u.username} to tap their badge on the reader…
+                    </Text>
+                  )}
+                  {enrollStatus === 'captured' && (
+                    <Text size="sm" c="green">
+                      Captured badge {capturedBadge}.
+                    </Text>
+                  )}
+                  {enrollStatus === 'expired' && (
+                    <Text size="sm" c="red">
+                      No tap detected — enrollment expired. Try again.
+                    </Text>
+                  )}
+                  <Button size="xs" variant="subtle" onClick={cancelEnroll}>
+                    {enrollStatus === 'captured' || enrollStatus === 'expired' ? 'Done' : 'Cancel'}
+                  </Button>
+                </Group>
+              )}
+            </Card>
+          ))}
+        </Stack>
+      )}
+    </WorkspacePage>
+  );
+};
+
+export default ForgeKeyBadgeEnrollmentPage;

--- a/frontend/src/pages/ForgeKeyDashboardPage.tsx
+++ b/frontend/src/pages/ForgeKeyDashboardPage.tsx
@@ -160,9 +160,17 @@ const ForgeKeyDashboardPage: React.FC = () => {
         description:
           'Health across every ForgeKey device — connectivity, firmware, e-paper panels, and recent activity.',
         action: (
-          <Button component={Link} to="/facilities/forgekey-devices" variant="default">
-            Manage devices
-          </Button>
+          <Group gap="xs">
+            <Button component={Link} to="/facilities/forgekey-devices" variant="default">
+              Manage devices
+            </Button>
+            <Button component={Link} to="/facilities/forgekey-badges" variant="default">
+              Badge enrollment
+            </Button>
+            <Button component={Link} to="/facilities/forgekey-access-log" variant="default">
+              Access log
+            </Button>
+          </Group>
         ),
       }}
     >

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1292,10 +1292,35 @@ export const authAPI = {
     api.post('/auth/logout/'),
 };
 
+// A member as returned by the staff-only user directory (op-tup). Backs the
+// access-control grant user-picker and the badge-enrollment admin: enough to
+// identify a member and show their current badge.
+export interface DirectoryUser {
+  id: number;
+  username: string;
+  first_name: string;
+  last_name: string;
+  full_name: string;
+  email: string;
+  badge_number: string | null;
+  is_active: boolean;
+}
+
 // User Profile API
 export const userAPI = {
   getProfile: () =>
     api.get<UserProfile>('/membership/profile/me/'),
+
+  // Staff-only directory for access-control pickers. ``search`` matches
+  // username / name / email; ``hasBadge`` narrows to members with (or without)
+  // a badge for the enrollment admin.
+  listUsers: (opts: { search?: string; hasBadge?: boolean } = {}) =>
+    api.get<{ results?: DirectoryUser[] } | DirectoryUser[]>('/membership/users/', {
+      params: {
+        ...(opts.search ? { search: opts.search } : {}),
+        ...(opts.hasBadge != null ? { has_badge: String(opts.hasBadge) } : {}),
+      },
+    }),
 
   updateProfile: (data: Partial<UserProfile>) =>
     api.put<UserProfile>('/membership/profile/update_me/', data),
@@ -2194,6 +2219,53 @@ export interface ForgeKeyIndicatorTestResponse {
   payload: ForgeKeyIndicatorPresentation;
 }
 
+// A row in the ForgeKey access/denial log (access-control interlock, op-vj9).
+// ``metadata.reason`` carries the deny reason for ``access_denied`` rows.
+export interface ForgeKeyAuditEvent {
+  id: string;
+  created_at: string;
+  action: string;
+  action_display: string;
+  actor: number | null;
+  actor_username: string | null;
+  asset: string | null;
+  asset_name: string | null;
+  device: string | null;
+  device_mac: string | null;
+  notes: string;
+  metadata: Record<string, unknown> | null;
+}
+
+// The access-control actions the access-log view filters on, mapped to their
+// human labels (must match the backend ``ForgeKeyAuditEvent`` action choices).
+export const FORGEKEY_ACCESS_ACTIONS: Record<string, string> = {
+  access_granted: 'Access granted',
+  access_denied: 'Access denied',
+  session_ended: 'Usage session ended',
+  badge_enrolled: 'Badge enrolled',
+};
+
+// Armed/captured state for the "enroll next scan" badge handshake. ``captured``
+// is non-null once the member has tapped and the interlock bound the UID.
+export interface ForgeKeyBadgeEnrollmentState {
+  armed: boolean;
+  armed_user_id: number | null;
+  reader_id: string | null;
+  captured: { user_id: number; badge_number: string } | null;
+}
+
+export interface ForgeKeyBadgeArmResponse {
+  armed: boolean;
+  user_id: number;
+  reader_id: string | null;
+  ttl_seconds: number;
+}
+
+export interface ForgeKeyBadgeSetResponse {
+  user_id: number;
+  badge_number: string | null;
+}
+
 export const forgekeyAPI = {
   listDevices: (opts: { capability?: string } = {}) =>
     api.get<{ results?: ForgeKeyDevice[] } | ForgeKeyDevice[]>('/forgekey/devices/', {
@@ -2244,6 +2316,66 @@ export const forgekeyAPI = {
     ),
   unlockLockout: (id: string) =>
     api.post<ForgeKeyDeviceLockout>(`/forgekey/lockouts/${id}/unlock/`),
+  // Grant a user access to an asset. ``authorized_by`` is set server-side to the
+  // caller; an optional ``expires_at`` makes the grant lapse automatically.
+  grantAuthorization: (body: {
+    asset: string;
+    user: number;
+    notes?: string;
+    expires_at?: string | null;
+  }) => api.post<ForgeKeyAssetAuthorization>('/forgekey/authorizations/', body),
+  // The grants for one member — backs the per-member "assets I'm authorized for"
+  // view. Pass ``activeOnly`` to drop revoked/expired rows.
+  listAuthorizationsForUser: (userId: number, opts: { activeOnly?: boolean } = {}) =>
+    api.get<{ results?: ForgeKeyAssetAuthorization[] } | ForgeKeyAssetAuthorization[]>(
+      '/forgekey/authorizations/',
+      { params: { user: userId, ...(opts.activeOnly ? { is_active: 'true' } : {}) } },
+    ),
+  // Access/denial log (op-vj9). Defaults to the access-control actions only
+  // (grant / deny / session-ended / badge-enrolled); pass filters to narrow.
+  listAccessLog: (
+    opts: {
+      accessOnly?: boolean;
+      action?: string;
+      asset?: string;
+      actor?: number;
+      device?: string;
+    } = {},
+  ) =>
+    api.get<{ results?: ForgeKeyAuditEvent[] } | ForgeKeyAuditEvent[]>('/forgekey/access-log/', {
+      params: {
+        ...(opts.accessOnly !== false ? { access_only: 'true' } : {}),
+        ...(opts.action ? { action: opts.action } : {}),
+        ...(opts.asset ? { asset: opts.asset } : {}),
+        ...(opts.actor != null ? { actor: opts.actor } : {}),
+        ...(opts.device ? { device: opts.device } : {}),
+      },
+    }),
+  // Badge enrollment (op-vj9). ``getBadgeEnrollmentState`` is the poll target for
+  // the arm flow; reading it with a ``userId`` consumes a captured result.
+  getBadgeEnrollmentState: (opts: { userId?: number; readerId?: string } = {}) =>
+    api.get<ForgeKeyBadgeEnrollmentState>('/forgekey/badge-enrollment/', {
+      params: {
+        ...(opts.userId != null ? { user_id: opts.userId } : {}),
+        ...(opts.readerId ? { reader_id: opts.readerId } : {}),
+      },
+    }),
+  armBadgeEnrollment: (body: { userId: number; readerId?: string }) =>
+    api.post<ForgeKeyBadgeArmResponse>('/forgekey/badge-enrollment/arm/', {
+      user_id: body.userId,
+      ...(body.readerId ? { reader_id: body.readerId } : {}),
+    }),
+  cancelBadgeEnrollment: (body: { readerId?: string } = {}) =>
+    api.post<{ armed: boolean }>('/forgekey/badge-enrollment/cancel/', {
+      ...(body.readerId ? { reader_id: body.readerId } : {}),
+    }),
+  // Set or clear a member's badge directly (manual-entry fallback). Pass
+  // ``badgeNumber: null`` to clear.
+  setBadge: (body: { userId: number; badgeNumber: string | null }) =>
+    api.post<ForgeKeyBadgeSetResponse>('/forgekey/badge-enrollment/set-badge/', {
+      user_id: body.userId,
+      badge_number: body.badgeNumber,
+    }),
   getOccupancy: (id: string, since: string = '24h') =>
     api.get<ForgeKeyOccupancyResponse>(`/forgekey/devices/${id}/occupancy/`, {
       params: { since },


### PR DESCRIPTION
Work bead: **op-tup** — Frontend: authorization management, badge enrollment, access log

Published by the openmakersuite refinery as the `mr`-mode merge handoff for op-tup. Branch was already current with `main` (0 behind `584a9fb`), so no rebase needed. Verified conflict-free with the in-flight PR #795 (op-vj9) — both touch `backend/forgekey/views.py` but in disjoint regions, so they are order-independent.

## Change
`feat(frontend): access authorization grant, badge enrollment, and access log UI`

Frontend + supporting backend (15 files): frontend `App.tsx`, `AssetForgeKeyAccessCard`, `ForgeKeyAccessLogPage`, `ForgeKeyBadgeEnrollmentPage`, `ForgeKeyDashboardPage`, `services/api.ts` (+ tests); backend `forgekey/views.py`, `membership/{serializers,urls,views}.py` (+ tests).

Landing is gated on the repo's required checks (CI Complete + Semgrep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)