### PR TITLE
test(config): fix REACT_APP_SENTRY_DSN regression in deployment-validation test (unblocks Backend Tests)

### DIFF
--- a/backend/config/tests/test_deployment_validation.py
+++ b/backend/config/tests/test_deployment_validation.py
@@ -126,7 +126,7 @@ class TestProductionEnvValidatorAC23:
             ("LETSENCRYPT_EMAIL", "", "LETSENCRYPT_EMAIL"),
             ("FORGEKEY_FIRMWARE_SIGNING_KEY", "not-a-pem", "FORGEKEY_FIRMWARE_SIGNING_KEY"),
             ("SENTRY_DSN", "http://abc@o0.ingest.sentry.io/123", "SENTRY_DSN"),
-            ("REACT_APP_SENTRY_DSN", "http://abc@o0.ingest.sentry.io/123", "REACT_APP_SENTRY_DSN"),
+            ("VITE_SENTRY_DSN", "http://abc@o0.ingest.sentry.io/123", "VITE_SENTRY_DSN"),
         ],
     )
     def test_unsafe_value_rejected(self, tmp_path, key, value, fragment):
@@ -161,7 +161,7 @@ class TestProductionEnvValidatorAC23:
         "key",
         [
             "SENTRY_DSN",
-            "REACT_APP_SENTRY_DSN",
+            "VITE_SENTRY_DSN",
         ],
     )
     def test_sentry_https_value_allowed(self, tmp_path, key):
@@ -176,7 +176,7 @@ class TestProductionEnvValidatorAC23:
         "key",
         [
             "SENTRY_DSN",
-            "REACT_APP_SENTRY_DSN",
+            "VITE_SENTRY_DSN",
         ],
     )
     def test_empty_sentry_value_allowed(self, tmp_path, key):


### PR DESCRIPTION
## Problem
`test_deployment_validation.py::...test_unsafe_value_rejected[REACT_APP_SENTRY_DSN-...]` fails on `main` (**1 failed / 2967 passed**), blocking Backend Tests on every PR (e.g. #840, which doesn't touch this code).

## Cause — a regression from #836
#836 (op-j1f, dashboard/Sentry fix) intentionally changed `scripts/validate-prod-env.sh` from `REACT_APP_SENTRY_DSN` → `VITE_SENTRY_DSN` (REACT_APP is the legacy CRA name, now a no-op — the app is on Vite; `validate-prod-env.sh:258`). But it didn't update `test_deployment_validation.py`, which still parametrized `REACT_APP_SENTRY_DSN`. The validator no longer rejects an unsafe `REACT_APP_SENTRY_DSN`, so `test_unsafe_value_rejected` fails. (The two "allowed" params passed accidentally — "not checked" happens to match "allowed".)

## Fix
Align the 3 test parametrizations to `VITE_SENTRY_DSN` (the var the validator now checks). **No source change** — the script already rejects http:// / allows https:// / allows empty for `VITE_SENTRY_DSN` (`validate-prod-env.sh:268-271`).

## Verification
OMS CI (Backend Tests) is the gate — this test executes the actual shell validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)