### PR TITLE
fix(forgekey): device lock/unlock drives the relay via per-channel power_set (ga-40w)

### DIFF
--- a/backend/forgekey/tests/test_access_control.py
+++ b/backend/forgekey/tests/test_access_control.py
@@ -675,3 +675,70 @@ class TestRelayChannelControl:
             resp = client.post(self._url(device), {"channel": 1}, format="json")
         assert resp.status_code == 400
         pub.assert_not_called()
+
+
+class TestRelayDevicePowerTranslation:
+    """ga-40w 'A': a device-level enable/disable on a ``power_relay`` device
+    fans out to one signed ``power_set`` per channel, so the web
+    'Power-off (lock)' button and ScanTTY ``d``/``e`` keys actually drive the
+    relay. Non-relay devices (lockers) keep the legacy ``enable``/``disable``
+    verb their firmware understands."""
+
+    def _enable_url(self, device):
+        return f"/api/forgekey/devices/{device.id}/enable/"
+
+    def _disable_url(self, device):
+        return f"/api/forgekey/devices/{device.id}/disable/"
+
+    def _make_relay(self, device):
+        device.capabilities = ["status_led", "power_relay"]
+        device.save(update_fields=["capabilities"])
+        return device
+
+    def test_enable_fans_out_power_set_on_per_channel(self, asset, device, admin_user):
+        self._make_relay(device)
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+        with patch("forgekey.views.publish_command", return_value="forgekey/x/command") as pub:
+            with patch("forgekey.views.enable_device") as task:
+                resp = client.post(self._enable_url(device))
+        assert resp.status_code == 200, resp.data
+        task.delay.assert_not_called()
+        sent = [c[0][1] for c in pub.call_args_list]
+        assert sorted(p["channel"] for p in sent) == [1, 2]
+        assert {p["cmd"] for p in sent} == {"power_set"}
+        assert {p["action"] for p in sent} == {"enable"}
+        assert DeviceCommand.objects.filter(device=device, command="power_set").count() == 2
+
+    def test_disable_powers_off_all_channels(self, asset, device, admin_user):
+        self._make_relay(device)
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+        with patch("forgekey.views.publish_command", return_value="forgekey/x/command") as pub:
+            with patch("forgekey.views.disable_device") as task:
+                resp = client.post(self._disable_url(device))
+        assert resp.status_code == 200, resp.data
+        task.delay.assert_not_called()
+        sent = [c[0][1] for c in pub.call_args_list]
+        assert sorted(p["channel"] for p in sent) == [1, 2]
+        assert {p["action"] for p in sent} == {"disable"}
+
+    def test_non_relay_device_keeps_legacy_verb(self, asset, device, admin_user):
+        # Default device fixture announces no power_relay capability.
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+        with patch("forgekey.views.publish_command") as pub:
+            with patch("forgekey.views.disable_device") as task:
+                resp = client.post(self._disable_url(device))
+        assert resp.status_code == 200, resp.data
+        task.delay.assert_called_once_with(device.mac_address, delay_seconds=0)
+        pub.assert_not_called()
+
+    def test_unauthorized_member_cannot_power_relay(self, asset, device, member):
+        self._make_relay(device)
+        client = APIClient()
+        client.force_authenticate(user=member)
+        with patch("forgekey.views.publish_command") as pub:
+            resp = client.post(self._disable_url(device))
+        assert resp.status_code == 403
+        pub.assert_not_called()

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -894,6 +894,14 @@ class DeviceTypeViewSet(viewsets.ModelViewSet):
         return super().get_permissions()
 
 
+# Hardware fact: every ForgeKey power-relay board in the field is 2-channel
+# (matches the firmware's kChannelCount). A device-level lock/unlock fans out
+# one signed power_set per channel (see ESP32DeviceViewSet._dispatch_relay_power).
+# When OMS starts caching per-device channel state (ga-40w live-state follow-up)
+# this should become per-device instead of a constant.
+POWER_RELAY_CHANNEL_COUNT = 2
+
+
 class ESP32DeviceViewSet(viewsets.ModelViewSet):
     """API endpoint for ESP32 devices."""
 
@@ -962,17 +970,65 @@ class ESP32DeviceViewSet(viewsets.ModelViewSet):
             status=status.HTTP_403_FORBIDDEN,
         )
 
