### PR TITLE
fix(forgekey): build full signed command envelope so firmware accepts commands (op-8pn)

### DIFF
--- a/backend/forgekey/services/device_commands.py
+++ b/backend/forgekey/services/device_commands.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import json
 import logging
+import time
+import uuid
 from typing import Any, Dict, Optional, Tuple
 
 from django.utils import timezone
@@ -36,35 +38,86 @@ class DeviceCommandError(RuntimeError):
 
 PUBACK_WAIT_SECONDS = 2.0
 
+# TTL (seconds) stamped onto every signed command envelope. The firmware
+# rejects a command whose ``expires_at`` has passed, so this bounds how long a
+# captured command stays replayable; it also matches the minted JWT's ``exp``.
+# Kept at the locker pipeline's default — short, but comfortably above device
+# NTP skew (an unsynced clock fails distinctly as ``clock_invalid``, not here).
+COMMAND_TTL_SECONDS = 60
 
-def _sign_command_payload(device: ESP32Device, payload: Dict[str, Any]) -> None:
-    """Add the signed ``jwt`` envelope field the firmware requires, in place.
+
+def _command_actor_label(actor: Optional[Any]) -> str:
+    """A non-empty, stable string naming who issued a command.
+
+    The firmware envelope requires a non-empty ``actor``; when no authenticated
+    user is attached (system/automation-driven commands), fall back to
+    ``"system"`` so those commands still validate.
+    """
+    if actor is not None:
+        username = getattr(actor, "username", None)
+        if username:
+            return str(username)
+        actor_id = getattr(actor, "id", None) or getattr(actor, "pk", None)
+        if actor_id is not None:
+            return str(actor_id)
+    return "system"
+
+
+def _sign_command_payload(
+    device: ESP32Device, payload: Dict[str, Any], *, actor: Optional[Any] = None
+) -> None:
+    """Stamp the full signed envelope the firmware requires, in place (op-8pn).
 
     Devices receive the command-signing public key as ``command_public_key_pem``
-    at enroll (``ForgeKeyEnrollView`` -> ``jwt_signing.get_jwt_public_key_pem``)
-    and refuse to act on any command lacking a verifiable top-level ``jwt``,
-    rejecting it as ``missing_envelope_field`` (op-8pn). We mint a short-TTL
-    ES256 JWT over ``{mac, cmd, exp}`` — mirroring the locker command pipeline
-    (``backend/lockers/services/commands.py``), which already passes its own
-    ``jwt`` — so every server -> device command goes out signed.
+    at enroll (``ForgeKeyEnrollView`` -> ``jwt_signing.get_jwt_public_key_pem``).
+    The firmware's ``CommandValidation::validate()`` (command_validation.cpp)
+    then rejects any command that is missing a non-empty
+    ``cmd``/``command_id``/``issued_at``/``expires_at``/``nonce``/``actor``
+    (``missing_envelope_field``) and demands a verifiable authenticator — a
+    top-level ``jwt`` (or detached ``signature``) — else
+    ``missing_authenticator``. We stamp the envelope and mint a short-TTL ES256
+    JWT whose claims bind ``cmd``/``command_id``/``nonce``/``actor`` to it, so
+    ``validateJwt()`` accepts it.
+
+    Every envelope field goes out as a JSON **string**: the firmware reads them
+    with ``doc["x"] | ""``, which yields ``""`` for a JSON *number* and would
+    fail the non-empty check — so epoch timestamps are stringified. ``nonce``
+    and ``command_id`` stay well under the firmware's 72-char replay-cache bound.
 
     No-ops when:
 
-    * the payload has no ``cmd`` verb (nothing to bind the JWT to),
-    * a caller already supplied a ``jwt`` (e.g. the locker publishers, which
-      mint their own with a bespoke TTL — never double-sign), or
+    * the payload has no ``cmd`` verb (nothing to sign),
+    * a caller already supplied a ``jwt`` (the locker publishers mint their own
+      over the jwt-only ``unlock`` path — never double-sign / re-stamp), or
     * no signing key is configured (dev/test rigs), matching the consumer's own
       ``is_jwt_signing_configured()`` gate so unsigned dev flows still work.
 
