### PR TITLE
feat(inventory): print asset_tag text under QR on the physical rivet tag (op-55y)

### DIFF
--- a/backend/inventory/services/asset_tag_service.py
+++ b/backend/inventory/services/asset_tag_service.py
@@ -1,9 +1,11 @@
 """Asset tag rendering service.
 
 Generates physical asset tag images (PNG) suitable for being riveted onto
-hardware. Each tag holds a QR code that links to the public scan page.
-Layout reserves clear zones around the rivet hole locations so the QR
-doesn't sit under the holes.
+hardware. Each tag holds a QR code that links to the public scan page, with
+the human-readable asset tag string (e.g. ``DMS-YYANNNSS``) printed directly
+beneath the QR so a tag is identifiable by eye without scanning. Layout
+reserves clear zones around the rivet hole locations so nothing sits under
+the holes.
 """
 
 from __future__ import annotations
@@ -11,7 +13,7 @@ from __future__ import annotations
 from io import BytesIO
 
 import qrcode
-from PIL import Image
+from PIL import Image, ImageDraw, ImageFont
 
 SCAN_URL_TEMPLATE = "https://dms.openmakersuite.net/scan/asset/{asset_id}"
 
@@ -24,6 +26,23 @@ RIVET_OFFSET = 0.25
 RIVET_RADIUS = 0.15
 
 DEFAULT_DPI = 1440
+
+# Fraction of the tag height reserved for the printed asset-tag text band that
+# sits beneath the QR. The asset tag is a single fixed-width line (DMS-YYANNNSS,
+# ~12 chars), so a modest band keeps the QR large while staying readable.
+TEXT_BAND_FRACTION = 0.13
+
+# Gap between the QR and the text band, as a fraction of tag height.
+TEXT_GAP_FRACTION = 0.025
+
+# TrueType fonts tried, in order, for the printed tag text. This mirrors the
+# sans style of the Brother PDF label (Helvetica); DejaVu Sans is the closest
+# font shipped on the print/CI hosts (same path used by the ESC-P renderer).
+# Falls back to PIL's built-in bitmap font if none of these can be loaded.
+_FONT_CANDIDATES = (
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+)
 
 
 class InvalidTagSizeError(ValueError):
@@ -46,16 +65,13 @@ def _build_qr_image(url: str, target_px: int) -> Image.Image:
     return img.resize((target_px, target_px), Image.Resampling.NEAREST)
 
 
-def render_asset_tag(asset, size: str = "standard", dpi: int = DEFAULT_DPI) -> bytes:
-    """Render an asset tag PNG and return the raw bytes.
+def _compute_layout(size: str, dpi: int) -> dict:
+    """Compute the pixel geometry of a tag: safe rect, QR box, and text box.
 
