### PR TITLE
fix(forgekey): emit canonical <mac> enroll topics + accept legacy chip-id topics

### DIFF
--- a/backend/forgekey/tests/test_enrollment.py
+++ b/backend/forgekey/tests/test_enrollment.py
@@ -144,8 +144,13 @@ def test_enroll_returns_documented_fields(api_client, enroll_url, active_ca, peo
     assert body["command_public_key_pem"].startswith("-----BEGIN PUBLIC KEY-----")
 
     policy = body["policy"]
-    assert policy["mqtt_topic_for_firmware"].endswith("/devices/chip-aabbccddeeff/firmware")
-    assert policy["mqtt_topic_for_pings"].endswith("/devices/chip-aabbccddeeff/ping")
+    # Canonical MAC-keyed topics (forgekey/<mac>/...) — the chip-id-keyed
+    # legacy form made the firmware contract check fail and wipe its creds.
+    assert policy["mqtt_topic_for_firmware"] == "forgekey/aabbccddeeff/firmware"
+    assert policy["mqtt_topic_for_commands"] == "forgekey/aabbccddeeff/command"
+    assert policy["mqtt_topic_for_status"] == "forgekey/aabbccddeeff/status"
+    # People counters carry a contract-valid pings topic (kind/occupancy).
+    assert policy["mqtt_topic_for_pings"] == "forgekey/aabbccddeeff/people_counter/occupancy"
     assert isinstance(policy["mqtt_broker_use_tls"], bool)
 
     # Top-level mirror still present so older firmware can read either form.
@@ -185,6 +190,118 @@ def test_enroll_issues_cert_that_verifies_against_active_ca(
         issued.tbs_certificate_bytes,
         ec.ECDSA(issued.signature_hash_algorithm),
     )
+
+
+# ---------------------------------------------------------------------------
+# Canonical <mac> topics + non-people-counter attribution (op-bej)
+# ---------------------------------------------------------------------------
+
+
+def _firmware_accepts_pings_topic(topic: str) -> bool:
+    """Mirror ``isValidPingsTopic()`` in the ForgeKey firmware (src/main.cpp).
+
+    The device clears its credentials when a stored, non-empty
+    ``mqtt_topic_for_pings`` fails this check, so an enroll response must hand
+    back either a topic this accepts or an empty string.
+    """
+    if not topic:
+        # Empty is fine: the firmware keeps its own MAC-derived default.
+        return True
+    if not topic.startswith("forgekey/"):
+        return False
+    segs = topic.split("/")
+    if len(segs) != 4:
+        return False
+    _prefix, mac, kind, leaf = segs
+    if len(mac) != 12 or any(c not in "0123456789abcdef" for c in mac):
+        return False
+    if kind in ("people_counter", "door_counter"):
+        return leaf == "occupancy"
+    if kind == "temperature_sensor":
+        return leaf == "reading"
+    return False
+
+
+def test_enroll_indicator_gets_canonical_topics_and_no_cred_wipe(api_client, enroll_url, active_ca):
+    # The indicator DeviceType is seeded by migration 0004; create it
+    # explicitly too (get-or-create) so the test holds under --no-migrations.
+    DeviceTypeFactory(code=DeviceType.TYPE_INDICATOR)
+    resp = _post_enroll(
+        api_client,
+        enroll_url,
+        meta_overrides={
+            "mac_address": "8C:BF:EA:8E:A4:0C",
+            "unique_chip_id": "00000ca48eeabf8c",
+            "sensor_kind": DeviceType.TYPE_INDICATOR,
+        },
+    )
+    assert resp.status_code == 201, resp.content
+    policy = resp.json()["policy"]
+
+    # Command/status/firmware are the canonical MAC-keyed topics.
+    assert policy["mqtt_topic_for_commands"] == "forgekey/8cbfea8ea40c/command"
+    assert policy["mqtt_topic_for_status"] == "forgekey/8cbfea8ea40c/status"
+    assert policy["mqtt_topic_for_firmware"] == "forgekey/8cbfea8ea40c/firmware"
+
+    # Indicator is not a pings class: emit nothing so the firmware keeps its
+    # default instead of wiping creds. The firmware contract check passes.
+    assert policy["mqtt_topic_for_pings"] == ""
+    assert _firmware_accepts_pings_topic(policy["mqtt_topic_for_pings"])
+
+    # Attributes to the indicator DeviceType, not people-counter.
+    device = ESP32Device.objects.get(mac_address="8C:BF:EA:8E:A4:0C")
+    assert device.device_type.code == DeviceType.TYPE_INDICATOR
+
+
+def test_enroll_people_counter_pings_topic_passes_firmware_contract(
+    api_client, enroll_url, active_ca, people_counter_type
+):
+    resp = _post_enroll(api_client, enroll_url)
+    assert resp.status_code == 201, resp.content
+    policy = resp.json()["policy"]
+    assert policy["mqtt_topic_for_pings"] == "forgekey/aabbccddeeff/people_counter/occupancy"
+    assert _firmware_accepts_pings_topic(policy["mqtt_topic_for_pings"])
+
+
+def test_enroll_temperature_sensor_pings_uses_reading_leaf(api_client, enroll_url, active_ca):
+    DeviceTypeFactory(code=DeviceType.TYPE_TEMPERATURE_SENSOR)
+    resp = _post_enroll(
+        api_client,
+        enroll_url,
+        meta_overrides={"sensor_kind": DeviceType.TYPE_TEMPERATURE_SENSOR},
+    )
+    assert resp.status_code == 201, resp.content
+    policy = resp.json()["policy"]
+    # Temperature sensors publish to .../reading, not .../occupancy — the
+    # firmware contract rejects the wrong leaf.
+    assert policy["mqtt_topic_for_pings"] == "forgekey/aabbccddeeff/temperature_sensor/reading"
+    assert _firmware_accepts_pings_topic(policy["mqtt_topic_for_pings"])
+
+
+def test_enroll_derives_mac_from_chip_id_when_mac_absent(api_client, enroll_url, active_ca):
+    DeviceTypeFactory(code=DeviceType.TYPE_INDICATOR)
+    # No mac_address sent: the MAC is reconstructed from the eFuse chip id
+    # (lower 6 bytes, byte-reversed) — 00000ca48eeabf8c -> 8cbfea8ea40c.
+    _key, csr_pem = _build_csr("8cbfea8ea40c")
+    meta = {
+        "unique_chip_id": "00000ca48eeabf8c",
+        "csr_pem": csr_pem,
+        "firmware_version": "1.0.0",
+        "sensor_kind": DeviceType.TYPE_INDICATOR,
+    }
+    resp = api_client.post(
+        enroll_url,
+        data={"metadata": json.dumps(meta)},
+        HTTP_X_FORGEKEY_PROVISIONING_TOKEN=PROVISIONING_TOKEN,
+        format="multipart",
+    )
+    assert resp.status_code == 201, resp.content
+    policy = resp.json()["policy"]
+    assert policy["mqtt_topic_for_commands"] == "forgekey/8cbfea8ea40c/command"
+    assert policy["mqtt_topic_for_firmware"] == "forgekey/8cbfea8ea40c/firmware"
+    # Derived MAC is persisted normalized so the device attributes correctly.
+    device = ESP32Device.objects.get(mac_address="8C:BF:EA:8E:A4:0C")
+    assert device.device_type.code == DeviceType.TYPE_INDICATOR
 
 
 # ---------------------------------------------------------------------------

--- a/backend/forgekey/tests/test_mqtt_webhook.py
+++ b/backend/forgekey/tests/test_mqtt_webhook.py
@@ -18,8 +18,8 @@ from django.urls import reverse
 
 import pytest
 
-from forgekey.models import OccupancyEvent
-from forgekey.tests.factories import ESP32DeviceFactory
+from forgekey.models import DeviceIdentity, OccupancyEvent
+from forgekey.tests.factories import DeviceTypeFactory, ESP32DeviceFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -311,3 +311,101 @@ class TestWebhookOccupancyEndToEnd:
         )
         assert response.status_code == 204
         assert OccupancyEvent.objects.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Legacy compat: chip-id-keyed topics from already-deployed devices (op-bej)
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookLegacyChipIdTopics:
+    """Pre-MAC firmware was provisioned with forgekey/devices/<chip-id>/...
+
+    topics and still publishes there. The webhook must keep accepting them by
+    resolving the chip id back to the device MAC before routing.
+    """
+
+    def _enrolled_people_counter(self, chip_id="00000ca48eeabf8c", mac="8C:BF:EA:8E:A4:0C"):
+        identity = DeviceIdentity.objects.create(device_id=chip_id)
+        pc_type = DeviceTypeFactory(code="people_counter")
+        return ESP32DeviceFactory(mac_address=mac, device_type=pc_type, identity=identity)
+
+    def test_legacy_ping_routes_to_occupancy_with_device_mac(self, api_client):
+        device = self._enrolled_people_counter()
+        with patch("forgekey.views.process_mqtt_occupancy.delay") as mock_delay:
+            response = _post(
+                api_client,
+                {
+                    "topic": "forgekey/devices/00000ca48eeabf8c/ping",
+                    "payload": json.dumps({"in": 2, "out": 1}),
+                },
+            )
+        assert response.status_code == 204
+        mock_delay.assert_called_once_with(
+            device.mac_address,
+            "people_counter",
+            {"in": 2, "out": 1},
+        )
+
+    def test_legacy_status_routes_to_status_with_device_mac(self, api_client):
+        device = self._enrolled_people_counter()
+        with patch("forgekey.views.process_mqtt_status_message.delay") as mock_delay:
+            response = _post(
+                api_client,
+                {
+                    "topic": "forgekey/devices/00000ca48eeabf8c/status",
+                    "payload": json.dumps({"online": True}),
+                },
+            )
+        assert response.status_code == 204
+        mock_delay.assert_called_once_with(device.mac_address, {"online": True})
+
+    def test_legacy_ping_derives_mac_when_device_not_enrolled(self, api_client):
+        # No ESP32Device row: fall back to deriving the MAC from the chip id
+        # (00000ca48eeabf8c -> 8cbfea8ea40c -> 8C:BF:EA:8E:A4:0C). Kind defaults
+        # to people_counter, the only class the legacy ping topic was used for.
+        with patch("forgekey.views.process_mqtt_occupancy.delay") as mock_delay:
+            response = _post(
+                api_client,
+                {
+                    "topic": "forgekey/devices/00000ca48eeabf8c/ping",
+                    "payload": json.dumps({"in": 1, "out": 0}),
+                },
+            )
+        assert response.status_code == 204
+        mock_delay.assert_called_once_with(
+            "8C:BF:EA:8E:A4:0C",
+            "people_counter",
+            {"in": 1, "out": 0},
+        )
+
+    def test_legacy_unresolvable_chip_is_dropped(self, api_client):
+        # Non-hex chip id and no device row → cannot resolve a MAC → dropped
+        # (204, no dispatch) rather than erroring or guessing.
+        with patch("forgekey.views.process_mqtt_occupancy.delay") as mock_delay:
+            response = _post(
+                api_client,
+                {
+                    "topic": "forgekey/devices/not-a-hex-chip/ping",
+                    "payload": json.dumps({"in": 1, "out": 0}),
+                },
+            )
+        assert response.status_code == 204
+        assert not mock_delay.called
+
+    def test_canonical_mac_topic_still_routes(self, api_client):
+        # Regression: the new forgekey/<mac>/<kind>/occupancy form is unaffected.
+        with patch("forgekey.views.process_mqtt_occupancy.delay") as mock_delay:
+            response = _post(
+                api_client,
+                {
+                    "topic": "forgekey/8cbfea8ea40c/people_counter/occupancy",
+                    "payload": json.dumps({"in": 1, "out": 0}),
+                },
+            )
+        assert response.status_code == 204
+        mock_delay.assert_called_once_with(
+            "8C:BF:EA:8E:A4:0C",
+            "people_counter",
+            {"in": 1, "out": 0},
+        )

