### PR TITLE
fix(inventory): de-dup asset detail QR into one + drop redundant Generate QR Code button

### DIFF
--- a/backend/inventory/tests/test_asset_tag.py
+++ b/backend/inventory/tests/test_asset_tag.py
@@ -80,6 +80,24 @@ class TestRenderAssetTag:
             pytest.skip("pyzbar not installed; cannot decode QR for verification")
         assert decoded == SCAN_URL_TEMPLATE.format(asset_id=asset.id)
 
+    def test_asset_with_tag_renders_qr_without_manual_generate(self):
+        # A saved asset already carries its human-readable asset_tag, and its
+        # single QR is produced on read by render_asset_tag. No manual
+        # "generate QR" step is required and no QR image is stored on the model
+        # (the redundant generate_qr UI flow was removed) — yet the on-read QR
+        # still resolves to the asset's scan page.
+        asset = AssetFactory()
+        assert asset.asset_tag  # tag present without any generate step
+        assert not asset.qr_code  # nothing generated / stored on the model
+
+        png = render_asset_tag(asset, size="standard")
+        img = _open_png(png)
+
+        decoded = _try_decode_qr(img)
+        if decoded is None:
+            pytest.skip("pyzbar not installed; cannot decode QR for verification")
+        assert decoded == SCAN_URL_TEMPLATE.format(asset_id=asset.id)
+
     def test_rivet_exclusion_zones_are_blank(self):
         asset = AssetFactory()
         png = render_asset_tag(asset, size="standard", dpi=1440)

--- a/frontend/src/__tests__/pages/AssetDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/AssetDetailPage.test.tsx
@@ -414,7 +414,11 @@ describe('AssetDetailPage', () => {
     });
   });
 