-    Args:
-        asset: Asset instance (must expose ``id`` UUID).
-        size: One of the keys in :data:`SIZES`.
-        dpi: Output resolution. Defaults to 1440 DPI.
-
-    Returns:
-        PNG-encoded bytes of the rendered tag.
+    Geometry depends only on ``size`` and ``dpi`` (not on the asset), so the
+    QR box and text box are deterministic and can be introspected by callers
+    and tests. The QR is horizontally centered in the safe rect with the text
+    band directly beneath it; the whole block is centered vertically.
     """
     if size not in SIZES:
         raise InvalidTagSizeError(f"Unknown asset tag size '{size}'. Valid sizes: {sorted(SIZES)}")
@@ -64,10 +80,8 @@ def render_asset_tag(asset, size: str = "standard", dpi: int = DEFAULT_DPI) -> b
     width_px = int(round(spec["width"] * dpi))
     height_px = int(round(spec["height"] * dpi))
 
-    img = Image.new("RGB", (width_px, height_px), "white")
-
     # Safe drawing rectangle: keep design clear of the rivet exclusion circles
-    # by inseting the full vertical band on each short edge.
+    # by insetting the full vertical band on each short edge.
     safe_left = int(round((RIVET_OFFSET + RIVET_RADIUS) * dpi))
     safe_right = width_px - safe_left
     safe_top = 0
@@ -75,17 +89,116 @@ def render_asset_tag(asset, size: str = "standard", dpi: int = DEFAULT_DPI) -> b
     safe_width = safe_right - safe_left
     safe_height = safe_bottom - safe_top
 
-    # QR fills the safe rect: largest square that fits within both dimensions,
-    # minus a small inner padding so the code doesn't kiss the rivet zones.
+    # Small inner padding so content doesn't kiss the rivet zones / edges.
     inner_padding = int(round(0.025 * dpi))
-    qr_size_px = max(64, min(safe_width, safe_height) - 2 * inner_padding)
+    gap = int(round(TEXT_GAP_FRACTION * spec["height"] * dpi))
+    text_band = int(round(TEXT_BAND_FRACTION * spec["height"] * dpi))
 
+    # QR is the largest square fitting the safe width and the height left over
+    # after reserving the text band + gap. On the standard tag this is still
+    # width-limited (QR unchanged); on the taller/large tag the QR shrinks
+    # slightly to make room for the text while staying well within scan range.
+    avail_height = safe_height - 2 * inner_padding - gap - text_band
+    qr_size = max(64, min(safe_width - 2 * inner_padding, avail_height))
+
+    # Center the QR + gap + text block vertically within the safe rect.
+    content_height = qr_size + gap + text_band
+    content_top = safe_top + max(inner_padding, (safe_height - content_height) // 2)
+
+    qr_x = safe_left + (safe_width - qr_size) // 2
+    qr_y = content_top
+
+    text_left = safe_left + inner_padding
+    text_right = safe_right - inner_padding
+    text_top = qr_y + qr_size + gap
+    text_bottom = text_top + text_band
+
+    return {
+        "width_px": width_px,
+        "height_px": height_px,
+        "safe": (safe_left, safe_top, safe_right, safe_bottom),
+        "qr": (qr_x, qr_y, qr_x + qr_size, qr_y + qr_size),
+        "qr_size": qr_size,
+        "text": (text_left, text_top, text_right, text_bottom),
+    }
+
+
+def _load_font(size_px: int) -> ImageFont.ImageFont:
+    """Load the tag text font at ``size_px``, falling back to the default."""
+    size_px = max(1, int(size_px))
+    for path in _FONT_CANDIDATES:
+        try:
+            return ImageFont.truetype(path, size_px)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def _fit_font(draw: ImageDraw.ImageDraw, text: str, max_width: int, max_height: int):
+    """Return the largest available font whose rendered ``text`` fits the box.
+
+    Starts at a font size equal to the band height (bounding the height) and
+    scales down proportionally if the text is wider than ``max_width``.
+    """
+    size_px = max(1, int(max_height))
+    font = _load_font(size_px)
+    left, _, right, _ = draw.textbbox((0, 0), text, font=font)
+    text_width = right - left
+    if text_width > max_width and text_width > 0:
+        size_px = max(1, int(size_px * max_width / text_width))
+        font = _load_font(size_px)
+    return font
+
+
+def _draw_tag_text(img: Image.Image, text: str, box: tuple[int, int, int, int]) -> None:
+    """Draw ``text`` centered within ``box`` (left, top, right, bottom)."""
+    left, top, right, bottom = box
+    max_width = right - left
+    max_height = bottom - top
+    if max_width <= 0 or max_height <= 0:
+        return
+
+    draw = ImageDraw.Draw(img)
+    font = _fit_font(draw, text, max_width, max_height)
+
+    # Center on the ink bounding box so bearings/descenders don't skew it.
+    ink_left, ink_top, ink_right, ink_bottom = draw.textbbox((0, 0), text, font=font)
+    text_width = ink_right - ink_left
+    text_height = ink_bottom - ink_top
+    cx = (left + right) // 2
+    cy = (top + bottom) // 2
+    draw_x = cx - text_width // 2 - ink_left
+    draw_y = cy - text_height // 2 - ink_top
+    draw.text((draw_x, draw_y), text, fill="black", font=font)
+
+
+def render_asset_tag(asset, size: str = "standard", dpi: int = DEFAULT_DPI) -> bytes:
+    """Render an asset tag PNG and return the raw bytes.
+
+    The tag holds a QR code (encoding the asset ``id`` scan URL) with the
+    human-readable ``asset_tag`` string printed directly beneath it. Assets
+    without an ``asset_tag`` render the QR only.
+
+    Args:
+        asset: Asset instance (must expose ``id`` UUID; may expose ``asset_tag``).
+        size: One of the keys in :data:`SIZES`.
+        dpi: Output resolution. Defaults to 1440 DPI.
+
+    Returns:
+        PNG-encoded bytes of the rendered tag.
+    """
+    layout = _compute_layout(size, dpi)
+
+    img = Image.new("RGB", (layout["width_px"], layout["height_px"]), "white")
+
+    qr_left, qr_top, _, _ = layout["qr"]
     qr_url = get_scan_url(asset)
-    qr_img = _build_qr_image(qr_url, qr_size_px)
+    qr_img = _build_qr_image(qr_url, layout["qr_size"])
+    img.paste(qr_img, (qr_left, qr_top))
 
-    qr_x = safe_left + (safe_width - qr_size_px) // 2
-    qr_y = safe_top + (safe_height - qr_size_px) // 2
-    img.paste(qr_img, (qr_x, qr_y))
+    tag_text = (getattr(asset, "asset_tag", "") or "").strip()
+    if tag_text:
+        _draw_tag_text(img, tag_text, layout["text"])
 
     buffer = BytesIO()
     # Pillow records DPI in metadata so downstream printers honor it.
@@ -111,14 +224,17 @@ def get_rivet_centers_px(size: str, dpi: int = DEFAULT_DPI) -> list[tuple[int, i
 
 def get_safe_rect_px(size: str, dpi: int = DEFAULT_DPI) -> tuple[int, int, int, int]:
     """Return the (left, top, right, bottom) pixel bounds of the safe drawing rect."""
-    if size not in SIZES:
-        raise InvalidTagSizeError(f"Unknown asset tag size '{size}'. Valid sizes: {sorted(SIZES)}")
-    spec = SIZES[size]
-    width_px = int(round(spec["width"] * dpi))
-    height_px = int(round(spec["height"] * dpi))
-    safe_left = int(round((RIVET_OFFSET + RIVET_RADIUS) * dpi))
-    safe_right = width_px - safe_left
-    return (safe_left, 0, safe_right, height_px)
+    return _compute_layout(size, dpi)["safe"]
+
+
+def get_qr_box_px(size: str, dpi: int = DEFAULT_DPI) -> tuple[int, int, int, int]:
+    """Return the (left, top, right, bottom) pixel box the QR is pasted into."""
+    return _compute_layout(size, dpi)["qr"]
+
+
+def get_text_box_px(size: str, dpi: int = DEFAULT_DPI) -> tuple[int, int, int, int]:
+    """Return the (left, top, right, bottom) pixel box the asset-tag text fills."""
+    return _compute_layout(size, dpi)["text"]
 
 
 __all__ = [
@@ -132,4 +248,6 @@ __all__ = [
     "get_scan_url",
     "get_rivet_centers_px",
     "get_safe_rect_px",
+    "get_qr_box_px",
+    "get_text_box_px",
 ]

--- a/backend/inventory/tests/test_asset_tag.py
+++ b/backend/inventory/tests/test_asset_tag.py
@@ -14,8 +14,10 @@ from inventory.services.asset_tag_service import (
     SCAN_URL_TEMPLATE,
     SIZES,
     InvalidTagSizeError,
+    get_qr_box_px,
     get_rivet_centers_px,
     get_safe_rect_px,
+    get_text_box_px,
     render_asset_tag,
 )
 from inventory.tests.factories import AssetFactory
@@ -93,52 +95,79 @@ class TestRenderAssetTag:
                         f"in rivet exclusion zone, got {px}"
                     )
 
-    def test_no_text_in_tag(self):
-        # The only non-white content on the tag should be the QR code itself —
-        # the call-to-action text was removed because it's unreadable at print
-        # size. Verify by checking that the bounding box of non-white pixels is
-        # square-ish (matches a QR) rather than a wide rectangle that would
-        # include text to the right of the code.
+    def test_asset_tag_text_printed_below_qr(self):
+        # The human-readable asset tag string is printed as text directly
+        # beneath the QR so a tag is identifiable by eye without scanning.
+        # Verify there is ink inside the reserved text band and that the band
+        # sits strictly below the QR (no overlap).
         asset = AssetFactory()
-        png = render_asset_tag(asset, size="standard", dpi=1440)
-        img = _open_png(png).convert("RGB")
-        white = Image.new("RGB", img.size, "white")
-        bbox = ImageChops.difference(img, white).getbbox()
-        assert bbox is not None, "tag rendered as fully blank"
-        bbox_w = bbox[2] - bbox[0]
-        bbox_h = bbox[3] - bbox[1]
-        # QR is square; allow a 5% tolerance.
-        assert abs(bbox_w - bbox_h) <= max(bbox_w, bbox_h) * 0.05, (
-            f"non-white region is not square (w={bbox_w}, h={bbox_h}); "
-            "indicates extra text rendering alongside QR"
-        )
-
-    def test_qr_code_takes_full_safe_rect(self):
-        # QR should fill the safe rect (the area between rivet exclusion zones).
-        # The limiting dimension is the safe-rect width on the standard tag.
-        asset = AssetFactory()
+        assert asset.asset_tag  # factory always assigns one
         png = render_asset_tag(asset, size="standard", dpi=1440)
         img = _open_png(png).convert("RGB")
 
+        left, top, right, bottom = get_text_box_px("standard", dpi=1440)
+        text_region = img.crop((left, top, right, bottom))
+        white = Image.new("RGB", text_region.size, "white")
+        text_bbox = ImageChops.difference(text_region, white).getbbox()
+        assert text_bbox is not None, "no asset-tag text rendered below the QR"
+
+        qr_box = get_qr_box_px("standard", dpi=1440)
+        assert top >= qr_box[3], "text band overlaps the QR vertically"
+
+    def test_asset_tag_text_printed_on_large_size(self):
+        # The large tag shrinks the QR slightly to fit the same text band.
+        asset = AssetFactory()
+        png = render_asset_tag(asset, size="large", dpi=1440)
+        img = _open_png(png).convert("RGB")
+
+        left, top, right, bottom = get_text_box_px("large", dpi=1440)
+        text_region = img.crop((left, top, right, bottom))
+        white = Image.new("RGB", text_region.size, "white")
+        assert (
+            ImageChops.difference(text_region, white).getbbox() is not None
+        ), "no asset-tag text rendered on the large tag"
+
+    def test_asset_without_tag_renders_qr_only(self):
+        # An asset with a blank tag renders the QR and no text (blank band),
+        # and must not raise.
+        asset = AssetFactory.build(asset_tag="")
+        png = render_asset_tag(asset, size="standard", dpi=1440)
+        img = _open_png(png).convert("RGB")
+
+        left, top, right, bottom = get_text_box_px("standard", dpi=1440)
+        text_region = img.crop((left, top, right, bottom))
+        white = Image.new("RGB", text_region.size, "white")
+        assert (
+            ImageChops.difference(text_region, white).getbbox() is None
+        ), "text band should be blank when the asset has no tag"
+
+    def test_qr_code_fills_its_box_within_safe_rect(self):
+        # The QR should fill its allotted box (dark modules reach ~85% of the
+        # box after the QR's own quiet zone), and that box must sit inside the
+        # safe rect (the area between the rivet exclusion zones). Measuring the
+        # QR box directly keeps this robust to the text printed beneath it.
+        asset = AssetFactory()
+        png = render_asset_tag(asset, size="standard", dpi=1440)
+        img = _open_png(png).convert("RGB")
+
+        qr_left, qr_top, qr_right, qr_bottom = get_qr_box_px("standard", dpi=1440)
         safe_left, safe_top, safe_right, safe_bottom = get_safe_rect_px("standard", dpi=1440)
-        safe_w = safe_right - safe_left
-        safe_h = safe_bottom - safe_top
-        limiting_dim = min(safe_w, safe_h)
+        assert safe_left <= qr_left and qr_right <= safe_right
+        assert safe_top <= qr_top and qr_bottom <= safe_bottom
 
-        white = Image.new("RGB", img.size, "white")
-        bbox = ImageChops.difference(img, white).getbbox()
+        qr_region = img.crop((qr_left, qr_top, qr_right, qr_bottom))
+        white = Image.new("RGB", qr_region.size, "white")
+        bbox = ImageChops.difference(qr_region, white).getbbox()
         assert bbox is not None
         bbox_w = bbox[2] - bbox[0]
         bbox_h = bbox[3] - bbox[1]
-        # QR fills the safe rect minus a small inner padding and minus the QR's
-        # own quiet zone — so the dark content reaches ~85% of the limiting
-        # safe-rect dimension.
+        qr_dim = qr_right - qr_left
         assert (
-            bbox_w >= limiting_dim * 0.85
-        ), f"QR width {bbox_w}px does not fill safe rect (limiting dim {limiting_dim}px)"
+            bbox_w >= qr_dim * 0.85
+        ), f"QR width {bbox_w}px does not fill its box (dim {qr_dim}px)"
         assert (
-            bbox_h >= limiting_dim * 0.85
-        ), f"QR height {bbox_h}px does not fill safe rect (limiting dim {limiting_dim}px)"
+            bbox_h >= qr_dim * 0.85
+        ), f"QR height {bbox_h}px does not fill its box (dim {qr_dim}px)"
 
     def test_render_executes_without_error_at_default_dpi(self):
         asset = AssetFactory()


### PR DESCRIPTION
## What
Prints the human-readable `asset_tag` (`DMS-YYANNNSS`) as a centered line **under the QR on the physical rivet tag** (`render_asset_tag` / `GET /assets/{id}/tag/`), which was QR-only. Completes the asset-ID feature — now **both** the Brother PDF label and the rivet tag carry the DMS tag.

- QR shrinks slightly on the large size to fit the text; standard QR unchanged.
- QR payload **unchanged** (still the `asset.id` scan URL).
- Added `get_qr_box_px`/`get_text_box_px` helpers; replaced the obsolete no-text test with text-present tests (standard / large / tagless).

## Verification
pytest `test_asset_tag.py` 17 passed + `test_asset_tag_id.py` 38 passed; rendered sample standard+large PNGs (QR + readable text confirmed); black/isort/flake8 clean. OMS CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)