### PR TITLE
fix(forgekey): accept X-ForgeKey-Bootstrap-Token alias at enroll

### DIFF
--- a/backend/forgekey/tests/test_enrollment.py
+++ b/backend/forgekey/tests/test_enrollment.py
@@ -98,6 +98,8 @@ def _post_enroll(
     meta_overrides=None,
     photo=None,
     token=PROVISIONING_TOKEN,
+    token_header="HTTP_X_FORGEKEY_PROVISIONING_TOKEN",
+    extra_headers=None,
 ):
     mac = (meta_overrides or {}).get("mac_address", "AA:BB:CC:DD:EE:FF")
     chip = (meta_overrides or {}).get("unique_chip_id", "chip-aabbccddeeff")
@@ -121,7 +123,9 @@ def _post_enroll(
         data["photo"] = photo
     kwargs = {"format": "multipart"}
     if token is not None:
-        kwargs["HTTP_X_FORGEKEY_PROVISIONING_TOKEN"] = token
+        kwargs[token_header] = token
+    if extra_headers:
+        kwargs.update(extra_headers)
     return api_client.post(url, data=data, **kwargs)
 
 
@@ -236,6 +240,37 @@ def test_enroll_wrong_token_returns_401_with_diagnostics(
     assert "expected_token_fingerprint" in body
     # The full secret must NEVER appear in the response.
     assert PROVISIONING_TOKEN not in resp.content.decode("utf-8")
+
+
+def test_enroll_accepts_bootstrap_token_alias(
+    api_client, enroll_url, active_ca, people_counter_type
+):
+    # Already-flashed devices send the enrollment token in the legacy
+    # X-ForgeKey-Bootstrap-Token header; it is accepted as a back-compat alias
+    # so they enroll without reflashing.
+    resp = _post_enroll(
+        api_client,
+        enroll_url,
+        photo=_jpeg(),
+        token_header="HTTP_X_FORGEKEY_BOOTSTRAP_TOKEN",
+    )
+    assert resp.status_code == 201, resp.content
+    assert resp.json()["device_id"] == "chip-aabbccddeeff"
+
+
+def test_enroll_canonical_token_header_takes_precedence_over_alias(
+    api_client, enroll_url, active_ca, people_counter_type
+):
+    # The canonical header is primary: when it carries a (wrong) value, the
+    # legacy alias is NOT consulted as a fallback.
+    resp = _post_enroll(
+        api_client,
+        enroll_url,
+        token="not-the-token",
+        extra_headers={"HTTP_X_FORGEKEY_BOOTSTRAP_TOKEN": PROVISIONING_TOKEN},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["code"] == "token_mismatch"
 
 
 def test_enroll_malformed_csr_returns_400(api_client, enroll_url, active_ca, people_counter_type):

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -154,6 +154,29 @@ def _token_fingerprint(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()[:8]
 
 
+# Header carrying the shared provisioning token. ``X-ForgeKey-Provisioning-Token``
+# is canonical; ``X-ForgeKey-Bootstrap-Token`` is a backward-compatible alias for
+# devices already flashed with the older firmware, so they enroll without being
+# reflashed. The canonical header is primary; the alias is consulted only as a
+# fallback.
+PROVISIONING_TOKEN_HEADER = "x-forgekey-provisioning-token"
+PROVISIONING_TOKEN_HEADER_ALIAS = "x-forgekey-bootstrap-token"
+
+
+def _provisioning_token_from_request(request) -> str:
+    """Resolve the provisioning token from either accepted request header.
+
+    Prefers the canonical ``X-ForgeKey-Provisioning-Token`` header and falls
+    back to the legacy ``X-ForgeKey-Bootstrap-Token`` alias only when the
+    canonical header is absent or empty. Returns the raw (unstripped) header
+    value, or ``""`` when neither header carries a value.
+    """
+    primary = request.headers.get(PROVISIONING_TOKEN_HEADER, "") or ""
+    if primary:
+        return primary
+    return request.headers.get(PROVISIONING_TOKEN_HEADER_ALIAS, "") or ""
+
+
 def _classify_provisioning_token(request) -> tuple[bool, str | None, dict]:
     """Validate the provisioning token and classify any failure.
 
@@ -163,7 +186,7 @@ def _classify_provisioning_token(request) -> tuple[bool, str | None, dict]:
     """
     raw_expected = getattr(settings, "FORGEKEY_PROVISIONING_TOKEN", "") or ""
     expected = raw_expected.strip()
-    raw_supplied = request.headers.get("x-forgekey-provisioning-token", "") or ""
+    raw_supplied = _provisioning_token_from_request(request)
     supplied = raw_supplied.strip()
 
     diagnostics = {
@@ -191,7 +214,10 @@ _AUTH_ERR_DETAILS = {
         "Server has no provisioning token configured. "
         "Set FORGEKEY_PROVISIONING_TOKEN on the backend."
     ),
-    AUTH_ERR_TOKEN_MISSING: ("Request is missing the X-ForgeKey-Provisioning-Token header."),
+    AUTH_ERR_TOKEN_MISSING: (
+        "Request is missing the X-ForgeKey-Provisioning-Token header "
+        "(or its legacy alias X-ForgeKey-Bootstrap-Token)."
+    ),
     AUTH_ERR_TOKEN_PLACEHOLDER: (
         "Device sent the placeholder provisioning token; "
         "publish the real token via rotate_provisioning_token."
@@ -243,7 +269,9 @@ class ForgeKeyDeviceEnrollView(APIView):
 
     Auth: shared ``FORGEKEY_PROVISIONING_TOKEN`` supplied in the
     ``X-ForgeKey-Provisioning-Token`` header (same bootstrap secret used by
-    the legacy ``/register/`` endpoint).
+    the legacy ``/register/`` endpoint). The legacy
+    ``X-ForgeKey-Bootstrap-Token`` header is accepted as a backward-compatible
+    alias for devices flashed with older firmware.
     """
 
     authentication_classes: list = []
@@ -317,12 +345,9 @@ class ForgeKeyDeviceEnrollView(APIView):
         raw_sensor_kind = meta.get("sensor_kind") or meta.get("device_type") or ""
         sensor_kind_code = normalize_sensor_kind(raw_sensor_kind) if raw_sensor_kind else ""
 
+        supplied_token = _provisioning_token_from_request(request)
         token_fp_full = (
-            hashlib.sha256(
-                (request.headers.get("x-forgekey-provisioning-token", "") or "").encode("utf-8")
-            ).hexdigest()
-            if request.headers.get("x-forgekey-provisioning-token")
-            else ""
+            hashlib.sha256(supplied_token.encode("utf-8")).hexdigest() if supplied_token else ""
         )
 
         identity, _ = DeviceIdentity.objects.get_or_create(device_id=unique_chip_id)

--- a/docs/forgekey-integration.md
+++ b/docs/forgekey-integration.md
@@ -57,7 +57,10 @@ ESP32 (boot)              OMS backend
 Headers:
 
 * `X-ForgeKey-Provisioning-Token` — must equal `FORGEKEY_PROVISIONING_TOKEN`.
-  Empty server config returns 401 unconditionally.
+  Empty server config returns 401 unconditionally. `X-ForgeKey-Bootstrap-Token`
+  is accepted as a backward-compatible legacy alias for this header (used by
+  devices flashed with older firmware); the canonical header takes precedence
+  when both are present.
 
 Body (`multipart/form-data`):
 
@@ -110,7 +113,8 @@ token — re-registering rotates the JWT.
 Headers:
 
 * `Authorization: Bearer <jwt>` (preferred), or
-* `X-ForgeKey-Provisioning-Token` (fallback).
+* `X-ForgeKey-Provisioning-Token` (fallback; the legacy
+  `X-ForgeKey-Bootstrap-Token` alias is also accepted).
 
 Body (`multipart/form-data`):
 


### PR DESCRIPTION
Accept the legacy `X-ForgeKey-Bootstrap-Token` header as a backward-compatible
alias for the provisioning token at device enroll.

Already-flashed devices send the enrollment token in the legacy
`X-ForgeKey-Bootstrap-Token` header, but the enroll endpoint read only
`X-ForgeKey-Provisioning-Token`, so those devices `401` with `token_missing`.
This change accepts the bootstrap header as a fallback so deployed devices
enroll without reflashing.

## Changes
- Add `_provisioning_token_from_request()`: canonical `X-ForgeKey-Provisioning-Token` is primary; `X-ForgeKey-Bootstrap-Token` is consulted only as a fallback. Used at both read sites (token classification + supplied-fingerprint diagnostics) so the alias is honored consistently.
- `token_missing` detail text now names both accepted headers.
- Tests: alias-supplied token enrolls (`201`); canonical header takes precedence over the alias when both are present (`forgekey/tests/test_enrollment.py`).
- Docs: note the legacy alias in `docs/forgekey-integration.md`.

No permission-matrix change (header handling, not a new endpoint).

## Verification (refinery pre-flight)
- Branch tests: `forgekey/tests/test_enrollment.py` — green.
- `manage.py check_permission_matrix` — **OK, 811 endpoints match** (no drift).
- Lint (black / isort / flake8) clean on changed files.
- Binding gate is CI (Backend Tests on PostgreSQL + Semgrep).

Work bead: op-90u

🤖 Generated with [Claude Code](https://claude.com/claude-code)
