### PR TITLE
fix(compose): disable inherited HTTP healthcheck on mqtt_consumer (op-cz8)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -301,6 +301,15 @@ services:
     image: oms-backend:local
     logging: *default-logging
     command: python manage.py mqtt_consumer
+    # mqtt_consumer reuses oms-backend:local, whose Dockerfile.prod bakes an
+    # HTTP liveness HEALTHCHECK (urlopen http://localhost:8000/api/health/livez/).
+    # This service runs no web server, so that probe can never succeed and the
+    # container is reported perpetually "unhealthy" (op-cz8). Disable the
+    # inherited probe; the consumer self-heals via paho's reconnect loop and the
+    # restart: unless-stopped policy below. (A real liveness check would need a
+    # heartbeat file written by the mgmt command — tracked separately.)
+    healthcheck:
+      disable: true
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## What
Disable the inherited HTTP `HEALTHCHECK` on the `mqtt_consumer` service.

## Why
`mqtt_consumer` reuses the `oms-backend:local` image, whose `Dockerfile.prod`
bakes an HTTP liveness `HEALTHCHECK` (`urlopen http://localhost:8000/api/health/livez/`).
This service runs `python manage.py mqtt_consumer` — **no web server** — so the
probe can never pass. The container is reported perpetually **unhealthy**
(FailingStreak >1200) even though it is connected to `emqx:1883` and subscribed
to device topics. Fixes op-cz8.

## Notes
- A real liveness check would need the consumer to write a heartbeat file (mgmt-command change); tracked as a follow-up. Meanwhile it self-heals via paho's reconnect loop + the existing `restart: unless-stopped`.
- Already applied directly to prod (147.135.5.141) to stop the false alarm; this PR makes it durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)