-  it('displays QR code when available', async () => {
+  it('no longer renders a standalone QR Code section or Generate QR Code button', async () => {
+    // The redundant standalone "QR Code" section and its manual "Generate QR
+    // Code" step were removed. Even though the serializer still returns a
+    // qr_code_url (mockAsset sets one), the page must not render that section —
+    // the single QR now lives in the Asset Tag section.
     render(
       <MantineProvider><MemoryRouter>
         <AssetDetailPage />
@@ -422,46 +426,18 @@ describe('AssetDetailPage', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('QR Code')).toBeInTheDocument();
+      expect(screen.getByText('Test Asset')).toBeInTheDocument();
     });
 
-    const qrImage = screen.getByAltText('QR Code');
-    expect(qrImage).toHaveAttribute('src', 'https://example.com/qr.png');
-  });
-
-  it('generates QR code when not available', async () => {
-    const assetWithoutQR = { ...mockAsset, qr_code_url: null };
-    mockAssetsAPI.getAsset.mockResolvedValueOnce({
-      data: assetWithoutQR,
-      status: 200,
-      statusText: 'OK',
-      headers: {},
-      config: {} as any,
-    });
-    mockAssetsAPI.generateQR.mockResolvedValueOnce({
-      data: {},
-      status: 200,
-      statusText: 'OK',
-      headers: {},
-      config: {} as any,
-    });
-
-    render(
-      <MantineProvider><MemoryRouter>
-        <AssetDetailPage />
-      </MemoryRouter></MantineProvider>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText('QR code not generated yet.')).toBeInTheDocument();
-    });
-
-    const generateButton = screen.getByText('Generate QR Code');
-    await userEvent.click(generateButton);
-
-    await waitFor(() => {
-      expect(mockAssetsAPI.generateQR).toHaveBeenCalledWith('test-id');
-    });
+    expect(screen.queryByText('QR Code')).not.toBeInTheDocument();
+    expect(screen.queryByAltText('QR Code')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Generate QR Code' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('QR code not generated yet.')
+    ).not.toBeInTheDocument();
+    expect(mockAssetsAPI.generateQR).not.toHaveBeenCalled();
   });
 
   it('hides asset tag section when not logged in', async () => {
@@ -518,6 +494,34 @@ describe('AssetDetailPage', () => {
         'src',
         expect.stringContaining('size=large')
       );
+    });
+
+    it('shows exactly one QR (the asset tag) and no Generate QR button', async () => {
+      render(
+        <MantineProvider><MemoryRouter>
+          <AssetDetailPage />
+        </MemoryRouter></MantineProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('asset-tag-section')).toBeInTheDocument();
+      });
+
+      // Exactly one QR on the page: the asset tag, rendered on-read from the
+      // tag endpoint (which encodes the /scan/asset/<id> URL that resolves to
+      // this asset). No standalone QR image, no manual generate step.
+      const qrImages = screen.getAllByAltText(/Asset tag/);
+      expect(qrImages).toHaveLength(1);
+      expect(qrImages[0]).toHaveAttribute(
+        'src',
+        expect.stringContaining('/inventory/assets/test-id/tag/')
+      );
+
+      expect(screen.queryByText('QR Code')).not.toBeInTheDocument();
+      expect(screen.queryByAltText('QR Code')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Generate QR Code' })
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/pages/AssetDetailPage.tsx
+++ b/frontend/src/pages/AssetDetailPage.tsx
@@ -1167,58 +1167,10 @@ const AssetDetailPage: React.FC = () => {
             </section>
           )}
 
-        {/* QR Code */}
-        <section className="asset-detail-section">
-          <h2>QR Code</h2>
-          {asset.qr_code_url ? (
-            <div className="qr-code-section">
-              <img src={asset.qr_code_url} alt="QR Code" className="qr-code-image" />
-              <div className="qr-code-actions">
-                <a
-                  href={asset.qr_code_url}
-                  download={`${asset.name}-qr-code.png`}
-                  className="download-button"
-                >
-                  Download QR Code
-                </a>
-                {asset.qr_code_scan_url && (
-                  <a
-                    href={asset.qr_code_scan_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="scan-link"
-                  >
-                    View Scan Page
-                  </a>
-                )}
-              </div>
-            </div>
-          ) : (
-            <div className="qr-code-section">
-              <p>QR code not generated yet.</p>
-              <button
-                className="generate-qr-button"
-                onClick={async () => {
-                  if (id) {
-                    try {
-                      await assetsAPI.generateQR(id);
-                      await loadAssetDetails();
-                    } catch (err: any) {
-                      showError(extractErrorMessage(err, 'Failed to generate QR code'));
-                    }
-                  }
-                }}
-              >
-                Generate QR Code
-              </button>
-            </div>
-          )}
-        </section>
-
-        {/* Asset Tag */}
+        {/* Asset Tag (the single QR — auto-generated with the tag, rendered on read) */}
         {isLoggedIn && id && (
           <section className="asset-detail-section" data-testid="asset-tag-section">
-            <h2>Asset Tag</h2>
+            <h2>Asset QR &amp; Tag</h2>
             <div className="asset-tag-section">
               <img
                 src={assetsAPI.getTagUrl(id, tagSize)}
@@ -1248,8 +1200,8 @@ const AssetDetailPage: React.FC = () => {
                 </a>
               </div>
               <p className="asset-tag-note" style={{ marginTop: '0.5rem', fontSize: '0.85rem', color: '#555' }}>
-                Designed for rivet mounting &mdash; holes at &frac14;&quot; from each
-                short edge for a 3/32&quot; rivet.
+                Scan the QR to open this asset&rsquo;s page. Designed for rivet mounting
+                &mdash; holes at &frac14;&quot; from each short edge for a 3/32&quot; rivet.
               </p>
             </div>
           </section>


### PR DESCRIPTION
## What (Ian, 07-08)
The Asset Detail page showed **two** QR codes (the "Asset Tag" QR and the "Scan Asset" QR) plus a "Generate QR Code" button — even though a QR already existed. Now there's **one** Asset QR (generated on-read as part of the asset-tag process), and the redundant Generate button is gone.

## Changes
Frontend-only (the QR is derived from the asset tag, no separate generate step needed): `AssetDetailPage.tsx` renders a single QR and removes the redundant second QR + Generate button; tests updated. Net removal (56 lines out of the page).

Rebased clean onto current main. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)