### PR TITLE
fix(inventory): honor ?asset/?status/?part filters on asset-problems endpoint (op-gpde)

### DIFF
--- a/backend/inventory/tests/test_asset_problem_filter.py
+++ b/backend/inventory/tests/test_asset_problem_filter.py
@@ -1,0 +1,97 @@
+"""
+Tests for AssetProblemViewSet query-param filtering.
+
+Regression coverage for the bug where ``/api/inventory/asset-problems/``
+ignored the ``?asset=`` filter and returned every problem for every asset
+(so every asset's detail showed the same global problem list). The viewset
+now honors ``?asset=``, ``?status=``, and ``?part=`` in ``get_queryset``.
+"""
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from inventory.models import AssetProblem
+from inventory.tests.factories import (
+    AssetFactory,
+    AssetPartFactory,
+    AssetProblemFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+LIST_URL = "/api/inventory/asset-problems/"
+
+
+def _ids(response):
+    """Return the set of problem ids in a (paginated) list response."""
+    assert response.status_code == status.HTTP_200_OK, response.content
+    return {row["id"] for row in response.json()["results"]}
+
+
+@pytest.mark.integration
+class TestAssetProblemFiltering:
+    def test_filter_by_asset_returns_only_that_asset(self):
+        """``?asset={id}`` returns only that asset's problems, not every one."""
+        asset_a = AssetFactory()
+        asset_b = AssetFactory()
+        problem_a = AssetProblemFactory(asset=asset_a)
+        problem_b = AssetProblemFactory(asset=asset_b)
+
+        resp = APIClient().get(LIST_URL, {"asset": str(asset_a.id)})
+
+        ids = _ids(resp)
+        assert str(problem_a.id) in ids
+        assert str(problem_b.id) not in ids
+        assert resp.json()["count"] == 1
+
+    def test_filter_by_status(self):
+        """``?status=`` narrows to problems in that status."""
+        asset = AssetFactory()
+        reported = AssetProblemFactory(asset=asset, status=AssetProblem.REPORTED)
+        resolved = AssetProblemFactory(asset=asset, status=AssetProblem.RESOLVED)
+
+        resp = APIClient().get(LIST_URL, {"status": AssetProblem.RESOLVED})
+
+        ids = _ids(resp)
+        assert str(resolved.id) in ids
+        assert str(reported.id) not in ids
+
+    def test_filter_by_part(self):
+        """``?part={id}`` narrows to problems flagged against that part."""
+        asset = AssetFactory()
+        part = AssetPartFactory(asset=asset)
+        with_part = AssetProblemFactory(asset=asset, part=part)
+        without_part = AssetProblemFactory(asset=asset, part=None)
+
+        resp = APIClient().get(LIST_URL, {"part": str(part.id)})
+
+        ids = _ids(resp)
+        assert str(with_part.id) in ids
+        assert str(without_part.id) not in ids
+
+    def test_asset_and_status_combine(self):
+        """Filters combine: ``?asset=A&status=reported`` intersects both."""
+        asset_a = AssetFactory()
+        asset_b = AssetFactory()
+        target = AssetProblemFactory(asset=asset_a, status=AssetProblem.REPORTED)
+        AssetProblemFactory(asset=asset_a, status=AssetProblem.RESOLVED)
+        AssetProblemFactory(asset=asset_b, status=AssetProblem.REPORTED)
+
+        resp = APIClient().get(
+            LIST_URL, {"asset": str(asset_a.id), "status": AssetProblem.REPORTED}
+        )
+
+        ids = _ids(resp)
+        assert ids == {str(target.id)}
+
+    def test_no_filter_returns_all(self):
+        """No query params still returns every problem (dashboard/global use)."""
+        problem_a = AssetProblemFactory(asset=AssetFactory())
+        problem_b = AssetProblemFactory(asset=AssetFactory())
+
+        resp = APIClient().get(LIST_URL)
+
+        ids = _ids(resp)
+        assert {str(problem_a.id), str(problem_b.id)} <= ids
+        assert resp.json()["count"] == 2

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -2352,6 +2352,29 @@ class AssetProblemViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = AssetProblemSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
 
+    def get_queryset(self):
+        """Honor the ``?asset=``, ``?status=``, and ``?part=`` query filters.
+
+        Clients (ScanTTY asset detail) GET ``?asset={id}`` to see only that
+        asset's problems; without this override the list returns *every*
+        problem for every asset. Filtering is done here in ``get_queryset``
+        rather than via ``filterset_fields`` because django-filter is not a
+        dependency of this project — this mirrors the sibling
+        ``LocationProblemViewSet``. Unfiltered requests still return all
+        problems (dashboard use).
+        """
+        qs = super().get_queryset()
+        asset_id = self.request.query_params.get("asset")
+        if asset_id:
+            qs = qs.filter(asset_id=asset_id)
+        status_filter = self.request.query_params.get("status")
+        if status_filter:
+            qs = qs.filter(status=status_filter)
+        part_id = self.request.query_params.get("part")
+        if part_id:
+            qs = qs.filter(part_id=part_id)
+        return qs
+
     @action(
         detail=True,
         methods=["post"],


### PR DESCRIPTION
## Problem
Every asset's detail page in ScanTTY (and the web app) showed the **same set of problems** — because `AssetProblemViewSet` was a plain `ReadOnlyModelViewSet` with no filtering, so `GET /api/inventory/asset-problems/?asset={id}` ignored the query param and returned **every** problem for **every** asset.

Reported by Ian: "it looks like every asset has two problems … I'm not sure if this is an OMS-specific bug (are we getting that data from the API?) or a ScanTTY bug." Confirmed OMS-side: ScanTTY correctly sends `?asset={id}` (asset_detail.go:131); the backend just didn't honor it.

## Fix
`AssetProblemViewSet.get_queryset()` now honors `?asset=`, `?status=`, and `?part=` query params. No filter still returns all (dashboard use). No new endpoint → no permission-matrix change.

## Tests
New `test_asset_problem_filter.py` (97 lines): problems on asset A vs B; `?asset=A` returns only A's; `?status=` filters; no-filter returns all.

Rebased clean onto current main (original branch was cut before #848 landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)