--- a/backend/forgekey/utils.py
+++ b/backend/forgekey/utils.py
@@ -248,6 +248,31 @@ def normalize_sensor_kind(sensor_kind: str) -> str:
     return (sensor_kind or "").strip().replace("-", "_").lower()
 
 
+def mac_from_chip_id(chip_id: str) -> str:
+    """Derive the device's base WiFi MAC from its eFuse ``unique_chip_id``.
+
+    ESP32 reports an 8-byte eFuse chip id; the factory base MAC is the lower
+    six bytes of that value in reversed byte order — e.g. chip id
+    ``00000ca48eeabf8c`` → MAC ``8cbfea8ea40c``. The firmware keys its MQTT
+    topics on this MAC, so when a device enrolls without sending ``mac_address``
+    we reconstruct it here rather than fall back to a chip-id-keyed topic the
+    firmware would reject.
+
+    Returns the bare lowercase 12-hex MAC, or ``""`` when ``chip_id`` is not a
+    parseable hex value of at least six bytes.
+    """
+    digits = (chip_id or "").strip().replace(":", "").replace("-", "").lower()
+    if len(digits) < 12:
+        return ""
+    low_six = digits[-12:]
+    try:
+        int(low_six, 16)
+    except ValueError:
+        return ""
+    octets = [low_six[i : i + 2] for i in range(0, 12, 2)]
+    return "".join(reversed(octets))
+
+
 def get_mqtt_firmware_topic(mac_address: str) -> str:
     """MQTT topic the firmware subscribes to for OTA advertisements.
 
@@ -263,6 +288,39 @@ def get_mqtt_ping_topic(mac_address: str, sensor_kind: str) -> str:
     """
     kind = normalize_sensor_kind(sensor_kind)
     return f"{settings.MQTT_TOPIC_PREFIX}/{_firmware_contract_mac(mac_address)}/{kind}/occupancy"
