### PR TITLE
fix(inventory): clear installed_in_asset on consume/retire/dispose (codex audit, op-ap9)

### DIFF
--- a/backend/inventory/models.py
+++ b/backend/inventory/models.py
@@ -3485,14 +3485,17 @@ class SerializedComponent(models.Model):
             self.installed_in_asset = None
         elif action == self.ACTION_CONSUME:
             event_asset = self.installed_in_asset
+            self.installed_in_asset = None
         elif action == self.ACTION_RETIRE:
             event_asset = self.installed_in_asset
+            self.installed_in_asset = None
         elif action == self.ACTION_DISPOSE:
             if not disposal_reason:
                 raise ValidationError("A disposal reason is required to dispose a component.")
             self.disposal_reason = disposal_reason
             self.disposed_at = now
             event_asset = self.installed_in_asset
+            self.installed_in_asset = None
 
         self.status = to_status
         with transaction.atomic():

--- a/backend/inventory/tests/test_serialized_component_api.py
+++ b/backend/inventory/tests/test_serialized_component_api.py
@@ -135,6 +135,7 @@ class TestSerializedComponentLifecycleApi:
         r3 = client.post(_action_url(component, "consume"), data={}, format="json")
         assert r3.status_code == 200
         assert r3.data["status"] == SerializedComponent.CONSUMED
+        assert r3.data["installed_in_asset"] is None
 
         r4 = client.post(
             _action_url(component, "dispose"),
@@ -232,6 +233,23 @@ class TestSerializedComponentLifecycleApi:
         )
         assert r_reinstall.status_code == 200
         assert r_reinstall.data["status"] == SerializedComponent.INSTALLED
+
+    def test_reusable_retire_from_installed_clears_current_asset(self, reusable_item):
+        client = _client(_user("staff8b", is_staff=True))
+        component = SerializedComponentFactory(item=reusable_item)
+        asset = AssetFactory()
+
+        client.post(_action_url(component, "receive"), data={}, format="json")
+        client.post(
+            _action_url(component, "install"),
+            data={"asset": str(asset.id)},
+            format="json",
+        )
+        resp = client.post(_action_url(component, "retire"), data={}, format="json")
+
+        assert resp.status_code == 200
+        assert resp.data["status"] == SerializedComponent.RETIRED
+        assert resp.data["installed_in_asset"] is None
 
 
 @pytest.mark.integration

--- a/backend/inventory/tests/test_serialized_component_models.py
+++ b/backend/inventory/tests/test_serialized_component_models.py
@@ -84,8 +84,10 @@ class TestConsumableLifecycle:
         assert component.installed_in_asset_id == asset.id
         assert component.installed_at is not None
 
-        component.apply_action(SerializedComponent.ACTION_CONSUME)
+        consume_event = component.apply_action(SerializedComponent.ACTION_CONSUME)
         assert component.status == SerializedComponent.CONSUMED
+        assert component.installed_in_asset is None
+        assert consume_event.asset_id == asset.id
 
         component.apply_action(SerializedComponent.ACTION_DISPOSE, disposal_reason="used up")
         assert component.status == SerializedComponent.DISPOSED
@@ -132,6 +134,22 @@ class TestConsumableLifecycle:
             component.apply_action(SerializedComponent.ACTION_DISPOSE)
         assert component.status == SerializedComponent.CONSUMED
 
+    def test_dispose_clears_stale_current_asset_link_but_logs_it(self):
+        asset = AssetFactory()
+        component = SerializedComponentFactory(
+            status=SerializedComponent.CONSUMED,
+            installed_in_asset=asset,
+        )
+
+        event = component.apply_action(
+            SerializedComponent.ACTION_DISPOSE,
+            disposal_reason="already spent",
+        )
+
+        assert component.status == SerializedComponent.DISPOSED
+        assert component.installed_in_asset is None
+        assert event.asset_id == asset.id
+
 
 @pytest.mark.unit
 class TestReusableLifecycle:
@@ -176,6 +194,20 @@ class TestReusableLifecycle:
         component.apply_action(SerializedComponent.ACTION_RECEIVE)
         component.apply_action(SerializedComponent.ACTION_RETIRE)
         assert component.status == SerializedComponent.RETIRED
+
+    def test_retire_from_installed_clears_asset_but_logs_it(self):
+        asset = AssetFactory()
+        component = SerializedComponentFactory(
+            item__serial_tracking_mode=InventoryItem.SERIAL_TRACKING_REUSABLE
+        )
+        component.apply_action(SerializedComponent.ACTION_RECEIVE)
+        component.apply_action(SerializedComponent.ACTION_INSTALL, asset=asset)
+
+        event = component.apply_action(SerializedComponent.ACTION_RETIRE)
+
+        assert component.status == SerializedComponent.RETIRED
+        assert component.installed_in_asset is None
+        assert event.asset_id == asset.id
 
     def test_cannot_consume_reusable(self):
         component = SerializedComponentFactory(


### PR DESCRIPTION
**Found by the codex completeness audit** of the serialized-component feature (op-ap9).

`SerializedComponent.apply_action` recorded the event's asset but did **not** clear `installed_in_asset` on **consume / retire / dispose** — so a consumed/retired/disposed unit still showed as *installed in* its machine (only `remove` cleared it). Data-integrity bug: a used-up or scrapped part shouldn't remain linked to an asset.

- models.py: set `installed_in_asset = None` on the consume/retire/dispose transitions.
- Tests: API assertions that the link clears after consume/dispose, + a new `test_reusable_retire_from_installed_clears_current_asset` and a model test.

Cherry-picked clean off main (the codex commit was stacked on op-9io's admin branch due to the concurrent-worker collision; the admin work is separately in **#828**). Verified via OMS CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)