### PR TITLE
feat(inventory): item form is_serialized + serial_tracking_mode toggle (op-5tc)

### DIFF
--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -496,9 +496,10 @@ class InventoryItemSerializer(serializers.ModelSerializer):
             "has_complete_nfpa_data",
             "is_active",
             "is_requestable",
-            # Serialized-component tracking (#818) — exposed read-only so the
-            # frontend can detect serialized items and branch the lifecycle UI
-            # on the tracking mode.
+            # Serialized-component tracking (#818). Writable so the item
+            # create/edit form can flag an item as serialized and pick the
+            # lifecycle tracking mode (op-5tc) — this is the switch that makes
+            # the whole serialized-component feature reachable.
             "is_serialized",
             "serial_tracking_mode",
             "last_scanned_at",
@@ -516,10 +517,6 @@ class InventoryItemSerializer(serializers.ModelSerializer):
             "qr_code",
             "created_at",
             "updated_at",
-            # Serialization config is managed via the model/admin and the
-            # SerializedComponent lifecycle, not edited through this serializer.
-            "is_serialized",
-            "serial_tracking_mode",
         ]
 
     def get_thumbnail(self, obj):

--- a/backend/inventory/tests/test_serialized_component_api.py
+++ b/backend/inventory/tests/test_serialized_component_api.py
@@ -278,8 +278,12 @@ class TestInventoryItemSerializesSerialConfig:
         assert resp.data["is_serialized"] is True
         assert resp.data["serial_tracking_mode"] == InventoryItem.SERIAL_TRACKING_REUSABLE
 
-    def test_serial_fields_are_read_only(self):
-        """Serialization config is not editable through the item serializer."""
+    def test_serial_fields_are_writable(self):
+        """Serialization config is editable through the item serializer (op-5tc).
+
+        The create/edit form flips these on; making them writable is what makes
+        the serialized-component feature reachable end-to-end.
+        """
         item = InventoryItemFactory(is_serialized=False)
         url = reverse("inventoryitem-detail", kwargs={"pk": item.pk})
         resp = _client(_user("staff7", is_staff=True)).patch(
@@ -292,7 +296,8 @@ class TestInventoryItemSerializesSerialConfig:
         )
         assert resp.status_code == 200
         item.refresh_from_db()
-        assert item.is_serialized is False
+        assert item.is_serialized is True
+        assert item.serial_tracking_mode == InventoryItem.SERIAL_TRACKING_REUSABLE
 
 
 @pytest.mark.integration

--- a/frontend/src/__tests__/pages/InventoryItemFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemFormPage.test.tsx
@@ -501,4 +501,117 @@ describe('InventoryItemFormPage', () => {
     // The in-progress form is untouched behind the banner.
     expect(screen.getByDisplayValue('Test Item')).toBeInTheDocument();
   });
