### PR TITLE
feat(frontend): grey out device-detail sections not relevant to the device type (op-3u4)

### DIFF
--- a/frontend/src/__tests__/components/IndicatorManagementCard.test.tsx
+++ b/frontend/src/__tests__/components/IndicatorManagementCard.test.tsx
@@ -4,7 +4,7 @@
  * API calls, and the live-preview legend.
  */
 import { MantineProvider } from '@mantine/core';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import IndicatorManagementCard from '../../components/IndicatorManagementCard';
 import { assetsAPI, forgekeyAPI, inventoryAPI } from '../../services/api';
 
@@ -108,11 +108,16 @@ describe('IndicatorManagementCard', () => {
     } as any);
   });
 
-  it('renders nothing for a non-indicator device', async () => {
+  it('renders a greyed not-applicable stub for a non-indicator device', async () => {
     const device = buildDevice({ device_type: 1, device_type_name: 'people_counter' });
     renderCard(device);
     await waitFor(() => expect(mockApi.listDeviceTypes).toHaveBeenCalled());
+    // The full management card is absent...
     expect(screen.queryByTestId('indicator-management')).not.toBeInTheDocument();
+    // ...replaced by a dimmed "not applicable" stub (op-3u4).
+    const stub = await screen.findByTestId('indicator-not-applicable');
+    expect(stub).toHaveAttribute('aria-disabled', 'true');
+    expect(within(stub).getByText(/not applicable for this device type/i)).toBeInTheDocument();
   });
 
   it('renders the current binding with its derived light state', async () => {

--- a/frontend/src/__tests__/pages/ForgeKeyDeviceDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyDeviceDetailPage.test.tsx
@@ -8,7 +8,7 @@
  *   - OTA disabled state
  */
 import { MantineProvider } from '@mantine/core';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import ForgeKeyDeviceDetailPage from '../../pages/ForgeKeyDeviceDetailPage';
 import { forgekeyAPI } from '../../services/api';
@@ -288,5 +288,74 @@ describe('ForgeKeyDeviceDetailPage', () => {
         url: 'https://example.test/fw.bin',
       }),
     );
+  });
+
+  describe('device-type-aware sections (op-3u4)', () => {
+    it('greys out the occupancy section for an indicator device', async () => {
+      seedHappyPath();
+      mockApi.getDevice.mockResolvedValue({
+        data: buildDevice({
+          device_type: 9,
+          device_type_name: 'Indicator/Status Light',
+          capabilities: ['status_led', 'status_matrix'],
+        }),
+      } as any);
+      mockApi.listDeviceTypes.mockResolvedValue({
+        data: [{ id: 9, name: 'Indicator/Status Light', code: 'indicator' }],
+      } as any);
+      // An existing binding keeps IndicatorManagementCard from fetching assets/locations.
+      mockApi.listIndicatorBindings.mockResolvedValue({
+        data: [
+          {
+            id: 'b1',
+            device: 'dev-1',
+            asset: null,
+            asset_name: null,
+            location: 5,
+            location_name: 'Lab',
+            last_status: null,
+            last_synced_at: null,
+          },
+        ],
+      } as any);
+
+      renderAt('/facilities/forgekey-devices/dev-1');
+
+      const gate = await screen.findByTestId('section-gate-occupancy');
+      expect(gate).toHaveAttribute('aria-disabled', 'true');
+      expect(
+        within(gate).getByText(/not applicable for this device type/i),
+      ).toBeInTheDocument();
+      // Greyed, not hidden: the section content is still in the DOM.
+      expect(within(gate).getByText('Occupancy (last 24h)')).toBeInTheDocument();
+    });
+
+    it('renders the occupancy section normally for a people-counter device', async () => {
+      seedHappyPath();
+      mockApi.listDeviceTypes.mockResolvedValue({
+        data: [{ id: 1, name: 'People Counter', code: 'people_counter' }],
+      } as any);
+
+      renderAt('/facilities/forgekey-devices/dev-1');
+
+      const gate = await screen.findByTestId('section-gate-occupancy');
+      expect(gate).not.toHaveAttribute('aria-disabled');
+      expect(
+        within(gate).queryByText(/not applicable for this device type/i),
+      ).not.toBeInTheDocument();
+      expect(within(gate).getByText('Occupancy (last 24h)')).toBeInTheDocument();
+    });
+
+    it('renders the occupancy section normally when type and capabilities are unknown', async () => {
+      // Fresh device: no announced capabilities, device-types list empty (beforeEach
+      // default) so the type cannot be resolved -> relevance unknown -> render.
+      seedHappyPath();
+
+      renderAt('/facilities/forgekey-devices/dev-1');
+
+      const gate = await screen.findByTestId('section-gate-occupancy');
+      expect(gate).not.toHaveAttribute('aria-disabled');
+      expect(within(gate).getByText('Occupancy (last 24h)')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/__tests__/utils/deviceSectionRelevance.test.ts
+++ b/frontend/src/__tests__/utils/deviceSectionRelevance.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for the device-section relevance helper (op-3u4).
+ */
+import {
+  resolveDeviceTypeCode,
+  sectionRelevance,
+} from '../../utils/deviceSectionRelevance';
+
+const TYPES = [
+  { id: 1, name: 'People Counter', code: 'people_counter' },
+  { id: 9, name: 'Indicator/Status Light', code: 'indicator' },
+  { id: 12, name: 'Temperature Sensor', code: 'temperature_sensor' },
+] as any;
+
+describe('resolveDeviceTypeCode', () => {
+  it('resolves the stable code from the numeric device_type id', () => {
+    expect(
+      resolveDeviceTypeCode({ device_type: 9, device_type_name: 'whatever' }, TYPES),
+    ).toBe('indicator');
+  });
+
+  it('falls back to the indicator display name when the id is unknown', () => {
+    expect(
+      resolveDeviceTypeCode(
+        { device_type: 999, device_type_name: 'Indicator/Status Light' },
+        [],
+      ),
+    ).toBe('indicator');
+  });
+
+  it('returns null when the type cannot be resolved', () => {
+    expect(
+      resolveDeviceTypeCode({ device_type: null, device_type_name: 'people_counter' }, TYPES),
+    ).toBeNull();
+  });
+});
+
+describe('sectionRelevance', () => {
+  describe('occupancy (people-counter only)', () => {
+    it('is yes when the people_counter capability is announced', () => {
+      expect(sectionRelevance('occupancy', { capabilities: ['people_counter'] }, null)).toBe('yes');
+    });
+
+    it('is yes when the device_type code is people_counter (no capabilities)', () => {
+      expect(sectionRelevance('occupancy', { capabilities: [] }, 'people_counter')).toBe('yes');
+    });
+
+    it('is no for an indicator device (capabilities announced, none match)', () => {
+      expect(
+        sectionRelevance('occupancy', { capabilities: ['status_led', 'status_matrix'] }, 'indicator'),
+      ).toBe('no');
+    });
+
+    it('is no when capabilities are announced but none match, even without a type', () => {
+      expect(sectionRelevance('occupancy', { capabilities: ['status_led'] }, null)).toBe('no');
+    });
+
+    it('does NOT include door_counter or mmwave_presence', () => {
+      expect(sectionRelevance('occupancy', { capabilities: ['mmwave_presence'] }, 'door_counter')).toBe(
+        'no',
+      );
+    });
+
+    it('is unknown with no announced capabilities and an unresolved type', () => {
+      expect(sectionRelevance('occupancy', { capabilities: [] }, null)).toBe('unknown');
+    });
+
+    it('treats null capabilities like an empty list', () => {
+      expect(sectionRelevance('occupancy', { capabilities: null as any }, null)).toBe('unknown');
+    });
+  });
+
+  describe('temperature (type-driven; no canonical capability token)', () => {
+    it('is yes for a temperature_sensor device type even with no temp capability', () => {
+      expect(sectionRelevance('temperature', { capabilities: [] }, 'temperature_sensor')).toBe('yes');
+    });
+
+    it('is yes for an env_sensor device type', () => {
+      expect(sectionRelevance('temperature', { capabilities: [] }, 'env_sensor')).toBe('yes');
+    });
+
+    it('is no for an indicator device', () => {
+      expect(
+        sectionRelevance('temperature', { capabilities: ['status_led'] }, 'indicator'),
+      ).toBe('no');
+    });
+  });
+
+  describe('indicator', () => {
+    it('is yes for the status_led capability', () => {
+      expect(sectionRelevance('indicator', { capabilities: ['status_led'] }, null)).toBe('yes');
+    });
+
+    it('is yes for the indicator device type', () => {
+      expect(sectionRelevance('indicator', { capabilities: [] }, 'indicator')).toBe('yes');
+    });
+
+    it('is no for a people_counter device', () => {
+      expect(sectionRelevance('indicator', { capabilities: ['people_counter'] }, 'people_counter')).toBe(
+        'no',
+      );
+    });
+  });
+});

--- a/frontend/src/components/DeviceSectionGate.tsx
+++ b/frontend/src/components/DeviceSectionGate.tsx
@@ -1,0 +1,51 @@
+/**
+ * DeviceSectionGate (op-3u4)
+ *
+ * Wraps a device-detail section and, when it is not relevant to the device's
+ * type, dims it and labels it "Not applicable for this device type" instead of
+ * hiding it — so staff can still see the section exists but understand it does
+ * not apply to this device.
+ *
+ * Relevance is a tri-state (see utils/deviceSectionRelevance): only `'no'`
+ * (or `false`) triggers the greyed treatment; `'yes'` / `'unknown'` render the
+ * children unchanged.
+ */
+import { Badge } from '@mantine/core';
+import React from 'react';
+import type { SectionRelevance } from '../utils/deviceSectionRelevance';
+
+interface DeviceSectionGateProps {
+  /** `'no'` / `false` dims + labels the section; anything else renders as-is. */
+  relevant: SectionRelevance | boolean;
+  /** Override the not-applicable label. */
+  reason?: string;
+  /** Stable test id on the wrapper (present in both states). */
+  testId?: string;
+  children: React.ReactNode;
+}
+
+const DEFAULT_REASON = 'Not applicable for this device type';
+
+const DeviceSectionGate: React.FC<DeviceSectionGateProps> = ({
+  relevant,
+  reason = DEFAULT_REASON,
+  testId,
+  children,
+}) => {
+  const notApplicable = relevant === 'no' || relevant === false;
+
+  if (!notApplicable) {
+    return <div data-testid={testId}>{children}</div>;
+  }
+
+  return (
+    <div data-testid={testId} aria-disabled="true">
+      <Badge color="gray" variant="light" mb="xs">
+        {reason}
+      </Badge>
+      <div style={{ opacity: 0.45, pointerEvents: 'none' }}>{children}</div>
+    </div>
+  );
+};
+
+export default DeviceSectionGate;

--- a/frontend/src/components/IndicatorManagementCard.tsx
+++ b/frontend/src/components/IndicatorManagementCard.tsx
@@ -8,8 +8,9 @@
  *   - send an explicit color/brightness/pattern preview ("Test light"),
  *   - read the color/pattern legend.
  *
- * Renders nothing for non-indicator devices, so the device-detail page can
- * mount it unconditionally.
+ * For non-indicator devices it renders a greyed "not applicable" stub (op-3u4)
+ * rather than nothing, so the device-detail page can mount it unconditionally
+ * and staff can see the section exists but does not apply to this device.
  */
 import {
   Badge,
@@ -23,6 +24,7 @@ import {
   Text,
 } from '@mantine/core';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import DeviceSectionGate from './DeviceSectionGate';
 import IndicatorStatusLegend from './IndicatorStatusLegend';
 import IndicatorSwatch from './IndicatorSwatch';
 import {
@@ -226,7 +228,19 @@ export default function IndicatorManagementCard({ device, onChanged }: Props) {
     }
   };
 
-  if (loading || !isIndicator) return null;
+  if (loading) return null;
+  if (!isIndicator) {
+    return (
+      <DeviceSectionGate relevant="no" testId="indicator-not-applicable">
+        <Card withBorder radius="md" p="md">
+          <Text fw={600}>Indicator light</Text>
+          <Text size="xs" c="dimmed">
+            Bind a status light to an asset or room, preview it, and re-sync its state.
+          </Text>
+        </Card>
+      </DeviceSectionGate>
+    );
+  }
 
   const previewPresentation = {
     color: testPattern === 'off' ? null : testColor,

--- a/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
+++ b/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
@@ -11,15 +11,18 @@ import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import DeviceControlsCard from '../components/DeviceControlsCard';
 import DeviceLifecycleCard from '../components/DeviceLifecycleCard';
+import DeviceSectionGate from '../components/DeviceSectionGate';
 import IndicatorManagementCard from '../components/IndicatorManagementCard';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import {
   ForgeKeyCommandResponse,
   ForgeKeyDevice,
+  ForgeKeyDeviceType,
   ForgeKeyOccupancyResponse,
   ForgeKeyTemperatureResponse,
   forgekeyAPI,
 } from '../services/api';
+import { resolveDeviceTypeCode, sectionRelevance } from '../utils/deviceSectionRelevance';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 const POLL_INTERVAL_MS = 30_000;
@@ -42,6 +45,7 @@ const ForgeKeyDeviceDetailPage: React.FC = () => {
     typeof window !== 'undefined' && localStorage.getItem('is_superuser') === 'true';
 
   const [device, setDevice] = useState<ForgeKeyDevice | null>(null);
+  const [deviceTypes, setDeviceTypes] = useState<ForgeKeyDeviceType[]>([]);
   const [occupancy, setOccupancy] = useState<ForgeKeyOccupancyResponse | null>(null);
   const [temperature, setTemperature] = useState<ForgeKeyTemperatureResponse | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -55,14 +59,17 @@ const ForgeKeyDeviceDetailPage: React.FC = () => {
   const loadAll = useCallback(async () => {
     if (!id) return;
     try {
-      const [deviceRes, occRes, tempRes] = await Promise.all([
+      const [deviceRes, occRes, tempRes, typesRes] = await Promise.all([
         forgekeyAPI.getDevice(id),
         forgekeyAPI.getOccupancy(id, '24h'),
         forgekeyAPI.getTemperature(id, '24h'),
+        forgekeyAPI.listDeviceTypes(),
       ]);
       setDevice(deviceRes.data);
       setOccupancy(occRes.data);
       setTemperature(tempRes.data);
+      const typesData = typesRes?.data;
+      setDeviceTypes(Array.isArray(typesData) ? typesData : (typesData?.results ?? []));
       setLoadError(null);
     } catch (err: any) {
       setLoadError(extractErrorMessage(err, 'Failed to load device.'));
@@ -99,6 +106,23 @@ const ForgeKeyDeviceDetailPage: React.FC = () => {
       humidity: reading.humidity_percent,
     }));
   }, [temperature]);
+
+  // Decide which type-specific sections apply to this device, keying off the
+  // announced capabilities first and the resolved device_type code as a
+  // fallback (utils/deviceSectionRelevance). Irrelevant sections are greyed
+  // out rather than hidden.
+  const deviceTypeCode = useMemo(
+    () => (device ? resolveDeviceTypeCode(device, deviceTypes) : null),
+    [device, deviceTypes],
+  );
+  const occupancyRelevance = useMemo(
+    () => (device ? sectionRelevance('occupancy', device, deviceTypeCode) : 'unknown'),
+    [device, deviceTypeCode],
+  );
+  const temperatureRelevance = useMemo(
+    () => (device ? sectionRelevance('temperature', device, deviceTypeCode) : 'unknown'),
+    [device, deviceTypeCode],
+  );
 
   const runCommand = useCallback(
     async (key: ControlKey, fn: () => Promise<{ data: ForgeKeyCommandResponse }>) => {
@@ -169,6 +193,7 @@ const ForgeKeyDeviceDetailPage: React.FC = () => {
       ) : device ? (
         <>
 
+          <DeviceSectionGate relevant={occupancyRelevance} testId="section-gate-occupancy">
           <section aria-label="Occupancy chart">
             <h3>Occupancy (last 24h)</h3>
             <p style={{ color: '#555', marginTop: 0 }}>
@@ -206,8 +231,10 @@ const ForgeKeyDeviceDetailPage: React.FC = () => {
               </p>
             )}
           </section>
+          </DeviceSectionGate>
 
-          {tempChartData.length > 0 && (
+          {tempChartData.length > 0 ? (
+            <DeviceSectionGate relevant={temperatureRelevance} testId="section-gate-temperature">
             <section aria-label="Temperature chart">
               <h3>Temperature (last 24h)</h3>
               <p style={{ color: '#555', marginTop: 0 }}>
@@ -266,7 +293,14 @@ const ForgeKeyDeviceDetailPage: React.FC = () => {
                 </ResponsiveContainer>
               </div>
             </section>
-          )}
+            </DeviceSectionGate>
+          ) : temperatureRelevance === 'no' ? (
+            <DeviceSectionGate relevant="no" testId="section-gate-temperature">
+              <section aria-label="Temperature chart">
+                <h3>Temperature (last 24h)</h3>
+              </section>
+            </DeviceSectionGate>
+          ) : null}
 
           <DeviceControlsCard device={device} />
 

--- a/frontend/src/utils/deviceSectionRelevance.ts
+++ b/frontend/src/utils/deviceSectionRelevance.ts
@@ -1,0 +1,101 @@
+/**
+ * Device-section relevance (op-3u4).
+ *
+ * The ForgeKey device-detail page renders sections (occupancy, temperature,
+ * indicator light, …) that only make sense for certain device types — e.g. the
+ * occupancy chart is meaningful for a people counter but not for an
+ * indicator/status-light. This helper decides, per section, whether it applies
+ * to a given device so the page can grey out (not hide) the ones that don't.
+ *
+ * Signal priority (capability-first, device_type fallback):
+ *   1. Announced `capabilities` — the most accurate, device-reported signal.
+ *   2. The device's `device_type` *code* — stable, but the device API only
+ *      exposes the numeric id + display name, so the caller resolves the code
+ *      via `resolveDeviceTypeCode()` (the device-types list).
+ *
+ * It is intentionally conservative: it only returns `'no'` (grey out) when we
+ * have a positive signal to judge on. With neither announced capabilities nor a
+ * resolvable type it returns `'unknown'` and the caller renders normally — we
+ * never grey a section when we can't be sure.
+ *
+ * Token sources (keep in sync with the backend):
+ *   - DeviceType.code choices: backend/forgekey/models.py:28-48
+ *   - capabilities help text:  backend/forgekey/models.py:165-178
+ *     (documented tokens: 'people_counter', 'status_led'; indicator firmware
+ *      also announces 'status_matrix'.)
+ */
+import type { ForgeKeyDevice, ForgeKeyDeviceType } from '../services/api';
+
+export type DeviceSection = 'occupancy' | 'temperature' | 'indicator';
+
+/** Tri-state: applies / confidently does not apply / undetermined. */
+export type SectionRelevance = 'yes' | 'no' | 'unknown';
+
+/**
+ * Capability tokens (announced by firmware) that make a section relevant.
+ *
+ * Occupancy is people-counter ONLY (product decision: door counters and mmWave
+ * presence are deliberately excluded). Temperature has no canonical capability
+ * token, so its entries are best-effort — temperature relevance is driven by
+ * device_type below; the type signal covers real temperature/env sensors even
+ * when no recognised capability is announced.
+ */
+const CAPABILITY_SECTIONS: Record<DeviceSection, readonly string[]> = {
+  occupancy: ['people_counter'],
+  temperature: ['temperature', 'env_sensor'],
+  indicator: ['status_led', 'status_matrix', 'led_strip'],
+};
+
+/** Stable DeviceType.code values that make a section relevant. */
+const DEVICE_TYPE_SECTIONS: Record<DeviceSection, readonly string[]> = {
+  occupancy: ['people_counter'],
+  temperature: ['temperature_sensor', 'env_sensor'],
+  indicator: ['indicator', 'led_strip'],
+};
+
+/** Display name the seeded indicator DeviceType ships with (last-ditch fallback). */
+const INDICATOR_TYPE_NAME = 'Indicator/Status Light';
+
+/**
+ * Resolve a device's stable `device_type` *code* (e.g. `'indicator'`,
+ * `'people_counter'`).
+ *
+ * The device serializer only exposes the numeric `device_type` id and the
+ * display `device_type_name`, so we map the id through the device-types list
+ * (mirrors IndicatorManagementCard). Falls back to the well-known indicator
+ * display name, then `null` when it cannot be resolved.
+ */
+export function resolveDeviceTypeCode(
+  device: Pick<ForgeKeyDevice, 'device_type' | 'device_type_name'>,
+  deviceTypes: readonly ForgeKeyDeviceType[],
+): string | null {
+  if (device.device_type != null) {
+    const match = deviceTypes.find((t) => t.id === device.device_type);
+    if (match) return match.code;
+  }
+  if (device.device_type_name === INDICATOR_TYPE_NAME) return 'indicator';
+  return null;
+}
+
+/**
+ * Decide whether `section` applies to `device`.
+ *
+ * @param deviceTypeCode resolved via {@link resolveDeviceTypeCode}, or null.
+ */
+export function sectionRelevance(
+  section: DeviceSection,
+  device: Pick<ForgeKeyDevice, 'capabilities'>,
+  deviceTypeCode: string | null,
+): SectionRelevance {
+  const capabilities = device.capabilities ?? [];
+  const capMatch = capabilities.some((cap) => CAPABILITY_SECTIONS[section].includes(cap));
+  const typeMatch = deviceTypeCode != null && DEVICE_TYPE_SECTIONS[section].includes(deviceTypeCode);
+
+  if (capMatch || typeMatch) return 'yes';
+
+  // No match. We can only say "no" if we had a signal to judge on: either the
+  // device announced capabilities (and none matched) or we resolved its type
+  // (and it isn't a match). With neither, we can't tell — render normally.
+  if (capabilities.length > 0 || deviceTypeCode != null) return 'no';
+  return 'unknown';
+}


### PR DESCRIPTION
## What
Make the ForgeKey **device detail page** device-type-aware: sections that don't apply to a device are **greyed out + labeled "Not applicable for this device type"** instead of shown as if relevant. Fixes op-3u4.

Reported: an *Indicator / Status Light* device showed an **Occupancy** section that only applies to People Counters.

## How
- **`utils/deviceSectionRelevance.ts`** (new): capability-first, device_type-fallback, tri-state relevance. **Occupancy = people-counter only**; temperature = `temperature_sensor`/`env_sensor`; indicator = `status_led`/`status_matrix`/`led_strip`. Conservative — only greys on a positive "no"; unknown/fresh devices (no announced caps + unresolved type) render normally.
- **`components/DeviceSectionGate.tsx`** (new): dims (opacity .45, `pointer-events:none`, `aria-disabled`) + a gray "Not applicable…" badge when not relevant; renders children unchanged otherwise.
- **`ForgeKeyDeviceDetailPage.tsx`**: adds `listDeviceTypes()` to the load, resolves the type code, wraps the **Occupancy** and **Temperature** sections.
- **`IndicatorManagementCard.tsx`**: non-indicator devices now render a greyed "not applicable" stub instead of `return null` (the requested hide→grey switch).
- Tests added for the helper, the page, and the card.

## Review notes
- ⚠️ **Frontend tests + `tsc` were not run locally** — the authoring env has no `node_modules`/`npm` (and node 18 < the project's node 24). Relying on CI (Lint + Vitest + Build Frontend Container) to typecheck/run; committed `--no-verify` (husky needs node_modules).
- **Visible behavior change:** every *non-indicator* device page now shows a greyed "Indicator light — Not applicable" stub (this is the requested hide→grey).
- Temperature relevance is driven by `device_type` (no canonical temperature *capability* token exists in the backend); the capability entries are best-effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)