-    Note: the JWT binds only ``cmd`` (plus ``mac``/``exp``); command parameters
-    (e.g. ``set_indicator``'s color/brightness/pattern) ride as unsigned
-    siblings, same as the locker pipeline today. Binding the parameters needs a
-    coordinated firmware change and is tracked as a follow-up.
+    Note: command *parameters* (e.g. ``set_indicator``'s color/brightness/
+    pattern) ride as unsigned siblings; binding them needs a coordinated
+    firmware change and is tracked as a follow-up.
     """
     cmd = payload.get("cmd")
     if not cmd or "jwt" in payload or not is_jwt_signing_configured():
         return
-    payload["jwt"] = make_command_jwt(mac=device.mac_address, cmd=str(cmd))
+
+    now = int(time.time())
+    command_id = str(payload.get("command_id") or uuid.uuid4())
+    nonce = uuid.uuid4().hex  # 32 chars, < firmware kReplayValueMax (72)
+    actor_label = _command_actor_label(actor)
+
+    payload["command_id"] = command_id
+    payload["issued_at"] = str(now)
+    payload["expires_at"] = str(now + COMMAND_TTL_SECONDS)
+    payload["nonce"] = nonce
+    payload["actor"] = actor_label
+    payload["jwt"] = make_command_jwt(
+        mac=device.mac_address,
+        cmd=str(cmd),
+        command_id=command_id,
+        nonce=nonce,
+        actor=actor_label,
+        exp_seconds=COMMAND_TTL_SECONDS,
+    )
 
 
 def publish_command(
@@ -98,7 +151,7 @@ def publish_command(
     topic = get_mqtt_command_topic(device.mac_address)
     payload = dict(command_payload)
     payload.setdefault("timestamp", timezone.now().isoformat())
-    _sign_command_payload(device, payload)
+    _sign_command_payload(device, payload, actor=actor)
 
     body = json.dumps(payload)
     broker = client or get_mqtt_client()

--- a/backend/forgekey/services/jwt_signing.py
+++ b/backend/forgekey/services/jwt_signing.py
@@ -122,14 +122,30 @@ def _b64url_encode(data: bytes) -> str:
     return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
 
 
-def make_command_jwt(*, mac: str, cmd: str, exp_seconds: int = 60) -> str:
+def make_command_jwt(
+    *,
+    mac: str,
+    cmd: str,
+    command_id: str | None = None,
+    nonce: str | None = None,
+    actor: str | None = None,
+    exp_seconds: int = 60,
+) -> str:
     """Sign a short-TTL command JWT for a ForgeKey device.
 
     The JWT is the credential the firmware verifies before acting on a
     `forgekey/<mac>/command` MQTT message — used by the locker / door /
     electronic-device pipeline (gh ForgeKey expansion, Phase 1).
 
-    Payload shape: ``{"mac": ..., "cmd": ..., "exp": <unix-seconds>}``.
+    Payload shape: ``{"mac": ..., "cmd": ..., "exp": <unix-seconds>}`` plus,
+    when supplied, ``command_id``/``nonce``/``actor``. Those extra claims bind
+    the JWT to the surrounding command *envelope*: the firmware's
+    ``validateJwt()`` (command_validation.cpp) rejects a command as
+    ``jwt_claim_mismatch`` unless the JWT's ``cmd``/``command_id``/``nonce``
+    equal the envelope's top-level fields (``actor``/``mac`` are matched only
+    when present). Callers that drive the full ``validate()`` envelope path
+    (``device_commands._sign_command_payload``) pass all three; the jwt-only
+    paths (lockers' ``unlock``) omit them and keep the minimal claim set.
     Signed with ES256 using the same key that backs EMQX device-auth
     JWTs, so firmware only carries one public-key trust root.
 
@@ -150,6 +166,13 @@ def make_command_jwt(*, mac: str, cmd: str, exp_seconds: int = 60) -> str:
         "cmd": cmd,
         "exp": int(time.time()) + exp_seconds,
     }
+    # Bind the JWT to the command envelope so validateJwt()'s claim checks pass.
+    if command_id:
+        payload["command_id"] = command_id
+    if nonce:
+        payload["nonce"] = nonce
+    if actor:
+        payload["actor"] = actor
 
     header_b64 = _b64url_encode(json.dumps(header, separators=(",", ":")).encode("utf-8"))
     payload_b64 = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))

