### PR TITLE
feat(project-storage): label preview on detail + surface overview (op-hh8)

### DIFF
--- a/frontend/src/__tests__/pages/FacilitiesProjectStorageListPage.test.tsx
+++ b/frontend/src/__tests__/pages/FacilitiesProjectStorageListPage.test.tsx
@@ -19,6 +19,10 @@ vi.mock('../../services/api', async () => {
     ...actual,
     projectStorageAPI: {
       list: jest.fn(),
+      labelUrl: jest.fn(
+        (_stintId: string, printer = 'brother_ql') =>
+          `https://labels.example/${printer}.png`,
+      ),
     },
   };
 });
@@ -159,5 +163,22 @@ describe('FacilitiesProjectStorageListPage', () => {
     renderPage();
     expect(await screen.findByText('Back room')).toBeInTheDocument();
     expect(screen.queryByText('Shelf A')).not.toBeInTheDocument();
+  });
+
+  test('per-row Preview opens a label modal for that stint', async () => {
+    mockAPI.list.mockResolvedValue(
+      ok({ count: 1, next: null, previous: null, results: [buildStint()] }),
+    );
+    renderPage();
+
+    // No modal / label request until the warden clicks Preview.
+    expect(await screen.findByTestId('stint-row-PS-AB23CDFG')).toBeInTheDocument();
+    expect(screen.queryByTestId('row-label-preview')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('preview-label-PS-AB23CDFG'));
+
+    const img = await screen.findByTestId('row-label-preview');
+    expect(img.getAttribute('src')).toBe('https://labels.example/brother_ql.png');
+    expect(mockAPI.labelUrl).toHaveBeenCalledWith('PS-AB23CDFG', 'brother_ql');
   });
 });

--- a/frontend/src/__tests__/pages/FacilitiesProjectStoragePage.labelPreview.test.tsx
+++ b/frontend/src/__tests__/pages/FacilitiesProjectStoragePage.labelPreview.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Label-preview + overview-discoverability tests for the warden detail
+ * page (op-hh8).
+ *
+ * Asserts:
+ *  - the detail panel renders a label <img> sourced from
+ *    projectStorageAPI.labelUrl(stintId, printer),
+ *  - the Brother QL / Epson TM toggle re-points the <img> at the other
+ *    printer's URL,
+ *  - the hero exposes a "View queue" link to the existing overview list.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import FacilitiesProjectStoragePage from '../../pages/FacilitiesProjectStoragePage';
+import { projectStorageAPI } from '../../services/api';
+import { ProjectStorageStint } from '../../types';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    projectStorageAPI: {
+      get: jest.fn(),
+      byMember: jest.fn(),
+      start: jest.fn(),
+      sendViolationNotice: jest.fn(),
+      moveToPurgatory: jest.fn(),
+      markRemoved: jest.fn(),
+      generateQr: jest.fn(),
+      list: jest.fn(),
+      // Distinct URL per printer so the toggle assertion is unambiguous.
+      labelUrl: jest.fn(
+        (_stintId: string, printer = 'brother_ql') =>
+          `https://labels.example/${printer}.png`,
+      ),
+    },
+  };
+});
+
+vi.mock('../../hooks/useNotifications', () => ({
+  useNotifications: () => ({
+    showSuccess: jest.fn(),
+    showError: jest.fn(),
+    showInfo: jest.fn(),
+  }),
+}));
+
+const mockAPI = projectStorageAPI as jest.Mocked<typeof projectStorageAPI>;
+
+const buildStint = (
+  overrides: Partial<ProjectStorageStint> = {},
+): ProjectStorageStint => ({
+  id: 1,
+  stint_id: 'PS-AB23CDFG',
+  username: 'alice',
+  first_name: 'Alice',
+  last_name: 'Aardvark',
+  email: 'alice@example.com',
+  display_name: 'Alice Aardvark',
+  project_title: 'Big Sculpture',
+  started_at: '2026-05-01T00:00:00Z',
+  expires_at: '2026-06-30T00:00:00Z',
+  removed_at: null,
+  notice_sent_at: null,
+  moved_to_purgatory_at: null,
+  storage_location_name: 'Shelf A',
+  purgatory_location_name: '',
+  notes: '',
+  status: 'active',
+  purgatory_at: null,
+  expiry_week: 26,
+  expiry_day_of_year: 181,
+  events: [],
+  qr_code_url: null,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  ...overrides,
+});
+
+const ok = <T,>(data: T) =>
+  ({
+    data,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {} as never,
+  }) as never;
+
+const renderAt = (path: string) =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route
+            path="/facilities/project-storage/:stintId"
+            element={<FacilitiesProjectStoragePage />}
+          />
+          <Route
+            path="/facilities/project-storage"
+            element={<FacilitiesProjectStoragePage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('FacilitiesProjectStoragePage — label preview + overview link', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAPI.byMember.mockResolvedValue(ok([]));
+    mockAPI.get.mockResolvedValue(ok(buildStint()));
+  });
+
+  test('renders the label image from labelUrl once the stint loads', async () => {
+    renderAt('/facilities/project-storage/PS-AB23CDFG');
+
+    const img = await screen.findByTestId('label-preview');
+    expect(img.getAttribute('src')).toBe('https://labels.example/brother_ql.png');
+    expect(mockAPI.labelUrl).toHaveBeenCalledWith('PS-AB23CDFG', 'brother_ql');
+  });
+
+  test('does not request a label before a stint is loaded', async () => {
+    renderAt('/facilities/project-storage');
+    // Bare lookup form: no stint, so no label preview and no labelUrl call.
+    expect(await screen.findByPlaceholderText(/PS-/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('label-preview')).not.toBeInTheDocument();
+    expect(mockAPI.labelUrl).not.toHaveBeenCalled();
+  });
+
+  test('printer toggle re-points the image at the other printer URL', async () => {
+    renderAt('/facilities/project-storage/PS-AB23CDFG');
+
+    const img = await screen.findByTestId('label-preview');
+    expect(img.getAttribute('src')).toBe('https://labels.example/brother_ql.png');
+
+    fireEvent.click(screen.getByText('Epson TM'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('label-preview').getAttribute('src'),
+      ).toBe('https://labels.example/epson_tm.png');
+    });
+    expect(mockAPI.labelUrl).toHaveBeenCalledWith('PS-AB23CDFG', 'epson_tm');
+  });
+
+  test('hero exposes a "View queue" link to the overview list', async () => {
+    renderAt('/facilities/project-storage/PS-AB23CDFG');
+
+    const link = await screen.findByTestId('view-queue-link');
+    expect(link.getAttribute('href')).toBe('/facilities/project-storage/queue');
+  });
+});