+
+  // ---- op-5tc: serialized-component toggle ----
+
+  it('renders the serial tracking toggle, hiding the mode select until enabled', async () => {
+    renderCreatePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByLabelText(/Track individual serial numbers/i).length
+      ).toBeGreaterThan(0);
+    });
+
+    // The tracking-mode select stays hidden until serialization is switched on.
+    expect(
+      screen.queryByPlaceholderText('Select how these units are used')
+    ).not.toBeInTheDocument();
+  });
+
+  it('reveals the tracking-mode select when serialization is enabled', async () => {
+    renderCreatePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByLabelText(/Track individual serial numbers/i).length
+      ).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getAllByLabelText(/Track individual serial numbers/i)[0]);
+
+    expect(
+      await screen.findByPlaceholderText('Select how these units are used')
+    ).toBeInTheDocument();
+  });
+
+  it('includes is_serialized + serial_tracking_mode in the create payload', async () => {
+    (api.inventoryAPI.createItem as jest.Mock).mockResolvedValue({
+      data: { ...mockItem, id: 'new-id' },
+    });
+
+    renderCreatePage();
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(/Name/i).length).toBeGreaterThan(0);
+    });
+    fillRequiredFields();
+
+    fireEvent.click(screen.getAllByLabelText(/Track individual serial numbers/i)[0]);
+    fireEvent.click(await screen.findByPlaceholderText('Select how these units are used'));
+    fireEvent.click(await screen.findByRole('option', { name: /Reusable/i }));
+
+    fireEvent.click(screen.getByText('Create Item'));
+
+    await waitFor(() => {
+      expect(api.inventoryAPI.createItem).toHaveBeenCalled();
+    });
+
+    const formData = (api.inventoryAPI.createItem as jest.Mock).mock.calls[0][0] as FormData;
+    expect(formData.get('is_serialized')).toBe('true');
+    expect(formData.get('serial_tracking_mode')).toBe('reusable');
+  });
+
+  it('sends is_serialized=false by default when serialization is off', async () => {
+    (api.inventoryAPI.createItem as jest.Mock).mockResolvedValue({
+      data: { ...mockItem, id: 'new-id' },
+    });
+
+    renderCreatePage();
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(/Name/i).length).toBeGreaterThan(0);
+    });
+    fillRequiredFields();
+    fireEvent.click(screen.getByText('Create Item'));
+
+    await waitFor(() => {
+      expect(api.inventoryAPI.createItem).toHaveBeenCalled();
+    });
+
+    const formData = (api.inventoryAPI.createItem as jest.Mock).mock.calls[0][0] as FormData;
+    expect(formData.get('is_serialized')).toBe('false');
+    expect(formData.get('serial_tracking_mode')).toBeNull();
+  });
+
+  it('hydrates serial config in edit mode and includes both fields on update', async () => {
+    (api.inventoryAPI.getItem as jest.Mock).mockResolvedValue({
+      data: { ...mockItem, is_serialized: true, serial_tracking_mode: 'reusable' },
+    });
+    (api.inventoryAPI.updateItem as jest.Mock).mockResolvedValue({ data: mockItem });
+
+    render(
+      <MantineProvider>
+        <MemoryRouter initialEntries={['/inventory/items/test-id/edit']}>
+          <Routes>
+            <Route path="/inventory/items/:id/edit" element={<InventoryItemFormPage />} />
+          </Routes>
+        </MemoryRouter>
+      </MantineProvider>
+    );
+
+    // The toggle hydrates on, so the mode select is populated with the fetched value.
+    expect((await screen.findAllByDisplayValue(/Reusable/i)).length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByText('Save Changes'));
+
+    await waitFor(() => {
+      expect(api.inventoryAPI.updateItem).toHaveBeenCalled();
+    });
+
+    // updateItem(id, formData) — the FormData is the second argument.
+    const formData = (api.inventoryAPI.updateItem as jest.Mock).mock.calls[0][1] as FormData;
+    expect(formData.get('is_serialized')).toBe('true');
+    expect(formData.get('serial_tracking_mode')).toBe('reusable');
+  });
 });

