### PR TITLE
fix(forgekey): always create ESP32Device on enroll; rename relay code to power_relay (op-3he)

### DIFF
--- a/backend/forgekey/migrations/0025_rename_ac_relay_to_power_relay.py
+++ b/backend/forgekey/migrations/0025_rename_ac_relay_to_power_relay.py
@@ -1,0 +1,74 @@
+"""Rename the relay DeviceType code ``ac_relay`` → ``power_relay`` (op-3he).
+
+The firmware ``sensor_kind`` and the MQTT topic kind both use ``power_relay``
+(``FORGEKEY_SENSOR_KIND=power-relay`` → ``normalize_sensor_kind`` → ``power_relay``;
+``MQTT_TOPIC_KIND=power_relay``; topics ``forgekey/<mac>/power_relay/...``), but the
+model's relay code was the historical ``ac_relay``. The enroll view matches a
+DeviceType by ``code == normalized sensor_kind``, so the mismatch meant relays
+never matched a type. This migration aligns the code with the firmware/topics.
+
+It (a) updates the ``DeviceType.code`` choices and (b) data-renames the existing
+seeded relay row's code in place (the PK / FK identity is preserved, so any rows
+pointing at the relay type keep pointing at the same row, now coded
+``power_relay``). The human-readable ``name`` ("AC Relay") is intentionally left
+unchanged. Historical migrations (0001/0002/0004/0011) keep their ``ac_relay``
+references on purpose — they are a stable record of the schema at their time.
+"""
+
+from django.db import migrations, models
+
+
+def rename_ac_relay_to_power_relay(apps, schema_editor):
+    DeviceType = apps.get_model("forgekey", "DeviceType")
+    # In-place code update: keeps the row's PK so every ESP32Device /
+    # FirmwareVersion / FirmwareBuild FK to the relay type is preserved.
+    DeviceType.objects.filter(code="ac_relay").update(code="power_relay")
+
+
+def rename_power_relay_to_ac_relay(apps, schema_editor):
+    DeviceType = apps.get_model("forgekey", "DeviceType")
+    DeviceType.objects.filter(code="power_relay").update(code="ac_relay")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("forgekey", "0024_assetauthorization_expires_at_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="devicetype",
+            name="code",
+            field=models.CharField(
+                choices=[
+                    ("indicator", "Indicator/Status Light"),
+                    ("badge_reader", "Badge Reader"),
+                    ("epaper_screen", "E-Paper Screen"),
+                    ("oled_screen", "OLED Screen"),
+                    ("temperature_sensor", "Temperature Sensor"),
+                    ("generic_input", "Generic Input"),
+                    ("generic_output", "Generic Output"),
+                    ("power_relay", "AC Relay"),
+                    ("power_measurement", "Power Measurement"),
+                    ("people_counter", "People Counter"),
+                    ("env_sensor", "Environmental Sensor"),
+                    ("door_counter", "Door Counter"),
+                    ("locker_latch", "Locker latch controller"),
+                    ("door_latch", "Door latch controller"),
+                    ("otp_keypad", "OTP keypad"),
+                    ("led_strip", "WS2818 LED strip controller"),
+                    ("reed_switch", "Door reed switch"),
+                    ("ir_break", "Inventory IR-break sensor"),
+                    ("mortise_key", "Mortise key (admin override) sensor"),
+                ],
+                help_text="Device type code",
+                max_length=30,
+                unique=True,
+            ),
+        ),
+        migrations.RunPython(
+            rename_ac_relay_to_power_relay,
+            rename_power_relay_to_ac_relay,
+        ),
+    ]

