### PR TITLE
test(frontend): adapt Select tests to Mantine 9.4 Combobox + bump @mantine to 9.4.1 (op-vxa)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,13 +10,13 @@
       "hasInstallScript": true,
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
-        "@mantine/core": "^9.0.0",
-        "@mantine/dates": "^9.0.0",
-        "@mantine/dropzone": "^9.0.0",
-        "@mantine/form": "^9.0.0",
-        "@mantine/hooks": "^9.0.0",
-        "@mantine/modals": "^9.0.0",
-        "@mantine/notifications": "^9.0.0",
+        "@mantine/core": "^9.4.1",
+        "@mantine/dates": "^9.4.1",
+        "@mantine/dropzone": "^9.4.1",
+        "@mantine/form": "^9.4.1",
+        "@mantine/hooks": "^9.4.1",
+        "@mantine/modals": "^9.4.1",
+        "@mantine/notifications": "^9.4.1",
         "@sentry/react": "^10.0.0",
         "@tabler/icons-react": "^3.35.0",
         "axios": "^1.16.0",
@@ -2343,58 +2343,58 @@
       }
     },
     "node_modules/@mantine/core": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-9.3.1.tgz",
-      "integrity": "sha512-4rBoHpggSohayE+Os7lKdbsHTw7m/uZRKYjk9DN6cKBhQIjdiULdcG+b4b5CMVZSqZDHPgT70uWGI7yqkn8Ufw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-9.4.1.tgz",
+      "integrity": "sha512-lZWEICrum4+vwKxzh/mk4RB1N6BqZ0Cshdl6lhm7OYLiQzmOaxKtOgyaWz+vr65G8mqTXjalZalB+wmMVBYK2Q==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
         "clsx": "^2.1.1",
         "react-number-format": "^5.4.5",
         "react-remove-scroll": "^2.7.2",
-        "type-fest": "^5.6.0"
+        "type-fest": "^5.7.0"
       },
       "peerDependencies": {
-        "@mantine/hooks": "9.3.1",
+        "@mantine/hooks": "9.4.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/dates": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-9.3.1.tgz",
-      "integrity": "sha512-Nh4XQyyV1AM0XRnUJugb1kNfCm++nkticsO8aroKmFPZ7cpGV7cjdL+4MJNPu1atS1EUePXl2VLLpKnrclpqOQ==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-9.4.1.tgz",
+      "integrity": "sha512-DoQDvQMAlIw6ohwhUwYuTYQevG9y5AQmYWkhOHUuavABFEZmtBglkwziBoATvxT09I/6I56UMPhproXcS6XUfg==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1"
       },
       "peerDependencies": {
-        "@mantine/core": "9.3.1",
-        "@mantine/hooks": "9.3.1",
+        "@mantine/core": "9.4.1",
+        "@mantine/hooks": "9.4.1",
         "dayjs": ">=1.0.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/dropzone": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@mantine/dropzone/-/dropzone-9.3.1.tgz",
-      "integrity": "sha512-WsjsMH9NUz5y9XAR/vOUbyb+y0X0Kud6KV1K/xURwrbxena2b1tl+WvjPO/6vRiJeTpFlMuoWF/8nwqnxoGUeg==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/dropzone/-/dropzone-9.4.1.tgz",
+      "integrity": "sha512-QmtwDsViRmIdiwpc3d1loV3ryb8L6O4y3aiuMnAcLxL31a9hUPlHUZAs6KSuA+XbziZDG4BjxRVYjB70PxwORg==",
       "license": "MIT",
       "dependencies": {
         "react-dropzone": "15.0.0"
       },
       "peerDependencies": {
-        "@mantine/core": "9.3.1",
-        "@mantine/hooks": "9.3.1",
+        "@mantine/core": "9.4.1",
+        "@mantine/hooks": "9.4.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/form": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-9.3.1.tgz",
-      "integrity": "sha512-dGJPcYGkfDnAPKHcnzgf2mSlnjwymaOyROiTEJNbbjE3OVoWbPaw8HwEKav1wATdxNYR9Bw1GHtbfbGTsm1Jww==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/form/-/form-9.4.1.tgz",
+      "integrity": "sha512-e4tqC/D8ii7maPySWIWY306MNljPRprHPhu0/jaZrX7sRyJy+C8V9aU+ZFKYliM1CeiH1UX88+q4hWFUWVEdQw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -2406,46 +2406,46 @@
       }
     },
     "node_modules/@mantine/hooks": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-9.3.1.tgz",
