### PR TITLE
feat(forgekey/rollouts): auto-update New Rollout version when a build succeeds

### DIFF
--- a/frontend/src/__tests__/pages/ForgeKeyFirmwareRolloutsPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyFirmwareRolloutsPage.test.tsx
@@ -9,6 +9,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import ForgeKeyFirmwareRolloutsPage, {
   defaultPioEnv,
+  pickFreshlySucceededVersion,
 } from '../../pages/ForgeKeyFirmwareRolloutsPage';
 import { forgekeyAPI } from '../../services/api';
 
@@ -280,4 +281,54 @@ describe('ForgeKeyFirmwareRolloutsPage', () => {
   // other → createFirmwareRollout) is exercised in the backend serializer
   // tests via the `device_type_code` field; driving the Mantine Select to
   // verify it E2E here adds brittle DOM coupling without catching more bugs.
+});
+
+describe('pickFreshlySucceededVersion', () => {
+  // The helper only reads id/status/firmware_version/completed_at; cast minimal
+  // fixtures to the full build type.
+  const mkBuild = (over: Record<string, unknown>) =>
+    ({
+      id: 'b1',
+      status: 'succeeded',
+      firmware_version: 'fw1',
+      completed_at: '2026-06-29T00:00:00Z',
+      ...over,
+    }) as any;
+
+  test('returns a newly succeeded build’s firmware_version and marks it seen', () => {
+    const seen = new Set<string>();
+    expect(pickFreshlySucceededVersion([mkBuild({ id: 'x', firmware_version: 'fwX' })], seen)).toBe(
+      'fwX',
+    );
+    expect(seen.has('x')).toBe(true);
+    // Same build on the next poll is no longer "fresh" → no re-trigger.
+    expect(
+      pickFreshlySucceededVersion([mkBuild({ id: 'x', firmware_version: 'fwX' })], seen),
+    ).toBeNull();
+  });
+
+  test('ignores non-succeeded builds and successes without a firmware_version', () => {
+    const seen = new Set<string>();
+    expect(pickFreshlySucceededVersion([mkBuild({ id: 'q', status: 'building' })], seen)).toBeNull();
+    expect(pickFreshlySucceededVersion([mkBuild({ id: 'n', firmware_version: null })], seen)).toBeNull();
+  });
+
+  test('picks the most recently completed among several fresh successes', () => {
+    const seen = new Set<string>();
+    expect(
+      pickFreshlySucceededVersion(
+        [
+          mkBuild({ id: 'old', firmware_version: 'fwOld', completed_at: '2026-06-29T00:00:00Z' }),
+          mkBuild({ id: 'new', firmware_version: 'fwNew', completed_at: '2026-06-29T02:00:00Z' }),
+        ],
+        seen,
+      ),
+    ).toBe('fwNew');
+  });
+
+  test('seeding seen with existing successes prevents auto-select on reload', () => {
+    const existing = [mkBuild({ id: 'e1', firmware_version: 'fwE' })];
+    const seen = new Set(existing.map((b) => b.id));
+    expect(pickFreshlySucceededVersion(existing, seen)).toBeNull();
+  });
 });

