### PR TITLE
fix(forgekey): sign device-command MQTT envelopes (op-8pn)

### DIFF
--- a/backend/forgekey/services/device_commands.py
+++ b/backend/forgekey/services/device_commands.py
@@ -24,6 +24,7 @@ from resilience.circuit import CircuitBreakerOpen, get_breaker
 from ..models import DeviceCommand, ESP32Device
 from ..tasks import get_mqtt_client
 from ..utils import get_mqtt_command_topic
+from .jwt_signing import is_jwt_signing_configured, make_command_jwt
 
 logger = logging.getLogger(__name__)
 audit_logger = logging.getLogger("forgekey.audit")
@@ -36,6 +37,36 @@ class DeviceCommandError(RuntimeError):
 PUBACK_WAIT_SECONDS = 2.0
 
 
+def _sign_command_payload(device: ESP32Device, payload: Dict[str, Any]) -> None:
+    """Add the signed ``jwt`` envelope field the firmware requires, in place.
+
+    Devices receive the command-signing public key as ``command_public_key_pem``
+    at enroll (``ForgeKeyEnrollView`` -> ``jwt_signing.get_jwt_public_key_pem``)
+    and refuse to act on any command lacking a verifiable top-level ``jwt``,
+    rejecting it as ``missing_envelope_field`` (op-8pn). We mint a short-TTL
+    ES256 JWT over ``{mac, cmd, exp}`` — mirroring the locker command pipeline
+    (``backend/lockers/services/commands.py``), which already passes its own
+    ``jwt`` — so every server -> device command goes out signed.
+
+    No-ops when:
+
+    * the payload has no ``cmd`` verb (nothing to bind the JWT to),
+    * a caller already supplied a ``jwt`` (e.g. the locker publishers, which
+      mint their own with a bespoke TTL — never double-sign), or
+    * no signing key is configured (dev/test rigs), matching the consumer's own
+      ``is_jwt_signing_configured()`` gate so unsigned dev flows still work.
+
+    Note: the JWT binds only ``cmd`` (plus ``mac``/``exp``); command parameters
+    (e.g. ``set_indicator``'s color/brightness/pattern) ride as unsigned
+    siblings, same as the locker pipeline today. Binding the parameters needs a
+    coordinated firmware change and is tracked as a follow-up.
+    """
+    cmd = payload.get("cmd")
+    if not cmd or "jwt" in payload or not is_jwt_signing_configured():
+        return
+    payload["jwt"] = make_command_jwt(mac=device.mac_address, cmd=str(cmd))
+
+
 def publish_command(
     device: ESP32Device,
     command_payload: Dict[str, Any],
@@ -45,6 +76,11 @@ def publish_command(
     client: Optional[mqtt.Client] = None,
 ) -> str:
     """Publish a JSON command payload to a device's MQTT command topic.
+
+    The command is signed into the envelope the firmware requires (a top-level
+    ``jwt``) via :func:`_sign_command_payload` before it goes on the wire, so
+    callers don't have to — see that helper for the no-op cases (pre-signed
+    locker commands, dev rigs without a signing key).
 
     Waits up to ``PUBACK_WAIT_SECONDS`` for the broker PUBACK before
     returning so callers get "broker has the message" rather than just
@@ -62,6 +98,7 @@ def publish_command(
     topic = get_mqtt_command_topic(device.mac_address)
     payload = dict(command_payload)
     payload.setdefault("timestamp", timezone.now().isoformat())
+    _sign_command_payload(device, payload)
 
     body = json.dumps(payload)
     broker = client or get_mqtt_client()

--- a/backend/forgekey/tests/test_device_commands.py
+++ b/backend/forgekey/tests/test_device_commands.py
@@ -12,9 +12,11 @@ Covers:
 from __future__ import annotations
 
 import json
+import time
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
 from django.utils import timezone
 
 import pytest
@@ -491,3 +493,103 @@ class TestWebhookTaskProcessesCmdAck:
         rec.refresh_from_db()
         assert rec.ack_status == DeviceCommand.ACK_OK
         assert rec.ack_at == first_ack_at
+
+
+def _verify_command_jwt(token: str) -> dict:
+    """Verify an ES256 command JWT against the configured public key and return
+    its claims, raising on signature failure.
+
+    Mirrors how the firmware verifies a command against the
+    ``command_public_key_pem`` it received at enroll — the public half of the
+    same key ``make_command_jwt`` signs with.
+    """
+    import base64
+
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+
+    from forgekey.services.jwt_signing import get_jwt_public_key_pem
+
+    def _b64url_decode(seg: str) -> bytes:
+        return base64.urlsafe_b64decode(seg + "=" * (-len(seg) % 4))
+
+    header_b64, payload_b64, signature_b64 = token.split(".")
+    signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
+    signature = _b64url_decode(signature_b64)
+    assert len(signature) == 64, "ES256 signature must be 64 bytes (r || s)"
+    r = int.from_bytes(signature[:32], "big")
+    s = int.from_bytes(signature[32:], "big")
+    public_key = serialization.load_pem_public_key(get_jwt_public_key_pem().encode("ascii"))
+    # Raises cryptography.exceptions.InvalidSignature on a bad signature.
+    public_key.verify(encode_dss_signature(r, s), signing_input, ec.ECDSA(hashes.SHA256()))
+    return json.loads(_b64url_decode(payload_b64))
+
+
+def _published_body(client: MagicMock) -> dict:
+    """The JSON body ``publish_command`` handed to the broker's ``publish``."""
+    args, _kwargs = client.publish.call_args
+    return json.loads(args[1])
+
+
+class TestPublishCommandSignsEnvelope:
+    """op-8pn: ``publish_command`` must wrap every server -> device command in
+    the signed ``jwt`` envelope the firmware verifies (against
+    ``command_public_key_pem``); an unsigned payload is rejected on-device as
+    ``missing_envelope_field``. The session-wide ``FORGEKEY_JWT_SIGNING_KEY``
+    fixture (``conftest.configure_forgekey_jwt_signing_key``) makes signing
+    active here, so these exercise the real signing path (publish_command is
+    NOT mocked).
+    """
+
+    def test_unsigned_command_gets_a_verifiable_jwt(self):
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:0E:01")
+        client = MagicMock()
+        client.publish.return_value = MagicMock(rc=0)
+
+        before = int(time.time())
+        publish_command(
+            device,
+            {
+                "cmd": "set_indicator",
+                "color": "green",
+                "brightness": "low",
+                "pattern": "solid",
+            },
+            client=client,
+        )
+        after = int(time.time())
+
+        body = _published_body(client)
+        assert "jwt" in body, "command envelope must carry a top-level jwt"
+        # Params still ride alongside as (unsigned) siblings, as today.
+        assert body["color"] == "green"
+        assert body["pattern"] == "solid"
+
+        claims = _verify_command_jwt(body["jwt"])
+        assert claims["mac"] == device.mac_address
+        assert claims["cmd"] == "set_indicator"
+        assert before + 60 <= claims["exp"] <= after + 60
+
+    def test_existing_jwt_is_not_overwritten(self):
+        """Locker publishers mint their own jwt (bespoke TTL) before calling
+        publish_command — those must never be double-signed."""
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:0E:02")
+        client = MagicMock()
+        client.publish.return_value = MagicMock(rc=0)
+
+        publish_command(device, {"cmd": "unlock", "jwt": "caller-supplied"}, client=client)
+
+        assert _published_body(client)["jwt"] == "caller-supplied"
+
+    def test_no_jwt_when_signing_key_unconfigured(self):
+        """Dev/test rigs without a signing key keep publishing raw, matching the
+        consumer's own ``is_jwt_signing_configured()`` gate."""
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:0E:03")
+        client = MagicMock()
+        client.publish.return_value = MagicMock(rc=0)
+
+        with override_settings(FORGEKEY_JWT_SIGNING_KEY=""):
+            publish_command(device, {"cmd": "restart"}, client=client)
+
+        assert "jwt" not in _published_body(client)


### PR DESCRIPTION
## Problem (op-8pn)

`publish_command` published the command as **raw JSON** to `forgekey/<mac>/command` with no signature. Devices are provisioned at enroll with `command_public_key_pem` (the public half of the JWT signing key) and verify commands against it, so the firmware rejected every command as `missing_envelope_field` — `set_indicator` and the other device commands no-op'd even when the device was connected.

```
[device 8C:BF:EA:8E:A4:0C/CMD] rx topic=forgekey/8cbfea8ea40c/command cmd=set_indicator len=205
[device 8C:BF:EA:8E:A4:0C/CMD] set_indicator rejected: missing_envelope_field
```

This was a half-shipped feature: signing existed on enroll (`get_jwt_public_key_pem` -> `command_public_key_pem`), in the locker publishers (`lockers/services/commands.py`), and on the verify/firmware side — but the generic forgekey publisher was never updated to sign.

## Resolved publish path

All server -> device commands funnel through `publish_command`, so signing there fixes every path in one place:

| Caller | Path |
|---|---|
| `set_indicator` (indicator bindings + manual test) | `services/indicator.py` -> `dispatch_command` -> **`publish_command`** |
| device ViewSet (`restart`/`status`/`identify`/`capture`/`blink`/`ota`) | `views._dispatch_command` -> **`publish_command`** |
| locker actions (`unlock`/`lockout`/...) | `lockers/services/commands.py` -> **`publish_command`** (already pass their own `jwt`) |

## The fix

`backend/forgekey/services/device_commands.py` — new `_sign_command_payload(device, payload)` helper, called inside `publish_command` before the payload is serialized. It adds a top-level `jwt`: a short-TTL **ES256** JWT over `{mac, cmd, exp}` minted by `make_command_jwt`, mirroring the locker pipeline exactly.

No-ops (so nothing else changes behavior):
- payload has no `cmd` verb,
- a caller already supplied a `jwt` (locker publishers, bespoke TTL — **never double-signed**),
- no signing key configured — gated on `is_jwt_signing_configured()`, matching the consumer's own gate, so dev rigs without a key keep publishing raw.

## Envelope field confirmed

The required envelope field is the **top-level `jwt`** (the JWT *is* the envelope+signature). Authority: the working locker pipeline (`{"cmd": "...", "jwt": "<ES256>", ...}`) plus the enroll wiring that hands the device `command_public_key_pem` = the public half of the `make_command_jwt` key. Note: the consumer's `handle_access_request_message` validator (mqtt_consumer.py ~L659) is for **inbound** `access/request` frames (device -> server) — the consumer never receives outbound commands, so `missing_envelope_field` is emitted by the **firmware** and forwarded via the `logs` topic.

## Tests

`backend/forgekey/tests/test_device_commands.py` — `TestPublishCommandSignsEnvelope`:
- an unsigned command gets a `jwt` that **verifies against `get_jwt_public_key_pem()`** with claims `mac`/`cmd`/`exp` (and params still ride alongside),
- a caller-supplied `jwt` is not overwritten (locker path),
- no `jwt` is added when the signing key is unconfigured.

Existing `publish_command` tests are unaffected (they don't assert body contents; the circuit-breaker test's `publish.assert_not_called()` still holds — signing is pure crypto before the broker call). Indicator tests mock `publish_command`, so their payload assertions are unaffected.

> No local Python/Django env was available in this worktree, so the suite wasn't run here — CI validates. The ES256 sign/verify round-trip (matching `make_command_jwt` and the firmware-side verification) was validated standalone with `cryptography`.

## Follow-ups / flags
- **Needs a device round-trip test** to confirm acceptance end-to-end, and to confirm the firmware compares the JWT `mac` claim in **colon-uppercase** form (this PR uses `device.mac_address`, matching the locker reference; the topic uses bare-lowercase separately).
- The JWT binds only the verb; `set_indicator` params (color/brightness/pattern) ride as **unsigned** siblings, same as lockers today. Binding params (e.g. a `ph` params-hash claim) requires a coordinated firmware change — deliberately out of scope here.
- Dependency: `FORGEKEY_JWT_SIGNING_KEY` must be set in prod. Confirmed present — devices enroll 201 (enroll 503s if the key can't load) and JWKS works.
- Secondary unsigned path (not this bug): the legacy `forgekey/tasks.py::send_mqtt_command` task publishes raw, bypassing `publish_command`. Should be routed through `publish_command` or given the same treatment in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)