### PR TITLE
fix(inventory): ArUco QR detector fallback to de-flake CI (op-6t2)

### DIFF
--- a/backend/inventory/services/work_order_ingest.py
+++ b/backend/inventory/services/work_order_ingest.py
@@ -131,22 +131,41 @@ def _decode_qr_payloads(image_bytes: bytes) -> List[str]:
 
         pil = Image.open(io.BytesIO(image_bytes)).convert("RGB")
         arr = np.array(pil)
-        detector = cv2.QRCodeDetector()
-        # Try multi-detect first (PDFs may carry multiple QRs); fall back to
-        # single-detect since multi can return False for clean single-QR pages.
-        try:
-            ok, decoded, _, _ = detector.detectAndDecodeMulti(arr)
-            if ok and decoded:
-                payloads.extend([d for d in decoded if d])
-        except Exception:  # noqa: BLE001  # nosec B110 - cv2 raises generic errors on bad images
-            pass
-        if not payloads:
+
+        # OpenCV ships two independent QR backends. The legacy QRCodeDetector
+        # silently mis-decodes ~1% of otherwise-clean QR images (the outcome is
+        # bit-pattern dependent, not a quality/resolution issue). Because the
+        # work-order QR carries a *random* UUID, that ~1% turned into a random
+        # CI flake — extraction returned None for the unlucky ids and the QR
+        # fallback test failed with "assert None == <uuid>" (op-6t2). The
+        # newer ArUco-based detector finds the finder pattern differently and
+        # decodes the cases the legacy detector drops (0 misses over 1500
+        # samples vs the legacy detector's ~17). So try the legacy detector
+        # first (fast, succeeds ~99% of the time) and fall back to the ArUco
+        # detector before giving up. getattr-guarded for OpenCV < 4.7.
+        detectors = [cv2.QRCodeDetector()]
+        aruco_qr_cls = getattr(cv2, "QRCodeDetectorAruco", None)
+        if aruco_qr_cls is not None:
+            detectors.append(aruco_qr_cls())
+
+        for detector in detectors:
+            # Try multi-detect first (PDFs may carry multiple QRs); fall back to
+            # single-detect since multi can return False for clean single-QR pages.
             try:
-                data, _, _ = detector.detectAndDecode(arr)
-                if data:
-                    payloads.append(data)
-            except Exception:  # noqa: BLE001  # nosec B110
+                ok, decoded, _, _ = detector.detectAndDecodeMulti(arr)
+                if ok and decoded:
+                    payloads.extend([d for d in decoded if d])
+            except Exception:  # noqa: BLE001  # nosec B110 - cv2 errors on bad images
                 pass
+            if not payloads:
+                try:
+                    data, _, _ = detector.detectAndDecode(arr)
+                    if data:
+                        payloads.append(data)
+                except Exception:  # noqa: BLE001  # nosec B110
+                    pass
+            if payloads:
+                break
     except Exception as exc:  # noqa: BLE001 - cv2 missing or image unreadable
         logger.debug("cv2 QR decode skipped: %s", exc)
 