--- a/frontend/src/pages/InventoryItemDetailPage.tsx
+++ b/frontend/src/pages/InventoryItemDetailPage.tsx
@@ -160,6 +160,7 @@ const InventoryItemDetailPage: React.FC = () => {
         {item.has_pending_reorder && <Badge color="blue">Reorder Pending</Badge>}
         {!item.is_active && <Badge color="gray">Inactive</Badge>}
         {item.is_hazardous && <Badge color="orange">Hazardous Material</Badge>}
+        {item.is_serialized && <Badge color="grape">Serialized</Badge>}
       </Group>
 
       {/* Tabs */}

--- a/frontend/src/pages/InventoryItemFormPage.tsx
+++ b/frontend/src/pages/InventoryItemFormPage.tsx
@@ -69,6 +69,8 @@ const InventoryItemFormPage: React.FC = () => {
       nfpa_instability_hazard: null,
       nfpa_special_hazards: '',
       ownership_type: 'space',
+      is_serialized: false,
+      serial_tracking_mode: null,
       is_active: true,
       notes: '',
     },
@@ -76,6 +78,7 @@ const InventoryItemFormPage: React.FC = () => {
 
   const isHazardous = watch('is_hazardous');
   const useCaseBasedReorder = watch('use_case_based_reorder');
+  const isSerialized = watch('is_serialized');
 
   useEffect(() => {
     loadInitialData();
@@ -136,6 +139,8 @@ const InventoryItemFormPage: React.FC = () => {
         ownership_type: item.ownership_type,
         owning_user: item.owning_user,
         owning_group: item.owning_group,
+        is_serialized: item.is_serialized ?? false,
+        serial_tracking_mode: item.serial_tracking_mode ?? null,
         is_active: item.is_active,
         notes: item.notes || '',
         image_url: item.image ? (item.image.startsWith('http') ? item.image : '') : '',
@@ -512,6 +517,40 @@ const InventoryItemFormPage: React.FC = () => {
                           />
                         </div>
                       </>
+                    )}
+                  </>
+                ),
+              },
+              {
+                title: 'Serial Tracking',
+                children: (
+                  <>
+                    <div>
+                      <Switch
+                        label="Track individual serial numbers"
+                        description="Track each physical unit of this item by serial number through a lifecycle."
+                        checked={isSerialized}
+                        onChange={(e) => {
+                          const checked = e.currentTarget.checked;
+                          setValue('is_serialized', checked);
+                          if (!checked) {
+                            setValue('serial_tracking_mode', null);
+                          }
+                        }}
+                      />
+                    </div>
+                    {isSerialized && (
+                      <FormSelect
+                        name="serial_tracking_mode"
+                        control={control}
+                        label="Tracking mode"
+                        required
+                        placeholder="Select how these units are used"
+                        data={[
+                          { value: 'consumable', label: 'Consumable (used up)' },
+                          { value: 'reusable', label: 'Reusable (installed / removed)' },
+                        ]}
+                      />
                     )}
                   </>
                 ),

--- a/frontend/src/pages/InventoryListPage.tsx
+++ b/frontend/src/pages/InventoryListPage.tsx
@@ -526,6 +526,7 @@ const InventoryListPage: React.FC = () => {
                       {item.needs_reorder && <Badge color="red" size="sm">Low Stock</Badge>}
                       {item.has_pending_reorder && <Badge color="blue" size="sm">Reorder Pending</Badge>}
                       {!item.is_active && <Badge color="gray" size="sm">Inactive</Badge>}
+                      {item.is_serialized && <Badge color="grape" size="sm">Serialized</Badge>}
                     </Group>
                   </Table.Td>
                   <Table.Td onClick={(e) => e.stopPropagation()}>

--- a/frontend/src/utils/formSchemas.ts
+++ b/frontend/src/utils/formSchemas.ts
@@ -120,6 +120,11 @@ export const inventoryItemSchema = z
     owning_user: z.number().int().positive().optional().nullable(),
     owning_group: z.number().int().positive().optional().nullable(),
 
+    // Serialized-component tracking — when enabled, individual units are
+    // tracked by serial number and the mode selects the lifecycle branch.
+    is_serialized: z.boolean().optional().default(false),
+    serial_tracking_mode: z.enum(['consumable', 'reusable']).nullable().optional(),
+
     // Other
     is_active: z.boolean().default(true),
     notes: z.string().optional(),


### PR DESCRIPTION
**Unblocks the serialized-component feature.** #818/#820 shipped every downstream surface (serial entry, receive-with-serial, usage tracking) but the item form had no control to set `is_serialized` — so nothing could turn it on and it all stayed hidden.

- Adds a **"Track serial numbers" toggle + Consumable/Reusable mode select** to the InventoryItem create/edit form (`InventoryItemFormPage` + `formSchemas`).
- Makes `is_serialized` / `serial_tracking_mode` **writable** in the inventory serializer (+ backend test).
- Serialized **badge** on the item list/detail; vitest for the form.

Once merged + deployed, marking an item serialized is a checkbox in the normal item form (no Django-admin workaround needed). Verified via OMS CI (Backend + Frontend Lint/Tests). Built by an `openmakersuite/claude` worker via `gc sling`, pushed for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)