### PR TITLE
feat(inventory): web report-problem affected-parts multi-select (op-3ak)

### DIFF
--- a/frontend/src/__tests__/pages/AssetDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/AssetDetailPage.test.tsx
@@ -847,5 +847,92 @@ describe('AssetDetailPage', () => {
         localStorage.removeItem('token');
       }
     });
+
+    // --- op-3ak: which-components-need-replace/fix multi-select -------------
+
+    it('renders a component multi-select in the report form (op-3ak)', async () => {
+      localStorage.setItem('token', 'fake-token');
+      try {
+        renderDetail();
+
+        await waitFor(() => {
+          expect(screen.getByText('Test Asset')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: /report problem/i }));
+
+        expect(
+          await screen.findByText(/which components need attention/i),
+        ).toBeInTheDocument();
+        // The asset's part (from mockAsset.parts) is offered as a checkbox.
+        expect(
+          screen.getByRole('checkbox', { name: /test part/i }),
+        ).toBeInTheDocument();
+      } finally {
+        localStorage.removeItem('token');
+      }
+    });
+
+    it('sends checked part ids as part_ids when submitting (op-3ak)', async () => {
+      localStorage.setItem('token', 'fake-token');
+      try {
+        mockAssetsAPI.reportProblem.mockResolvedValue({
+          data: { id: 'prob-2', affected_parts: [] },
+          status: 201,
+          statusText: 'Created',
+          headers: {},
+          config: {} as any,
+        });
+
+        renderDetail();
+
+        await waitFor(() => {
+          expect(screen.getByText('Test Asset')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: /report problem/i }));
+
+        const description = await screen.findByPlaceholderText(/describe the problem/i);
+        fireEvent.change(description, { target: { value: 'Belt worn' } });
+        fireEvent.click(screen.getByRole('checkbox', { name: /test part/i }));
+        fireEvent.click(screen.getByRole('button', { name: /submit problem/i }));
+
+        await waitFor(() =>
+          expect(mockAssetsAPI.reportProblem).toHaveBeenCalledWith('test-id', 'Belt worn', [
+            'part-1',
+          ]),
+        );
+      } finally {
+        localStorage.removeItem('token');
+      }
+    });
+
+    it('shows the flagged components on a reported problem (op-3ak)', async () => {
+      mockAssetsAPI.getAssetProblems.mockResolvedValue({
+        data: [
+          {
+            ...mockProblems[0],
+            affected_parts: [
+              {
+                id: '9',
+                part_name: 'Flagged Belt',
+                part_sku: 'FB-1',
+                quantity_needed: 3,
+                is_required: true,
+              },
+            ],
+          },
+        ],
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      } as any);
+
+      renderDetail();
+
+      expect(await screen.findByText(/components flagged/i)).toBeInTheDocument();
+      expect(screen.getByText(/flagged belt/i)).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/__tests__/pages/AssetScanPage.test.tsx
+++ b/frontend/src/__tests__/pages/AssetScanPage.test.tsx
@@ -341,4 +341,86 @@ describe('AssetScanPage — modal flows', () => {
     // …and the offline photo is surfaced as a non-fatal, actionable failure.
     expect(await screen.findByText(/photo 1 failed to upload/i)).toBeInTheDocument();
   });
+
+  // --- op-3ak: which-components-need-replace/fix multi-select ---------------
+
+  const assetPart = {
+    id: 'part-1',
+    asset: 'asset-1',
+    asset_name: 'Test Asset',
+    asset_tag: '',
+    part: 'p1',
+    part_name: 'Drive Belt',
+    part_sku: 'SKU1',
+    quantity_needed: 2,
+    is_required: true,
+    maintenance_interval_days: null,
+    last_replaced_at: null,
+    days_since_replacement: null,
+    needs_replacement: false,
+    notes: '',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  };
+
+  test('renders an optional component multi-select from the asset parts', async () => {
+    localStorage.setItem('token', 'fake-token');
+    (api.assetsAPI.scanAsset as jest.Mock).mockResolvedValue({
+      data: { ...mockAsset, parts: [assetPart] },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText(/which components need attention/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: /drive belt/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('sends checked part ids as part_ids when reporting a problem', async () => {
+    localStorage.setItem('token', 'fake-token');
+    (api.assetsAPI.scanAsset as jest.Mock).mockResolvedValue({
+      data: { ...mockAsset, parts: [assetPart] },
+    });
+    (api.assetsAPI.reportProblem as jest.Mock).mockResolvedValue({
+      data: { id: 'prob-1', affected_parts: [] },
+    });
+
+    renderPage();
+
+    const textarea = await screen.findByPlaceholderText(/describe the problem/i);
+    fireEvent.change(textarea, { target: { value: 'Belt is frayed' } });
+    fireEvent.click(screen.getByRole('checkbox', { name: /drive belt/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^report problem$/i }));
+
+    await waitFor(() =>
+      expect(api.assetsAPI.reportProblem).toHaveBeenCalledWith(
+        'asset-1',
+        'Belt is frayed',
+        ['part-1'],
+      ),
+    );
+  });
+
+  test('reports description-only (no part_ids) when no component is checked', async () => {
+    localStorage.setItem('token', 'fake-token');
+    (api.assetsAPI.scanAsset as jest.Mock).mockResolvedValue({
+      data: { ...mockAsset, parts: [assetPart] },
+    });
+    (api.assetsAPI.reportProblem as jest.Mock).mockResolvedValue({
+      data: { id: 'prob-1', affected_parts: [] },
+    });
+
+    renderPage();
+
+    const textarea = await screen.findByPlaceholderText(/describe the problem/i);
+    fireEvent.change(textarea, { target: { value: 'Belt is frayed' } });
+    fireEvent.click(screen.getByRole('button', { name: /^report problem$/i }));
+
+    await waitFor(() =>
+      expect(api.assetsAPI.reportProblem).toHaveBeenCalledWith('asset-1', 'Belt is frayed'),
+    );
+  });
 });

--- a/frontend/src/__tests__/services/api.test.ts
+++ b/frontend/src/__tests__/services/api.test.ts
@@ -719,6 +719,41 @@ describe('API Service', () => {
       expect(response.data.description).toBe('Broken part');
     });
 
+    test('reportProblem sends part_ids when components are flagged', async () => {
+      const mockResponse = {
+        id: '1',
+        asset: 'test-id',
+        description: 'Broken part',
+        status: 'reported',
+        affected_parts: [
+          { id: '5', part_name: 'Belt', part_sku: 'B-1', quantity_needed: 1, is_required: true },
+        ],
+      };
+
+      mock.onPost('/inventory/assets/test-id/report_problem/').reply((config) => {
+        expect(JSON.parse(config.data)).toEqual({
+          description: 'Broken part',
+          part_ids: ['5', '7'],
+        });
+        return [201, mockResponse];
+      });
+
+      const response = await assetsAPI.reportProblem('test-id', 'Broken part', ['5', '7']);
+
+      expect(response.data.affected_parts[0].part_name).toBe('Belt');
+    });
+
+    test('reportProblem omits part_ids when the flagged list is empty', async () => {
+      mock.onPost('/inventory/assets/test-id/report_problem/').reply((config) => {
+        expect(JSON.parse(config.data)).toEqual({ description: 'Broken part' });
+        return [201, { id: '1', description: 'Broken part' }];
+      });
+
+      const response = await assetsAPI.reportProblem('test-id', 'Broken part', []);
+
+      expect(response.data.description).toBe('Broken part');
+    });
+
     test('generateQR generates QR code', async () => {
       mock.onPost('/inventory/assets/test-id/generate_qr/').reply(200, {});
 

--- a/frontend/src/pages/AssetDetailPage.tsx
+++ b/frontend/src/pages/AssetDetailPage.tsx
@@ -38,6 +38,8 @@ const AssetDetailPage: React.FC = () => {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
   const [showReportForm, setShowReportForm] = useState<boolean>(false);
   const [problemDescription, setProblemDescription] = useState<string>('');
+  // AssetPart ids the reporter flags as needing replace/fix (optional).
+  const [affectedPartIds, setAffectedPartIds] = useState<string[]>([]);
   const [submittingProblem, setSubmittingProblem] = useState<boolean>(false);
   const [resolvingProblemId, setResolvingProblemId] = useState<string | null>(null);
   const [resolutionNotes, setResolutionNotes] = useState<string>('');
@@ -277,6 +279,14 @@ const AssetDetailPage: React.FC = () => {
     }
   };
 
+  const toggleAffectedPart = (partId: string) => {
+    setAffectedPartIds((existing) =>
+      existing.includes(partId)
+        ? existing.filter((pid) => pid !== partId)
+        : [...existing, partId],
+    );
+  };
+
   const handleReportProblem = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!id || !problemDescription.trim()) {
@@ -286,8 +296,15 @@ const AssetDetailPage: React.FC = () => {
 
     try {
       setSubmittingProblem(true);
-      await assetsAPI.reportProblem(id, problemDescription);
+      // Only pass part ids when some are checked so a description-only report
+      // sends the exact same 2-argument call as before.
+      if (affectedPartIds.length > 0) {
+        await assetsAPI.reportProblem(id, problemDescription, affectedPartIds);
+      } else {
+        await assetsAPI.reportProblem(id, problemDescription);
+      }
       setProblemDescription('');
+      setAffectedPartIds([]);
       setShowReportForm(false);
       await loadAssetDetails();
     } catch (err: any) {
@@ -728,6 +745,32 @@ const AssetDetailPage: React.FC = () => {
                   disabled={submittingProblem}
                   style={{ width: '100%', padding: '0.5rem', marginBottom: '0.5rem', fontFamily: 'inherit' }}
                 />
+                {asset.parts && asset.parts.length > 0 && (
+                  <fieldset
+                    className="affected-parts"
+                    style={{ border: '1px solid #ddd', borderRadius: '4px', padding: '0.5rem', marginBottom: '0.5rem' }}
+                  >
+                    <legend>Which components need attention? (optional)</legend>
+                    {asset.parts.map((part) => (
+                      <label
+                        key={part.id}
+                        className="affected-part-option"
+                        style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', marginBottom: '0.25rem' }}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={affectedPartIds.includes(String(part.id))}
+                          onChange={() => toggleAffectedPart(String(part.id))}
+                          disabled={submittingProblem}
+                        />
+                        <span>
+                          {part.part_name}
+                          {part.quantity_needed ? ` (qty ${part.quantity_needed})` : ''}
+                        </span>
+                      </label>
+                    ))}
+                  </fieldset>
+                )}
                 <div style={{ display: 'flex', gap: '0.5rem' }}>
                   <button
                     type="submit"
@@ -741,6 +784,7 @@ const AssetDetailPage: React.FC = () => {
                     onClick={() => {
                       setShowReportForm(false);
                       setProblemDescription('');
+                      setAffectedPartIds([]);
                     }}
                     disabled={submittingProblem}
                     style={{ padding: '0.5rem 1rem', background: '#ccc', border: 'none', borderRadius: '4px', cursor: 'pointer' }}
@@ -783,6 +827,19 @@ const AssetDetailPage: React.FC = () => {
                     <p className="problem-description">{problem.description}</p>
                     {problem.reported_by && (
                       <p className="problem-reported-by">Reported by: {problem.reported_by}</p>
+                    )}
+                    {problem.affected_parts && problem.affected_parts.length > 0 && (
+                      <div className="problem-affected-parts">
+                        <strong>Components flagged:</strong>
+                        <ul>
+                          {problem.affected_parts.map((part) => (
+                            <li key={part.id}>
+                              {part.part_name}
+                              {part.quantity_needed ? ` (qty ${part.quantity_needed})` : ''}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
                     )}
                     {problem.resolution_notes && (
                       <div className="problem-resolution">

--- a/frontend/src/pages/AssetScanPage.tsx
+++ b/frontend/src/pages/AssetScanPage.tsx
@@ -33,6 +33,8 @@ const AssetScanPage: React.FC = () => {
 
   // Form state (authenticated users)
   const [problemDescription, setProblemDescription] = useState('');
+  // AssetPart ids the reporter flags as needing replace/fix (optional).
+  const [affectedPartIds, setAffectedPartIds] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [actionSuccess, setActionSuccess] = useState<string | null>(null);
   const [problemPhotos, setProblemPhotos] = useState<File[]>([]);
@@ -54,6 +56,14 @@ const AssetScanPage: React.FC = () => {
       if (url) URL.revokeObjectURL(url);
       return existing.filter((_, i) => i !== index);
     });
+  };
+
+  const toggleAffectedPart = (partId: string) => {
+    setAffectedPartIds((existing) =>
+      existing.includes(partId)
+        ? existing.filter((id) => id !== partId)
+        : [...existing, partId],
+    );
   };
 
   useEffect(() => {
@@ -233,8 +243,14 @@ const AssetScanPage: React.FC = () => {
 
     try {
       setSubmitting(true);
-      const reportResp = await assetsAPI.reportProblem(asset.id, problemDescription);
+      // Only pass part ids when some are checked so a description-only report
+      // sends the exact same 2-argument call as before.
+      const reportResp =
+        affectedPartIds.length > 0
+          ? await assetsAPI.reportProblem(asset.id, problemDescription, affectedPartIds)
+          : await assetsAPI.reportProblem(asset.id, problemDescription);
       const problemId = reportResp.data?.id;
+      const flaggedParts = reportResp.data?.affected_parts ?? [];
 
       if (problemId && problemPhotos.length > 0) {
         for (let i = 0; i < problemPhotos.length; i += 1) {
@@ -255,9 +271,19 @@ const AssetScanPage: React.FC = () => {
       setProblemPhotos([]);
       setPhotoPreviews([]);
       setProblemDescription('');
+      setAffectedPartIds([]);
+      const parts: string[] = [];
+      if (problemPhotos.length > 0) {
+        parts.push(`${problemPhotos.length} photo(s)`);
+      }
+      if (flaggedParts.length > 0) {
+        parts.push(
+          `flagged: ${flaggedParts.map((p) => p.part_name).join(', ')}`,
+        );
+      }
       setActionSuccess(
-        problemPhotos.length > 0
-          ? `Problem reported with ${problemPhotos.length} photo(s)`
+        parts.length > 0
+          ? `Problem reported (${parts.join('; ')})`
           : 'Problem reported successfully',
       );
       setTimeout(() => setActionSuccess(null), 3000);
@@ -673,6 +699,27 @@ const AssetScanPage: React.FC = () => {
                       required
                       disabled={submitting}
                     />
+                    {asset.parts && asset.parts.length > 0 && (
+                      <fieldset className="affected-parts">
+                        <legend>Which components need attention? (optional)</legend>
+                        {asset.parts.map((part) => (
+                          <label key={part.id} className="affected-part-option">
+                            <input
+                              type="checkbox"
+                              checked={affectedPartIds.includes(String(part.id))}
+                              onChange={() => toggleAffectedPart(String(part.id))}
+                              disabled={submitting}
+                            />
+                            <span>
+                              {part.part_name}
+                              {part.quantity_needed
+                                ? ` (qty ${part.quantity_needed})`
+                                : ''}
+                            </span>
+                          </label>
+                        ))}
+                      </fieldset>
+                    )}
                     <Stack gap="xs" mt="sm" mb="sm">
                       <Text size="sm" fw={500}>
                         Add photos (optional)

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -510,8 +510,13 @@ export const assetsAPI = {
   unlockAsset: (id: string) =>
     api.post<Asset>(`/inventory/assets/${id}/unlock/`),
 
-  reportProblem: (id: string, description: string) =>
-    api.post<AssetProblem>(`/inventory/assets/${id}/report_problem/`, { description }),
+  // `partIds` are AssetPart ids the reporter flagged as needing replace/fix.
+  // Only sent when non-empty so description-only reports keep the same payload.
+  reportProblem: (id: string, description: string, partIds?: string[]) =>
+    api.post<AssetProblem>(`/inventory/assets/${id}/report_problem/`, {
+      description,
+      ...(partIds && partIds.length > 0 ? { part_ids: partIds } : {}),
+    }),
 
   resolveProblem: (id: string, problemId: string, resolutionNotes?: string, status?: string) =>
     api.post(`/inventory/assets/${id}/resolve_problem/`, {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -391,6 +391,10 @@ export interface AssetProblem {
   resolved_at: string | null;
   resolved_by: string;
   photos: AssetProblemPhoto[];
+  // Components (AssetParts) the reporter flagged as needing replace/fix.
+  // The API returns a compact shape (id, part_name, part_sku, quantity_needed,
+  // is_required) via AffectedAssetPartSerializer.
+  affected_parts?: AssetPart[];
 }
 
 export type LocationProblemStatus = 'reported' | 'in_progress' | 'resolved' | 'closed';


### PR DESCRIPTION
Web UI for the affected-parts feature (backend #831; ScanTTY parity = scantty #55). When reporting an asset problem, the reporter can select which of the asset's components (AssetParts) need replace/fix.

- `services/api.ts`: `reportProblem(id, description, partIds?)` sends `part_ids`; `types/index.ts`: `affected_parts` on AssetProblem.
- `AssetScanPage.tsx` + `AssetDetailPage.tsx`: optional component checkboxes in the report-problem form → part_ids; affected components shown on the problem. Description-only reporting still works.
- +204 lines of vitest (both pages + api).

Verified via OMS CI (Frontend Lint/Tests). Completes the affected-parts feature end-to-end (backend #831 + web + ScanTTY #55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)