--- a/backend/inventory/tests/test_work_order_id_extraction.py
+++ b/backend/inventory/tests/test_work_order_id_extraction.py
@@ -284,6 +284,45 @@ class TestExtractWorkOrderId:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Regression for op-6t2: the legacy cv2.QRCodeDetector silently mis-decodes
+# ~1% of otherwise-clean QR images. Because the WO id is a random UUID, that
+# turned into a random CI flake (extraction returned None → "assert None ==
+# <uuid>"). _decode_qr_payloads must fall back to the more robust ArUco-based
+# detector so a legacy miss still resolves.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+class TestQrDecoderFallback:
+    @qr_decoder_required
+    def test_aruco_detector_rescues_legacy_qr_miss(self, monkeypatch):
+        import cv2
+
+        if not hasattr(cv2, "QRCodeDetectorAruco"):
+            pytest.skip("cv2.QRCodeDetectorAruco unavailable (OpenCV < 4.7)")
+
+        wo_id = str(uuid.uuid4())
+        qr_png = _qr_png_bytes(f"http://example.com/maintenance/work-orders/{wo_id}")
+
+        class _AlwaysMissDetector:
+            """Stand-in for the legacy detector's ~1% silent-miss behaviour."""
+
+            def detectAndDecodeMulti(self, _img):
+                return False, [], None, None
+
+            def detectAndDecode(self, _img):
+                return "", None, None
+
+        # Force the legacy backend to miss; the ArUco fallback must still decode.
+        monkeypatch.setattr(cv2, "QRCodeDetector", _AlwaysMissDetector)
+
+        payloads = _decode_qr_payloads(qr_png)
+        assert any(
+            wo_id in p for p in payloads
+        ), "ArUco fallback should decode a QR the legacy detector missed"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # AC 5: failure path returns a structured error listing what was tried
 # ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes **op-6t2**: `inventory/tests/test_work_order_id_extraction.py::TestExtractWorkOrderId::test_extracts_id_from_qr_code` failed randomly in CI (`assert None == <uuid>`), making OMS `main` CI intermittently red and blocking all OMS PRs (e.g. #806).

## Root cause

The legacy `cv2.QRCodeDetector` **silently mis-decodes ~1% of otherwise-clean QR images** — the outcome is bit-pattern dependent, *not* a resolution/quality issue (the embedded image is a clean 450×450). Because each work-order QR encodes a **random `uuid.uuid4()`**, that ~1% miss rate turned into a random per-run flake: on the unlucky ids the QR fallback returned `None` and the test failed.

`pyzbar` — the code's intended secondary decoder — is **non-functional in CI** (no `libzbar0` system lib), so a legacy-detector miss had no rescue.

**The `#805` / `cv2.aruco` link is coincidental.** A controlled experiment ran the *same* set of QR images with and without the `cv2.aruco` render/detect suite executed immediately before each decode:

```
same 120 images, NO aruco  : 2 fails
same 120 images, aruco b4  : 2 fails   <- identical
```

So `cv2.aruco` does not pollute `cv2.QRCodeDetector`. `#805` merely shifted test counts/worker-distribution enough to change which CI runs happened to roll the pre-existing ~1% flake. (The bead's turnkey "force aruco before QR" repro is inconclusive because pytest reorders the two args and runs the QR test first.)

## Quantified, over N=1500 PDF-round-tripped QR images

| decoder | failures |
|---|---|
| legacy `cv2.QRCodeDetector` (old behaviour) | **17 / 1500 (1.13%)** |
| `cv2.QRCodeDetectorAruco` | **0 / 1500** |
| cascade legacy → ArUco (this PR) | **0 / 1500** |

## The fix (product code)

`inventory/services/work_order_ingest.py::_decode_qr_payloads` now falls back to **`cv2.QRCodeDetectorAruco`** (mainline OpenCV ≥ 4.7; we pin `opencv-python-headless==4.13.0.92`) when the legacy detector returns nothing. The ArUco-based detector locates the finder pattern differently and decodes exactly the cases the legacy detector drops. It only runs on the ~1% of images the fast legacy path misses, so there's no meaningful perf cost, and it's `getattr`-guarded for older OpenCV builds. This is also a genuine production win — real hand-filled-then-scanned forms are *more* marginal than these synthetic images.

A deterministic regression test (`TestQrDecoderFallback`) monkeypatches the legacy detector to always miss and asserts the ArUco fallback still resolves the id.

## Test evidence (before / after)

**Before** (old code path = legacy detector only): 17/1500 random QR images failed to decode → ~1.1% flake.

**After** (this PR):
- New regression test passes; full QR-extraction file + fiducials serial: `23 passed in 71.90s`.
- Broad CI-like xdist run `pytest inventory fiducials forgekey -n auto`: **`1253 passed, 3 skipped`** (0 failures).
- Cascade decoder: **0 failures over 1500** random PDF-round-tripped QR images.

## Impact

Unblocks OMS `main` CI (op-6t2) and the PRs gated on it, including **#806**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
