### PR TITLE
fix(forgekey): mqtt_consumer ingests device capability announcements (ga-c6m)

### DIFF
--- a/backend/forgekey/management/commands/mqtt_consumer.py
+++ b/backend/forgekey/management/commands/mqtt_consumer.py
@@ -48,6 +48,7 @@ from forgekey.models import (
 )
 from forgekey.services import access_control
 from forgekey.services.jwt_signing import JwtSigningError, is_jwt_signing_configured
+from forgekey.tasks import process_mqtt_device_capabilities
 from forgekey.utils import (
     SERVER_JWT_SUBJECT,
     generate_server_jwt,
@@ -501,6 +502,39 @@ def _topic_matches_status(topic: str) -> bool:
     return len(parts) == 3 and parts[0] == settings.MQTT_TOPIC_PREFIX and parts[2] == "status"
 
 
+def _topic_matches_capabilities(topic: str) -> bool:
+    parts = topic.split("/")
+    return len(parts) == 3 and parts[0] == settings.MQTT_TOPIC_PREFIX and parts[2] == "capabilities"
+
+
+def handle_capabilities_message(topic: str, payload: bytes) -> bool:
+    """Ingest a retained capability announcement (``<prefix>/<mac>/capabilities``).
+
+    Devices publish their capability set at boot. Without ingesting it the
+    device-detail page never learns a relay device supports ``power_relay``, so
+    the per-channel relay controls — and the device-level lock→``power_set``
+    translation (ga-40w) — never appear. Delegates to
+    :func:`forgekey.tasks.process_mqtt_device_capabilities`.
+    """
+    parts = topic.split("/")
+    if len(parts) != 3:
+        logger.warning("Dropping capabilities: malformed topic %r", topic)
+        return False
+    if _mac_from_topic_segment(parts[1]) is None:
+        logger.warning("Dropping capabilities: bad MAC %r in %r", parts[1], topic)
+        return False
+    try:
+        body = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        logger.warning("Dropping capabilities on %s: invalid JSON (%s)", topic, exc)
+        return False
+    if not isinstance(body, dict):
+        logger.warning("Dropping capabilities on %s: payload not an object", topic)
+        return False
+    process_mqtt_device_capabilities(parts[1], body)
+    return True
+
+
 def _topic_matches_ota_status(topic: str) -> bool:
     parts = topic.split("/")
     return (
@@ -732,6 +766,8 @@ def dispatch_message(topic: str, payload: bytes) -> None:
             handle_log_message(topic, payload)
         elif _topic_matches_status(topic):
             handle_status_message(topic, payload)
+        elif _topic_matches_capabilities(topic):
+            handle_capabilities_message(topic, payload)
         else:
             logger.debug("Ignoring message on unsubscribed topic %s", topic)
     except Exception:
@@ -790,6 +826,7 @@ class Command(BaseCommand):
         ota_status_filter = f"{prefix}/+/ota/status"
         log_filter = f"{prefix}/+/logs"
         access_request_filter = f"{prefix}/+/access/request"
+        capabilities_filter = f"{prefix}/+/capabilities"
 
         # Startup grace window for CONNACK failures. EMQX's JWT authenticator
         # populates its JWKS cache asynchronously after a (re)start; in that
@@ -820,7 +857,7 @@ class Command(BaseCommand):
                 return
             connect_state["first_connect_done"] = True
             logger.info(
-                "MQTT consumer connected to %s:%s; subscribing to %s, %s, %s, %s, %s, %s",
+                "MQTT consumer connected to %s:%s; subscribing to %s, %s, %s, %s, %s, %s, %s",
                 host,
                 port,
                 occupancy_filter,
@@ -829,6 +866,7 @@ class Command(BaseCommand):
                 ota_status_filter,
                 log_filter,
                 access_request_filter,
+                capabilities_filter,
             )
             c.subscribe(
                 [
@@ -838,6 +876,7 @@ class Command(BaseCommand):
                     (ota_status_filter, 1),
                     (log_filter, 1),
                     (access_request_filter, 1),
+                    (capabilities_filter, 1),
                 ]
             )
 

--- a/backend/forgekey/tests/test_mqtt_consumer.py
+++ b/backend/forgekey/tests/test_mqtt_consumer.py
@@ -28,6 +28,7 @@ from forgekey.management.commands.mqtt_consumer import (
     LOG_RATE_LIMIT_MAX_EVENTS,
     _connack_log_level,
     dispatch_message,
+    handle_capabilities_message,
     handle_log_message,
     handle_occupancy_message,
     handle_status_message,
@@ -144,6 +145,33 @@ class TestMqttConsumer:
     def test_handle_status_message_unknown_mac_returns_false(self):
         topic = "forgekey/aabbccddeeff/status"
         assert handle_status_message(topic, b"{}") is False
+
+    def test_handle_capabilities_message_ingests_capability_set(self):
+        # ga-c6m: the consumer must ingest the retained capabilities announce
+        # so the device-detail page can render the power_relay (and other)
+        # capability cards. The consumer previously dropped this topic.
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:CA:9A:01", capabilities=[])
+        topic = f"forgekey/{_topic_segment(device.mac_address)}/capabilities"
+        payload = json.dumps(
+            {"capabilities": ["status_led", "power_relay"], "firmware_version": "1.2.3"}
+        ).encode("utf-8")
+
+        assert handle_capabilities_message(topic, payload) is True
+        device.refresh_from_db()
+        assert "power_relay" in device.capabilities
+        assert device.capabilities_announced_at is not None
+
+    def test_dispatch_routes_capabilities_topic(self):
+        # The dispatch table + subscription must actually wire /capabilities
+        # through to the handler — the bug was a missing route, not a missing
+        # handler.
+        device = ESP32DeviceFactory(mac_address="AA:BB:CC:CA:9A:02", capabilities=[])
+        topic = f"forgekey/{_topic_segment(device.mac_address)}/capabilities"
+        payload = json.dumps({"capabilities": ["status_led", "power_relay"]}).encode("utf-8")
+
+        dispatch_message(topic, payload)
+        device.refresh_from_db()
+        assert "power_relay" in device.capabilities
 
     def test_dispatch_message_swallows_handler_exceptions(self, caplog):
         # Even an internal explosion in a handler must not propagate — the


### PR DESCRIPTION
## mqtt_consumer never ingested device capabilities → no relay buttons (ga-c6m)

### Why the ch1/ch2 buttons didn't appear (bench, 06-30)
The per-channel relay card (and #814's lock→`power_set` translation) only show for devices whose `capabilities` include `power_relay`. The device announces `["status_led","power_relay"]` (retained) to `forgekey/<mac>/capabilities` at boot — but the **prod `mqtt_consumer`** (`docker-compose.prod.yml` → `manage.py mqtt_consumer`) had **no handler, matcher, or subscription** for that topic. It subscribes to occupancy/reading/status/ota/logs/access only, so it dropped the announce (`Ignoring message on unsubscribed topic`) and `ESP32Device.capabilities` stayed `[]`.

`process_mqtt_device_capabilities` already existed and was tested, but was only wired into the **EMQX→HTTP webhook** path (`MqttWebhookView._dispatch`) — not the consumer that actually runs.

### Fix
Wire capabilities into the consumer (the path we know runs), delegating to the existing `process_mqtt_device_capabilities`:
- `_topic_matches_capabilities` matcher
- `handle_capabilities_message` handler (drops malformed topic / bad MAC / non-JSON, like the other handlers)
- `dispatch_message` route
- subscription `forgekey/+/capabilities`

**Self-healing:** on (re)connect the consumer subscribes to `…/capabilities`, and because the device's announce is **retained**, the broker redelivers it immediately — so already-deployed devices populate their capabilities without a reboot. (Affects *all* capability-gated UI, not just relays.)

### Tests / checks
- 2 new (`test_mqtt_consumer`): handler ingests the capability set; `dispatch_message` routes the `/capabilities` topic. **36 passed.**
- black / isort / flake8 clean. No circular import (`from forgekey.tasks import …` verified by the test suite importing the module).

### After merge + deploy
The consumer picks up the retained announce → the device-detail page shows the **🔌 Power relay** card with per-channel Enable/Disable, and the "Power-off (lock)" / ScanTTY `d`/`e` paths (#814) start translating to `power_set`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