--- a/frontend/src/pages/ForgeKeyFirmwareRolloutsPage.tsx
+++ b/frontend/src/pages/ForgeKeyFirmwareRolloutsPage.tsx
@@ -26,7 +26,7 @@ import {
   TextInput,
   Title,
 } from '@mantine/core';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Navigate } from 'react-router-dom';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import {
@@ -68,6 +68,27 @@ const DEFAULT_PIO_ENV = 'seeed_xiao_esp32s3';
 
 /** Default PlatformIO env for a device-type code (overridable in the form). */
 export const defaultPioEnv = (code: string): string => PIO_ENV_BY_CODE[code] ?? DEFAULT_PIO_ENV;
+
+/**
+ * Pick the firmware-version id to auto-select in the New Rollout form when a
+ * build *newly* succeeds. Returns the `firmware_version` of the most recently
+ * completed not-yet-seen succeeded build (mutating `seen` to mark the fresh
+ * ones handled), or `null` when nothing new succeeded. Seeding `seen` with the
+ * builds present on first load keeps page reloads / pre-existing successes from
+ * hijacking the form — only a success observed live updates the version.
+ */
+export const pickFreshlySucceededVersion = (
+  builds: ForgeKeyFirmwareBuild[],
+  seen: Set<string>,
+): string | null => {
+  const fresh = builds.filter(
+    (b) => b.status === 'succeeded' && b.firmware_version && !seen.has(b.id),
+  );
+  fresh.forEach((b) => seen.add(b.id));
+  if (fresh.length === 0) return null;
+  const newest = fresh.reduce((a, b) => ((a.completed_at ?? '') >= (b.completed_at ?? '') ? a : b));
+  return newest.firmware_version ?? null;
+};
 
 const fmtBuildElapsed = (build: ForgeKeyFirmwareBuild): string | null => {
   if (!build.started_at) return null;
@@ -117,6 +138,10 @@ const ForgeKeyFirmwareRolloutsPage: React.FC = () => {
   const [logBuildId, setLogBuildId] = useState<string | null>(null);
   const [redispatchingBuildId, setRedispatchingBuildId] = useState<string | null>(null);
 
+  // Succeeded builds we've already reacted to — seeded on first load so only a
+  // build that succeeds while the page is open auto-updates the rollout version.
+  const seenSucceededBuilds = useRef<Set<string> | null>(null);
+
   useEffect(() => {
     if (!isStaff && !isSuperuser) return undefined;
     let cancelled = false;
@@ -141,20 +166,40 @@ const ForgeKeyFirmwareRolloutsPage: React.FC = () => {
         /* ePaper rollouts are secondary on this page; ignore transient errors */
       }
     };
+    const loadVersions = async () => {
+      try {
+        const res = await forgekeyAPI.listFirmwareVersions();
+        if (!cancelled) setVersions(asList(res.data).filter((v) => v.is_active !== false));
+      } catch {
+        /* versions refresh is best-effort; keep the last good list */
+      }
+    };
     const loadBuilds = async () => {
       try {
         const res = await forgekeyAPI.listFirmwareBuilds();
-        if (!cancelled) setBuilds(asList(res.data));
+        if (cancelled) return;
+        const list = asList(res.data);
+        setBuilds(list);
+        // Auto-update the New Rollout version when a build *newly* succeeds, so a
+        // fresh build is one click from a rollout instead of a manual re-pick.
+        if (seenSucceededBuilds.current === null) {
+          // First load: remember existing successes so reloads don't hijack the form.
+          seenSucceededBuilds.current = new Set(
+            list.filter((b) => b.status === 'succeeded' && b.firmware_version).map((b) => b.id),
+          );
+        } else {
+          const picked = pickFreshlySucceededVersion(list, seenSucceededBuilds.current);
+          if (picked) {
+            // Refresh the dropdown first so the just-built version is selectable.
+            await loadVersions();
+            if (!cancelled) setFormVersion(picked);
+          }
+        }
       } catch {
         /* builds are secondary; ignore transient errors */
       }
     };
-    forgekeyAPI
-      .listFirmwareVersions()
-      .then((res) => {
-        if (!cancelled) setVersions(asList(res.data).filter((v) => v.is_active !== false));
-      })
-      .catch(() => undefined);
+    loadVersions();
     forgekeyAPI
       .listDeviceTypes()
       .then((res) => {
@@ -167,6 +212,7 @@ const ForgeKeyFirmwareRolloutsPage: React.FC = () => {
     const handle = window.setInterval(() => {
       loadRollouts();
       loadEpaperRollouts();
+      loadVersions();
       loadBuilds();
     }, POLL_INTERVAL_MS);
     return () => {


### PR DESCRIPTION
## Auto-update the New Rollout version when a firmware build succeeds

### Problem
On the ForgeKey firmware rollouts page, the version list was fetched **once on
mount** and never refreshed. When a build finished successfully while the page
was open, the freshly-built `FirmwareVersion` didn't show up in the **New
Rollout** dropdown — and the version field never updated — so operators had to
reload the page to roll out what they'd just built.

### Fix (`ForgeKeyFirmwareRolloutsPage.tsx`)
- The 30s poll now also **refreshes the versions list**, so new builds appear in
  the dropdown without a reload.
- When a build **newly transitions to `succeeded`**, the form **auto-selects its
  `firmware_version`** (the build row already carries the new `FirmwareVersion`
  id — no string matching). A `useRef` seeded on first load keeps page reloads /
  pre-existing successes from hijacking the form; only a success observed *live*
  updates the field.
- Pairs with the backend's existing `_stage_draft_rollout` (auto-creates a draft
  rollout on build success) for a real "build → one click → rollout" flow.

Selection logic is extracted into a pure, exported `pickFreshlySucceededVersion()`
(newest-by-`completed_at`, marks builds seen, ignores non-success / versionless
builds) with unit tests.

### Tests / checks
- **vitest: 13 passed** (4 new helper tests + existing page tests).
- **eslint: clean**; the changed file **typechecks clean**. (`tsc` is not a CI
  gate; pre-existing zod-v4 / missing-Record-key errors in other files are
  untouched — noted separately, e.g. `UniversalScannerPage` missing
  `project_storage_stint`.)

### ScanTTY parity
ScanTTY has firmware *monitoring* (device-detail + epaper panel firmware status)
but **no rollout-creation flow**, so there's no TUI equivalent to update here.
Rollout creation in ScanTTY is a separate pre-existing parity gap — flagged, not
in scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
