### PR TITLE
fix(dashboard): harden vs non-array widgets + close Sentry frontend-capture gap (op-j1f)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -52,6 +52,10 @@ FRONTEND_URL=https://oms.example.com
 # avoid plaintext error transport). Empty is allowed.
 SENTRY_DSN=
 SENTRY_ENVIRONMENT=production
+# VITE_SENTRY_DSN — the FRONTEND Sentry DSN. MUST be set for browser error
+# capture. Vite inlines VITE_* at BUILD time, so this has to be present when the
+# frontend image is built (not just at runtime); if empty, Sentry.init() no-ops
+# and the app's ErrorBoundary reports nothing — uncaught SPA crashes vanish.
 VITE_SENTRY_DSN=
 # Profiling — continuous mode (sentry-sdk 2.x). 1.0 = every Django/Celery
 # worker process emits profiles while a trace is active. Drop toward 0.0

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -208,10 +208,18 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ needs.determine-tags.outputs.frontend_tags }}
+          # Vite inlines VITE_* at build time, so the frontend Sentry DSN must
+          # reach the image build or Sentry.init() silently no-ops and browser
+          # crashes are never captured (op-j1f). Set the VITE_SENTRY_DSN repo
+          # secret; empty is tolerated (build succeeds, Sentry stays off) and
+          # mirrors docker-compose.prod.yml's ${VITE_SENTRY_DSN:-}. (Comments
+          # must stay OUT of the block scalar below — each line there is a
+          # literal build-arg passed straight to buildx.)
           build-args: |
             VITE_API_URL=/api
             VITE_GIT_HASH=${{ steps.git.outputs.hash }}
             VITE_GITHUB_URL=https://github.com/${{ github.repository }}
+            VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/frontend/src/__tests__/pages/DashboardPage.test.tsx
+++ b/frontend/src/__tests__/pages/DashboardPage.test.tsx
@@ -171,4 +171,64 @@ describe('DashboardPage', () => {
       expect(screen.getByText(/No widgets configured/i)).toBeInTheDocument();
     });
   });
