### PR TITLE
feat(inventory): item computed metrics endpoint + web detail row (op-88vf, issue-5)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -1322,6 +1322,9 @@ views:
       low_stock:
         permission_classes:
         - IsAuthenticatedOrReadOnly
+      metrics:
+        permission_classes:
+        - AllowAny
       my_sig_inventory:
         permission_classes:
         - IsAuthenticated

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -636,6 +636,40 @@ class InventoryItemDetailSerializer(InventoryItemSerializer):
         return {"trend": "no_data", "change_percentage": None}
 
 
+class InventoryMetricsSerializer(serializers.Serializer):
+    """Computed stock + cost metrics for the inventory-item detail view.
+
+    Powers the ``SKU · QOH · QOO · QA · QC · QIT · RP · Lead · Cost`` row on
+    the web item-detail page and the paired ScanTTY TUI row (issue-5). The
+    field names below are a pinned contract shared with the ScanTTY worker, so
+    do not rename them.
+
+    All values are computed in ``InventoryItemViewSet.metrics``; this
+    serializer only shapes the output and is fed a plain ``dict`` (not a model
+    instance). Quantities are numbers; money fields are DRF ``DecimalField``s
+    (serialized as strings, matching the item serializer's ``unit_cost``).
+    """
+
+    current_stock = serializers.IntegerField()  # QOH — on hand
+    quantity_on_order = serializers.IntegerField()  # QOO — open PO units
+    quantity_available = serializers.FloatField()  # QA — QOH minus QC
+    quantity_committed = serializers.FloatField()  # QC — open work-order demand
+    quantity_in_transit = serializers.IntegerField()  # QIT — partially-received (⊆ QOO)
+    reorder_point = serializers.IntegerField()  # RP — reorder_quantity
+    lead_time_days = serializers.IntegerField(allow_null=True)  # Lead — average_lead_time
+    unit_cost = serializers.DecimalField(  # Cost — per-item, or per-case when case-based
+        max_digits=10, decimal_places=2, allow_null=True
+    )
+    cost_trend = serializers.ChoiceField(choices=["up", "down", "flat", "no_history"])
+    last_po_unit_cost = (
+        serializers.DecimalField(  # most recent PO unit cost (for the arrow tooltip)
+            max_digits=10, decimal_places=4, allow_null=True
+        )
+    )
+    is_case_based = serializers.BooleanField()
+    case_size = serializers.IntegerField(allow_null=True)  # units per case (quantity_per_package)
+
+
 class AssetPartSerializer(serializers.ModelSerializer):
     """Serializer for asset parts/consumables."""
 