--- a/backend/forgekey/migrations/0026_esp32device_device_type_nullable.py
+++ b/backend/forgekey/migrations/0026_esp32device_device_type_nullable.py
@@ -1,0 +1,38 @@
+"""Make ``ESP32Device.device_type`` nullable (op-3he).
+
+The enroll view used to silently skip creating an ESP32Device when the
+device's ``sensor_kind`` matched no DeviceType. With the gate removed, the
+device must still get a row even when its type is unknown — so the FK has to
+allow NULL. ``on_delete`` stays PROTECT (you still cannot delete a DeviceType
+that has devices); only ``null``/``blank`` change.
+"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("forgekey", "0025_rename_ac_relay_to_power_relay"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="esp32device",
+            name="device_type",
+            field=models.ForeignKey(
+                blank=True,
+                help_text=(
+                    "Type of device. Nullable: a device whose enroll-time sensor_kind "
+                    "has no matching DeviceType is still created (with no type) so it "
+                    "appears in the device list rather than being silently dropped "
+                    "(op-3he)."
+                ),
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="devices",
+                to="forgekey.devicetype",
+            ),
+        ),
+    ]

--- a/backend/forgekey/migrations/0027_backfill_enrolled_esp32devices.py
+++ b/backend/forgekey/migrations/0027_backfill_enrolled_esp32devices.py
@@ -1,0 +1,75 @@
+"""Backfill ESP32Device rows for already-enrolled devices missing one (op-3he).
+
+Before the enroll-view gate was removed, a device whose normalized
+``sensor_kind`` matched no DeviceType (e.g. the relay sending ``power_relay``
+against the old ``ac_relay`` code) got a DeviceEnrollment + DeviceCertificate
+but NO ESP32Device — so it returned 201 with working mTLS yet never appeared in
+the device list. This recreates those orphaned rows the right way: for every
+``issued`` enrollment whose MAC has no ESP32Device, create one linked to the
+enrollment's identity, with ``device_type`` matched by ``code == sensor_kind``
+(NULL when unmapped), copying the MAC / firmware / telemetry the enrollment
+carries.
+
+This runs after 0025 (so the relay enrollment's ``power_relay`` sensor_kind now
+matches the renamed DeviceType code) and after 0026 (so ``device_type`` may be
+NULL for unmapped kinds). It is the data path that recreates the relay row
+(MAC 58:8C:81:9E:76:C0 / enrollment 7cd60ac2 / identity 72ebbb0b).
+"""
+
+from django.db import migrations
+
+
+def backfill_missing_esp32devices(apps, schema_editor):
+    DeviceEnrollment = apps.get_model("forgekey", "DeviceEnrollment")
+    ESP32Device = apps.get_model("forgekey", "ESP32Device")
+    DeviceType = apps.get_model("forgekey", "DeviceType")
+
+    handled_macs = set()
+    # Most-recent issued enrollment per MAC wins (it carries the live cert).
+    issued = (
+        DeviceEnrollment.objects.filter(status="issued")
+        .exclude(mac_address="")
+        .order_by("-requested_at")
+    )
+    for enr in issued:
+        mac = (enr.mac_address or "").strip()
+        if not mac or mac in handled_macs:
+            continue
+        handled_macs.add(mac)
+        if ESP32Device.objects.filter(mac_address=mac).exists():
+            continue
+
+        device_type = None
+        if enr.sensor_kind:
+            device_type = DeviceType.objects.filter(code=enr.sensor_kind).first()
+
+        # ``identity`` is a OneToOne; only attach it when still free. It should
+        # be free (no ESP32Device exists for this device yet), but guard in case
+        # a row was created MAC-first and already claimed this identity.
+        identity = enr.device
+        if identity is not None and ESP32Device.objects.filter(identity=identity).exists():
+            identity = None
+
+        ESP32Device.objects.create(
+            mac_address=mac,
+            device_type=device_type,
+            firmware_version=enr.firmware_version or "",
+            boot_count=enr.boot_count,
+            free_heap=enr.free_heap,
+            ip=enr.ip_address,
+            identity=identity,
+            last_seen=enr.approved_at or enr.requested_at,
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("forgekey", "0026_esp32device_device_type_nullable"),
+    ]
+
+    operations = [
+        # No clean reverse: we cannot tell which ESP32Device rows this created
+        # versus rows added later by the (now-fixed) enroll path.
+        migrations.RunPython(backfill_missing_esp32devices, migrations.RunPython.noop),
+    ]

--- a/backend/forgekey/models.py
+++ b/backend/forgekey/models.py
@@ -33,7 +33,11 @@ class DeviceType(models.Model):
     TYPE_TEMPERATURE_SENSOR = "temperature_sensor"
     TYPE_GENERIC_INPUT = "generic_input"
     TYPE_GENERIC_OUTPUT = "generic_output"
-    TYPE_AC_RELAY = "ac_relay"
+    # Firmware sensor_kind + MQTT topic kind both use ``power_relay`` (see
+    # ForgeKey FORGEKEY_SENSOR_KIND / MQTT_TOPIC_KIND), so the DeviceType code
+    # matches them. The human-readable name stays "AC Relay". Renamed from the
+    # historical ``ac_relay`` by migration 0025 (op-3he).
+    TYPE_AC_RELAY = "power_relay"
     TYPE_POWER_MEASUREMENT = "power_measurement"
     TYPE_PEOPLE_COUNTER = "people_counter"
     TYPE_ENV_SENSOR = "env_sensor"
@@ -107,8 +111,14 @@ class ESP32Device(models.Model):
     device_type = models.ForeignKey(
         DeviceType,
         on_delete=models.PROTECT,
+        null=True,
+        blank=True,
         related_name="devices",
-        help_text="Type of device",
+        help_text=(
+            "Type of device. Nullable: a device whose enroll-time sensor_kind has "
+            "no matching DeviceType is still created (with no type) so it appears "
+            "in the device list rather than being silently dropped (op-3he)."
+        ),
     )
     name = models.CharField(
         max_length=200,

--- a/backend/forgekey/tests/test_device_types.py
+++ b/backend/forgekey/tests/test_device_types.py
@@ -59,20 +59,22 @@ class TestDeviceTypeManagement:
         assert resp.status_code == 403
 
     def test_member_cannot_create(self, member_api_client):
-        DeviceType.objects.filter(code="ac_relay").delete()  # free the code; member still blocked
+        DeviceType.objects.filter(
+            code="power_relay"
+        ).delete()  # free the code; member still blocked
         resp = member_api_client.post(
             reverse("forgekey:device-type-list"),
-            {"name": "Member Relay", "code": "ac_relay"},
+            {"name": "Member Relay", "code": "power_relay"},
             format="json",
         )
         assert resp.status_code == 403
 
     def test_staff_can_create_a_freed_code(self, admin_api_client):
-        DeviceType.objects.filter(code="ac_relay").delete()
+        DeviceType.objects.filter(code="power_relay").delete()
         resp = admin_api_client.post(
             reverse("forgekey:device-type-list"),
-            {"name": "Bench Relay", "code": "ac_relay", "description": "", "is_active": True},
+            {"name": "Bench Relay", "code": "power_relay", "description": "", "is_active": True},
             format="json",
         )
         assert resp.status_code == 201, resp.data
-        assert DeviceType.objects.filter(code="ac_relay", name="Bench Relay").exists()
+        assert DeviceType.objects.filter(code="power_relay", name="Bench Relay").exists()

--- a/backend/forgekey/tests/test_enrollment.py
+++ b/backend/forgekey/tests/test_enrollment.py
@@ -8,12 +8,15 @@ in the firmware-contract shape (``CN=forgekey-<lowercase-mac-no-sep>``).
 
 from __future__ import annotations
 
+import importlib
 import json
+import logging
 from io import BytesIO
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.urls import reverse
+from django.utils import timezone
 
 import pytest
 from cryptography import x509
@@ -455,3 +458,125 @@ def test_enroll_returns_503_when_no_ca_configured(api_client, enroll_url, people
     resp = _post_enroll(api_client, enroll_url)
     assert resp.status_code == 503
     assert resp.json()["code"] == "ca_unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Device-row creation: sensor_kind → DeviceType matching + no silent drop (op-3he)
+# ---------------------------------------------------------------------------
+
+
+def test_enroll_power_relay_creates_device_with_power_relay_type(api_client, enroll_url, active_ca):
+    # Firmware sends sensor_kind "power-relay"; normalize_sensor_kind maps it to
+    # "power_relay", which now matches the relay DeviceType code (renamed from
+    # the historical "ac_relay"). The device must get a row attributed to it.
+    relay_type = DeviceTypeFactory(code=DeviceType.TYPE_AC_RELAY)
+    assert relay_type.code == "power_relay"  # constant renamed by op-3he
+
+    resp = _post_enroll(
+        api_client,
+        enroll_url,
+        meta_overrides={
+            "mac_address": "58:8C:81:9E:76:C0",
+            "unique_chip_id": "chip-588c819e76c0",
+            "sensor_kind": "power-relay",  # firmware form (hyphen)
+        },
+    )
+    assert resp.status_code == 201, resp.content
+
+    device = ESP32Device.objects.get(mac_address="58:8C:81:9E:76:C0")
+    assert device.device_type is not None
+    assert device.device_type.code == "power_relay"
+    # Linked back to the per-chip identity created by enroll.
+    assert device.identity is not None
+    assert device.identity.device_id == "chip-588c819e76c0"
+
+
+def test_enroll_unknown_sensor_kind_still_creates_device_and_warns(
+    api_client, enroll_url, active_ca, caplog
+):
+    # A sensor_kind with no matching DeviceType must NOT be silently dropped:
+    # the device still gets a row (device_type NULL) and a warning is logged.
+    with caplog.at_level(logging.WARNING, logger="forgekey.views"):
+        resp = _post_enroll(
+            api_client,
+            enroll_url,
+            meta_overrides={
+                "mac_address": "AA:BB:CC:DD:EE:09",
+                "unique_chip_id": "chip-unknownkind",
+                "sensor_kind": "totally-unknown-kind",
+            },
+        )
+    assert resp.status_code == 201, resp.content
+
+    device = ESP32Device.objects.get(mac_address="AA:BB:CC:DD:EE:09")
+    assert device.device_type is None
+    assert device.identity is not None
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        "no DeviceType matches sensor_kind" in m and "totally_unknown_kind" in m for m in messages
+    ), messages
+
+
+def test_backfill_migration_creates_missing_esp32device_rows():
+    # Issued enrollment for a relay MAC with NO ESP32Device row — the exact
+    # orphaned state the old silent-drop gate produced. The 0027 backfill must
+    # create the row, matching device_type by code == sensor_kind.
+    relay_type = DeviceTypeFactory(code=DeviceType.TYPE_AC_RELAY)  # power_relay
+    identity = DeviceIdentity.objects.create(
+        device_id="chip-backfill-relay",
+        status=DeviceIdentity.STATUS_ACTIVE,
+    )
+    DeviceEnrollment.objects.create(
+        device=identity,
+        csr_pem="dummy",
+        mac_address="58:8C:81:9E:76:C0",
+        sensor_kind="power_relay",
+        firmware_version="9.9.9",
+        status=DeviceEnrollment.STATUS_ISSUED,
+        approved_at=timezone.now(),
+    )
+    # An issued enrollment whose sensor_kind matches no DeviceType — still backfilled.
+    unknown_identity = DeviceIdentity.objects.create(
+        device_id="chip-backfill-unknown",
+        status=DeviceIdentity.STATUS_ACTIVE,
+    )
+    DeviceEnrollment.objects.create(
+        device=unknown_identity,
+        csr_pem="dummy",
+        mac_address="AA:BB:CC:DD:EE:77",
+        sensor_kind="no_such_kind",
+        status=DeviceEnrollment.STATUS_ISSUED,
+        approved_at=timezone.now(),
+    )
+    # A PENDING (not issued) enrollment must NOT be backfilled.
+    DeviceEnrollment.objects.create(
+        csr_pem="dummy",
+        mac_address="AA:BB:CC:DD:EE:88",
+        sensor_kind="power_relay",
+        status=DeviceEnrollment.STATUS_PENDING,
+    )
+
+    assert not ESP32Device.objects.filter(mac_address="58:8C:81:9E:76:C0").exists()
+
+    migration = importlib.import_module("forgekey.migrations.0027_backfill_enrolled_esp32devices")
+    from django.apps import apps as global_apps
+
+    migration.backfill_missing_esp32devices(global_apps, None)
+
+    relay_device = ESP32Device.objects.get(mac_address="58:8C:81:9E:76:C0")
+    assert relay_device.identity_id == identity.id
+    assert relay_device.device_type == relay_type
+    assert relay_device.device_type.code == "power_relay"
+    assert relay_device.firmware_version == "9.9.9"
+
+    unknown_device = ESP32Device.objects.get(mac_address="AA:BB:CC:DD:EE:77")
+    assert unknown_device.device_type is None
+    assert unknown_device.identity_id == unknown_identity.id
+
+    # Pending enrollment got no device row.
+    assert not ESP32Device.objects.filter(mac_address="AA:BB:CC:DD:EE:88").exists()
+
+    # Idempotent: a second run does not duplicate or error.
+    migration.backfill_missing_esp32devices(global_apps, None)
+    assert ESP32Device.objects.filter(mac_address="58:8C:81:9E:76:C0").count() == 1

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -459,17 +459,29 @@ class ForgeKeyDeviceEnrollView(APIView):
                     device_type_obj = None
                     if sensor_kind_code:
                         device_type_obj = DeviceType.objects.filter(code=sensor_kind_code).first()
-                    if device_type_obj is not None:
-                        esp_device = ESP32Device.objects.create(
-                            mac_address=device_mac,
-                            device_type=device_type_obj,
-                            firmware_version=meta.get("firmware_version", "") or "",
-                            boot_count=meta.get("boot_count"),
-                            free_heap=meta.get("free_heap"),
-                            ip=meta.get("ip") or meta.get("ip_address"),
-                            last_seen=now,
-                            identity=identity,
+                    if device_type_obj is None:
+                        # No DeviceType matches this sensor_kind. Create the
+                        # device anyway (device_type is nullable) so a device
+                        # that enrolled + got a cert always appears in the list
+                        # instead of being silently dropped (op-3he). Warn so the
+                        # missing/mismatched DeviceType code gets noticed.
+                        logger.warning(
+                            "ForgeKey enroll: no DeviceType matches sensor_kind %r "
+                            "(mac %s, identity %s) — creating ESP32Device with no type.",
+                            sensor_kind_code or "",
+                            device_mac,
+                            identity.device_id if identity else "?",
                         )
+                    esp_device = ESP32Device.objects.create(
+                        mac_address=device_mac,
+                        device_type=device_type_obj,
+                        firmware_version=meta.get("firmware_version", "") or "",
+                        boot_count=meta.get("boot_count"),
+                        free_heap=meta.get("free_heap"),
+                        ip=meta.get("ip") or meta.get("ip_address"),
+                        last_seen=now,
+                        identity=identity,
+                    )
                 else:
                     update_fields = []
                     if esp_device.identity_id != identity.id:

--- a/frontend/src/pages/ForgeKeyDeviceTypesPage.tsx
+++ b/frontend/src/pages/ForgeKeyDeviceTypesPage.tsx
@@ -42,7 +42,7 @@ const CODE_OPTIONS = [
   { value: 'temperature_sensor', label: 'Temperature Sensor' },
   { value: 'generic_input', label: 'Generic Input' },
   { value: 'generic_output', label: 'Generic Output' },
-  { value: 'ac_relay', label: 'AC Relay' },
+  { value: 'power_relay', label: 'AC Relay' },
   { value: 'power_measurement', label: 'Power Measurement' },
   { value: 'people_counter', label: 'People Counter' },
   { value: 'env_sensor', label: 'Environmental Sensor' },


### PR DESCRIPTION
## Summary

Fixes **op-3he**: ForgeKey enroll silently dropped devices whose `sensor_kind` had no matching `DeviceType.code`. A relay (firmware `sensor_kind=power-relay` → normalized `power_relay`) never got an `ESP32Device` row because the model coded the relay `ac_relay`, so it returned 201 with working mTLS yet never appeared in the device list. Any future kind whose normalized `sensor_kind` lacked a matching code (otp_keypad, locker, …) would have failed the same way.

Implements **Approach A** (Ian's decision):

1. **Rename relay code `ac_relay` → `power_relay`** to match the firmware `sensor_kind` + MQTT topic kind (both already `power_relay`). `TYPE_AC_RELAY = "power_relay"` (display name stays "AC Relay"). Migration **0025** alters the `DeviceType.code` choices and data-renames the seeded row in place (PK preserved → existing FKs follow). Historical migrations keep their `ac_relay` references.
2. **Remove the silent-drop gate** (`views.py`): enroll now always creates the `ESP32Device`, with `device_type=None` when the kind is unmapped, and logs a warning. Migration **0026** makes `ESP32Device.device_type` nullable.
3. **Backfill** migration **0027**: for each `issued` `DeviceEnrollment` whose MAC has no `ESP32Device`, create one — `device_type` matched by `code == sensor_kind` (else null), linked to the enrollment's identity, copying mac/firmware/telemetry. Recreates the orphaned relay (mac `58:8C:81:9E:76:C0` / enrollment `7cd60ac2` / identity `72ebbb0b`).

Also updates the frontend device-type dropdown value (it mirrors `TYPE_CHOICES`) and the device-type tests to the renamed code.

## Tests

New/extended in `forgekey/tests/test_enrollment.py`:
- enroll `sensor_kind=power-relay` → `ESP32Device` with `device_type.code == power_relay`
- enroll an unknown `sensor_kind` → device created with `device_type=None` + warning logged
- backfill creates missing rows for issued enrollments (matches type by code, leaves unmapped null, skips pending, idempotent)

Results: full `forgekey/tests` suite **722 passed**; `makemigrations --check` clean; black/isort/flake8 clean; inventory power-tracking (relay) test green.

## Judgment calls

- **`device_type` nullability migration was needed**: it was a required FK (`on_delete=PROTECT`, no `null`). 0026 adds `null=True, blank=True`; `on_delete=PROTECT` is unchanged. Required so the gate removal can persist a typeless device.
- **Backfill device-type matching**: exact `DeviceType.code == enrollment.sensor_kind`. After 0025 the relay enrollment's `power_relay` sensor_kind matches the renamed code; unmapped kinds get `device_type=None`.
- The rename is an in-place `UPDATE` of the existing row's `code` (not delete+recreate), so every FK to the relay DeviceType is preserved.
- No prod changes; not merged.

Bead: op-3he

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