+
+  it('renders the empty state (not a crash) when getWidgets returns a non-array', async () => {
+    // A mis-deployed gateway/login HTML page or a serializer shape change
+    // can make getWidgets resolve to a non-array. The page must coerce that
+    // to the empty state rather than let `widgets.filter` throw into the
+    // app-level error boundary (op-j1f).
+    (dashboardAPI.getWidgets as jest.Mock).mockResolvedValueOnce({
+      data: { detail: 'Authentication credentials were not provided.' },
+    });
+
+    render(
+      <MantineProvider>
+        <BrowserRouter>
+          <DashboardPage />
+        </BrowserRouter>
+      </MantineProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/No widgets configured/i)).toBeInTheDocument();
+    });
+    // The grid never mounts — a non-array must not reach react-grid-layout.
+    expect(screen.queryByTestId('grid-layout')).not.toBeInTheDocument();
+  });
+
+  it('unwraps a paginated { results: [...] } envelope into widgets', async () => {
+    // Defensive fallback: if the endpoint ever returns a DRF-paginated
+    // envelope instead of a bare array, the widgets in `results` still render.
+    const mockWidgets = [
+      {
+        id: 1,
+        widget_type: 'low_stock',
+        position_x: 0,
+        position_y: 0,
+        width: 2,
+        height: 2,
+        is_visible: true,
+        order: 0,
+        settings: {},
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      },
+    ];
+
+    (dashboardAPI.getWidgets as jest.Mock).mockResolvedValueOnce({
+      data: { count: 1, next: null, previous: null, results: mockWidgets },
+    });
+
+    render(
+      <MantineProvider>
+        <BrowserRouter>
+          <DashboardPage />
+        </BrowserRouter>
+      </MantineProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('low-stock-widget')).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -47,7 +47,17 @@ const DashboardPage: React.FC = () => {
       setLoading(true);
       setError(null);
       const response = await dashboardAPI.getWidgets();
-      setWidgets(response.data);
+      // The widgets endpoint returns a bare array, but a mis-deployed
+      // gateway/login HTML page — or a serializer change to a paginated
+      // `{ results: [...] }` envelope — can hand back a non-array. Coerce
+      // defensively so a bad response degrades to the empty state instead
+      // of throwing when `.filter`/`.map` runs on a non-array and taking
+      // the whole page into the error boundary (op-j1f).
+      const payload = response.data as unknown;
+      const list: DashboardWidgetType[] = Array.isArray(payload)
+        ? payload
+        : (payload as { results?: DashboardWidgetType[] } | null)?.results ?? [];
+      setWidgets(list);
     } catch (err: any) {
       setError(err.response?.data?.error || 'Failed to load dashboard widgets');
       console.error('Error loading widgets:', err);

--- a/scripts/validate-prod-env.sh
+++ b/scripts/validate-prod-env.sh
@@ -17,9 +17,10 @@
 #   - ForgeKey: FORGEKEY_PROVISIONING_TOKEN (warned if empty/placeholder)
 #   - Webhook tokens: POSTMARK_INBOUND_TOKEN, LOCATION_PING_TOKEN (warned if empty)
 #   - Email: EMAIL_BACKEND must not be the console backend in prod
-#   - Sentry: if SENTRY_DSN / REACT_APP_SENTRY_DSN set, must be an https:// URL.
-#     A warning fires when Sentry is unconfigured (no observability sink —
-#     production errors will only land in container logs).
+#   - Sentry: if SENTRY_DSN (backend) / VITE_SENTRY_DSN (frontend) set, must be
+#     an https:// URL. A warning fires when either is unconfigured — an empty
+#     VITE_SENTRY_DSN silently disables ALL frontend error capture (Sentry.init
+#     no-ops), so that warning is loud.
 #   - Cookie security: SESSION_COOKIE_SECURE and CSRF_COOKIE_SECURE default to
 #     `not DEBUG` in settings.py. Operators who explicitly override either to
 #     a falsy value when DEBUG=0 are warned — this re-enables plaintext cookies
@@ -246,9 +247,16 @@ if [ -z "${DEFAULT_FROM_EMAIL:-}" ] || is_placeholder "${DEFAULT_FROM_EMAIL:-}";
 fi
 
 # --- 10. Sentry --------------------------------------------------------------
-# Sentry DSNs are optional-but-validated: empty is fine, but any value that's
+# Sentry DSNs are optional-but-validated: empty is allowed, but any value that's
 # set must be an https:// URL — http leaks events in plaintext, and a typo
 # would silently disable error reporting in production.
+#
+# Two independent sinks:
+#   - SENTRY_DSN       — backend (Django/Celery) errors.
+#   - VITE_SENTRY_DSN  — frontend SPA errors. Vite inlines VITE_* at BUILD time,
+#                        so it must be present when the frontend image is built.
+#                        (The legacy CRA name REACT_APP_SENTRY_DSN is a no-op
+#                        under Vite and is intentionally no longer validated.)
 
 if [ -n "${SENTRY_DSN:-}" ]; then
     case "$SENTRY_DSN" in
@@ -257,10 +265,10 @@ if [ -n "${SENTRY_DSN:-}" ]; then
     esac
 fi
 
-if [ -n "${REACT_APP_SENTRY_DSN:-}" ]; then
-    case "$REACT_APP_SENTRY_DSN" in
+if [ -n "${VITE_SENTRY_DSN:-}" ]; then
+    case "$VITE_SENTRY_DSN" in
         https://*) ;;
-        *) err "REACT_APP_SENTRY_DSN must be an https:// URL for production (got: $REACT_APP_SENTRY_DSN)." ;;
+        *) err "VITE_SENTRY_DSN must be an https:// URL for production (got: $VITE_SENTRY_DSN)." ;;
     esac
 fi
 
@@ -270,7 +278,16 @@ fi
 # proceed if the operator has accepted that trade-off.
 
 if [ -z "${SENTRY_DSN:-}" ]; then
-    warn "SENTRY_DSN is not set — production errors will only appear in container logs. Configure Sentry for visibility into crashes and 5xx responses."
+    warn "SENTRY_DSN is not set — backend errors will only appear in container logs. Configure Sentry for visibility into crashes and 5xx responses."
+fi
+
+# VITE_SENTRY_DSN empty is the confirmed silent-failure mode behind op-j1f: the
+# frontend ships without Sentry.init(), so every uncaught render error — the
+# dashboard "Something went wrong" boundary included — vanishes and never
+# reaches Sentry. It is invisible at runtime and only reproducible in prod, so
+# warn LOUDLY rather than letting the build ship blind.
+if [ -z "${VITE_SENTRY_DSN:-}" ]; then
+    warn "VITE_SENTRY_DSN is not set — the frontend build ships WITHOUT Sentry (Sentry.init no-ops), so browser crashes are NEVER captured (this is the gap that hid op-j1f). Set VITE_SENTRY_DSN before building the frontend image."
 fi
 
 # --- 10a. Cookie security ----------------------------------------------------


### PR DESCRIPTION
## Problem (P0)
The logged-in dashboard showed the "Something went wrong" error boundary, and the error never appeared in Sentry.

**Root cause (investigated):** the dashboard code isn't at fault — neither #833 (auth guard, render-neutral for logged-in users) nor #834 (dep refresh) can crash it, and current `main` renders cleanly. The crash is most likely a **stale prod bundle** or a **non-array `/dashboard/widgets/` response**, and it was **invisible because Sentry is never initialized in the deployed frontend** (`VITE_SENTRY_DSN` ships empty → `Sentry.init` no-ops → `captureException` does nothing).

## Fix (defense-in-depth + close the blind spot)
1. **DashboardPage** tolerates a non-array `getWidgets()` response (array → use, `{results}` → unwrap, else → empty state) so a bad/HTML/paginated response degrades gracefully instead of white-screening the page. + 2 tests.
2. **Sentry wiring:** `validate-prod-env.sh` now validates `VITE_SENTRY_DSN` (https when set) and **warns loudly when empty** (the gap that hid this); `docker-build.yml` registry build passes the `VITE_SENTRY_DSN` build-arg; `.env.prod.example` documents it. **No DSN value committed.**

## ⚠️ Operator action to fully recover prod
Set a real `VITE_SENTRY_DSN` in the prod `.env`/secret and **redeploy the frontend from current `main`** (the deploy bakes it in). Redeploying from `main` alone likely fixes the crash if prod is on a stale bundle; the DSN makes future errors visible.

## Verification
Frontend `npm run lint` 0 errors · `test:fast` **1043 passed** (incl. new tests) · `bash -n validate-prod-env.sh` clean. OMS CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)