### PR TITLE
feat(forgekey): per-channel enable/disable for the 2ch power relay (ga-40w)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -748,6 +748,9 @@ views:
       recent_commands:
         permission_classes:
         - IsAdminUser
+      relay_channel:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
       retire:
         permission_classes:
         - IsAdminUser

--- a/backend/forgekey/serializers.py
+++ b/backend/forgekey/serializers.py
@@ -604,3 +604,16 @@ class ForgeKeyAuditEventSerializer(serializers.ModelSerializer):
             "metadata",
         ]
         read_only_fields = fields
+
+
+class RelayChannelCommandSerializer(serializers.Serializer):
+    """Validate a per-channel power-relay command (ga-40w).
+
+    Targets one channel of the power relay. ``channel`` is 1-indexed to match
+    the firmware ``power_relay`` capability (``kChannelCount == 2``); ``on``
+    selects enable vs disable. Mapped to a signed ``power_set`` command by
+    ``ESP32DeviceViewSet.relay_channel``.
+    """
+
+    channel = serializers.IntegerField(min_value=1, max_value=2)
+    on = serializers.BooleanField()

--- a/backend/forgekey/tests/test_access_control.py
+++ b/backend/forgekey/tests/test_access_control.py
@@ -621,3 +621,57 @@ class TestAccessLogApi:
         client.force_authenticate(user=member)
         resp = client.get("/api/forgekey/access-log/?access_only=true")
         assert resp.status_code == 403
+
+
+class TestRelayChannelControl:
+    """ga-40w: per-channel power-relay enable/disable via a signed
+    ``power_set`` command (not the legacy ``enable``/``disable`` verbs, which
+    the firmware's power_relay capability doesn't handle)."""
+
+    def _url(self, device):
+        return f"/api/forgekey/devices/{device.id}/relay-channel/"
+
+    def test_staff_can_enable_a_channel(self, asset, device, admin_user):
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+        with patch("forgekey.views.publish_command", return_value="forgekey/x/command") as pub:
+            resp = client.post(self._url(device), {"channel": 2, "on": True}, format="json")
+        assert resp.status_code == 200, resp.data
+        sent = pub.call_args[0][1]  # full_payload handed to publish_command
+        assert sent["cmd"] == "power_set"
+        assert sent["channel"] == 2
+        assert sent["action"] == "enable"
+        rec = DeviceCommand.objects.get(device=device)
+        assert rec.command == "power_set"
+
+    def test_disable_sends_disable_action(self, asset, device, admin_user):
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+        with patch("forgekey.views.publish_command", return_value="forgekey/x/command") as pub:
+            resp = client.post(self._url(device), {"channel": 1, "on": False}, format="json")
+        assert resp.status_code == 200, resp.data
+        assert pub.call_args[0][1]["action"] == "disable"
+
+    def test_unauthorized_member_cannot_control_channel(self, asset, device, member):
+        client = APIClient()
+        client.force_authenticate(user=member)
+        with patch("forgekey.views.publish_command") as pub:
+            resp = client.post(self._url(device), {"channel": 1, "on": True}, format="json")
+        assert resp.status_code == 403
+        pub.assert_not_called()
+
+    def test_invalid_channel_is_rejected(self, asset, device, admin_user):
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+        with patch("forgekey.views.publish_command") as pub:
+            resp = client.post(self._url(device), {"channel": 3, "on": True}, format="json")
+        assert resp.status_code == 400
+        pub.assert_not_called()
+
+    def test_missing_on_field_is_rejected(self, asset, device, admin_user):
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+        with patch("forgekey.views.publish_command") as pub:
+            resp = client.post(self._url(device), {"channel": 1}, format="json")
+        assert resp.status_code == 400
+        pub.assert_not_called()

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -82,6 +82,7 @@ from .serializers import (
     OccupancyEventSerializer,
     OperationalModeSerializer,
     PowerMeterReadingSerializer,
+    RelayChannelCommandSerializer,
     RoomOperationalModeSerializer,
     TemperatureReadingSerializer,
 )
@@ -994,6 +995,31 @@ class ESP32DeviceViewSet(viewsets.ModelViewSet):
                 "device": device.mac_address,
                 "delay": delay_seconds,
             }