--- a/backend/inventory/tests/test_inventory_metrics.py
+++ b/backend/inventory/tests/test_inventory_metrics.py
@@ -1,0 +1,328 @@
+"""API tests for the inventory item computed-metrics endpoint (issue-5).
+
+Covers the ``GET /api/inventory/items/<id>/metrics/`` contract that powers the
+``SKU · QOH · QOO · QA · QC · QIT · RP · Lead · Cost`` row on the web
+item-detail page and the paired ScanTTY TUI row. Each computed field
+(QOO/QIT/QC/QA/cost trend/case cost) has fixture-backed coverage.
+"""
+
+from datetime import timedelta
+from decimal import Decimal
+
+from django.urls import reverse
+from django.utils import timezone
+
+import pytest
+from rest_framework import status
+
+from inventory.models import MaintenanceItem, MaintenanceMaterial, WorkOrder
+from inventory.tests.factories import AssetFactory, InventoryItemFactory
+from reorder_queue.models import PurchaseOrder, PurchaseOrderItem
+from reorder_queue.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+CONTRACT_FIELDS = {
+    "current_stock",
+    "quantity_on_order",
+    "quantity_available",
+    "quantity_committed",
+    "quantity_in_transit",
+    "reorder_point",
+    "lead_time_days",
+    "unit_cost",
+    "cost_trend",
+    "last_po_unit_cost",
+    "is_case_based",
+    "case_size",
+}
+
+
+_DEFAULT_PO_UNIT_COST = Decimal("1.0000")
+
+
+def _metrics_url(item):
+    return reverse("inventoryitem-metrics", kwargs={"pk": str(item.id)})
+
+
+def _po_line(
+    item,
+    *,
+    po_status,
+    quantity_ordered,
+    quantity_received=0,
+    unit_cost_ordered=_DEFAULT_PO_UNIT_COST,
+    is_voided=False,
+    created_by=None,
+):
+    """Create a PurchaseOrder + a single line for ``item``'s primary supplier."""
+    item_supplier = item.primary_item_supplier
+    po = PurchaseOrder.objects.create(
+        supplier=item_supplier.supplier,
+        created_by=created_by or UserFactory(),
+        status=po_status,
+    )
+    return PurchaseOrderItem.objects.create(
+        purchase_order=po,
+        item_supplier=item_supplier,
+        quantity_ordered=quantity_ordered,
+        quantity_received=quantity_received,
+        unit_cost_ordered=unit_cost_ordered,
+        is_voided=is_voided,
+    )
+
+
+def _committed_material(item, asset, *, quantity, wo_statuses):
+    """Attach ``quantity`` of ``item`` to a fresh task carrying ``wo_statuses``."""
+    task = MaintenanceItem.objects.create(asset=asset, title="task")
+    for wo_status in wo_statuses:
+        WorkOrder.objects.create(maintenance_item=task, status=wo_status)
+    return MaintenanceMaterial.objects.create(
+        maintenance_item=task,
+        inventory_item=item,
+        name="widget",
+        quantity=Decimal(quantity),
+    )
+
+
+class TestMetricsEndpointContract:
+    def test_endpoint_is_public_and_returns_exact_contract(self, api_client):
+        item = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=4)
+
+        response = api_client.get(_metrics_url(item))
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        # Exactly the pinned contract — no more, no less (ScanTTY depends on it).
+        assert set(data.keys()) == CONTRACT_FIELDS
+        assert data["current_stock"] == 10
+        assert data["reorder_point"] == 4
+
+    def test_reorder_point_and_lead_time_echo_the_item(self, api_client):
+        item = InventoryItemFactory(
+            image=None, current_stock=5, reorder_quantity=9, average_lead_time=14
+        )
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["reorder_point"] == 9  # RP == reorder_quantity
+        assert data["lead_time_days"] == 14  # Lead == average_lead_time
+
+
+class TestQuantityOnOrder:
+    def test_counts_open_pos_and_excludes_closed_and_voided(self, api_client):
+        item = InventoryItemFactory(image=None, current_stock=0, reorder_quantity=1)
+        user = UserFactory()
+
+        # Counted — the three open statuses.
+        _po_line(item, po_status=PurchaseOrder.SENT, quantity_ordered=5, created_by=user)
+        _po_line(item, po_status=PurchaseOrder.CONFIRMED, quantity_ordered=7, created_by=user)
+        _po_line(
+            item,
+            po_status=PurchaseOrder.PARTIALLY_RECEIVED,
+            quantity_ordered=10,
+            quantity_received=4,
+            created_by=user,
+        )
+        # Not counted — draft / received / cancelled.
+        _po_line(item, po_status=PurchaseOrder.DRAFT, quantity_ordered=100, created_by=user)
+        _po_line(
+            item,
+            po_status=PurchaseOrder.RECEIVED,
+            quantity_ordered=100,
+            quantity_received=100,
+            created_by=user,
+        )
+        _po_line(item, po_status=PurchaseOrder.CANCELLED, quantity_ordered=100, created_by=user)
+        # Not counted — a voided line on an otherwise-open PO.
+        _po_line(
+            item,
+            po_status=PurchaseOrder.SENT,
+            quantity_ordered=100,
+            is_voided=True,
+            created_by=user,
+        )
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_on_order"] == 22  # 5 + 7 + 10
+
+    def test_zero_when_no_purchase_orders(self, api_client):
+        item = InventoryItemFactory(image=None, current_stock=3, reorder_quantity=1)
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_on_order"] == 0
+        assert data["quantity_in_transit"] == 0
+
+
+class TestQuantityInTransit:
+    def test_is_pending_on_partially_received_lines_only(self, api_client):
+        item = InventoryItemFactory(image=None, current_stock=0, reorder_quantity=1)
+        user = UserFactory()
+
+        # Partially received: 10 ordered, 4 received -> 6 in transit.
+        _po_line(
+            item,
+            po_status=PurchaseOrder.PARTIALLY_RECEIVED,
+            quantity_ordered=10,
+            quantity_received=4,
+            created_by=user,
+        )
+        # A fully-received line on a partial PO contributes nothing in transit.
+        _po_line(
+            item,
+            po_status=PurchaseOrder.PARTIALLY_RECEIVED,
+            quantity_ordered=8,
+            quantity_received=8,
+            created_by=user,
+        )
+        # A plain sent line is on order but not yet in transit.
+        _po_line(item, po_status=PurchaseOrder.SENT, quantity_ordered=5, created_by=user)
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_in_transit"] == 6
+        # QIT is a subset of QOO by definition.
+        assert data["quantity_on_order"] == 23  # 10 + 8 + 5
+        assert data["quantity_in_transit"] <= data["quantity_on_order"]
+
+
+class TestQuantityCommittedAndAvailable:
+    def test_counts_only_open_work_order_materials(self, api_client):
+        item = InventoryItemFactory(image=None, current_stock=20, reorder_quantity=1)
+        asset = AssetFactory()
+
+        _committed_material(item, asset, quantity="3", wo_statuses=[WorkOrder.STATUS_OPEN])
+        _committed_material(item, asset, quantity="2", wo_statuses=[WorkOrder.STATUS_IN_PROGRESS])
+        _committed_material(item, asset, quantity="1", wo_statuses=[WorkOrder.STATUS_BLOCKED])
+        # Completed work order -> not committed.
+        _committed_material(item, asset, quantity="100", wo_statuses=[WorkOrder.STATUS_COMPLETED])
+        # Material with no work order at all -> not committed.
+        _committed_material(item, asset, quantity="50", wo_statuses=[])
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_committed"] == 6.0  # 3 + 2 + 1
+        assert data["quantity_available"] == 14.0  # 20 on hand - 6 committed
+
+    def test_material_not_double_counted_across_multiple_open_work_orders(self, api_client):
+        """A task with several open work orders must not multiply its material."""
+        item = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=1)
+        asset = AssetFactory()
+
+        _committed_material(
+            item,
+            asset,
+            quantity="4",
+            wo_statuses=[WorkOrder.STATUS_OPEN, WorkOrder.STATUS_IN_PROGRESS],
+        )
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_committed"] == 4.0  # not 8.0
+        assert data["quantity_available"] == 6.0
+
+    def test_available_can_go_negative_when_overcommitted(self, api_client):
+        item = InventoryItemFactory(image=None, current_stock=1, reorder_quantity=1)
+        asset = AssetFactory()
+
+        _committed_material(item, asset, quantity="5", wo_statuses=[WorkOrder.STATUS_OPEN])
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_committed"] == 5.0
+        assert data["quantity_available"] == -4.0
+
+
+class TestCostAndTrend:
+    def test_no_history_when_item_has_no_purchase_orders(self, api_client):
+        item = InventoryItemFactory(image=None, reorder_quantity=1, unit_cost=Decimal("4.00"))
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["cost_trend"] == "no_history"
+        assert data["last_po_unit_cost"] is None
+
+    @pytest.mark.parametrize(
+        "current, last_po, expected",
+        [
+            (Decimal("5.00"), Decimal("4.0000"), "up"),
+            (Decimal("3.00"), Decimal("4.0000"), "down"),
+            (Decimal("4.00"), Decimal("4.0000"), "flat"),
+        ],
+    )
+    def test_trend_compares_current_cost_to_last_po(self, api_client, current, last_po, expected):
+        item = InventoryItemFactory(image=None, reorder_quantity=1, unit_cost=current)
+        _po_line(
+            item,
+            po_status=PurchaseOrder.RECEIVED,
+            quantity_ordered=1,
+            quantity_received=1,
+            unit_cost_ordered=last_po,
+        )
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["cost_trend"] == expected
+        assert Decimal(data["last_po_unit_cost"]) == last_po
+        assert Decimal(data["unit_cost"]) == current
+
+    def test_trend_uses_the_most_recent_po_line(self, api_client):
+        item = InventoryItemFactory(image=None, reorder_quantity=1, unit_cost=Decimal("5.00"))
+        older = _po_line(
+            item,
+            po_status=PurchaseOrder.RECEIVED,
+            quantity_ordered=1,
+            quantity_received=1,
+            unit_cost_ordered=Decimal("9.0000"),
+        )
+        newer = _po_line(
+            item,
+            po_status=PurchaseOrder.RECEIVED,
+            quantity_ordered=1,
+            quantity_received=1,
+            unit_cost_ordered=Decimal("4.0000"),
+        )
+        # auto_now_add can tie in tests; stamp created_at so ordering is stable.
+        now = timezone.now()
+        PurchaseOrderItem.objects.filter(pk=older.pk).update(created_at=now - timedelta(days=2))
+        PurchaseOrderItem.objects.filter(pk=newer.pk).update(created_at=now - timedelta(days=1))
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert Decimal(data["last_po_unit_cost"]) == Decimal("4.0000")
+        assert data["cost_trend"] == "up"  # current 5.00 > most-recent 4.00
+
+
+class TestCaseBasedCost:
+    def test_case_based_reports_case_cost_and_size(self, api_client):
+        # package_cost is derived as unit_cost * quantity_per_package = 2.00 * 12.
+        item = InventoryItemFactory(
+            image=None,
+            reorder_quantity=1,
+            current_stock=100,
+            use_case_based_reorder=True,
+            unit_cost=Decimal("2.00"),
+            quantity_per_package=12,
+        )
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["is_case_based"] is True
+        assert data["case_size"] == 12
+        assert Decimal(data["unit_cost"]) == Decimal("24.00")  # per-case cost
+
+    def test_per_item_cost_when_not_case_based(self, api_client):
+        item = InventoryItemFactory(
+            image=None,
+            reorder_quantity=1,
+            current_stock=100,
+            unit_cost=Decimal("2.50"),
+            quantity_per_package=1,
+        )
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["is_case_based"] is False
+        assert Decimal(data["unit_cost"]) == Decimal("2.50")  # per-unit cost

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -73,6 +73,7 @@ from .serializers import (
     FixtureSerializer,
     InventoryItemDetailSerializer,
     InventoryItemSerializer,
+    InventoryMetricsSerializer,
     ItemSupplierSerializer,
     LocationProblemSerializer,
     LocationReconcileItemSerializer,
@@ -494,6 +495,7 @@ class InventoryItemViewSet(viewsets.ModelViewSet):
         if self.action in [
             "list",
             "retrieve",
+            "metrics",
             "low_stock",
             "reordered",
             "download_card",
@@ -1029,6 +1031,128 @@ class InventoryItemViewSet(viewsets.ModelViewSet):
             },
             status=status.HTTP_201_CREATED,
         )
