### PR TITLE
test: stabilize OMS suite — de-flake user-directory search (op-rvf)

### DIFF
--- a/backend/membership/tests/test_user_directory.py
+++ b/backend/membership/tests/test_user_directory.py
@@ -50,11 +50,18 @@ class TestUserDirectoryListing:
         assert "id" in alice
 
     def test_search_matches_username_name_email(self, staff_client):
-        UserFactory(username="zoe_smith", first_name="Zoe", last_name="Smith", email="zoe@x.io")
+        UserFactory(username="zoe_smith", first_name="Zoe", last_name="Qzwxsmith", email="zoe@x.io")
         UserFactory(username="other", first_name="Pat", last_name="Jones", email="pat@x.io")
 
-        by_name = _results(staff_client.get("/api/membership/users/?search=smith"))
+        # Search a *unique* surname token, never a real word like "smith": the
+        # shared test DB also holds the ``staff_client`` auth user, whose
+        # ``last_name`` is a random Faker surname and is "Smith" ~2% of the time,
+        # which used to pollute a bare ``search=smith`` result (op-rvf).
+        by_name = _results(staff_client.get("/api/membership/users/?search=qzwxsmith"))
         assert {r["username"] for r in by_name} == {"zoe_smith"}
+
+        by_username = _results(staff_client.get("/api/membership/users/?search=zoe_smith"))
+        assert {r["username"] for r in by_username} == {"zoe_smith"}
 
         by_email = _results(staff_client.get("/api/membership/users/?search=pat@x.io"))
         assert {r["username"] for r in by_email} == {"other"}


### PR DESCRIPTION
## Stabilize the OpenMakerSuite test suite (op-rvf)

The OMS pytest suite has been intermittently red under the full-suite xdist run. This PR fixes the membership flake (op-rvf) at its root cause and reports a bounded flake-hunt across the rest of the suite.

### Flake fixed: op-rvf
`backend/membership/tests/test_user_directory.py::TestUserDirectoryListing::test_search_matches_username_name_email`

**Symptom:** intermittently `assert {"zoe_smith","user52"} == {"zoe_smith"}` — the user-directory `?search=smith` matched an unexpected extra user.

**Root cause (confirmed by reproduction):** the `?search=` filter is a correct `icontains` over username/first/last/email. The `staff_client` fixture authenticates as `UserFactory(is_staff=True)`, whose `last_name = Faker("last_name")` is a random US surname — and Faker's en_US `last_name()` returns **"Smith" ~2.17% of the time** (the most heavily-weighted surname; measured 4339/200000 over 1000 distinct names). That staff/auth user is listed by the directory, so on ~1 run in 46 its surname *was* "Smith" and `search=smith` returned it alongside `zoe_smith`. The `user52` username is just the staff user's process-global `factory.Sequence` value under the full suite. This is **not** cross-test leakage (`django_db` rolls back per test) — it is an *ambient fixture user inside the query scope* with a randomly-matching name.

Reproduced deterministically before the fix (staff user forced to `last_name="Smith"` → `search=smith` returns both users → assert fails).

**Fix:** search a unique synthetic token (`qzwxsmith`) that cannot occur in a Faker name, so the assertion depends only on the users the test creates. Added a username-match assertion (the test name promises username/name/email). **No production change** — the substring search is the intended picker behavior; the test was just using a colliding real word.

### Flake-hunt (bounded, per the op-rvf bead plan)
Statically audited the whole suite for the same bug class plus other nondeterminism, and ran the full `-n auto` suite:

- **Same pattern (list/filter endpoint + ambient fixture object in scope):** op-rvf was the only instance. Every other list/filter test filters by a specific FK or exact value (`location=…`, `drop_type="ap"`, `breaker=…`) that the auth fixture never satisfies, and the auth fixtures create a `User` — which only the membership user-directory endpoint lists/searches.
- **Specific `factory.Sequence` value assertions** (`user0`, `BADGE0001`, …) would be xdist-distribution-dependent — **none exist**; sequence-like literals in tests are explicit `create_user(...)` values, not generated ones.
- **Explicit randomness** (`random`/`choice`/`sample`/`shuffle`) in tests — **none**; the only nondeterminism source is Faker in factories, and op-rvf was the only place it leaked into an assertion.

**No additional flakes surfaced; no new beads filed.**

### Stability evidence
- **Before:** `search=smith` collided with the `staff_client` fixture surname ~2.17%/run → intermittent CI red (op-rvf; also blocked #806).
- **After:** unique token `qzwxsmith` cannot collide with any Faker name, so the assertion is deterministic.
  - Full `-n auto` run (exact CI command, with coverage): **2811 passed, 3 skipped, 0 failed** in 12m11s; coverage **89.63% ≥ 85%** gate.
  - Fixed test file passes in isolation (5 passed).
  - Hunt was bounded to one full run (a single `-n auto` run is ~12 min); the PR's own Docker Build Test / Backend Tests provide an independent full-suite run.
- `makemigrations --check` clean (no model changes); `black` / `isort` / `flake8` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)