--- a/backend/forgekey/tests/test_command_jwt.py
+++ b/backend/forgekey/tests/test_command_jwt.py
@@ -127,3 +127,35 @@ def test_command_jwt_raises_when_signing_key_missing():
     with override_settings(FORGEKEY_JWT_SIGNING_KEY=""):
         with pytest.raises(JwtSigningError):
             make_command_jwt(mac="AA:BB:CC:11:22:33", cmd="unlock")
+
+
+def test_command_jwt_binds_envelope_claims_when_provided(keypair):
+    """The full ``validate()`` envelope path (set_indicator, relay, …) passes
+    command_id/nonce/actor so the firmware's validateJwt() claim checks match
+    the top-level envelope fields."""
+    private_pem, public_pem = keypair
+    with _settings_with(private_pem):
+        token = make_command_jwt(
+            mac="AA:BB:CC:11:22:33",
+            cmd="set_indicator",
+            command_id="cmd-123",
+            nonce="nonce-abc",
+            actor="alice",
+        )
+    payload = _verify_es256(token, public_pem)
+    assert payload["cmd"] == "set_indicator"
+    assert payload["command_id"] == "cmd-123"
+    assert payload["nonce"] == "nonce-abc"
+    assert payload["actor"] == "alice"
+
+
+def test_command_jwt_omits_envelope_claims_when_absent(keypair):
+    """Locker / unlock callers pass only mac+cmd; the JWT stays minimal so the
+    jwt-only path keeps validating (no spurious claim binding)."""
+    private_pem, public_pem = keypair
+    with _settings_with(private_pem):
+        token = make_command_jwt(mac="AA:BB:CC:11:22:33", cmd="unlock")
+    payload = _verify_es256(token, public_pem)
+    assert "command_id" not in payload
+    assert "nonce" not in payload
+    assert "actor" not in payload

--- a/backend/forgekey/tests/test_device_commands.py
+++ b/backend/forgekey/tests/test_device_commands.py
@@ -24,7 +24,11 @@ from rest_framework.test import APIClient
 
 from forgekey.management.commands.mqtt_consumer import handle_status_message
 from forgekey.models import DeviceCommand
-from forgekey.services.device_commands import apply_command_ack, publish_command
+from forgekey.services.device_commands import (
+    apply_command_ack,
+    dispatch_command,
+    publish_command,
+)
 from forgekey.tasks import process_mqtt_status_message
 from forgekey.tests.factories import ESP32DeviceFactory
 
@@ -532,6 +536,64 @@ def _published_body(client: MagicMock) -> dict:
     return json.loads(args[1])
 
 
