### PR TITLE
feat(inventory): wire Django admin for serialized components (op-9io)

### DIFF
--- a/backend/inventory/admin.py
+++ b/backend/inventory/admin.py
@@ -18,6 +18,7 @@ from .models import (
     AssetPart,
     AssetProblem,
     Category,
+    ComponentUsageEvent,
     InventoryItem,
     ItemSupplier,
     Location,
@@ -30,6 +31,7 @@ from .models import (
     MaintenanceTask,
     MaintenanceTool,
     PriceHistory,
+    SerializedComponent,
     StockReconciliation,
     Supplier,
     UsageLog,
@@ -347,6 +349,16 @@ class AssetPartInline(admin.TabularInline):
         return "—"
 
 
+class SerializedComponentInline(admin.TabularInline):
+    """Serial-numbered units of a serialized item, editable from the item page."""
+
+    model = SerializedComponent
+    extra = 0
+    fields = ["serial_number", "lot", "status", "installed_in_asset"]
+    autocomplete_fields = ["installed_in_asset"]
+    show_change_link = True
+
+
 @admin.register(InventoryItem)
 class InventoryItemAdmin(admin.ModelAdmin):
     list_display = [
@@ -360,6 +372,7 @@ class InventoryItemAdmin(admin.ModelAdmin):
         "use_case_based_reorder",
         "is_active",
         "is_requestable",
+        "is_serialized",
         "hazmat_status_icon",
         "api_link",
         "reorder_link",
@@ -369,6 +382,7 @@ class InventoryItemAdmin(admin.ModelAdmin):
         "location",
         "is_active",
         "is_requestable",
+        "is_serialized",
         "is_hazardous",
         "use_case_based_reorder",
     ]
@@ -386,7 +400,7 @@ class InventoryItemAdmin(admin.ModelAdmin):
         "hazmat_compliance_status",
         "index_card_preview",
     ]
-    inlines = [ItemSupplierInline]
+    inlines = [ItemSupplierInline, SerializedComponentInline]
     fieldsets = (
         (
             "Basic Information",
@@ -407,6 +421,19 @@ class InventoryItemAdmin(admin.ModelAdmin):
         (
             "Stock Information",
             {"fields": ("current_stock", "minimum_stock", "reorder_quantity")},
+        ),
+        (
+            "Serial Tracking",
+            {
+                "fields": ("is_serialized", "serial_tracking_mode"),
+                "classes": ("collapse",),
+                "description": (
+                    "When enabled, individual physical units of this item are tracked "
+                    "by serial number as SerializedComponents that move through a "
+                    "lifecycle. Consumable units are used up; reusable units can be "
+                    "installed and removed repeatedly before retirement."
+                ),
+            },
         ),
         (
             "Case-Based Reordering",
@@ -671,6 +698,93 @@ class InventoryItemAdmin(admin.ModelAdmin):
                 f"Successfully regenerated QR codes for {count} item(s).",
                 level=messages.SUCCESS,
             )
+
+
+@admin.register(SerializedComponent)
+class SerializedComponentAdmin(admin.ModelAdmin):
+    """Admin for individual serial-numbered units of a serialized item."""
+
+    list_display = [
+        "serial_number",
+        "item",
+        "lot",
+        "status",
+        "installed_in_asset",
+        "received_at",
+        "installed_at",
+        "disposed_at",
+    ]
+    list_filter = ["status", "item"]
+    search_fields = ["serial_number", "lot", "item__name", "item__sku"]
+    autocomplete_fields = ["item", "installed_in_asset"]
+    raw_id_fields = ["provenance_delivery_item", "provenance_purchase_order_item"]
+    readonly_fields = ["id", "created_at", "updated_at"]
+    date_hierarchy = "received_at"
+    fieldsets = (
+        (None, {"fields": ("id", "item", "serial_number", "lot", "status")}),
+        (
+            "Installation",
+            {"fields": ("installed_in_asset", "received_at", "installed_at")},
+        ),
+        (
+            "Disposal",
+            {
+                "fields": ("disposed_at", "disposal_reason"),
+                "classes": ("collapse",),
+            },
+        ),
+        (
+            "Provenance",
+            {
+                "fields": (
+                    "provenance_delivery_item",
+                    "provenance_purchase_order_item",
+                ),
+                "classes": ("collapse",),
+            },
+        ),
+        (
+            "Audit",
+            {"fields": ("created_at", "updated_at"), "classes": ("collapse",)},
+        ),
+    )
+
+
+@admin.register(ComponentUsageEvent)
+class ComponentUsageEventAdmin(admin.ModelAdmin):
+    """Read-only audit log of serialized-component lifecycle actions."""
+
+    list_display = ["at", "component", "action", "asset", "actor", "created_at"]
+    list_filter = ["action", "at"]
+    search_fields = [
+        "component__serial_number",
+        "component__item__name",
+        "asset__name",
+        "actor__username",
+        "notes",
+    ]
+    readonly_fields = [
+        "id",
+        "component",
+        "asset",
+        "action",
+        "at",
+        "actor",
+        "notes",
+        "created_at",
+    ]
+    date_hierarchy = "at"
+
+    def has_add_permission(self, request):
+        # Events are written by SerializedComponent.apply_action(), never by hand.
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        # Audit log is view-only.
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
 
 
 @admin.register(PriceHistory)

--- a/backend/inventory/tests/test_serialized_component_admin.py
+++ b/backend/inventory/tests/test_serialized_component_admin.py
@@ -1,0 +1,69 @@
+"""Admin smoke tests for the serialized-component surface.
+
+Verifies that the SerializedComponent / ComponentUsageEvent registrations and
+the InventoryItem serial-tracking fieldset + inline load without error for a
+staff user (changelist / add / change views return the expected status).
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from inventory.models import ComponentUsageEvent, SerializedComponent
+from inventory.tests.factories import InventoryItemFactory, SerializedComponentFactory
+
+User = get_user_model()
+
+
+class SerializedComponentAdminSmokeTest(TestCase):
+    """Changelist / add / change views load for the new admin registrations."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.item = InventoryItemFactory(is_serialized=True)
+        cls.component = SerializedComponentFactory(item=cls.item)
+        cls.event = ComponentUsageEvent.objects.create(
+            component=cls.component,
+            action=SerializedComponent.ACTION_RECEIVE,
+        )
+
+    def setUp(self):
+        self.admin_user = User.objects.create_superuser(
+            username="serial-admin",
+            email="serial-admin@test.com",
+            password="pw",
+        )
+        self.client.force_login(self.admin_user)
+
+    def test_inventory_item_change_view_has_serial_fields_and_inline(self):
+        """Item change page renders the serial-tracking fieldset + inline."""
+        url = reverse("admin:inventory_inventoryitem_change", args=[self.item.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "is_serialized")
+        self.assertContains(response, "serial_tracking_mode")
+        # Inline formset for serial-numbered units is present on the page.
+        self.assertContains(response, "serialized_components")
+
+    def test_serialized_component_changelist_loads(self):
+        url = reverse("admin:inventory_serializedcomponent_changelist")
+        self.assertEqual(self.client.get(url).status_code, 200)
+
+    def test_serialized_component_add_view_loads(self):
+        url = reverse("admin:inventory_serializedcomponent_add")
+        self.assertEqual(self.client.get(url).status_code, 200)
+
+    def test_serialized_component_change_view_loads(self):
+        url = reverse("admin:inventory_serializedcomponent_change", args=[self.component.pk])
+        self.assertEqual(self.client.get(url).status_code, 200)
+
+    def test_component_usage_event_changelist_loads(self):
+        url = reverse("admin:inventory_componentusageevent_changelist")
+        self.assertEqual(self.client.get(url).status_code, 200)
+
+    def test_component_usage_event_is_read_only(self):
+        """Audit log disallows adds but still renders its view-only detail page."""
+        add_url = reverse("admin:inventory_componentusageevent_add")
+        self.assertEqual(self.client.get(add_url).status_code, 403)
+        change_url = reverse("admin:inventory_componentusageevent_change", args=[self.event.pk])
+        self.assertEqual(self.client.get(change_url).status_code, 200)


### PR DESCRIPTION
Closes the /admin/ gap in the serialized-component feature: #818 added the models but never registered them in Django admin.

- Registers **SerializedComponent** + **ComponentUsageEvent** in admin (list_display / filters / search / read-only audit fields).
- Exposes **is_serialized** + **serial_tracking_mode** on `InventoryItemAdmin` (fieldset + list_filter).
- Adds a **SerializedComponent inline** on the item admin so units are viewable/addable from the item page.
- admin.py +116, new admin smoke test +69.

So an operator can now manage serials from `/admin/` (in addition to the web app form/toggle from #824). Verified via OMS CI (Backend Lint/Tests runs the admin test).

Note: this commit landed on a mis-named branch due to a concurrent-worker collision on the shared checkout (op-9io + the op-ap9 codex audit ran at once); rescued to this branch — the commit is clean/admin-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)