### PR TITLE
chore(deps): @hookform/resolvers 3.3.4 → 5.4.0 (zod 4 alignment) (op-vxr)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@hookform/resolvers": "^3.3.4",
+        "@hookform/resolvers": "^5.4.0",
         "@mantine/core": "^9.0.0",
         "@mantine/dates": "^9.0.0",
         "@mantine/dropzone": "^9.0.0",
@@ -2218,10 +2218,15 @@
       "license": "MIT"
     },
     "node_modules/@hookform/resolvers": {
-      "version": "3.10.0",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
       "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
       "peerDependencies": {
-        "react-hook-form": "^7.0.0"
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "node": ">=24.0.0"
   },
   "dependencies": {
-    "@hookform/resolvers": "^3.3.4",
+    "@hookform/resolvers": "^5.4.0",
     "@mantine/core": "^9.0.0",
     "@mantine/dates": "^9.0.0",
     "@mantine/dropzone": "^9.0.0",

--- a/frontend/src/hooks/useFormValidation.ts
+++ b/frontend/src/hooks/useFormValidation.ts
@@ -2,22 +2,27 @@
  * Custom hook for form validation setup with react-hook-form and Zod
  */
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm, UseFormReturn } from 'react-hook-form';
+import { FieldValues, Resolver, useForm, UseFormReturn } from 'react-hook-form';
 import { z } from 'zod';
 
-export interface UseFormValidationOptions<T extends z.ZodTypeAny> {
+// Constrain to schemas whose Zod input *and* output are objects: react-hook-form
+// requires `FieldValues` for its generic, and @hookform/resolvers v5 requires the
+// schema's input type to extend `FieldValues` to select its resolver overload.
+export interface UseFormValidationOptions<T extends z.ZodType<FieldValues, FieldValues>> {
   schema: T;
   defaultValues?: Partial<z.infer<T>>;
   mode?: 'onBlur' | 'onChange' | 'onSubmit' | 'onTouched' | 'all';
 }
 
-export function useFormValidation<T extends z.ZodTypeAny>({
+export function useFormValidation<T extends z.ZodType<FieldValues, FieldValues>>({
   schema,
   defaultValues,
   mode = 'onBlur',
 }: UseFormValidationOptions<T>): UseFormReturn<z.infer<T>> {
   return useForm<z.infer<T>>({
-    resolver: zodResolver(schema),
+    // v5 resolvers type field-values on the schema's Zod *input* (defaulted fields
+    // are optional pre-parse); callers seed defaults, so assert the *output* type.
+    resolver: zodResolver(schema) as Resolver<z.infer<T>>,
     defaultValues: defaultValues as any,
     mode,
   });

--- a/frontend/src/pages/AssetFormPage.tsx
+++ b/frontend/src/pages/AssetFormPage.tsx
@@ -45,7 +45,7 @@ import {
   IconChevronUp,
 } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, Resolver, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import AssetMaintenanceSection from '../components/assets/AssetMaintenanceSection';
@@ -130,7 +130,13 @@ const AssetFormPage: React.FC = () => {
     setValue,
     reset,
   } = useForm<AssetFormData>({
-    resolver: zodResolver(assetFormSchema),
+    // @hookform/resolvers v5 infers a schema's Zod *input* type (fields with
+    // `.default()` are optional pre-parse) as the resolver's field-value type,
+    // which diverges from AssetFormData (the *output* type, defaults applied).
+    // This form seeds every field via `defaultValues`, so its field values are
+    // the output shape — assert the resolver against it to keep the form typed
+    // on AssetFormData without threading z.input/z.output through the tree.
+    resolver: zodResolver(assetFormSchema) as Resolver<AssetFormData>,
     defaultValues: {
       name: '',
       description: '',

--- a/frontend/src/pages/InventoryItemFormPage.tsx
+++ b/frontend/src/pages/InventoryItemFormPage.tsx
@@ -6,7 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Alert, Button, Group, Modal, Paper, Stack, Switch, Text, TextInput, Title } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, Resolver, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import NFPADiamond from '../components/NFPADiamond';
 import SupplierRelationshipForm, { SupplierRelationship } from '../components/SupplierRelationshipForm';
@@ -48,7 +48,10 @@ const InventoryItemFormPage: React.FC = () => {
     setValue,
     reset,
   } = useForm<InventoryItemFormData>({
-    resolver: zodResolver(inventoryItemSchema),
+    // v5 resolvers infer the schema's Zod *input* type (fields with `.default()`
+    // are optional pre-parse); this form seeds all fields via defaultValues, so
+    // its field values are the *output* shape — assert against InventoryItemFormData.
+    resolver: zodResolver(inventoryItemSchema) as Resolver<InventoryItemFormData>,
     defaultValues: {
       name: '',
       description: '',

--- a/frontend/src/pages/MaintenanceItemFormPage.tsx
+++ b/frontend/src/pages/MaintenanceItemFormPage.tsx
@@ -16,7 +16,7 @@ import {
 } from '@mantine/core';
 import { IconAlertCircle, IconPlus, IconTrash } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
-import { useForm, useWatch } from 'react-hook-form';
+import { Resolver, useForm, useWatch } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import { FormInput } from '../components/forms/FormInput';
 import { FormLayout } from '../components/forms/FormLayout';
@@ -58,7 +58,10 @@ const MaintenanceItemFormPage: React.FC = () => {
   });
 
   const { control, handleSubmit, reset, setValue } = useForm<MaintenanceItemFormData>({
-    resolver: zodResolver(maintenanceItemFormSchema),
+    // v5 resolvers infer the schema's Zod *input* type (fields with `.default()`
+    // are optional pre-parse); this form seeds all fields via defaultValues, so
+    // its field values are the *output* shape — assert against MaintenanceItemFormData.
+    resolver: zodResolver(maintenanceItemFormSchema) as Resolver<MaintenanceItemFormData>,
     defaultValues: {
       title: '',
       description: '',

--- a/frontend/src/pages/SupplierFormPage.tsx
+++ b/frontend/src/pages/SupplierFormPage.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, Resolver, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import { FormInput } from '../components/forms/FormInput';
 import { FormLayout } from '../components/forms/FormLayout';
@@ -39,7 +39,10 @@ const SupplierFormPage: React.FC = () => {
     formState: { errors },
     reset,
   } = useForm<SupplierFormData>({
-    resolver: zodResolver(supplierSchema),
+    // v5 resolvers infer the schema's Zod *input* type (fields with `.default()`
+    // are optional pre-parse); this form seeds all fields via defaultValues, so
+    // its field values are the *output* shape — assert against SupplierFormData.
+    resolver: zodResolver(supplierSchema) as Resolver<SupplierFormData>,
     defaultValues: {
       name: '',
       supplier_type: 'local',

--- a/frontend/src/pages/WebhookFormPage.tsx
+++ b/frontend/src/pages/WebhookFormPage.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, Resolver, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import { FormInput } from '../components/forms/FormInput';
 import { FormLayout } from '../components/forms/FormLayout';
@@ -57,7 +57,10 @@ const WebhookFormPage: React.FC = () => {
     reset,
     watch,
   } = useForm<WebhookFormData>({
-    resolver: zodResolver(webhookSchema),
+    // v5 resolvers infer the schema's Zod *input* type (fields with `.default()`
+    // are optional pre-parse); this form seeds all fields via defaultValues, so
+    // its field values are the *output* shape — assert against WebhookFormData.
+    resolver: zodResolver(webhookSchema) as Resolver<WebhookFormData>,
     defaultValues: {
       name: '',
       description: '',


### PR DESCRIPTION
## What

Upgrade `@hookform/resolvers` `^3.3.4` → `^5.4.0`. Part of the op-vxr major-dep review (react-grid-layout 1→2 ships as a separate PR).

## Why

`@hookform/resolvers` 3.x is the zod-3-era resolver, but the repo runs `zod ^4` (4.4.3). v5's zod resolver auto-detects zod 3 vs 4 at runtime and maps zod-4 issues correctly. This closes the prior gap where a cross-field `.refine()` failure threw an unhandled `ZodError` (mismatched `instanceof` across zod copies) instead of rendering the field message.

## Breaking-change handling

v5 infers a schema's Zod **input** and **output** types separately. Forms whose schemas use `.default()` (Asset, Inventory, Webhook, Maintenance, Supplier) have an input type (defaulted fields optional pre-parse) that diverges from their `z.infer` **output** type, so `useForm<FormData>` no longer accepts `zodResolver(schema)` directly.

Each form already seeds **every** field via `defaultValues`, so at runtime its field values are the output shape. Fix: assert the resolver against `<Form>FormData` at the single point of divergence — no `z.input`/`z.output` threading through the component tree, no runtime change. The (currently unused) `useFormValidation` hook gets the same treatment, which additionally clears 3 pre-existing `tsc` errors.

- Requires `react-hook-form >= 7.55.0` — already on **7.80.0**. ✓
- `UserProfilePage` / `SiteSettingsPage` schemas have no `.default()` (input == output) and needed no change.

## Verification

- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run test:ci` — **1049/1049 pass** (139 files)
- `npm run build` — ok
- `tsc` — **zero net-new** type errors vs. baseline (baseline `tsc` is not clean and is not a CI gate); net −3

🤖 Generated with [Claude Code](https://claude.com/claude-code)