+
+    @action(detail=True, methods=["get"], permission_classes=[AllowAny])
+    def metrics(self, request, pk=None):
+        """Computed stock + cost metrics for the item detail view (issue-5).
+
+        Powers the ``SKU · QOH · QOO · QA · QC · QIT · RP · Lead · Cost`` row on
+        the web item-detail page and the paired ScanTTY TUI row. The field
+        names are a pinned contract shared with the ScanTTY worker — see
+        ``InventoryMetricsSerializer``. Read-only; no migration.
+        """
+        from django.db.models import ExpressionWrapper, IntegerField, Sum
+
+        from reorder_queue.models import PurchaseOrder, PurchaseOrderItem
+
+        item = self.get_object()
+
+        # QOO — units on open purchase orders (sent / confirmed / partially
+        # received), excluding voided lines.
+        on_order_statuses = [
+            PurchaseOrder.SENT,
+            PurchaseOrder.CONFIRMED,
+            PurchaseOrder.PARTIALLY_RECEIVED,
+        ]
+        quantity_on_order = (
+            PurchaseOrderItem.objects.filter(
+                item_supplier__item=item,
+                is_voided=False,
+                purchase_order__status__in=on_order_statuses,
+            ).aggregate(total=Sum("quantity_ordered"))["total"]
+            or 0
+        )
+
+        # QIT — still-pending units on partially-received POs. A line is "in
+        # transit" when some but not all of it has arrived. This is a subset of
+        # QOO (partially_received ∈ on-order statuses), so QIT ≤ QOO.
+        quantity_in_transit = (
+            PurchaseOrderItem.objects.filter(
+                item_supplier__item=item,
+                is_voided=False,
+                purchase_order__status=PurchaseOrder.PARTIALLY_RECEIVED,
+                quantity_received__lt=F("quantity_ordered"),
+            ).aggregate(
+                total=Sum(
+                    ExpressionWrapper(
+                        F("quantity_ordered") - F("quantity_received"),
+                        output_field=IntegerField(),
+                    )
+                )
+            )[
+                "total"
+            ]
+            or 0
+        )
+
+        # QC — quantity committed to open work orders. Collect distinct material
+        # ids first so a task with several open work orders doesn't multiply the
+        # join and double-count the material's quantity.
+        open_wo_statuses = [
+            WorkOrder.STATUS_OPEN,
+            WorkOrder.STATUS_IN_PROGRESS,
+            WorkOrder.STATUS_BLOCKED,
+        ]
+        committed_material_ids = list(
+            MaintenanceMaterial.objects.filter(
+                inventory_item=item,
+                maintenance_item__work_orders__status__in=open_wo_statuses,
+            )
+            .values_list("id", flat=True)
+            .distinct()
+        )
+        quantity_committed = float(
+            MaintenanceMaterial.objects.filter(id__in=committed_material_ids).aggregate(
+                total=Sum("quantity")
+            )["total"]
+            or 0
+        )
+
+        # QA — available = on hand minus committed.
+        quantity_available = float(item.current_stock) - quantity_committed
+
+        # Cost trend vs the most recent purchase-order line for this item. The
+        # comparison is per-unit on both sides (item.unit_cost vs the PO's
+        # unit_cost_ordered), independent of case-based packaging.
+        latest_po_item = (
+            PurchaseOrderItem.objects.filter(item_supplier__item=item)
+            .order_by("-created_at")
+            .first()
+        )
+        current_unit_cost = item.unit_cost  # primary supplier's per-unit cost
+        if latest_po_item is None:
+            last_po_unit_cost = None
+            cost_trend = "no_history"
+        else:
+            last_po_unit_cost = latest_po_item.unit_cost_ordered
+            if current_unit_cost is None or last_po_unit_cost is None:
+                cost_trend = "no_history"
+            elif current_unit_cost > last_po_unit_cost:
+                cost_trend = "up"
+            elif current_unit_cost < last_po_unit_cost:
+                cost_trend = "down"
+            else:
+                cost_trend = "flat"
+
+        # Cost shown on the row: the case cost for case-based items (what you
+        # actually pay per package), else the per-unit cost.
+        display_cost = item.package_cost if item.use_case_based_reorder else current_unit_cost
+
+        payload = {
+            "current_stock": item.current_stock,
+            "quantity_on_order": quantity_on_order,
+            "quantity_available": quantity_available,
+            "quantity_committed": quantity_committed,
+            "quantity_in_transit": quantity_in_transit,
+            "reorder_point": item.reorder_quantity,
+            "lead_time_days": item.average_lead_time,
+            "unit_cost": display_cost,
+            "cost_trend": cost_trend,
+            "last_po_unit_cost": last_po_unit_cost,
+            "is_case_based": item.use_case_based_reorder,
+            "case_size": item.quantity_per_package,
+        }
+        return Response(InventoryMetricsSerializer(payload).data)
 
     def _resolve_location(self, value):
         if not value:

--- a/docs/API_PERMISSION_MATRIX.md
+++ b/docs/API_PERMISSION_MATRIX.md
@@ -83,6 +83,7 @@ below are public.
 | --- | --- | --- | --- | --- |
 | POST | `inventory/items/<id>/scan/` | public | Increment scan count when a member scans a QR code. | Required: per-IP throttle + duplicate-submit dedupe. |
 | GET  | `inventory/items/<id>/public/` | public | Public read of scannable item fields (no cost/supplier data). | Not required (read). |
+| GET  | `inventory/items/<id>/metrics/` | public | Computed stock + cost metrics row (QOH/QOO/QA/QC/QIT/RP/Lead/Cost + trend). Mirrors `retrieve`'s exposure — includes cost. | Not required (read). |
 | GET  | `inventory/items/by-qr/<qr>/` | public | Resolve a QR code to a public item view. | Not required (read). |
 | POST | `inventory/items/<id>/report-need/` | public | Member reports the bin needs restocking. | Required: per-IP throttle + dedupe per (item, day). |
 | POST | `inventory/items/<id>/report-problem/` | public | Member reports a problem with the item. | Required: per-IP throttle + dedupe per (item, day). |

--- a/frontend/src/__tests__/components/InventoryMetricsRow.test.tsx
+++ b/frontend/src/__tests__/components/InventoryMetricsRow.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Tests for InventoryMetricsRow (issue-5) — the prominent
+ * SKU · QOH · QOO · QA · QC · QIT · RP · Lead · Cost strip on the item detail
+ * page.
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+
+import InventoryMetricsRow from '../../components/inventory/InventoryMetricsRow';
+import { InventoryItemMetrics } from '../../types';
+
+const buildMetrics = (overrides: Partial<InventoryItemMetrics> = {}): InventoryItemMetrics => ({
+  current_stock: 10,
+  quantity_on_order: 7,
+  quantity_available: 6,
+  quantity_committed: 4,
+  quantity_in_transit: 3,
+  reorder_point: 5,
+  lead_time_days: 14,
+  unit_cost: '5.00',
+  cost_trend: 'up',
+  last_po_unit_cost: '4.0000',
+  is_case_based: false,
+  case_size: null,
+  ...overrides,
+});
+
+const renderRow = (metrics: InventoryItemMetrics, sku = 'SKU-123') =>
+  render(
+    <MantineProvider>
+      <InventoryMetricsRow sku={sku} metrics={metrics} />
+    </MantineProvider>,
+  );
+
+describe('InventoryMetricsRow', () => {
+  it('renders every metric cell with its computed value', () => {
+    renderRow(buildMetrics());
+
+    expect(screen.getByTestId('inventory-metrics-row')).toBeInTheDocument();
+    expect(screen.getByTestId('metric-sku')).toHaveTextContent('SKU-123');
+    expect(screen.getByTestId('metric-qoh')).toHaveTextContent('10');
+    expect(screen.getByTestId('metric-qoo')).toHaveTextContent('7');
+    expect(screen.getByTestId('metric-qa')).toHaveTextContent('6');
+    expect(screen.getByTestId('metric-qc')).toHaveTextContent('4');
+    expect(screen.getByTestId('metric-qit')).toHaveTextContent('3');
+    expect(screen.getByTestId('metric-rp')).toHaveTextContent('5');
+    expect(screen.getByTestId('metric-lead')).toHaveTextContent('14d');
+  });
+
+  it('shows the per-unit cost with an up-trend arrow', () => {
+    renderRow(buildMetrics({ unit_cost: '5.00', cost_trend: 'up' }));
+
+    const cost = screen.getByTestId('metric-cost');
+    expect(cost).toHaveTextContent('Cost');
+    expect(cost).toHaveTextContent('$5.00');
+    expect(cost).toHaveTextContent('↑');
+    expect(screen.getByTestId('cost-trend-up')).toBeInTheDocument();
+  });
+
+  it('shows a down-trend arrow when the cost has fallen', () => {
+    renderRow(buildMetrics({ cost_trend: 'down' }));
+
+    expect(screen.getByTestId('metric-cost')).toHaveTextContent('↓');
+    expect(screen.getByTestId('cost-trend-down')).toBeInTheDocument();
+  });
+
+  it('labels the cost per-case and shows the case size for case-based items', () => {
+    renderRow(buildMetrics({ is_case_based: true, case_size: 12, unit_cost: '24.00' }));
+
+    const cost = screen.getByTestId('metric-cost');
+    expect(cost).toHaveTextContent('Cost/case');
+    expect(cost).toHaveTextContent('$24.00');
+  });
+
+  it('renders em-dashes for missing lead time and cost, and no arrow without history', () => {
+    renderRow(
+      buildMetrics({ lead_time_days: null, unit_cost: null, cost_trend: 'no_history' }),
+    );
+
+    expect(screen.getByTestId('metric-lead')).toHaveTextContent('—');
+    expect(screen.getByTestId('metric-cost')).toHaveTextContent('—');
+    expect(screen.queryByTestId('cost-trend-no_history')).not.toBeInTheDocument();
+  });
+
+  it('formats fractional committed/available quantities to two decimals', () => {
+    renderRow(buildMetrics({ quantity_committed: 2.5, quantity_available: 7.5 }));
+
+    expect(screen.getByTestId('metric-qc')).toHaveTextContent('2.50');
+    expect(screen.getByTestId('metric-qa')).toHaveTextContent('7.50');
+  });
+});