-      "integrity": "sha512-zAOlxV59j5CDgAnExN+ypaR6dVW1vwMKDvKUxIlUVd/e52qxYnPyYRD+shJmyOLaZRuQmVF0R/7mJAjt2jw9cA==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-9.4.1.tgz",
+      "integrity": "sha512-eTI8wmzPx3r98zgKIEuvukmoGTHBhmtI6+9E6o2DbTmEU2eM1bCdjE2vFdf0op2AlRO0KEYEcZhNQi4T/SJk0A==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.0"
       }
     },
     "node_modules/@mantine/modals": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@mantine/modals/-/modals-9.3.1.tgz",
-      "integrity": "sha512-JqP1o6hrfQJ5UCq97HJsI7uIPDy+WwvWwkkfctWqcYkFJA2DU8dVoPqvEhnhDQUIXNci3sx6XDoQZAq1Qg57mw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/modals/-/modals-9.4.1.tgz",
+      "integrity": "sha512-z5G3Biz7/5Ybz5Z8u5Xyvo9UBmFhAX/YXMf6U96ejvtAB11xVnCo8m37R5DJyzeFEqB4D1tvUgWiVVPBb+yadw==",
       "license": "MIT",
       "peerDependencies": {
-        "@mantine/core": "9.3.1",
-        "@mantine/hooks": "9.3.1",
+        "@mantine/core": "9.4.1",
+        "@mantine/hooks": "9.4.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/notifications": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-9.3.1.tgz",
-      "integrity": "sha512-irkD9uszgVftthbCLd+4lS7M1jkhL4sVrZASv8+43aIkncW+oQkCFpBuaOAf6uRcMjmQ7XnKs2O8bXYzl/DqgQ==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-9.4.1.tgz",
+      "integrity": "sha512-Sm1g8E8RkFmesxpNz9zFvOjkTVxOa7dJJjMGoHNIXH+9/wO0s9kInny4mVnxTbLJJsD6nTqIQlk1v8tq2C4Ftw==",
       "license": "MIT",
       "dependencies": {
-        "@mantine/store": "9.3.1",
+        "@mantine/store": "9.4.1",
         "react-transition-group": "4.4.5"
       },
       "peerDependencies": {
-        "@mantine/core": "9.3.1",
-        "@mantine/hooks": "9.3.1",
+        "@mantine/core": "9.4.1",
+        "@mantine/hooks": "9.4.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       }
     },
     "node_modules/@mantine/store": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-9.3.1.tgz",
-      "integrity": "sha512-UZ8wGKfF/NFMHCDl1Rd0M8XtHdt4W1w3V4ohNpFSaP3nSjJ+Cu1FT+iIWtXwC0Ogha8XnuVQ7vm/dw2BUfpw+g==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-9.4.1.tgz",
+      "integrity": "sha512-/DCZq0aqqIdm03J0RJ7pbzoau2cwY8ndSOjskHOKHhTeWMnOBdCKXA3oMO5aIDldDqJ9T7Io4Boh4Pt461zNQw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.0"

--- a/frontend/src/__tests__/components/AssetForgeKeyAccessCard.test.tsx
+++ b/frontend/src/__tests__/components/AssetForgeKeyAccessCard.test.tsx
@@ -85,7 +85,7 @@ const buildLockout = (overrides: Partial<any> = {}) => ({
 
 const renderCard = (assetId = 'a1') =>
   render(
-    <MantineProvider>
+    <MantineProvider env="test">
       <AssetForgeKeyAccessCard assetId={assetId} />
     </MantineProvider>,
   );

--- a/frontend/src/__tests__/components/IndicatorManagementCard.test.tsx
+++ b/frontend/src/__tests__/components/IndicatorManagementCard.test.tsx
@@ -88,7 +88,7 @@ const buildBinding = (overrides: Partial<any> = {}) => ({
 
 const renderCard = (device = buildDevice()) =>
   render(
-    <MantineProvider>
+    <MantineProvider env="test">
       <IndicatorManagementCard device={device as any} />
     </MantineProvider>,
   );

--- a/frontend/src/__tests__/components/RoomOperationalModeControl.test.tsx
+++ b/frontend/src/__tests__/components/RoomOperationalModeControl.test.tsx
@@ -41,13 +41,16 @@ const buildMode = (overrides: Partial<any> = {}) => ({
 
 const renderControl = () =>
   render(
-    <MantineProvider>
+    <MantineProvider env="test">
       <RoomOperationalModeControl locationId={5} locationName="Wood Shop" />
     </MantineProvider>,
   );
 
 const pickMode = async (label: string) => {
-  fireEvent.click(screen.getByLabelText('Set mode'));
+  // Mantine 9.4 gives the eagerly-rendered listbox an accessible name via
+  // aria-labelledby, so 'Set mode' now matches both the input and the listbox.
+  // Scope to the input element to keep targeting the Select control.
+  fireEvent.click(screen.getByLabelText('Set mode', { selector: 'input' }));
   fireEvent.click(await screen.findByRole('option', { name: label }));
 };
 

--- a/frontend/src/__tests__/pages/AssetFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/AssetFormPage.test.tsx
@@ -23,7 +23,7 @@ vi.mock('react-router-dom', async () => ({
 
 const renderWithMantine = (component: React.ReactElement) => {
   return render(
-    <MantineProvider>
+    <MantineProvider env="test">
       {component}
     </MantineProvider>
   );

--- a/frontend/src/__tests__/pages/ForgeKeyAccessLogPage.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyAccessLogPage.test.tsx
@@ -53,7 +53,7 @@ const deniedEvent = {
 
 const renderPage = (initialEntry = '/facilities/forgekey-access-log') =>
   render(
-    <MantineProvider>
+    <MantineProvider env="test">
       <MemoryRouter initialEntries={[initialEntry]}>
         <Routes>
           <Route path="/facilities/forgekey-access-log" element={<ForgeKeyAccessLogPage />} />

--- a/frontend/src/__tests__/pages/InventoryItemFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemFormPage.test.tsx
@@ -133,7 +133,7 @@ describe('InventoryItemFormPage', () => {
 
   const renderCreatePage = () => {
     return render(
-      <MantineProvider>
+      <MantineProvider env="test">
         <MemoryRouter initialEntries={['/inventory/items/new']}>
           <Routes>
             <Route path="/inventory/items/new" element={<InventoryItemFormPage />} />
@@ -149,7 +149,7 @@ describe('InventoryItemFormPage', () => {
     });
 
     return render(
-      <MantineProvider>
+      <MantineProvider env="test">
         <MemoryRouter initialEntries={[`/inventory/items/${itemId}/edit`]}>
           <Routes>
             <Route path="/inventory/items/:id/edit" element={<InventoryItemFormPage />} />
@@ -401,7 +401,7 @@ describe('InventoryItemFormPage', () => {
     });
 
     render(
-      <MantineProvider>
+      <MantineProvider env="test">
         <MemoryRouter initialEntries={['/inventory/items/test-id/edit']}>
           <Routes>
             <Route
@@ -469,7 +469,7 @@ describe('InventoryItemFormPage', () => {
     (api.inventoryAPI.getItem as jest.Mock).mockResolvedValue({ data: mockItem });
 
     render(
-      <MantineProvider>
+      <MantineProvider env="test">
         <MemoryRouter initialEntries={['/inventory/items/test-id/edit']}>
           <SessionExpiredBanner />
           <Routes>
@@ -591,7 +591,7 @@ describe('InventoryItemFormPage', () => {
     (api.inventoryAPI.updateItem as jest.Mock).mockResolvedValue({ data: mockItem });
 
     render(
-      <MantineProvider>
+      <MantineProvider env="test">
         <MemoryRouter initialEntries={['/inventory/items/test-id/edit']}>
           <Routes>
             <Route path="/inventory/items/:id/edit" element={<InventoryItemFormPage />} />

--- a/frontend/src/__tests__/pages/InventoryListPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryListPage.test.tsx
@@ -170,7 +170,7 @@ describe('InventoryListPage', () => {
 
   const renderPage = () => {
     return render(
-      <MantineProvider>
+      <MantineProvider env="test">
         <MemoryRouter>
           <InventoryListPage />
         </MemoryRouter>
@@ -493,7 +493,7 @@ describe('InventoryListPage', () => {
   it('shows the re-login banner with a return path on session expiry, keeping the list', async () => {
     sessionStorage.clear();
     render(
-      <MantineProvider>
+      <MantineProvider env="test">
         <MemoryRouter>
           <SessionExpiredBanner />
           <InventoryListPage />


### PR DESCRIPTION
## What
Unblocks the `@mantine` 9.4.1 bump held back in #834. Mantine 9.4's Combobox no longer opens the dropdown on `fireEvent.click`, which broke Select-based tests across the app. Adapts those tests and bumps `@mantine/*` to 9.4.1.
- Test files adapted: InventoryListPage, InventoryItemFormPage, AssetFormPage, ForgeKeyAccessLogPage, AssetForgeKeyAccessCard, IndicatorManagementCard, RoomOperationalModeControl.

## Verification
OMS CI is the gate — lint + `test:fast` + the full suite validate the Mantine bump end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)