+        )
+
+    @action(detail=True, methods=["post"], url_path="relay-channel")
+    def relay_channel(self, request, pk=None):
+        """Enable/disable a single power-relay channel (ga-40w).
+
+        Body: ``{"channel": 1|2, "on": true|false}``. Emits a signed
+        ``power_set`` command — the verb the firmware's ``power_relay``
+        capability handles (it reads ``channel`` + ``action``); the legacy
+        ``enable``/``disable`` verbs don't route to that capability. Same
+        per-asset authorization as :meth:`enable` / :meth:`disable`.
+        """
+        device = self.get_object()
+        denied = self._authorize_relay(request, device, "relay-channel")
+        if denied is not None:
+            return denied
+        serializer = RelayChannelCommandSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        channel = serializer.validated_data["channel"]
+        on = serializer.validated_data["on"]
+        return self._dispatch_command(
+            device,
+            request.user,
+            {"cmd": "power_set", "channel": channel, "action": "enable" if on else "disable"},
+            "power_set",
         )
 
     @action(detail=True, methods=["post"])

--- a/frontend/src/__tests__/pages/ForgeKeyDeviceDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyDeviceDetailPage.test.tsx
@@ -28,6 +28,7 @@ vi.mock('../../services/api', async () => {
       ping: jest.fn(),
       identify: jest.fn(),
       recentCommands: jest.fn(),
+      setRelayChannel: jest.fn(),
       // IndicatorManagementCard (mounted for indicator devices) probes these on
       // load; the test device is a people_counter, so it renders nothing.
       listDeviceTypes: jest.fn(),
@@ -123,6 +124,48 @@ describe('ForgeKeyDeviceDetailPage', () => {
   afterEach(() => {
     localStorage.removeItem('is_staff');
     localStorage.removeItem('is_superuser');
+  });
+
+  it('enables a power-relay channel from the capability card (ga-40w)', async () => {
+    seedHappyPath();
+    mockApi.getDevice.mockResolvedValue({
+      data: buildDevice({
+        capabilities: ['power_relay'],
+        capabilities_announced_at: '2026-05-01T03:00:00Z',
+      }),
+    } as any);
+    mockApi.setRelayChannel.mockResolvedValue({ data: { command_id: 'c1' } } as any);
+
+    renderAt('/facilities/forgekey-devices/dev-1');
+
+    fireEvent.click(await screen.findByTestId('relay-channel-1-enable'));
+    await waitFor(() => expect(mockApi.setRelayChannel).toHaveBeenCalledWith('dev-1', 1, true));
+  });
+
+  it('disables a power-relay channel from the capability card (ga-40w)', async () => {
+    seedHappyPath();
+    mockApi.getDevice.mockResolvedValue({
+      data: buildDevice({ capabilities: ['power_relay'] }),
+    } as any);
+    mockApi.setRelayChannel.mockResolvedValue({ data: {} } as any);
+
+    renderAt('/facilities/forgekey-devices/dev-1');
+
+    fireEvent.click(await screen.findByTestId('relay-channel-2-disable'));
+    await waitFor(() => expect(mockApi.setRelayChannel).toHaveBeenCalledWith('dev-1', 2, false));
+  });
+
+  it('surfaces an error when a relay-channel command fails (ga-40w)', async () => {
+    seedHappyPath();
+    mockApi.getDevice.mockResolvedValue({
+      data: buildDevice({ capabilities: ['power_relay'] }),
+    } as any);
+    mockApi.setRelayChannel.mockRejectedValue(new Error('broker down'));
+
+    renderAt('/facilities/forgekey-devices/dev-1');
+
+    fireEvent.click(await screen.findByTestId('relay-channel-1-enable'));
+    expect(await screen.findByTestId('relay-channel-error')).toBeInTheDocument();
   });
 
   it('renders the temperature chart when the device reports readings', async () => {

--- a/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
+++ b/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
@@ -369,6 +369,7 @@ const KNOWN_CAPABILITIES: Record<string, { icon: string; label: string }> = {
   mmwave_presence: { icon: '📡', label: 'mmWave presence' },
   button: { icon: '🔘', label: 'Button' },
   status_led: { icon: '💡', label: 'Status LED' },
+  power_relay: { icon: '🔌', label: 'Power relay' },
 };
 
 interface CapabilitiesSectionProps {
@@ -476,6 +477,8 @@ const CapabilityRow: React.FC<CapabilityRowProps> = ({
         )}
       </div>
     );
+  } else if (capability === 'power_relay') {
+    body = <PowerRelayWidget device={device} />;
   }
 
   return (
@@ -498,6 +501,67 @@ const MmwavePresenceWidget: React.FC<{ device: ForgeKeyDevice }> = () => (
 const ButtonEventWidget: React.FC<{ device: ForgeKeyDevice }> = () => (
   <small style={{ color: '#777' }}>No recent button events.</small>
 );
+
+const RELAY_CHANNELS = [1, 2];
+
+// Per-channel control of the 2-channel power relay (ga-40w). Each click emits a
+// signed `power_set` command for that channel; the device has no live
+// channel-state feed to this page yet, so we surface controls + errors rather
+// than the current on/off.
+const PowerRelayWidget: React.FC<{ device: ForgeKeyDevice }> = ({ device }) => {
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const send = async (channel: number, on: boolean) => {
+    setBusy(`${channel}:${on}`);
+    setError(null);
+    try {
+      await forgekeyAPI.setRelayChannel(device.id, channel, on);
+    } catch (err) {
+      setError(
+        extractErrorMessage(err, `Failed to ${on ? 'enable' : 'disable'} channel ${channel}.`),
+      );
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+      {RELAY_CHANNELS.map((ch) => (
+        <div
+          key={ch}
+          data-testid={`relay-channel-${ch}`}
+          style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}
+        >
+          <span style={{ color: '#555', minWidth: '5.5rem' }}>Channel {ch}</span>
+          <button
+            type="button"
+            onClick={() => send(ch, true)}
+            disabled={busy !== null}
+            data-testid={`relay-channel-${ch}-enable`}
+          >
+            {busy === `${ch}:true` ? 'Enabling…' : 'Enable'}
+          </button>
+          <button
+            type="button"
+            onClick={() => send(ch, false)}
+            disabled={busy !== null}
+            data-testid={`relay-channel-${ch}-disable`}
+          >
+            {busy === `${ch}:false` ? 'Disabling…' : 'Disable'}
+          </button>
+        </div>
+      ))}
+      {error && (
+        <small style={{ color: '#c0392b' }} data-testid="relay-channel-error">
+          {error}
+        </small>
+      )}
+      <small style={{ color: '#777' }}>Live on/off state isn’t reported to this page yet.</small>
+    </div>
+  );
+};
 
 interface ControlButtonProps {
   label: string;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2281,6 +2281,10 @@ export const forgekeyAPI = {
   enableDevice: (id: string) => api.post(`/forgekey/devices/${id}/enable/`),
   disableDevice: (id: string, delaySeconds?: number) =>
     api.post(`/forgekey/devices/${id}/disable/`, delaySeconds ? { delay_seconds: delaySeconds } : {}),
+  // Per-channel power-relay control (ga-40w): emits a signed `power_set`
+  // command targeting one channel of the 2-channel relay.
+  setRelayChannel: (id: string, channel: number, on: boolean) =>
+    api.post<ForgeKeyCommandResponse>(`/forgekey/devices/${id}/relay-channel/`, { channel, on }),
   retireDevice: (id: string) => api.post<ForgeKeyDevice>(`/forgekey/devices/${id}/retire/`),
   reactivateDevice: (id: string) => api.post<ForgeKeyDevice>(`/forgekey/devices/${id}/reactivate/`),
   deleteDevice: (id: string) => api.delete(`/forgekey/devices/${id}/`),


### PR DESCRIPTION
## Per-channel enable/disable for the 2-channel power relay (ga-40w)

Adds the ability to enable/disable **each channel** of the power relay from the
ForgeKey device detail page.

### Backend
New `ESP32DeviceViewSet.relay_channel` action — `POST /api/forgekey/devices/{id}/relay-channel/`
with `{channel, on}` — emitting a **signed `power_set`** command. That's the verb
the firmware's `power_relay` capability actually handles (it reads `channel` +
`action`); the legacy `enable`/`disable` verbs (`cmd=enable`/`disable`) don't
route to that capability, so per-channel control needs the `power_set` path.
Reuses the existing `_dispatch_command` chokepoint (audit row + op-8pn envelope
signing); validated by `RelayChannelCommandSerializer` (channel 1–2, `on` bool);
same per-asset authorization as `enable`/`disable`.

### Frontend
A `power_relay` capability card on the device detail page with **Enable / Disable
buttons per channel**, wired to `forgekeyAPI.setRelayChannel`. Live on/off state
isn't surfaced to this page yet (the device doesn't feed channel state here) —
noted as a follow-up.

### Firmware
**No change** — `power_relay` already supports per-channel via
`cmd=power_set {channel, action}` (`power_relay.cpp` `setFromCommand`,
`kChannelCount = 2`).

### Tests / checks
- Backend: 5 (enable/disable happy paths, 403 unauthorized, 400 invalid/missing) — pass; flake8 clean.
- Frontend: 3 (enable, disable, error surface); detail-page vitest **13 passed**;
  eslint clean; changed files typecheck-clean; full `test:fast` 133 files passed.

### ScanTTY parity
The same per-channel controls land in the ScanTTY TUI in a companion PR
(ga-40w / scantty-frontend-parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