+    def _is_power_relay(self, device):
+        """True if the device announced the ``power_relay`` capability.
+
+        Mirrors the frontend's capability gate: only relay devices fan a
+        device-level enable/disable out to per-channel ``power_set`` — lockers
+        keep the bare ``enable``/``disable`` verb their firmware understands.
+        """
+        return "power_relay" in (device.capabilities or [])
+
+    def _dispatch_relay_power(self, device, actor, *, on):
+        """Translate a device-level enable/disable into per-channel ``power_set``.
+
+        The firmware's ``power_relay`` capability only handles ``power_set``
+        (per channel); the bare ``enable``/``disable`` verbs route to locker
+        firmware, not the relay (``main.cpp`` dispatch), so the web
+        "Power-off (lock)" button and ScanTTY ``d``/``e`` keys were no-ops on
+        relay hardware. There is no all-channels verb, so emit one signed
+        ``power_set`` per channel. Each channel gets its own audit row +
+        command_id (same chokepoint as :meth:`relay_channel`).
+        """
+        action = "enable" if on else "disable"
+        command_ids = []
+        topic = None
+        for channel in range(1, POWER_RELAY_CHANNEL_COUNT + 1):
+            try:
+                record, topic = self._emit_command(
+                    device,
+                    actor,
+                    {"cmd": "power_set", "channel": channel, "action": action},
+                    "power_set",
+                )
+            except DeviceCommandError as exc:
+                return Response({"detail": str(exc)}, status=status.HTTP_502_BAD_GATEWAY)
+            command_ids.append(str(record.id))
+        return Response(
+            {
+                "status": f"power {'on' if on else 'off'} command sent",
+                "device": device.mac_address,
+                "topic": topic,
+                "command_ids": command_ids,
+                "channels": list(range(1, POWER_RELAY_CHANNEL_COUNT + 1)),
+            }
+        )
+
     @action(detail=True, methods=["post"])
     def enable(self, request, pk=None):
         """Enable a device (turn on power, etc.).
 
         Requires authorization for the bound asset (or staff override) — see
-        :meth:`_authorize_relay`.
+        :meth:`_authorize_relay`. For ``power_relay`` devices the device-level
+        on maps to a signed ``power_set`` per channel (see
+        :meth:`_dispatch_relay_power`); lockers keep the legacy verb path.
         """
         device = self.get_object()
         denied = self._authorize_relay(request, device, "enable")
         if denied is not None:
             return denied
+        if self._is_power_relay(device):
+            return self._dispatch_relay_power(device, request.user, on=True)
         enable_device.delay(device.mac_address)
         return Response({"status": "enable command sent", "device": device.mac_address})
 
@@ -981,12 +1037,18 @@ class ESP32DeviceViewSet(viewsets.ModelViewSet):
         """Disable a device (turn off power, etc.).
 
         Requires authorization for the bound asset (or staff override) — see
-        :meth:`_authorize_relay`.
+        :meth:`_authorize_relay`. For ``power_relay`` devices the device-level
+        off maps to a signed ``power_set`` per channel (see
+        :meth:`_dispatch_relay_power`); ``delay_seconds`` is not supported on
+        that path (the firmware ``power_set`` has no delay) and is ignored.
+        Lockers keep the legacy verb path (with delay).
         """
         device = self.get_object()
         denied = self._authorize_relay(request, device, "disable")
         if denied is not None:
             return denied
+        if self._is_power_relay(device):
+            return self._dispatch_relay_power(device, request.user, on=False)
         delay_seconds = int(request.data.get("delay_seconds", 0))
         disable_device.delay(device.mac_address, delay_seconds=delay_seconds)
         return Response(
@@ -1506,10 +1568,14 @@ class ESP32DeviceViewSet(viewsets.ModelViewSet):
             }
         )
 
-    def _dispatch_command(self, device, actor, payload, audit_action):
-        # Persist an audit row first so the firmware can echo its UUID back
-        # on the status topic and the UI can render live ack feedback. The
-        # row is dropped on broker failure to avoid orphan history entries.
+    def _emit_command(self, device, actor, payload, audit_action):
+        """Persist an audit row + publish one signed command.
+
+        Returns ``(record, topic)``; raises :class:`DeviceCommandError` on
+        broker failure (the audit row is dropped first so no orphan history
+        entry survives). Shared by :meth:`_dispatch_command` (single command)
+        and :meth:`_dispatch_relay_power` (one per relay channel).
+        """
         actor_user = (
             actor if (actor is not None and getattr(actor, "is_authenticated", False)) else None
         )