--- a/frontend/src/__tests__/pages/InventoryItemDetailPage.cycleCount.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemDetailPage.cycleCount.test.tsx
@@ -106,6 +106,7 @@ const cycleCountResponse = {
 
 const setupItem = (item: Record<string, unknown>) => {
   (api.inventoryAPI.getItem as jest.Mock).mockResolvedValue({ data: item });
+  (api.inventoryAPI.getItemMetrics as jest.Mock).mockResolvedValue({ data: null });
   (api.inventoryAPI.getUsageLogs as jest.Mock).mockResolvedValue({ data: { results: [] } });
   (api.reorderAPI.listRequests as jest.Mock).mockResolvedValue({ data: { results: [] } });
   (api.assetsAPI.listAssets as jest.Mock).mockResolvedValue({ data: { results: [] } });

--- a/frontend/src/__tests__/pages/InventoryItemDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemDetailPage.test.tsx
@@ -91,10 +91,28 @@ describe('InventoryItemDetailPage', () => {
     days_since_last_count: null,
   };
 
+  const mockMetrics = {
+    current_stock: 10,
+    quantity_on_order: 20,
+    quantity_available: 8,
+    quantity_committed: 2,
+    quantity_in_transit: 5,
+    reorder_point: 20,
+    lead_time_days: 7,
+    unit_cost: '15.99',
+    cost_trend: 'flat' as const,
+    last_po_unit_cost: '15.99',
+    is_case_based: false,
+    case_size: null,
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     (api.inventoryAPI.getItem as jest.Mock).mockResolvedValue({
       data: mockItem,
+    });
+    (api.inventoryAPI.getItemMetrics as jest.Mock).mockResolvedValue({
+      data: mockMetrics,
     });
     (api.inventoryAPI.getUsageLogs as jest.Mock).mockResolvedValue({
       data: { results: [] },
@@ -432,5 +450,36 @@ describe('InventoryItemDetailPage', () => {
     expect(screen.getByText(/where you left off/i)).toBeInTheDocument();
     expect(consumePendingReturnTo()).toBe('/inventory/items/test-id');
     expect(screen.getByText('Test Item')).toBeInTheDocument();
+  });
+
+  // ---- issue-5 metrics strip ----
+
+  it('renders the computed metrics strip near the top of the detail view', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item')).toBeInTheDocument();
+    });
+
+    const row = await screen.findByTestId('inventory-metrics-row');
+    expect(row).toBeInTheDocument();
+    // A couple of computed values from the mocked /metrics/ payload.
+    expect(screen.getByTestId('metric-qoo')).toHaveTextContent('20');
+    expect(screen.getByTestId('metric-qit')).toHaveTextContent('5');
+  });
+
+  it('still renders the item when the metrics call fails (graceful degradation)', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (api.inventoryAPI.getItemMetrics as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item')).toBeInTheDocument();
+    });
+
+    // The item view is intact; only the metrics strip is absent.
+    expect(screen.queryByTestId('inventory-metrics-row')).not.toBeInTheDocument();
+    consoleError.mockRestore();
   });
 });