+def _norm_mac(mac: str) -> str:
+    return mac.replace(":", "").replace("-", "").lower()
+
+
+def _firmware_validate(body: dict, device_mac: str) -> "str | None":
+    """Python mirror of the firmware's ``CommandValidation::validate()`` +
+    ``validateJwt()`` (ForgeKey ``src/security/command_validation.cpp``), enough
+    to prove the server's envelope would be *accepted on-device* (op-8pn
+    round-trip). Returns the firmware error code, or ``None`` if it validates.
+
+    Mirrors the contract exactly: every envelope field is read as a string
+    (a JSON number reads back as ``""`` on-device), the authenticator is a
+    top-level ``jwt``/``signature``, and the JWT claims must bind to the
+    envelope.
+    """
+
+    def _nonempty_str(value) -> bool:
+        return isinstance(value, str) and value != ""
+
+    for field in ("cmd", "command_id", "issued_at", "expires_at", "nonce", "actor"):
+        if not _nonempty_str(body.get(field)):
+            return "missing_envelope_field"
+    if not _nonempty_str(body.get("jwt")) and not _nonempty_str(body.get("signature")):
+        return "missing_authenticator"
+    if len(body["command_id"]) >= 72 or len(body["nonce"]) >= 72:
+        return "envelope_field_too_long"
+    try:
+        issued_at = int(body["issued_at"])
+        expires_at = int(body["expires_at"])
+    except (TypeError, ValueError):
+        return "invalid_timestamp"
+    now = int(time.time())
+    if expires_at <= issued_at:
+        return "expired"
+    if now > expires_at:
+        return "expired"
+    if issued_at > now + 300:  # kIssuedAtFutureSkewS
+        return "issued_in_future"
+
+    # Authenticator: JWT path. _verify_command_jwt raises on a bad signature.
+    claims = _verify_command_jwt(body["jwt"])
+    claim_command_id = claims.get("command_id") or claims.get("jti") or ""
+    claim_actor = claims.get("actor") or claims.get("sub") or ""
+    claim_mac = claims.get("mac") or claims.get("device") or ""
+    if (
+        claims.get("cmd", "") != body["cmd"]
+        or claim_command_id != body["command_id"]
+        or claims.get("nonce", "") != body["nonce"]
+        or (claim_actor and claim_actor != body["actor"])
+    ):
+        return "jwt_claim_mismatch"
+    if claim_mac and _norm_mac(claim_mac) != _norm_mac(device_mac):
+        return "wrong_device"
+    if int(claims["exp"]) < now:
+        return "expired"
+    return None
+
+
 class TestPublishCommandSignsEnvelope:
     """op-8pn: ``publish_command`` must wrap every server -> device command in
     the signed ``jwt`` envelope the firmware verifies (against
@@ -566,21 +628,89 @@ class TestPublishCommandSignsEnvelope:
         assert body["color"] == "green"
         assert body["pattern"] == "solid"
 
+        # All six envelope fields must be present, non-empty, and STRING-typed
+        # (the firmware reads them with `doc[x] | ""`, which yields "" for a
+        # JSON number -> missing_envelope_field).
+        for field in ("cmd", "command_id", "issued_at", "expires_at", "nonce", "actor"):
+            assert field in body, f"envelope missing required field {field!r}"
+            assert (
+                isinstance(body[field], str) and body[field]
+            ), f"envelope field {field!r} must be a non-empty string, got {body[field]!r}"
+        # command_id / nonce stay under the firmware's 72-char replay bound.
+        assert len(body["command_id"]) < 72
+        assert len(body["nonce"]) < 72
+        # issued_at/expires_at are epoch-second strings; expires_at is TTL later.
+        assert before <= int(body["issued_at"]) <= after
+        assert int(body["expires_at"]) == int(body["issued_at"]) + 60
+        # No authenticated actor -> the system fallback.
+        assert body["actor"] == "system"
+
+        # The JWT claims must bind to the envelope or validateJwt() rejects it
+        # as jwt_claim_mismatch.
         claims = _verify_command_jwt(body["jwt"])
         assert claims["mac"] == device.mac_address
         assert claims["cmd"] == "set_indicator"
+        assert claims["command_id"] == body["command_id"]
+        assert claims["nonce"] == body["nonce"]
+        assert claims["actor"] == body["actor"]
         assert before + 60 <= claims["exp"] <= after + 60
+
+    def test_envelope_passes_firmware_validate_contract(self):
+        """The published envelope + JWT pass the same checks the firmware's
+        ``validate()``/``validateJwt()`` run, so a real device accepts it
+        (op-8pn round-trip) — the regression that proves we cleared
+        ``missing_envelope_field`` *and* ``missing_authenticator``."""
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:0E:07")
+        client = MagicMock()
+        client.publish.return_value = MagicMock(rc=0)
+
+        dispatch_command(
+            device,
+            {"cmd": "set_indicator", "color": "red", "pattern": "solid"},
+            audit_action="set_indicator",
+            client=client,
+        )
+
+        body = _published_body(client)
+        assert _firmware_validate(body, device.mac_address) is None
+        # command_id is the DeviceCommand row id (ack correlation) and is what
+        # the JWT binds to — not a throwaway.
+        assert body["command_id"] == str(DeviceCommand.objects.get().id)
+
+    def test_actor_username_flows_into_envelope_and_jwt(self):
+        """An authenticated actor's username lands in the envelope + bound JWT
+        claim; the firmware matches them (jwt_claim_mismatch otherwise)."""
+
+        class _Actor:
+            username = "alice"
+            is_authenticated = True
+
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:0E:08")
+        client = MagicMock()
+        client.publish.return_value = MagicMock(rc=0)
+
+        publish_command(device, {"cmd": "restart"}, actor=_Actor(), client=client)
+
+        body = _published_body(client)
+        assert body["actor"] == "alice"
+        assert _verify_command_jwt(body["jwt"])["actor"] == "alice"
+        assert _firmware_validate(body, device.mac_address) is None
 
     def test_existing_jwt_is_not_overwritten(self):
         """Locker publishers mint their own jwt (bespoke TTL) before calling