+
+
+# Sensor kinds whose enroll-time ``mqtt_topic_for_pings`` the firmware accepts,
+# mapped to the leaf segment it requires. This mirrors ``isValidPingsTopic()``
+# in the ForgeKey firmware (``src/main.cpp``): the device validates the topic we
+# hand back against exactly these shapes and WIPES its credentials on any
+# mismatch. For every other class (indicator, lock, …) we emit no pings topic so
+# the firmware keeps its own MAC-derived default instead of clearing creds.
+_PINGS_CONTRACT_LEAF = {
+    "people_counter": "occupancy",
+    "door_counter": "occupancy",
+    "temperature_sensor": "reading",
+}
+
+
+def get_mqtt_pings_topic(mac_address: str, sensor_kind: str) -> str:
+    """Enroll-response ``mqtt_topic_for_pings`` for ``sensor_kind``.
+
+    Returns the firmware-contract topic
+    ``forgekey/<mac>/<kind>/<occupancy|reading>`` for the people-counter,
+    door-counter, and temperature-sensor classes the firmware validates, or
+    ``""`` for any other class (e.g. indicator) so the device keeps its built-in
+    default and does not clear its credentials. Also returns ``""`` when no MAC
+    is known.
+    """
+    contract_mac = _firmware_contract_mac(mac_address)
+    if not contract_mac:
+        return ""
+    kind = normalize_sensor_kind(sensor_kind)
+    leaf = _PINGS_CONTRACT_LEAF.get(kind)
+    if not leaf:
+        return ""
+    return f"{settings.MQTT_TOPIC_PREFIX}/{contract_mac}/{kind}/{leaf}"
 
 
 def get_mqtt_ota_trigger_topic(mac_address: str) -> str:

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -115,10 +115,11 @@ from .tasks import (
     request_device_status,
 )
 from .utils import (
-    device_command_topic_for,
-    device_firmware_topic_for,
-    device_ping_topic_for,
-    device_status_topic_for,
+    get_mqtt_command_topic,
+    get_mqtt_firmware_topic,
+    get_mqtt_pings_topic,
+    get_mqtt_status_topic,
+    mac_from_chip_id,
     normalize_mac_address,
     normalize_sensor_kind,
     verify_device_jwt,
@@ -345,6 +346,17 @@ class ForgeKeyDeviceEnrollView(APIView):
         raw_sensor_kind = meta.get("sensor_kind") or meta.get("device_type") or ""
         sensor_kind_code = normalize_sensor_kind(raw_sensor_kind) if raw_sensor_kind else ""
 
+        # The whole MQTT topic + ACL contract is MAC-keyed. Prefer the MAC the
+        # device reported; if it enrolled without one, derive it from the eFuse
+        # chip id (ESP32 base MAC = lower 6 bytes of unique_chip_id, byte-
+        # reversed) so the topics we hand back still match what the firmware
+        # subscribes / publishes on. Empty only when neither source yields a MAC.
+        device_mac = mac_normalized
+        if not device_mac:
+            derived_mac = mac_from_chip_id(unique_chip_id)
+            if derived_mac:
+                device_mac = normalize_mac_address(derived_mac)
+
         supplied_token = _provisioning_token_from_request(request)
         token_fp_full = (
             hashlib.sha256(supplied_token.encode("utf-8")).hexdigest() if supplied_token else ""
@@ -404,7 +416,7 @@ class ForgeKeyDeviceEnrollView(APIView):
                 device=identity,
                 csr_pem=csr_pem,
                 unique_chip_id=unique_chip_id,
-                mac_address=mac_normalized,
+                mac_address=device_mac,
                 sensor_kind=sensor_kind_code,
                 firmware_version=meta.get("firmware_version", "") or "",
                 chip_info=meta.get("chip_info") or {},
@@ -441,15 +453,15 @@ class ForgeKeyDeviceEnrollView(APIView):
             enrollment.save()
 
             esp_device = None
-            if mac_normalized:
-                esp_device = ESP32Device.objects.filter(mac_address=mac_normalized).first()
+            if device_mac:
+                esp_device = ESP32Device.objects.filter(mac_address=device_mac).first()
                 if esp_device is None:
                     device_type_obj = None
                     if sensor_kind_code:
                         device_type_obj = DeviceType.objects.filter(code=sensor_kind_code).first()
                     if device_type_obj is not None:
                         esp_device = ESP32Device.objects.create(
-                            mac_address=mac_normalized,
+                            mac_address=device_mac,
                             device_type=device_type_obj,
                             firmware_version=meta.get("firmware_version", "") or "",
                             boot_count=meta.get("boot_count"),
@@ -488,10 +500,18 @@ class ForgeKeyDeviceEnrollView(APIView):
         broker_host = settings.PUBLIC_MQTT_BROKER_HOST or settings.MQTT_BROKER_HOST
         broker_port = settings.PUBLIC_MQTT_BROKER_PORT
         broker_tls = settings.PUBLIC_MQTT_BROKER_USE_TLS
-        firmware_topic = device_firmware_topic_for(unique_chip_id)
-        ping_topic = device_ping_topic_for(unique_chip_id)
-        command_topic = device_command_topic_for(unique_chip_id)
-        status_topic = device_status_topic_for(unique_chip_id)
+        # Hand back the canonical MAC-keyed topics the firmware (and the OMS MQTT
+        # consumer) expect. The pings topic is class-aware: it is only emitted
+        # for the sensor kinds the firmware's contract check accepts, and is
+        # left empty otherwise (e.g. indicator) so the device does not wipe its
+        # credentials. command/status/firmware are derived from the device MAC.
+        if device_mac:
+            firmware_topic = get_mqtt_firmware_topic(device_mac)
+            ping_topic = get_mqtt_pings_topic(device_mac, sensor_kind_code)
+            command_topic = get_mqtt_command_topic(device_mac)
+            status_topic = get_mqtt_status_topic(device_mac)
+        else:
+            firmware_topic = ping_topic = command_topic = status_topic = ""
 
         policy = {
             "mqtt_broker_host": broker_host,
@@ -695,6 +715,21 @@ class MqttWebhookView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        # Legacy compat: pre-MAC firmware was provisioned with chip-id-keyed
+        # topics (forgekey/devices/<chip-id>/...). Already-deployed devices
+        # still publish there, so rewrite those into the canonical
+        # forgekey/<mac>/... shape before routing instead of dropping them.
+        if len(parts) >= 4 and parts[1] == "devices":
+            canonical = self._canonicalize_legacy_parts(parts)
+            if canonical is None:
+                logger.info(
+                    "ForgeKey webhook: ignoring legacy topic for unresolved chip %s",
+                    parts[2],
+                )
+                # 204, not an error: EMQX should not retry a topic we drop.
+                return Response(status=status.HTTP_204_NO_CONTENT)
+            parts = canonical
+
         try:
             mac = normalize_mac_address(parts[1])
         except Exception:
@@ -708,6 +743,52 @@ class MqttWebhookView(APIView):
             logger.info("ForgeKey webhook: ignoring unrouted topic %s", topic)
             # Still 204 — EMQX should not retry topics we deliberately drop.
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def _canonicalize_legacy_parts(self, parts: list[str]) -> list[str] | None:
+        """Rewrite a legacy ``forgekey/devices/<chip-id>/<suffix...>`` topic into
+        its canonical ``forgekey/<mac>/...`` equivalent so the normal dispatcher
+        routes it.
+
+        Returns the rewritten parts, or ``None`` when the chip id cannot be
+        resolved to a device MAC (the message is then dropped). ``parts`` is
+        ``[<prefix>, "devices", <chip-id>, <suffix...>]`` with at least four
+        elements.
+        """
+        chip_id = parts[2]
+        mac, kind = self._resolve_legacy_chip(chip_id)
+        if not mac:
+            return None
+        suffix = parts[3:]
+        # The legacy occupancy ping had no <kind> segment; the canonical form
+        # carries one. Re-insert it (from the device's type, defaulting to a
+        # people counter — the only class the chip-id ping topic was emitted
+        # for) so the occupancy route matches.
+        if suffix == ["ping"]:
+            return [parts[0], mac, kind or DeviceType.TYPE_PEOPLE_COUNTER, self.OCCUPANCY_SUFFIX]
+        # Every other legacy suffix already has the canonical shape once the
+        # devices/<chip-id> prefix is replaced by the bare MAC.
+        return [parts[0], mac, *suffix]
+
+    @staticmethod
+    def _resolve_legacy_chip(chip_id: str) -> tuple[str, str]:
+        """Resolve a legacy chip id to ``(mac, sensor_kind)`` for routing.
+
+        Prefers the enrolled ``ESP32Device`` (authoritative MAC + type); falls
+        back to deriving the MAC from the chip id when no device row is linked
+        yet. Returns ``("", "")`` when neither yields a MAC.
+        """
+        device = (
+            ESP32Device.objects.select_related("device_type")
+            .filter(identity__device_id=chip_id)
+            .first()
+        )
+        if device is not None:
+            kind = device.device_type.code if device.device_type_id else ""
+            return device.mac_address, kind
+        derived = mac_from_chip_id(chip_id)
+        if derived:
+            return normalize_mac_address(derived), ""
+        return "", ""
 
     @staticmethod
     def _ip_allowed(request) -> bool:


### PR DESCRIPTION
Emit canonical `forgekey/<mac>/...` enroll topics and accept the legacy
chip-id-keyed inbound topics for backward compatibility.

## Problem
Device enrollment returned `201`, but the enroll response handed back legacy
chip-id-keyed topics (`forgekey/devices/<chip-id>/ping`) while the firmware,
`docs/contracts/mqtt.md`, and OMS's MQTT consumer all expect
`forgekey/<mac>/...`. The firmware's `isValidPingsTopic()` rejected the wrong
shape and cleared provisioning, forcing an endless re-enroll loop.

## Change (product-owner decision: support BOTH)
- **Enroll** (`ForgeKeyDeviceEnrollView`): hand back canonical MAC-keyed
  command/status/firmware topics; `pings` is class-aware via
  `get_mqtt_pings_topic()` mirroring the firmware contract
  (`<kind>/occupancy` for counters, `<kind>/reading` for temperature, `""`
  for other classes so the device keeps its default). MAC prefers the
  reported `mac_address`, else derives from the eFuse `unique_chip_id` via
  `mac_from_chip_id()`.
- **Legacy inbound compat** (`MqttWebhookView`): rewrite
  `forgekey/devices/<chip-id>/<suffix>` into canonical `forgekey/<mac>/...`
  before routing (MAC resolved from the enrolled `ESP32Device` or derived);
  unresolvable chips dropped (`204`) rather than mis-routed.
- Legacy `device_*_topic_for` helpers kept in `utils.py` for the inbound
  migration window.

No permission-matrix / routing change (enroll/webhook logic only).

## Verification (refinery pre-flight)
- Branch tests: `forgekey/tests/test_enrollment.py` + `test_mqtt_webhook.py` — green.
- `manage.py check_permission_matrix` — **OK, 811 endpoints match** (no drift).
- Lint (black / isort / flake8) clean on changed files.
- Binding gate is CI (Backend Tests on PostgreSQL + Semgrep).

> Note from author: needs a prod deploy to dms.openmakersuite.net to take effect.

Work bead: op-bej

🤖 Generated with [Claude Code](https://claude.com/claude-code)