--- a/frontend/src/components/ProjectStorageLabelPreview.tsx
+++ b/frontend/src/components/ProjectStorageLabelPreview.tsx
@@ -1,0 +1,65 @@
+/**
+ * Claim-label preview for a project-storage stint.
+ *
+ * Renders the server-rendered label PNG
+ * (GET /api/project-storage/stints/{id}/label/?printer=…) with a
+ * Brother QL / Epson TM toggle so a warden can eyeball either printer's
+ * output. Styled to mirror the kiosk's post-create preview
+ * (ProjectStorageKioskPage): a bordered gray panel with an uppercase
+ * caption and a contained image.
+ *
+ * The label PNG is only fetched while this component is mounted, so
+ * callers get lazy loading for free by rendering it conditionally (e.g.
+ * only once a stint has loaded).
+ */
+import { Image, Paper, SegmentedControl, Stack, Text } from '@mantine/core';
+import React, { useState } from 'react';
+
+import { projectStorageAPI } from '../services/api';
+
+export type LabelPrinter = 'brother_ql' | 'epson_tm';
+
+const PRINTER_OPTIONS: { label: string; value: LabelPrinter }[] = [
+  { label: 'Brother QL', value: 'brother_ql' },
+  { label: 'Epson TM', value: 'epson_tm' },
+];
+
+interface ProjectStorageLabelPreviewProps {
+  stintId: string;
+  /** testid for the <img>; the toggle gets `${testId}-printer`. */
+  testId?: string;
+}
+
+const ProjectStorageLabelPreview: React.FC<ProjectStorageLabelPreviewProps> = ({
+  stintId,
+  testId = 'label-preview',
+}) => {
+  const [printer, setPrinter] = useState<LabelPrinter>('brother_ql');
+
+  return (
+    <Paper withBorder radius="md" p="md" bg="gray.0">
+      <Stack gap="xs" align="center">
+        <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+          Label preview
+        </Text>
+        <SegmentedControl
+          size="xs"
+          value={printer}
+          onChange={(v) => setPrinter(v as LabelPrinter)}
+          data={PRINTER_OPTIONS}
+          data-testid={`${testId}-printer`}
+        />
+        <Image
+          src={projectStorageAPI.labelUrl(stintId, printer)}
+          alt={`Label for stint ${stintId} (${printer})`}
+          fit="contain"
+          h={200}
+          fallbackSrc=""
+          data-testid={testId}
+        />
+      </Stack>
+    </Paper>
+  );
+};
+
+export default ProjectStorageLabelPreview;

--- a/frontend/src/pages/FacilitiesProjectStorageListPage.tsx
+++ b/frontend/src/pages/FacilitiesProjectStorageListPage.tsx
@@ -20,15 +20,18 @@ import {
   Button,
   Group,
   Loader,
+  Modal,
   Paper,
   SegmentedControl,
   Stack,
   Table,
   Text,
 } from '@mantine/core';
