### PR TITLE
fix(access): restrict ForgeKey access log to staff (IsAdminUser)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -877,10 +877,10 @@ views:
     actions:
       list:
         permission_classes:
-        - IsAuthenticated
+        - IsAdminUser
       retrieve:
         permission_classes:
-        - IsAuthenticated
+        - IsAdminUser
   forgekey.views.ForgeKeyCertificateRevocationListView:
     permission_classes:
     - AllowAny

--- a/backend/forgekey/tests/test_access_control.py
+++ b/backend/forgekey/tests/test_access_control.py
@@ -593,8 +593,11 @@ class TestAccessLogApi:
         AssetAuthorizationFactory(asset=asset, user=member, is_active=True)
         ac.handle_access_request(device.mac_address, _badge_payload())  # ACCESS_GRANTED
 
+        # The access log is staff-only (op-2se), so the reader is an admin even
+        # though the access event was logged against a plain member.
+        staff = UserFactory(is_staff=True)
         client = APIClient()
-        client.force_authenticate(user=member)
+        client.force_authenticate(user=staff)
         resp = client.get("/api/forgekey/access-log/?access_only=true")
         assert resp.status_code == 200
         actions = {row["action"] for row in resp.data["results"]}
@@ -607,3 +610,14 @@ class TestAccessLogApi:
             ]
         )
         assert ForgeKeyAuditEvent.ACTION_ACCESS_GRANTED in actions
+
+    def test_non_staff_member_cannot_read_access_log(self, asset, device, member):
+        # A plain authenticated member is forbidden from the access log (op-2se):
+        # IsAdminUser on ForgeKeyAuditEventViewSet returns 403, not the rows.
+        AssetAuthorizationFactory(asset=asset, user=member, is_active=True)
+        ac.handle_access_request(device.mac_address, _badge_payload())  # ACCESS_GRANTED
+
+        client = APIClient()
+        client.force_authenticate(user=member)
+        resp = client.get("/api/forgekey/access-log/?access_only=true")
+        assert resp.status_code == 403

--- a/backend/forgekey/tests/test_audit_events.py
+++ b/backend/forgekey/tests/test_audit_events.py
@@ -211,3 +211,59 @@ class TestFirmwareAuditEvents:
         assert event.actor == actor
         assert event.authorization == authorization
         assert event.asset == authorization.asset