--- a/frontend/src/components/inventory/InventoryMetricsRow.tsx
+++ b/frontend/src/components/inventory/InventoryMetricsRow.tsx
@@ -1,0 +1,143 @@
+/**
+ * InventoryMetricsRow — compact, prominent stock + cost strip for the item
+ * detail page (issue-5): SKU · QOH · QOO · QA · QC · QIT · RP · Lead · Cost.
+ *
+ * Fed by GET /api/inventory/items/<id>/metrics/. Ian flagged that this
+ * information was hard to get from a single screen, so the row sits at the top
+ * of the detail view. Purely presentational — the page fetches the metrics and
+ * passes them in (the paired ScanTTY TUI renders the same contract).
+ */
+import { Group, Paper, Stack, Text } from '@mantine/core';
+import React from 'react';
+
+import { InventoryCostTrend, InventoryItemMetrics } from '../../types';
+
+interface InventoryMetricsRowProps {
+  sku: string;
+  metrics: InventoryItemMetrics;
+}
+
+const TREND_ARROW: Record<InventoryCostTrend, string> = {
+  up: '↑',
+  down: '↓',
+  flat: '→',
+  no_history: '',
+};
+
+// Cost going up is bad (red), down is good (green); flat/unknown stay neutral.
+const TREND_COLOR: Record<InventoryCostTrend, string | undefined> = {
+  up: 'red',
+  down: 'green',
+  flat: undefined,
+  no_history: undefined,
+};
+
+const TREND_LABEL: Record<InventoryCostTrend, string> = {
+  up: 'Cost up vs the last purchase order',
+  down: 'Cost down vs the last purchase order',
+  flat: 'Cost unchanged vs the last purchase order',
+  no_history: 'No purchase-order history yet',
+};
+
+const formatMoney = (value: string | null): string =>
+  value == null ? '—' : `$${parseFloat(value).toFixed(2)}`;
+
+const formatQuantity = (value: number): string =>
+  Number.isInteger(value) ? String(value) : value.toFixed(2);
+
+interface MetricCellProps {
+  label: string;
+  value: React.ReactNode;
+  tooltip: string;
+  testId: string;
+}
+
+const MetricCell: React.FC<MetricCellProps> = ({ label, value, tooltip, testId }) => (
+  <Stack gap={2} align="center" miw={52} title={tooltip} data-testid={testId}>
+    <Text size="xs" c="dimmed" fw={700} tt="uppercase">
+      {label}
+    </Text>
+    <Text size="lg" fw={700}>
+      {value}
+    </Text>
+  </Stack>
+);
+
+const InventoryMetricsRow: React.FC<InventoryMetricsRowProps> = ({ sku, metrics }) => {
+  const costLabel = metrics.is_case_based ? 'Cost/case' : 'Cost';
+  const costTooltipBase = metrics.is_case_based
+    ? `Cost per case${metrics.case_size ? ` of ${metrics.case_size}` : ''}`
+    : 'Cost per unit';
+  const trendArrow = TREND_ARROW[metrics.cost_trend];
+  const trendColor = TREND_COLOR[metrics.cost_trend];
+
+  const costValue = (
+    <>
+      {formatMoney(metrics.unit_cost)}
+      {trendArrow && (
+        <Text span c={trendColor} data-testid={`cost-trend-${metrics.cost_trend}`}>
+          {' '}
+          {trendArrow}
+        </Text>
+      )}
+    </>
+  );
+
+  return (
+    <Paper withBorder p="md" radius="md" data-testid="inventory-metrics-row">
+      <Group justify="space-between" wrap="wrap" gap="md">
+        <MetricCell testId="metric-sku" label="SKU" value={sku} tooltip="Stock keeping unit" />
+        <MetricCell
+          testId="metric-qoh"
+          label="QOH"
+          value={formatQuantity(metrics.current_stock)}
+          tooltip="Quantity on hand"
+        />
+        <MetricCell
+          testId="metric-qoo"
+          label="QOO"
+          value={formatQuantity(metrics.quantity_on_order)}
+          tooltip="Quantity on order (open purchase orders)"
+        />
+        <MetricCell
+          testId="metric-qa"
+          label="QA"
+          value={formatQuantity(metrics.quantity_available)}
+          tooltip="Quantity available (on hand − committed)"
+        />
+        <MetricCell
+          testId="metric-qc"
+          label="QC"
+          value={formatQuantity(metrics.quantity_committed)}
+          tooltip="Quantity committed to open work orders"
+        />
+        <MetricCell
+          testId="metric-qit"
+          label="QIT"
+          value={formatQuantity(metrics.quantity_in_transit)}
+          tooltip="Quantity in transit (partially received)"
+        />
+        <MetricCell
+          testId="metric-rp"
+          label="RP"
+          value={formatQuantity(metrics.reorder_point)}
+          tooltip="Reorder point"
+        />
+        <MetricCell
+          testId="metric-lead"
+          label="Lead"
+          value={metrics.lead_time_days == null ? '—' : `${metrics.lead_time_days}d`}
+          tooltip="Lead time in days"
+        />
+        <MetricCell
+          testId="metric-cost"
+          label={costLabel}
+          value={costValue}
+          tooltip={`${costTooltipBase} — ${TREND_LABEL[metrics.cost_trend]}`}
+        />
+      </Group>
+    </Paper>
+  );
+};
+
+export default InventoryMetricsRow;