@@ -1521,22 +1587,30 @@ class ESP32DeviceViewSet(viewsets.ModelViewSet):
         )
         full_payload = dict(payload)
         full_payload["command_id"] = str(record.id)
-
         try:
             topic = publish_command(device, full_payload, actor=actor, audit_action=audit_action)
-        except DeviceCommandError as exc:
+        except DeviceCommandError:
             record.delete()
-            return Response({"detail": str(exc)}, status=status.HTTP_502_BAD_GATEWAY)
-
+            raise
         record.payload = full_payload
         record.save(update_fields=["payload"])
+        return record, topic
+
+    def _dispatch_command(self, device, actor, payload, audit_action):
+        # Persist an audit row first so the firmware can echo its UUID back
+        # on the status topic and the UI can render live ack feedback. The
+        # row is dropped on broker failure to avoid orphan history entries.
+        try:
+            record, topic = self._emit_command(device, actor, payload, audit_action)
+        except DeviceCommandError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_502_BAD_GATEWAY)
         return Response(
             {
                 "status": f"{audit_action} command sent",
                 "device": device.mac_address,
                 "topic": topic,
                 "command_id": str(record.id),
-                "dispatched_at": full_payload.get("timestamp", timezone.now().isoformat()),
+                "dispatched_at": record.payload.get("timestamp", timezone.now().isoformat()),
             }
         )
 


### PR DESCRIPTION
## Device lock/unlock actually drives the relay now (ga-40w, option A)

### The bug (seen at the bench 06-30)
The web **"Power-off (lock)" / "Power-on (unlock)"** buttons (`DeviceLifecycleCard`) and the **ScanTTY `d`/`e`** keys both POST `/api/forgekey/devices/{id}/disable|enable/`, which emitted a bare top-level `cmd=disable|enable`. op-8pn/#811 *signed* those (so the envelope validates — `len=636`), but the firmware's `power_relay` capability only routes `power_set`/`relay_set` (`main.cpp:567`); everything else hits `unknown cmd` (`:716`). The bare `enable`/`disable` verbs are **locker dialect** — on relay hardware the lock/unlock controls were silent no-ops:

```
CMD: rx ... cmd=disable len=636
[WARN] CMD: unknown cmd: 'disable'
error: "unknown_command"
```

### The fix
For devices that announce the **`power_relay`** capability, `enable`/`disable` now fan out **one signed `power_set` per channel** (`ESP32DeviceViewSet._dispatch_relay_power`) — the verb the firmware actually routes to the relay (same path #813's per-channel card uses). Lockers keep the bare-verb path.

- Firmware has **no all-channels verb**, so we enumerate `POWER_RELAY_CHANNEL_COUNT` (=2, the only relay hardware in the field; becomes per-device once OMS caches channel state — the ga-40w live-state follow-up).
- `delay_seconds` is **ignored** for relay devices (the firmware `power_set` has no delay); lockers keep it.
- Gated on the announced capability, mirroring the frontend card's gate.
- Refactor: extracted the audit-row + `publish_command` core of `_dispatch_command` into `_emit_command`, reused by the per-channel fan-out. Response shape of `_dispatch_command` is unchanged.

### Backend-only — both frontends fixed, no UI change
The web buttons and ScanTTY `d`/`e` **already call these endpoints**, so this fixes both with zero frontend/TUI change (parity holds via the shared API). No new endpoints → no permission-matrix change.

### Tests / checks (local, sqlite)
- 4 new: relay enable & disable fan out `power_set` per channel; non-relay device keeps the legacy verb; unauthorized member → 403.
- `test_access_control` **60 passed**; `test_device_commands` + `test_tasks` + `test_command_jwt` **76 passed** (covers the `_dispatch_command` refactor); **black / isort / flake8 clean**.

### Deploy note
Like #813, this only helps once deployed — and it depends on OMS having ingested the device's `power_relay` capability announce (same gate as the web relay card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