+
+
+class TestAccessLogPermissions:
+    """The access log is staff-only (op-2se): ``IsAdminUser`` on
+    ``ForgeKeyAuditEventViewSet``. A plain authenticated member must not be able
+    to read who was granted or denied access — only staff/admins can."""
+
+    def _event(self, actor=None):
+        return record_event(
+            action=ForgeKeyAuditEvent.ACTION_ACCESS_GRANTED,
+            actor=actor,
+            asset=AssetFactory(),
+        )
+
+    def test_non_staff_member_forbidden_from_list(self, api_client):
+        member = UserFactory(is_staff=False)
+        self._event(actor=member)
+        api_client.force_authenticate(user=member)
+
+        response = api_client.get(reverse("forgekey:access-log-list"))
+
+        assert response.status_code == 403, response.content
+
+    def test_non_staff_member_forbidden_from_retrieve(self, api_client):
+        member = UserFactory(is_staff=False)
+        event = self._event(actor=member)
+        api_client.force_authenticate(user=member)
+
+        response = api_client.get(reverse("forgekey:access-log-detail", kwargs={"pk": event.pk}))
+
+        assert response.status_code == 403, response.content
+
+    def test_staff_user_can_list(self, api_client):
+        staff = UserFactory(is_staff=True)
+        self._event(actor=staff)
+        api_client.force_authenticate(user=staff)
+
+        response = api_client.get(reverse("forgekey:access-log-list"))
+
+        assert response.status_code == 200, response.content
+
+    def test_staff_user_can_retrieve(self, api_client):
+        staff = UserFactory(is_staff=True)
+        event = self._event(actor=staff)
+        api_client.force_authenticate(user=staff)
+
+        response = api_client.get(reverse("forgekey:access-log-detail", kwargs={"pk": event.pk}))
+
+        assert response.status_code == 200, response.content
+
+    def test_unauthenticated_request_denied(self, api_client):
+        self._event()
+
+        response = api_client.get(reverse("forgekey:access-log-list"))
+
+        assert response.status_code in {401, 403}, response.content

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -1828,7 +1828,7 @@ class ForgeKeyAuditEventViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = ForgeKeyAuditEvent.objects.select_related("actor", "asset", "device").all()
     serializer_class = ForgeKeyAuditEventSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAdminUser]
 
     ACCESS_ACTIONS = [
         ForgeKeyAuditEvent.ACTION_ACCESS_GRANTED,

--- a/docs/API_PERMISSION_MATRIX.md
+++ b/docs/API_PERMISSION_MATRIX.md
@@ -154,7 +154,7 @@ below are public.
 | any | `forgekey/devices/...` (CRUD) | member-rw | `IsAuthenticatedOrReadOnly` on `ESP32DeviceViewSet`/`AssetDeviceViewSet`/`DeviceTypeViewSet`/`DeviceLockoutViewSet`/`DeviceUsageViewSet`. Custom write `@action`s elevate to `IsAdminUser`. |
 | any | `forgekey/firmware/...` | member | `IsAuthenticated` on `FirmwareVersionViewSet` and `DeviceFirmwareUpdateViewSet`. |
 | any | `forgekey/badge-enrollment/...` | admin | `IsAdminUser` on `BadgeEnrollmentViewSet` (list/arm/cancel/set_badge) — staff-only badge↔member enrollment for the access-control interlock. |
-| GET | `forgekey/access-log/` | member | `IsAuthenticated` on `ForgeKeyAuditEventViewSet` (list/retrieve) — access grant/deny/session audit events. |
+| GET | `forgekey/access-log/` | admin | `IsAdminUser` on `ForgeKeyAuditEventViewSet` (list/retrieve) — staff-only access grant/deny/session audit events. |
 | POST | `forgekey/devices/enroll/` | device-token | `AllowAny` at DRF; the view validates the provisioning token (`X-ForgeKey-Provisioning-Token` → `FORGEKEY_PROVISIONING_TOKEN`), validates the CSR, signs it, and links the resulting cert to a `DeviceIdentity`. Replaces the prior `/devices/register/` endpoint. |
 | POST | `forgekey/devices/<id>/photo/` | device-token | `AllowAny` at DRF; signed device payload is validated in the view body. |
 | GET | `forgekey/firmware/<id>/download/` | device-token | `AllowAny` + signed download URL. |


### PR DESCRIPTION
Restrict the ForgeKey access log to staff/admin readers.

The access log (`ForgeKeyAuditEventViewSet` — access grant/deny/session audit
events) was readable by any authenticated member. This change gates it to
staff/admin only. Follow-up to the access-control interlock (ga-5nt).

## Changes
- **views**: `ForgeKeyAuditEventViewSet.permission_classes` `IsAuthenticated` → `IsAdminUser` (gates both `list` and `retrieve`).
- **permission matrix**: regenerated `config/api_permission_matrix.yaml` (list/retrieve entries flip to `IsAdminUser`) and updated the forgekey/access-log row in `docs/API_PERMISSION_MATRIX.md` (member → admin).
- **tests**: a non-staff member now gets `403` on access-log list and retrieve while staff get `200` (`forgekey/tests/test_audit_events.py`); the existing `access_only` filter test switches to a staff reader and a non-staff `403` case is added (`forgekey/tests/test_access_control.py`).

Frontend staff-gating already shipped with the access-log UI (op-tup):
`ForgeKeyAccessLogPage` redirects non-staff via `<Navigate>`, and the only
access-log nav link lives on the staff-gated `ForgeKeyDashboardPage`.

## Verification (refinery pre-flight)
- Branch tests: `forgekey/tests/test_access_control.py` + `test_audit_events.py` — **66 passed**.
- Permission-matrix sync: `manage.py check_permission_matrix` — **OK, 811 endpoints match**.
- Lint (black / isort / flake8) clean on changed files.
- Binding gate is CI (Backend Tests on PostgreSQL + Semgrep).

Work bead: op-2se

🤖 Generated with [Claude Code](https://claude.com/claude-code)