--- a/frontend/src/pages/InventoryItemDetailPage.tsx
+++ b/frontend/src/pages/InventoryItemDetailPage.tsx
@@ -25,13 +25,14 @@ import { IconClipboardCheck, IconEdit, IconQrcode } from '@tabler/icons-react';
 import { QRCodeSVG } from 'qrcode.react';
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import InventoryMetricsRow from '../components/inventory/InventoryMetricsRow';
 import SerializedComponentsPanel from '../components/inventory/SerializedComponentsPanel';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import NFPADiamond from '../components/NFPADiamond';
 import StockHistoryChart from '../components/StockHistoryChart';
 import { useNotifications } from '../hooks/useNotifications';
 import { assetsAPI, CycleCountPayload, inventoryAPI, reorderAPI } from '../services/api';
-import { Asset, InventoryItem, ReorderRequest, UsageLog } from '../types';
+import { Asset, InventoryItem, InventoryItemMetrics, ReorderRequest, UsageLog } from '../types';
 import { showError } from '../utils/dialogs';
 
 // Cycle-count reason options (op-c7y4). Mirrors the reconciliation grid's
@@ -167,6 +168,7 @@ const InventoryItemDetailPage: React.FC = () => {
   const navigate = useNavigate();
 
   const [item, setItem] = useState<InventoryItem | null>(null);
+  const [metrics, setMetrics] = useState<InventoryItemMetrics | null>(null);
   const [usageLogs, setUsageLogs] = useState<UsageLog[]>([]);
   const [reorderHistory, setReorderHistory] = useState<ReorderRequest[]>([]);
   const [linkedAssets, setLinkedAssets] = useState<Asset[]>([]);
@@ -190,8 +192,9 @@ const InventoryItemDetailPage: React.FC = () => {
     // and show "Item not found" even though the item exists — uid0 hit
     // this on items with no linked-assets filter match where assetsAPI
     // returned a 400.
-    const [itemRes, usageLogsRes, reorderRes, assetsRes] = await Promise.allSettled([
+    const [itemRes, metricsRes, usageLogsRes, reorderRes, assetsRes] = await Promise.allSettled([
       inventoryAPI.getItem(id),
+      inventoryAPI.getItemMetrics(id),
       inventoryAPI.getUsageLogs(id),
       reorderAPI.listRequests({ status: undefined }),
       assetsAPI.listAssets({ inventory_item: id }),
@@ -201,6 +204,12 @@ const InventoryItemDetailPage: React.FC = () => {
       setItem(itemRes.value.data);
     } else {
       console.error('Error loading item:', itemRes.reason);
+    }
+
+    if (metricsRes.status === 'fulfilled') {
+      setMetrics(metricsRes.value.data);
+    } else {
+      console.error('Error loading item metrics:', metricsRes.reason);
     }
 
     if (usageLogsRes.status === 'fulfilled') {
@@ -305,6 +314,10 @@ const InventoryItemDetailPage: React.FC = () => {
         {item.is_hazardous && <Badge color="orange">Hazardous Material</Badge>}
         {item.is_serialized && <Badge color="grape">Serialized</Badge>}
       </Group>
+
+      {/* Prominent metrics strip — hard to get from a single screen otherwise
+          (issue-5): SKU · QOH · QOO · QA · QC · QIT · RP · Lead · Cost. */}
+      {metrics && <InventoryMetricsRow sku={item.sku} metrics={metrics} />}
 
       {/* Tabs */}
       <Tabs value={activeTab} onChange={setActiveTab}>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,7 +2,7 @@
  * API service for communicating with the Django backend
  */
 import axios from 'axios';
-import { ActiveMaintenanceRow, Asset, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
+import { ActiveMaintenanceRow, Asset, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, InventoryItemMetrics, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
 
 /**
  * Resolves the API base URL based on environment.
@@ -208,6 +208,9 @@ api.interceptors.response.use(
 export const inventoryAPI = {
   getItem: (id: string) =>
     api.get<InventoryItem>(`/inventory/items/${id}/`),
+
+  getItemMetrics: (id: string) =>
+    api.get<InventoryItemMetrics>(`/inventory/items/${id}/metrics/`),
 
   getItemSuppliers: (itemId: string) =>
     api.get<{ results: ItemSupplier[] }>(`/inventory/item-suppliers/?item_id=${itemId}`),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -195,6 +195,26 @@ export interface InventoryItem {
   days_since_last_count: number | null;
 }
 
+export type InventoryCostTrend = 'up' | 'down' | 'flat' | 'no_history';
+
+// Computed stock + cost metrics for the item-detail metrics row (issue-5).
+// Served by GET /api/inventory/items/<id>/metrics/. Quantities are numbers;
+// money fields arrive as decimal strings (matching InventoryItem.unit_cost).
+export interface InventoryItemMetrics {
+  current_stock: number; // QOH — on hand
+  quantity_on_order: number; // QOO — open PO units
+  quantity_available: number; // QA — on hand minus committed
+  quantity_committed: number; // QC — open work-order demand
+  quantity_in_transit: number; // QIT — partially-received (⊆ QOO)
+  reorder_point: number; // RP
+  lead_time_days: number | null; // Lead
+  unit_cost: string | null; // Cost — per-item, or per-case when case-based
+  cost_trend: InventoryCostTrend;
+  last_po_unit_cost: string | null;
+  is_case_based: boolean;
+  case_size: number | null; // units per case
+}
+
 export interface UsageLog {
   id: number;
   item: string;


### PR DESCRIPTION
## What (Ian, 07-07)
The inventory item detail now shows a computed metrics row — `SKU · QOH · QOO · QA · QC · QIT · RP · Lead · Cost` — with the on-order / in-transit / committed quantities and a cost trend, "since it's not easy to get this information from a single screen."

## Backend
New `GET /api/inventory/items/{id}/metrics/` (dedicated detail endpoint — avoids N+1 on the item list) → `InventoryMetricsSerializer`:
- `quantity_on_order` (QOO) — open PO line units (sent/confirmed/partially-received, not voided)
- `quantity_in_transit` (QIT) — partially-received pending units (⊆ QOO)
- `quantity_committed` (QC) — open work-order material demand
- `quantity_available` (QA) — QOH − QC
- `reorder_point` (RP = reorder_quantity), `lead_time_days`, `unit_cost`
- `cost_trend` (up/down/flat/no_history) + `last_po_unit_cost` — vs the most recent PO for the item
- `is_case_based`, `case_size`

## Completeness
metrics @action + serializer + **permission matrix** (regenerated + docs) + **web** `InventoryMetricsRow` component wired into `InventoryItemDetailPage` + api.ts + types + backend tests (328 lines: each computed field with fixture POs/WOs/price history) + vitest (row render).

## Notes
- Rebased clean onto current main (#850). Shares `InventoryItemViewSet` + item serializer with the cycle-count PR (#851) → whichever merges second needs a trivial additive rebase (keep both @actions/field sets).
- **Cross-project note:** `quantity_available`/`quantity_committed` are floats here; I'm shipping a small ScanTTY follow-up so its client parses them as floats (the #89 client assumed int) — flagged by the cross-project validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)