### PR TITLE
fix(forgekey): sign legacy relay command path so enable/disable/status validate (op-8pn follow-up)

### DIFF
--- a/backend/config/tests/test_task_idempotency.py
+++ b/backend/config/tests/test_task_idempotency.py
@@ -139,6 +139,7 @@ class TestWebhookPayloadIsDeduplicatable:
         mock_post.assert_not_called()
 
 
+@pytest.mark.django_db
 class TestMQTTCommandIsLevelTriggered:
     """ForgeKey commands are level-triggered: replay publishes the same
     state-changing message, which the device idempotently applies.

--- a/backend/forgekey/tasks.py
+++ b/backend/forgekey/tasks.py
@@ -214,9 +214,7 @@ def send_mqtt_command(
         if device is not None:
             from .services.device_commands import publish_command
 
-            topic = publish_command(
-                device, command_payload, audit_action=command, client=client
-            )
+            topic = publish_command(device, command_payload, audit_action=command, client=client)
             logger.info(f"Sent command '{command}' to device {mac_address}")
             return {
                 "success": True,

--- a/backend/forgekey/tasks.py
+++ b/backend/forgekey/tasks.py
@@ -196,16 +196,43 @@ def send_mqtt_command(
         # ``command``. The older ``"command"`` key was silently dropped by
         # firmware so /enable, /disable, and /status were no-ops on the
         # device side even after the topic was correct.
-        message = {
-            "cmd": command,
-            "timestamp": timezone.now().isoformat(),
-        }
-
+        command_payload: Dict[str, Any] = {"cmd": command}
         if payload:
-            message.update(payload)
+            command_payload.update(payload)
 
-        message_json = json.dumps(message)
-        result = client.publish(topic, message_json, qos=1)
+        # op-8pn: the firmware now rejects any command lacking the signed
+        # envelope (missing_envelope_field) — the relay enable/disable/status
+        # path runs through here, so route enrolled devices through
+        # publish_command, which stamps the command_id/issued_at/expires_at/
+        # nonce/actor envelope + JWT (same chokepoint as the DRF / indicator /
+        # relay-access paths). Imported lazily to avoid the tasks <-> device_
+        # commands circular import (device_commands imports get_mqtt_client
+        # from this module). A device we have no row for can't be signed for;
+        # fall back to the legacy raw publish (firmware will reject it, but the
+        # relay endpoints always pass an enrolled device's MAC).
+        device = ESP32Device.objects.filter(mac_address=mac_address).first()
+        if device is not None:
+            from .services.device_commands import publish_command
+
+            topic = publish_command(
+                device, command_payload, audit_action=command, client=client
+            )
+            logger.info(f"Sent command '{command}' to device {mac_address}")
+            return {
+                "success": True,
+                "mac_address": mac_address,
+                "command": command,
+                "topic": topic,
+            }
+
+        logger.warning(
+            "send_mqtt_command: no ESP32Device row for %s; publishing UNSIGNED "
+            "(command=%s) — firmware will reject without the op-8pn envelope",
+            mac_address,
+            command,
+        )
+        command_payload["timestamp"] = timezone.now().isoformat()
+        result = client.publish(topic, json.dumps(command_payload), qos=1)
 
         if result.rc == mqtt.MQTT_ERR_SUCCESS:
             logger.info(f"Sent command '{command}' to device {mac_address}")

--- a/backend/forgekey/tests/test_tasks.py
+++ b/backend/forgekey/tests/test_tasks.py
@@ -5,6 +5,7 @@ Tests for ForgeKey Celery tasks (with mocked MQTT).
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.test import override_settings
 
 from forgekey.models import ESP32Device
 from forgekey.tasks import (
@@ -56,6 +57,32 @@ class TestMQTTTasks:
         body_obj = json.loads(body)
         assert body_obj["cmd"] == "enable"
         assert "command" not in body_obj
+
+    @patch("forgekey.tasks.get_mqtt_client")
+    def test_send_mqtt_command_signs_for_enrolled_device(self, mock_get_client):
+        """op-8pn: relay enable/disable/status (which run through
+        send_mqtt_command) must go out in the firmware's signed envelope for an
+        enrolled device — a raw payload is rejected on-device as
+        ``missing_envelope_field``."""
+        import json
+
+        from forgekey.services.jwt_signing import generate_jwt_signing_keypair
+
+        mock_client = MagicMock()
+        mock_client.publish.return_value = MagicMock(rc=0)
+        mock_get_client.return_value = mock_client
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:00:0F:01")
+        private_pem, _ = generate_jwt_signing_keypair()
+
+        with override_settings(FORGEKEY_JWT_SIGNING_KEY=private_pem):
+            result = send_mqtt_command(device.mac_address, "disable", {"delay_seconds": 5})
+
+        assert result["success"] is True
+        body = json.loads(mock_client.publish.call_args[0][1])
+        assert body["cmd"] == "disable"
+        assert body["delay_seconds"] == 5  # params still ride alongside
+        for field in ("command_id", "issued_at", "expires_at", "nonce", "actor", "jwt"):
+            assert body.get(field), f"signed envelope missing {field!r}"
 
     @patch("forgekey.tasks.send_mqtt_command")
     def test_enable_device(self, mock_send_command):

--- a/backend/forgekey/tests/test_tasks.py
+++ b/backend/forgekey/tests/test_tasks.py
@@ -4,8 +4,9 @@ Tests for ForgeKey Celery tasks (with mocked MQTT).
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 from django.test import override_settings
+
+import pytest
 
 from forgekey.models import ESP32Device
 from forgekey.tasks import (


### PR DESCRIPTION
## op-8pn follow-up — sign the legacy relay command path

### Problem (caught at the bench, post-#810)
With #810 merged & deployed, signed commands work on real hardware: `restart`
(len 629) and `identify` (len 649) were **accepted**. But the **relay**
`enable`/`disable` arrived as `len=66/67` with `command_id=""` — **raw,
unsigned** — and the firmware rejected them with `missing_envelope_field`.

Root cause: the DRF relay endpoints fire `enable_device` / `disable_device` /
`request_device_status` Celery tasks, which all funnel through the legacy
`forgekey.tasks.send_mqtt_command` — and that published a raw `{"cmd": …}`
payload, bypassing the `publish_command` signing chokepoint #810 added. (This is
the "route legacy `tasks.py` via `publish_command`" follow-up flagged on the
op-8pn bead.)

### Fix
`send_mqtt_command` now looks up the `ESP32Device` and routes through
`publish_command` when found — so `enable`/`disable`/`status` go out in the same
signed envelope (`command_id`/`issued_at`/`expires_at`/`nonce`/`actor` + JWT) as
the DRF / indicator / relay-access paths. The import is lazy to avoid the
`tasks ↔ device_commands` circular import. An unknown-device call keeps the
legacy raw publish (now logged as **UNSIGNED**) — but the relay endpoints always
pass an enrolled device's MAC, so production always signs.

### Tests
- New `test_send_mqtt_command_signs_for_enrolled_device` asserts an enrolled
  device's command goes out as the full signed envelope (params still ride
  alongside).
- Existing bare-MAC task tests still exercise the (now clearly-logged) raw
  fallback.
- forgekey + lockers: **802 passed**; flake8 clean. (Local sqlite — CI Postgres
  is the authoritative gate.)

### After merge → deploy
At the bench, relay `enable`/`disable` should be **accepted** just like
`restart`/`identify` were (`len 66/67, command_id=""` → full signed envelope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