-        publish_command — those must never be double-signed."""
+        publish_command over the jwt-only ``unlock`` path — those must never be
+        double-signed nor re-stamped with the full envelope."""
         device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:0E:02")
         client = MagicMock()
         client.publish.return_value = MagicMock(rc=0)
 
         publish_command(device, {"cmd": "unlock", "jwt": "caller-supplied"}, client=client)
 
-        assert _published_body(client)["jwt"] == "caller-supplied"
+        body = _published_body(client)
+        assert body["jwt"] == "caller-supplied"
+        # Pre-signed commands take the jwt-only path: we must not re-stamp them.
+        assert "command_id" not in body
+        assert "nonce" not in body
 
     def test_no_jwt_when_signing_key_unconfigured(self):
         """Dev/test rigs without a signing key keep publishing raw, matching the


### PR DESCRIPTION
## op-8pn — sign device-command envelopes so firmware accepts commands

### Problem
Server→device commands went out as a raw payload (or, after #804, with only a
`{mac,cmd,exp}` JWT). The firmware's `CommandValidation::validate()`
(`ForgeKey/src/security/command_validation.cpp:307`) requires a **full
envelope** before it even checks the authenticator, so every `set_indicator` /
relay command was rejected on-device with `missing_envelope_field` — confirmed
at the bench 2026-06-28. This blocked **all on-device control** (indicator
colors / op-8ph, relay enable/disable).

### Fix
Centralized in `_sign_command_payload` — the single chokepoint that every
ForgeKey command flows through (`set_indicator` via `indicator.py`, relay via
`access_control.py`, and `restart`/`blink`/`identify`/… via the views’
`_dispatch_command`). Locker publishers pre-sign their own JWT over the
jwt-only `unlock` path and are skipped (the existing `"jwt" in payload` guard).

- **Full envelope, all JSON strings:** `command_id`, `issued_at`,
  `expires_at`, `nonce`, `actor`. The firmware reads each as `doc[x] | ""`,
  which yields `""` for a JSON *number* → epoch timestamps are stringified.
  `nonce` (uuid4 hex, 32) and `command_id` (uuid, 36) stay under the firmware’s
  72-char replay-cache bound.
- **JWT bound to the envelope:** `make_command_jwt` now carries
  `command_id`/`nonce`/`actor` claims so `validateJwt()`’s claim-matching
  passes. Callers that pass only `mac`+`cmd` (lockers) keep a minimal JWT, so
  the jwt-only path is unchanged.

Firmware error progression now: `missing_envelope_field` →
`missing_authenticator` → **accepted**. `command_id` reuses the
`DeviceCommand` row id for ack correlation.

### Why the JWT path (not detached signature)
The JWT is self-contained — the firmware reconstructs its signing input from
the token, so there’s no canonicalization byte-matching risk — and the
existing ES256 machinery already produces exactly the 64-byte `r||s` raw
signature `verifyEs256RawSignature` expects. The detached-`signature` path over
`canonicalSigningInput` would need a new signer *and* byte-exact agreement on
the 6-field format for no benefit.

### Tests
- `_firmware_validate` — a Python mirror of `validate()` + `validateJwt()`
  asserts the published envelope + JWT would be **accepted on-device** (the
  regression proving both rejections are cleared, signature included).
- Claim-binding, actor-flow, and "locker JWT not re-stamped" coverage.
- **forgekey + lockers: 801 passed**; command-signing files: 46 passed; flake8 clean.
- Run locally on the sqlite test DB (no Postgres creds on this box); change is
  pure-Python, so CI’s Postgres run is the authoritative gate.

### Before the bench round-trip
- `FORGEKEY_JWT_SIGNING_KEY` must be **active on prod** (else the JWT mint
  no-ops → you’d see `missing_authenticator`).
- The device’s `command_public_key_pem` (issued at enroll) must match that key.

### Follow-ups (tracked on the op-8pn bead)
- Sign command **parameters** (color/brightness ride unsigned today).
- Route legacy `tasks.py` `send_mqtt_command` through `publish_command`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
