### PR TITLE
fix(inventory): make serialized add-unit reachable when item not yet serialized (op-qff)

### DIFF
--- a/frontend/src/__tests__/components/SerializedComponentsPanel.test.tsx
+++ b/frontend/src/__tests__/components/SerializedComponentsPanel.test.tsx
@@ -139,6 +139,31 @@ describe('SerializedComponentsPanel', () => {
     expect(await screen.findByText('SN-9999')).toBeInTheDocument();
   });
 
+  it('shows an enable-tracking CTA (not a dead panel) when the item is not serialized', async () => {
+    const onEnableTracking = jest.fn();
+    render(
+      <MantineProvider>
+        <SerializedComponentsPanel
+          itemId={ITEM_ID}
+          isSerialized={false}
+          onEnableTracking={onEnableTracking}
+        />
+      </MantineProvider>,
+    );
+
+    // The state is explained rather than silently empty...
+    expect(await screen.findByTestId('serialized-not-tracked')).toBeInTheDocument();
+    // ...the add-unit form is not offered for a non-serialized item...
+    expect(screen.queryByTestId('serialized-add-toggle')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('serialized-add-serial')).not.toBeInTheDocument();
+    // ...no units are fetched (nothing to list)...
+    expect(mockAPI.list).not.toHaveBeenCalled();
+
+    // ...and the CTA hands off to enabling serial tracking.
+    fireEvent.click(screen.getByTestId('serialized-enable-tracking'));
+    expect(onEnableTracking).toHaveBeenCalledTimes(1);
+  });
+
   it('loads and shows per-unit usage history on expand', async () => {
     mockAPI.list.mockResolvedValue(listResponse([buildUnit()]));
     mockAPI.listUsageEvents.mockResolvedValue({

--- a/frontend/src/__tests__/pages/InventoryItemDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemDetailPage.test.tsx
@@ -286,6 +286,26 @@ describe('InventoryItemDetailPage', () => {
     expect(linkedAssetsTab).toBeInTheDocument();
   });
 
+  it('always offers a Serialized Units tab and guides enabling tracking when the item is not serialized', async () => {
+    // mockItem has no is_serialized flag, so the item is not serialized.
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item')).toBeInTheDocument();
+    });
+
+    // The tab is present even for a non-serialized item — no dead end.
+    const serializedTab = screen.getByRole('tab', { name: /Serialized Units/i });
+    expect(serializedTab).toBeInTheDocument();
+
+    fireEvent.click(serializedTab);
+
+    // Instead of an empty panel, the user sees why and a way forward.
+    expect(await screen.findByTestId('serialized-not-tracked')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('serialized-enable-tracking'));
+    expect(mockNavigate).toHaveBeenCalledWith('/inventory/items/test-id/edit');
+  });
+
   it('handles missing item gracefully', async () => {
     (api.inventoryAPI.getItem as jest.Mock).mockRejectedValue({
       response: { data: { detail: 'Not found' } },

--- a/frontend/src/components/inventory/SerializedComponentsPanel.tsx
+++ b/frontend/src/components/inventory/SerializedComponentsPanel.tsx
@@ -51,6 +51,16 @@ interface Props {
   itemId: string;
   /** Owning item's tracking mode, shown as context in the header. */
   trackingMode?: SerializedTrackingMode;
+  /**
+   * Whether the owning item is flagged `is_serialized`. When false the panel
+   * shows a discoverable "turn this on" call-to-action instead of a dead,
+   * empty units view — a user who came here to add a serial number gets a
+   * clear next step rather than no input field (op-qff). Defaults to true so
+   * existing serialized callers are unaffected.
+   */
+  isSerialized?: boolean;
+  /** Invoked by the "Enable serial tracking" CTA shown when not serialized. */
+  onEnableTracking?: () => void;
 }
 
 const fmtDateTime = (iso: string | null): string =>
@@ -64,7 +74,12 @@ const fmtDateTime = (iso: string | null): string =>
       })
     : '—';
 
-const SerializedComponentsPanel: React.FC<Props> = ({ itemId, trackingMode }) => {
+const SerializedComponentsPanel: React.FC<Props> = ({
+  itemId,
+  trackingMode,
+  isSerialized = true,
+  onEnableTracking,
+}) => {
   const [units, setUnits] = useState<SerializedComponent[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -93,6 +108,14 @@ const SerializedComponentsPanel: React.FC<Props> = ({ itemId, trackingMode }) =>
   const [disposalReason, setDisposalReason] = useState('');
 
   const load = useCallback(async () => {
+    // A non-serialized item has no units to fetch — skip the request and let
+    // the panel render its "enable serial tracking" CTA instead.
+    if (!isSerialized) {
+      setUnits([]);
+      setTotal(0);
+      setLoading(false);
+      return;
+    }
     try {
       setLoading(true);
       setError(null);
@@ -105,7 +128,7 @@ const SerializedComponentsPanel: React.FC<Props> = ({ itemId, trackingMode }) =>
     } finally {
       setLoading(false);
     }
-  }, [itemId]);
+  }, [itemId, isSerialized]);
 
   useEffect(() => {
     load();
@@ -264,6 +287,35 @@ const SerializedComponentsPanel: React.FC<Props> = ({ itemId, trackingMode }) =>
   );
 
   const truncated = total > units.length;
+
+  // The item isn't tracked by serial number: don't strand the user in front of
+  // an empty panel with no way to add a unit. Explain the state and offer a
+  // direct path to turn serial tracking on (op-qff).
+  if (!isSerialized) {
+    return (
+      <Paper withBorder p="md" data-testid="serialized-components-panel">
+        <Group gap="xs" mb="sm">
+          <Title order={4}>Serialized units</Title>
+        </Group>
+        <Alert color="blue" variant="light" data-testid="serialized-not-tracked">
+          This item isn&apos;t tracked by serial number yet, so there are no units
+          to add. Turn on serial tracking to record individual units by serial
+          number and follow their lifecycle (receive, install, consume, retire,
+          dispose).
+        </Alert>
+        {onEnableTracking && (
+          <Button
+            mt="sm"
+            leftSection={<IconPlus size={14} />}
+            onClick={onEnableTracking}
+            data-testid="serialized-enable-tracking"
+          >
+            Enable serial tracking
+          </Button>
+        )}
+      </Paper>
+    );
+  }
 
   return (
     <Paper withBorder p="md" data-testid="serialized-components-panel">

--- a/frontend/src/pages/InventoryItemDetailPage.tsx
+++ b/frontend/src/pages/InventoryItemDetailPage.tsx
@@ -171,9 +171,10 @@ const InventoryItemDetailPage: React.FC = () => {
           <Tabs.Tab value="reorder-history">Reorder History</Tabs.Tab>
           <Tabs.Tab value="usage-logs">Usage Logs</Tabs.Tab>
           <Tabs.Tab value="linked-assets">Linked Assets</Tabs.Tab>
-          {item.is_serialized && (
-            <Tabs.Tab value="serialized-units">Serialized Units</Tabs.Tab>
-          )}
+          {/* Always present so a user looking to add a serial number can find
+              it — even when the item isn't flagged serialized yet, the panel
+              explains the state and links to enabling it (op-qff). */}
+          <Tabs.Tab value="serialized-units">Serialized Units</Tabs.Tab>
         </Tabs.List>
 
         {/* Overview Tab */}
@@ -454,15 +455,17 @@ const InventoryItemDetailPage: React.FC = () => {
           </Card>
         </Tabs.Panel>
 
-        {/* Serialized Units Tab — per-unit lifecycle for serialized items */}
-        {item.is_serialized && (
-          <Tabs.Panel value="serialized-units" pt="md">
-            <SerializedComponentsPanel
-              itemId={item.id}
-              trackingMode={item.serial_tracking_mode}
-            />
-          </Tabs.Panel>
-        )}
+        {/* Serialized Units Tab — per-unit lifecycle for serialized items.
+            Shown for every item; when the item isn't serialized the panel
+            renders a CTA to enable tracking rather than a dead view (op-qff). */}
+        <Tabs.Panel value="serialized-units" pt="md">
+          <SerializedComponentsPanel
+            itemId={item.id}
+            trackingMode={item.serial_tracking_mode}
+            isSerialized={item.is_serialized ?? false}
+            onEnableTracking={() => navigate(`/inventory/items/${item.id}/edit`)}
+          />
+        </Tabs.Panel>
       </Tabs>
     </WorkspacePage>
   );


### PR DESCRIPTION
## Problem
In the web frontend, trying to **add a serial number showed no input field**.

## Root cause
`SerializedComponentsPanel`'s add-unit form + lifecycle actions already worked — but the whole **"Serialized Units" tab was gated on `item.is_serialized`**. On an item not yet marked serialized there was no tab, no input, and no explanation → a dead end.

## Fix (frontend-only)
- Always render the "Serialized Units" tab.
- **Serialized item:** unchanged (add-unit form + receive/install/consume/retire/dispose).
- **Not-yet-serialized item:** a clear message + an **"Enable serial tracking" CTA** routing to the item edit form — so the state is obvious instead of an empty panel.
- Tests: CTA state (no add form / no list fetch / fires callback) + detail-page always-visible tab + CTA→edit nav; existing add-serial render/submit test retained.

## Verification
node24 `npm run lint` 0 errors · `vitest` **1043 passed** (139 files). OMS CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)