+import { IconEye } from '@tabler/icons-react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
+import ProjectStorageLabelPreview from '../components/ProjectStorageLabelPreview';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import { projectStorageAPI } from '../services/api';
 import { ProjectStorageStatus, ProjectStorageStint } from '../types';
@@ -75,6 +78,10 @@ const FacilitiesProjectStorageListPage: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  // Row-level label preview: the stint whose label modal is open, or null.
+  const [previewStint, setPreviewStint] = useState<ProjectStorageStint | null>(
+    null,
+  );
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -190,6 +197,7 @@ const FacilitiesProjectStorageListPage: React.FC = () => {
                     <Table.Th>Location</Table.Th>
                     <Table.Th>Expires</Table.Th>
                     <Table.Th>Stint</Table.Th>
+                    <Table.Th>Label</Table.Th>
                   </Table.Tr>
                 </Table.Thead>
                 <Table.Tbody>
@@ -229,6 +237,17 @@ const FacilitiesProjectStorageListPage: React.FC = () => {
                           {s.stint_id}
                         </Text>
                       </Table.Td>
+                      <Table.Td>
+                        <Button
+                          variant="subtle"
+                          size="compact-xs"
+                          leftSection={<IconEye size={14} />}
+                          onClick={() => setPreviewStint(s)}
+                          data-testid={`preview-label-${s.stint_id}`}
+                        >
+                          Preview
+                        </Button>
+                      </Table.Td>
                     </Table.Tr>
                   ))}
                 </Table.Tbody>
@@ -237,6 +256,24 @@ const FacilitiesProjectStorageListPage: React.FC = () => {
           </Paper>
         )}
       </Stack>
+
+      <Modal
+        opened={previewStint !== null}
+        onClose={() => setPreviewStint(null)}
+        title={
+          previewStint
+            ? `Label — ${previewStint.stint_id}`
+            : 'Label preview'
+        }
+        centered
+      >
+        {previewStint && (
+          <ProjectStorageLabelPreview
+            stintId={previewStint.stint_id}
+            testId="row-label-preview"
+          />
+        )}
+      </Modal>
     </WorkspacePage>
   );
 };

--- a/frontend/src/pages/FacilitiesProjectStoragePage.tsx
+++ b/frontend/src/pages/FacilitiesProjectStoragePage.tsx
@@ -33,11 +33,13 @@ import {
   IconCamera,
   IconCheck,
   IconKeyboard,
+  IconList,
   IconMail,
   IconQrcode,
 } from '@tabler/icons-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import ProjectStorageLabelPreview from '../components/ProjectStorageLabelPreview';
 import QRScanner from '../components/QRScanner';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import { useNotifications } from '../hooks/useNotifications';
@@ -254,11 +256,24 @@ const FacilitiesProjectStoragePage: React.FC = () => {
         description:
           'Look up a project-storage stint by QR scan or by typing the stint ID. ' +
           'Send violation notices, move items to purgatory, and mark stints removed.',
-        action: stint ? (
-          <Button variant="default" onClick={refresh}>
-            Refresh
-          </Button>
-        ) : undefined,
+        action: (
+          <Group gap="xs">
+            {stint && (
+              <Button variant="default" onClick={refresh}>
+                Refresh
+              </Button>
+            )}
+            <Button
+              component={Link}
+              to="/facilities/project-storage/queue"
+              variant="light"
+              leftSection={<IconList size={16} />}
+              data-testid="view-queue-link"
+            >
+              View queue
+            </Button>
+          </Group>
+        ),
       }}
     >
       {/* Input row: HID/text on the left, camera scan on the right. */}
@@ -407,6 +422,12 @@ const FacilitiesProjectStoragePage: React.FC = () => {
                 {stint.qr_code_url ? 'Regenerate QR' : 'Generate QR'}
               </Button>
             </Group>
+
+            {/*
+              Claim-label preview. Only mounted here (inside the loaded-stint
+              block) so the label PNG is fetched lazily once a stint resolves.
+            */}
+            <ProjectStorageLabelPreview stintId={stint.stint_id} />
 
             {stint.qr_code_url && (
               <Paper p="md" withBorder>


### PR DESCRIPTION
Adds the storage-item **label preview** and surfaces the existing items **overview**.

- New `ProjectStorageLabelPreview` component: renders the printable claim-tag PNG via the existing `projectStorageAPI.labelUrl()` with a Brother/Epson printer toggle.
- Shows the preview on the warden detail page (`FacilitiesProjectStoragePage`); adds a link to the existing queue/overview (`/facilities/project-storage/queue`) + a per-row preview affordance.
- Frontend-only — the label endpoint + `labelUrl()` already exist. Single model (personal = blank project_title).

Built by an `openmakersuite/claude` worker via `gc sling`; pushed for review. Verified via OMS CI (Frontend Lint/Tests/E2E) rather than a local run this pass. **ScanTTY parity** = sc-aqh (in progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)