### PR TITLE
fix(project-storage): add reprint endpoint + web parity button (op-9lmz)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -2360,6 +2360,9 @@ views:
       print_queue:
         permission_classes:
         - AllowAny
+      reprint:
+        permission_classes:
+        - IsAdminUser
       retrieve:
         permission_classes:
         - IsStorageAdminOrStaff

--- a/backend/project_storage/tests/test_api.py
+++ b/backend/project_storage/tests/test_api.py
@@ -234,6 +234,81 @@ class TestMarkRemoved:
         assert resp.status_code == 409
 
 
+class TestReprint:
+    """Warden re-queues a printed stint's claim ticket (ScanTTY + web).
+
+    reprint is the reverse of the daemon's mark-printed: it clears
+    printed_at so the stint re-appears in print-queue and the Pi daemon
+    reprints it on the next poll.
+    """
+
+    def test_clears_printed_at_and_requeues(self, staff_client):
+        # A printed stint has dropped off the print queue.
+        stint = ProjectStorageStintFactory(printed_at=timezone.now())
+        assert not any(
+            row["stint_id"] == stint.stint_id
+            for row in staff_client.get("/api/project-storage/stints/print-queue/").json()
+        )
+        resp = staff_client.post(
+            f"/api/project-storage/stints/{stint.stint_id}/reprint/",
+            {"note": "reprint please"},
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+        stint.refresh_from_db()
+        # printed_at cleared → the daemon sees it in the queue again.
+        assert stint.printed_at is None
+        assert resp.json()["stint_id"] == stint.stint_id
+        assert any(
+            row["stint_id"] == stint.stint_id
+            for row in staff_client.get("/api/project-storage/stints/print-queue/").json()
+        )
+
+    def test_records_reprint_event(self, staff_client):
+        stint = ProjectStorageStintFactory(printed_at=timezone.now())
+        staff_client.post(
+            f"/api/project-storage/stints/{stint.stint_id}/reprint/",
+            {"note": "warden note"},
+            format="json",
+        )
+        ev = stint.events.filter(actor_label="reprint requested").first()
+        assert ev is not None
+        assert ev.event_type == ProjectStorageEvent.EVENT_NOTE_ADDED
+        # The warden is recorded as the structured actor, like the other
+        # IsAdminUser mutations (mark-removed etc.).
+        assert ev.actor is not None and ev.actor.username == "warden"
+        assert ev.note == "warden note"
+
+    def test_reprint_on_never_printed_is_harmless(self, staff_client):
+        # printed_at already NULL (stint still queued) — reprint is a
+        # no-op on the field but still records the warden's intent.
+        stint = ProjectStorageStintFactory()
+        assert stint.printed_at is None
+        resp = staff_client.post(f"/api/project-storage/stints/{stint.stint_id}/reprint/")
+        assert resp.status_code == 200, resp.content
+        stint.refresh_from_db()
+        assert stint.printed_at is None
+        assert stint.events.filter(actor_label="reprint requested").count() == 1
+
+    def test_storage_admin_cannot_reprint(self, storage_admin_client):
+        # Storage Admin is a read-only group — same tightening as
+        # mark-removed / send-notice: they must not re-queue prints.
+        stint = ProjectStorageStintFactory(printed_at=timezone.now())
+        resp = storage_admin_client.post(f"/api/project-storage/stints/{stint.stint_id}/reprint/")
+        assert resp.status_code == 403
+        stint.refresh_from_db()
+        assert stint.printed_at is not None  # unchanged
+
+    def test_anonymous_rejected(self, client):
+        stint = ProjectStorageStintFactory(printed_at=timezone.now())
+        resp = client.post(f"/api/project-storage/stints/{stint.stint_id}/reprint/")
+        assert resp.status_code in (401, 403)
+
+    def test_unknown_stint_returns_404(self, staff_client):
+        resp = staff_client.post("/api/project-storage/stints/PS-NOPE0000/reprint/")
+        assert resp.status_code == 404
+
+
 # ---------------------------------------------------------------------------
 # Label render endpoint — Pi daemon pulls this
 # ---------------------------------------------------------------------------

--- a/backend/project_storage/views.py
+++ b/backend/project_storage/views.py
@@ -395,6 +395,35 @@ class ProjectStorageStintViewSet(viewsets.ReadOnlyModelViewSet):
     @action(
         detail=True,
         methods=["post"],
+        url_path="reprint",
+        permission_classes=[IsAdminUser],
+    )
+    def reprint(self, request, stint_id: str):
+        """Warden re-queues a stint's claim ticket for printing.
+
+        The reverse of the daemon's ``mark_printed``: clearing ``printed_at``
+        drops the stint back into ``print_queue`` so the Pi daemon reprints
+        its label on its next poll. Gated to ``IsAdminUser`` like the other
+        warden mutations — the daemon never reprints on its own.
+
+        Unblocks the ScanTTY reprint action (and the web parity button),
+        both of which already POST this path.
+        """
+        stint = self.get_object()
+        stint.printed_at = None
+        stint.save(update_fields=["printed_at", "updated_at"])
+        ProjectStorageEvent.objects.create(
+            stint=stint,
+            event_type=ProjectStorageEvent.EVENT_NOTE_ADDED,
+            actor=request.user if request.user.is_authenticated else None,
+            actor_label="reprint requested",
+            note=request.data.get("note", ""),
+        )
+        return Response(ProjectStorageStintSerializer(stint).data)
+
+    @action(
+        detail=True,
+        methods=["post"],
         url_path="generate-qr",
         permission_classes=[IsStorageAdminOrStaff],
     )

--- a/frontend/src/__tests__/pages/FacilitiesProjectStoragePage.reprint.test.tsx
+++ b/frontend/src/__tests__/pages/FacilitiesProjectStoragePage.reprint.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * Reprint claim-ticket parity test for the warden detail page (op-9lmz).
+ *
+ * The ScanTTY reprint action and this web button both POST
+ * /project-storage/stints/{id}/reprint/ to re-queue a claim ticket for
+ * printing (the backend clears printed_at so the Pi daemon reprints on
+ * its next poll). Asserts the button renders once a stint loads, that a
+ * click POSTs reprint with the stint_id, that the returned stint (with
+ * its new "reprint requested" audit event) is reflected in the timeline,
+ * and that success/failure surface a notification.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import FacilitiesProjectStoragePage from '../../pages/FacilitiesProjectStoragePage';
+import { projectStorageAPI } from '../../services/api';
+import { ProjectStorageStint } from '../../types';
+
+// Stable notification spies so we can assert the toast fired.
+const notify = vi.hoisted(() => ({
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+  showInfo: vi.fn(),
+}));
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    projectStorageAPI: {
+      get: jest.fn(),
+      byMember: jest.fn(),
+      start: jest.fn(),
+      sendViolationNotice: jest.fn(),
+      moveToPurgatory: jest.fn(),
+      markRemoved: jest.fn(),
+      generateQr: jest.fn(),
+      reprint: jest.fn(),
+      list: jest.fn(),
+      labelUrl: jest.fn(
+        (_stintId: string, printer = 'brother_ql') =>
+          `https://labels.example/${printer}.png`,
+      ),
+    },
+  };
+});
+
+vi.mock('../../hooks/useNotifications', () => ({
+  useNotifications: () => notify,
+}));
+
+const mockAPI = projectStorageAPI as jest.Mocked<typeof projectStorageAPI>;
+
+const buildStint = (
+  overrides: Partial<ProjectStorageStint> = {},
+): ProjectStorageStint => ({
+  id: 1,
+  stint_id: 'PS-AB23CDFG',
+  username: 'alice',
+  first_name: 'Alice',
+  last_name: 'Aardvark',
+  email: 'alice@example.com',
+  display_name: 'Alice Aardvark',
+  project_title: 'Big Sculpture',
+  started_at: '2026-05-01T00:00:00Z',
+  expires_at: '2026-06-30T00:00:00Z',
+  removed_at: null,
+  notice_sent_at: null,
+  moved_to_purgatory_at: null,
+  storage_location_name: 'Shelf A',
+  purgatory_location_name: '',
+  notes: '',
+  status: 'active',
+  purgatory_at: null,
+  expiry_week: 26,
+  expiry_day_of_year: 181,
+  events: [],
+  qr_code_url: null,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  ...overrides,
+});
+
+const ok = <T,>(data: T) =>
+  ({
+    data,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {} as never,
+  }) as never;
+
+const renderAt = (path: string) =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route
+            path="/facilities/project-storage/:stintId"
+            element={<FacilitiesProjectStoragePage />}
+          />
+          <Route
+            path="/facilities/project-storage"
+            element={<FacilitiesProjectStoragePage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+describe('FacilitiesProjectStoragePage — reprint claim ticket', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAPI.byMember.mockResolvedValue(ok([]));
+    mockAPI.get.mockResolvedValue(ok(buildStint()));
+  });
+
+  test('renders a Reprint claim ticket button once a stint loads', async () => {
+    renderAt('/facilities/project-storage/PS-AB23CDFG');
+    const button = await screen.findByTestId('reprint-ticket-button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Reprint claim ticket');
+  });
+
+  test('clicking reprint POSTs the endpoint and reflects the returned stint', async () => {
+    // The reprint response carries the new audit event the backend logs.
+    mockAPI.reprint.mockResolvedValue(
+      ok(
+        buildStint({
+          events: [
+            {
+              id: 99,
+              event_type: 'note_added',
+              actor_username: 'warden',
+              actor_label: 'reprint requested',
+              note: '',
+              created_at: '2026-06-01T00:00:00Z',
+            },
+          ],
+        }),
+      ),
+    );
+
+    renderAt('/facilities/project-storage/PS-AB23CDFG');
+    const button = await screen.findByTestId('reprint-ticket-button');
+
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(mockAPI.reprint).toHaveBeenCalledWith('PS-AB23CDFG'),
+    );
+    // The returned stint (with its new reprint event) is now displayed.
+    expect(await screen.findByText(/reprint requested/)).toBeInTheDocument();
+    expect(notify.showSuccess).toHaveBeenCalledWith(
+      expect.stringContaining('Reprint queued for PS-AB23CDFG'),
+    );
+  });
+
+  test('surfaces an error when the reprint request fails', async () => {
+    mockAPI.reprint.mockRejectedValue(new Error('boom'));
+
+    renderAt('/facilities/project-storage/PS-AB23CDFG');
+    const button = await screen.findByTestId('reprint-ticket-button');
+
+    fireEvent.click(button);
+
+    await waitFor(() => expect(notify.showError).toHaveBeenCalled());
+    expect(notify.showSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/FacilitiesProjectStoragePage.tsx
+++ b/frontend/src/pages/FacilitiesProjectStoragePage.tsx
@@ -35,6 +35,7 @@ import {
   IconKeyboard,
   IconList,
   IconMail,
+  IconPrinter,
   IconQrcode,
 } from '@tabler/icons-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -97,7 +98,7 @@ const FacilitiesProjectStoragePage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [showScanner, setShowScanner] = useState(false);
   const [actionInFlight, setActionInFlight] = useState<
-    'notice' | 'purgatory' | 'removed' | 'qr' | null
+    'notice' | 'purgatory' | 'removed' | 'qr' | 'reprint' | null
   >(null);
 
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -226,6 +227,25 @@ const FacilitiesProjectStoragePage: React.FC = () => {
       notifications.showSuccess(`Regenerated QR for ${resp.data.stint_id}.`);
     } catch (err) {
       notifications.showError(extractErrorMessage(err, 'Could not regenerate QR.'));
+    } finally {
+      setActionInFlight(null);
+    }
+  };
+
+  // One-click reprint: clears printed_at on the backend so the stint
+  // re-enters the Pi daemon's print queue and the label reprints on the
+  // next poll. Parity with the ScanTTY reprint action.
+  const reprintTicket = async () => {
+    if (!stint) return;
+    setActionInFlight('reprint');
+    try {
+      const resp = await projectStorageAPI.reprint(stint.stint_id);
+      setStint(resp.data);
+      notifications.showSuccess(
+        `Reprint queued for ${resp.data.stint_id} — the label printer picks it up shortly.`,
+      );
+    } catch (err) {
+      notifications.showError(extractErrorMessage(err, 'Could not queue reprint.'));
     } finally {
       setActionInFlight(null);
     }
@@ -420,6 +440,15 @@ const FacilitiesProjectStoragePage: React.FC = () => {
                 data-testid="regenerate-qr-button"
               >
                 {stint.qr_code_url ? 'Regenerate QR' : 'Generate QR'}
+              </Button>
+              <Button
+                variant="default"
+                leftSection={<IconPrinter size={16} />}
+                loading={actionInFlight === 'reprint'}
+                onClick={reprintTicket}
+                data-testid="reprint-ticket-button"
+              >
+                Reprint claim ticket
               </Button>
             </Group>
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -4051,6 +4051,13 @@ export const projectStorageAPI = {
       note: note ?? '',
     }),
 
+  // Warden re-queues the claim ticket for printing — the backend clears
+  // printed_at so the Pi daemon reprints the label on its next poll.
+  reprint: (stintId: string, note?: string) =>
+    api.post<ProjectStorageStint>(`/project-storage/stints/${stintId}/reprint/`, {
+      note: note ?? '',
+    }),
+
   labelUrl: (stintId: string, printer: 'brother_ql' | 'epson_tm' = 'brother_ql') =>
     `${API_BASE_URL}/project-storage/stints/${stintId}/label/?printer=${printer}`,
 


### PR DESCRIPTION
## Problem
Reprinting a project-storage claim ticket from ScanTTY returned **HTTP 404**. ScanTTY (project_storage.go:184) POSTs `/api/project-storage/stints/{id}/reprint/` — the correct path — but `ProjectStorageStintViewSet` had **no `reprint` @action** (it was never built; the paired backend bead fell through). The route didn't exist → Django 404.

## Fix
Adds the `reprint` @action to `ProjectStorageStintViewSet`: `POST /api/project-storage/stints/{id}/reprint/` (IsAdminUser). It drops the stint back into the print queue (clears `printed_at` → the Pi daemon reprints on its next poll) and records a `ProjectStorageEvent` audit note. Mirrors the `mark_printed`/`mark_removed` signatures + `stint_id` lookup.

## Completeness (full-stack)
- Backend `reprint` @action + `ProjectStorageEvent` audit trail
- **Permission matrix** registered (`api_permission_matrix.yaml`) — CI matrix test passes
- **Web parity**: "Reprint claim ticket" button on `FacilitiesProjectStoragePage` + `api.ts` method
- Backend tests (reprint re-queues the stint; permission gate) + frontend test

Unblocks the ScanTTY reprint action (already calls the correct path — no ScanTTY change needed) and adds the web button for parity. Rebased clean onto current main (#849).

🤖 Generated with [Claude Code](https://claude.com/claude-code)