### PR TITLE
ci(backend): catch conflicting/missing Django migrations at PR time (op-yfrf)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,35 @@ jobs:
           ALLOWED_HOSTS: localhost,127.0.0.1
           REDIS_URL: redis://localhost:6379/0
 
+      - name: Check for conflicting migration leaves
+        run: |
+          # Fails when an app's migration graph has more than one leaf node —
+          # e.g. two PRs each branch a 0079 migration off 0078 and both land,
+          # leaving 0079_a and 0079_b as siblings. Django's `migrate` aborts at
+          # startup on such a graph ("multiple leaf nodes"), so on 2026-07-08
+          # this turned into a prod deploy outage that failed every deploy until
+          # the 0080 merge migration landed (PR #864). The drift check above
+          # also trips on this today, but only as a side effect of graph
+          # loading; this is the explicit, named gate that tells a developer to
+          # run `makemigrations --merge`. It reads the on-disk graph only (no
+          # DB) — see backend/config/management/commands/check_migration_conflicts.py.
+          #
+          # IMPORTANT: this only sees the conflict when CI evaluates a tree that
+          # contains BOTH leaves. GitHub already runs PR CI against the
+          # PR-merged-into-base ref, but a stale PR is merged against an old
+          # base. Enable branch protection "Require branches to be up to date
+          # before merging" so a PR adding 0079 is rebased onto a main that
+          # already has the other 0079 (and CI re-runs) before the merge button
+          # unlocks. That branch-protection setting is what makes this gate fire.
+          cd backend
+          python manage.py check_migration_conflicts
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_makerspace_inventory
+          SECRET_KEY: test-secret-key-for-ci-only
+          DEBUG: 1
+          ALLOWED_HOSTS: localhost,127.0.0.1
+          REDIS_URL: redis://localhost:6379/0
+
       - name: Run migrations
         run: |
           cd backend

--- a/backend/config/management/commands/check_migration_conflicts.py
+++ b/backend/config/management/commands/check_migration_conflicts.py
@@ -1,0 +1,67 @@
+"""``manage.py check_migration_conflicts`` — fail on a multi-leaf migration graph.
+
+Two PRs that each branch a new migration off the same parent (e.g. two
+``0079`` migrations off ``0078_supplier_ordering_adapter``) produce *two leaf
+nodes* in that app's migration graph once both land on ``main``. Django's
+``migrate`` refuses to run against such a graph — it aborts at startup with::
+
+    Conflicting migrations detected; multiple leaf nodes in the migration
+    graph: (0079_alter_workordersubmission_source,
+    0079_assetmeter_assetmeterreading_and_more in inventory).
+
+which turns every deploy into an outage until a merge migration is committed
+(the 2026-07-08 incident + PR #864). This command surfaces that same conflict
+at PR time so CI fails instead of the deploy.
+
+It inspects the migration graph *on disk only* (``MigrationLoader(None)``), so
+it needs no database connection and keys off exactly what
+``makemigrations --merge`` would. CI runs it as its own step; the companion
+test ``config/tests/test_migration_conflicts.py`` keeps the repo's own graph
+single-leaf.
+
+Note for reviewers: the existing ``makemigrations --check --dry-run`` drift
+step *does* also abort on a multi-leaf graph in the current Django, but only
+as an incidental side effect of graph loading — its stated job is
+missing-migration drift. This command is the explicit, purpose-built conflict
+gate, so a distinct CI failure tells a developer to run ``--merge`` rather
+than ``makemigrations``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from django.core.management.base import BaseCommand
+from django.db.migrations.loader import MigrationLoader
+
+
+class Command(BaseCommand):
+    help = "Fail if any app's migration graph has multiple leaf nodes (a conflict)."
+
+    def handle(self, *args, **options):
+        # connection=None builds the graph from the migration files on disk
+        # without querying any database for applied migrations — the same
+        # loader makemigrations uses to detect merge conflicts. This keeps the
+        # check fast and usable in any CI job, DB or not.
+        loader = MigrationLoader(None, ignore_no_migrations=True)
+        conflicts = loader.detect_conflicts()
+
+        if not conflicts:
+            self.stdout.write(
+                self.style.SUCCESS("OK — every app's migration graph has a single leaf node.")
+            )
+            return
+
+        self.stderr.write(
+            self.style.ERROR(
+                "Conflicting migrations detected; multiple leaf nodes in the migration graph:"
+            )
+        )
+        for app_label, leaves in sorted(conflicts.items()):
+            self.stderr.write(f"  {app_label}: {', '.join(sorted(leaves))}")
+        self.stderr.write(
+            "\nTwo migrations branch off the same parent. Rebase onto the latest "
+            "main and run `python manage.py makemigrations --merge` to add a merge "
+            "migration, then commit it."
+        )
+        sys.exit(1)

--- a/backend/config/tests/test_migration_conflicts.py
+++ b/backend/config/tests/test_migration_conflicts.py
@@ -1,0 +1,80 @@
+"""Tests for ``manage.py check_migration_conflicts``.
+
+Regression guard for the 2026-07-08 deploy outage (PR #864): two ``0079``
+inventory migrations branched off ``0078`` created a multi-leaf graph that
+aborted every ``migrate`` at startup. These tests make that class of conflict
+fail in CI instead of at deploy.
+
+``check_migration_conflicts`` reads the migration graph on disk only
+(``MigrationLoader(None)``), so none of these tests need a database.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+
+import pytest
+
+# The command builds its loader through this name; patch it here to simulate
+# graph states without writing throwaway migration files to disk.
+_LOADER = "config.management.commands.check_migration_conflicts.MigrationLoader"
+
+
+def test_repo_migration_graph_has_no_conflicts():
+    """The committed migration graph must be single-leaf per app.
+
+    This is the canary: if two migrations ever branch off the same parent and
+    both land, this goes red (locally under pytest and in the CI step that runs
+    the same command). Exit 0 == no ``SystemExit`` raised.
+    """
+    out = StringIO()
+    call_command("check_migration_conflicts", stdout=out, stderr=StringIO())
+    assert "single leaf node" in out.getvalue()
+
+
+def test_command_exits_nonzero_on_conflict():
+    """A multi-leaf graph must make the command exit 1 so CI goes red, and the
+    message must name the offending app, its leaves, and the ``--merge`` fix."""
+    fake_conflicts = {"inventory": ["0079_alter_workordersubmission_source", "0079_assetmeter"]}
+    with mock.patch(_LOADER) as loader_cls:
+        loader_cls.return_value.detect_conflicts.return_value = fake_conflicts
+        err = StringIO()
+        with pytest.raises(SystemExit) as excinfo:
+            call_command("check_migration_conflicts", stdout=StringIO(), stderr=err)
+
+    assert excinfo.value.code == 1
+    message = err.getvalue()
+    assert "multiple leaf nodes" in message
+    assert "inventory: 0079_alter_workordersubmission_source, 0079_assetmeter" in message
+    assert "makemigrations --merge" in message
+
+
+def test_command_succeeds_on_clean_graph():
+    """No conflicts => exit 0 with a success message (no ``SystemExit``)."""
+    with mock.patch(_LOADER) as loader_cls:
+        loader_cls.return_value.detect_conflicts.return_value = {}
+        out = StringIO()
+        call_command("check_migration_conflicts", stdout=out, stderr=StringIO())
+
+    assert "single leaf node" in out.getvalue()
+
+
+def test_multiple_apps_conflicting_are_all_reported():
+    """Every conflicting app is listed, sorted, so one CI run surfaces them all."""
+    fake_conflicts = {
+        "inventory": ["0079_a", "0079_b"],
+        "membership": ["0005_x", "0005_y"],
+    }
+    with mock.patch(_LOADER) as loader_cls:
+        loader_cls.return_value.detect_conflicts.return_value = fake_conflicts
+        err = StringIO()
+        with pytest.raises(SystemExit) as excinfo:
+            call_command("check_migration_conflicts", stdout=StringIO(), stderr=err)
+
+    assert excinfo.value.code == 1
+    message = err.getvalue()
+    assert "inventory: 0079_a, 0079_b" in message
+    assert "membership: 0005_x, 0005_y" in message

--- a/docs/INCIDENTS/migration-leaf-conflict.md
+++ b/docs/INCIDENTS/migration-leaf-conflict.md
@@ -1,0 +1,81 @@
+# Incident runbook: conflicting migration leaves broke every deploy
+
+> Tracking bead: **op-yfrf** (P1). Incident date: **2026-07-08**.
+> Fix that unblocked deploy: **PR #864** (`0080_merge_20260708_1504`).
+> CI guard added by this bead: `manage.py check_migration_conflicts` +
+> the "Check for conflicting migration leaves" step in `.github/workflows/ci.yml`.
+
+## Symptom
+
+Every production deploy failed. The backend container aborted at startup
+during `migrate`:
+
+```
+django.db.migrations.exceptions.CommandError:
+  Conflicting migrations detected; multiple leaf nodes in the migration
+  graph: (0079_alter_workordersubmission_source,
+  0079_assetmeter_assetmeterreading_and_more in inventory).
+To fix them run 'python manage.py makemigrations --merge'
+```
+
+CI had been green on both PRs. The conflict only appeared once both were on
+`main`, so it was invisible until the deploy pipeline ran `migrate`.
+
+## Root cause
+
+Two PRs each branched a **new `0079` inventory migration off the same parent**
+(`0078_supplier_ordering_adapter`) and both merged:
+
+- #860 (Asset Meter): `inventory/0079_assetmeter_assetmeterreading_and_more`
+- #862 (OMR scan reader): `inventory/0079_alter_workordersubmission_source`
+
+That left **two leaf nodes** in the `inventory` migration graph. Django refuses
+to build a migration plan when an app has more than one leaf — `migrate` (and
+any command that loads the graph) aborts.
+
+Why CI never caught it: each PR, evaluated on its own, had exactly **one** `0079`
+leaf (its own). A single-leaf graph is valid, so `makemigrations --check` passed
+on each PR. The conflict is a property of the *pair*, which no CI run ever saw
+because neither PR was rebased onto a `main` that already contained the other's
+`0079` before it merged.
+
+## Mitigations in place (op-yfrf fix)
+
+1. **Explicit CI gate.** `backend/config/management/commands/check_migration_conflicts.py`
+   loads the on-disk migration graph (`MigrationLoader(None)`, no database) and
+   exits non-zero if any app has multiple leaf nodes. The `backend-tests` job
+   runs it as the **"Check for conflicting migration leaves"** step, and
+   `config/tests/test_migration_conflicts.py` runs the same check inside the
+   suite (so `cd backend && pytest` catches a committed conflict locally too).
+
+   Run it by hand any time:
+
+   ```
+   cd backend && python manage.py check_migration_conflicts
+   ```
+
+2. **Branch protection — action required (Ian).** The CI gate only sees the
+   conflict when it evaluates a tree containing **both** leaves. GitHub runs PR
+   CI against the PR-merged-into-base ref, but a *stale* PR is merged against an
+   old base, so the second `0079` can still slip through. Turn on, for `main`:
+
+   > Settings → Branches → branch protection rule for `main` →
+   > **"Require branches to be up to date before merging"**
+
+   With that on, a PR that adds `0079` must be rebased onto a `main` that already
+   has the other `0079` (and re-run CI) before its merge button unlocks — at
+   which point the graph has both leaves and the CI step fails, as intended.
+
+## If it happens again
+
+Rebase the offending branch onto the latest `main`, then add a merge migration
+and commit it:
+
+```
+cd backend
+python manage.py makemigrations --merge   # writes an inventory/00NN_merge_*.py
+git add inventory/migrations/00NN_merge_*.py
+```
+
+Re-run `python manage.py check_migration_conflicts` — it should print
+`OK — every app's migration graph has a single leaf node.`


### PR DESCRIPTION
## What & why

Root cause of the **2026-07-08 prod deploy outage**: two PRs each branched a
`0079` inventory migration off `0078_supplier_ordering_adapter` in parallel and
both merged —

- #860 (Asset Meter): `inventory/0079_assetmeter_assetmeterreading_and_more`
- #862 (OMR scan reader): `inventory/0079_alter_workordersubmission_source`

leaving **two leaf nodes** in the migration graph. Django's `migrate` aborts at
startup on a multi-leaf graph, so every deploy failed until the `0080` merge
migration landed (#864). CI never caught it because each PR, evaluated on its
own, had a single `0079` leaf — the conflict is a property of the *pair*.

## Change

- **`backend/config/management/commands/check_migration_conflicts.py`** — loads
  the on-disk migration graph (`MigrationLoader(None)`, **no DB**) and exits
  non-zero if any app has more than one leaf node. Models the existing
  `check_permission_matrix` command.
- **`.github/workflows/ci.yml`** — new **"Check for conflicting migration
  leaves"** step in `backend-tests`, right after the existing drift check.
- **`backend/config/tests/test_migration_conflicts.py`** — 4 tests, incl. an
  in-suite canary asserting the repo's own graph stays single-leaf.
- **`docs/INCIDENTS/migration-leaf-conflict.md`** — incident runbook.

The existing `makemigrations --check --dry-run` drift step is kept as the
**missing-migration guard**. Note: I empirically found that in the current
Django (6.0.6) that drift step *also* aborts on a multi-leaf graph — but only
as an incidental side effect of graph loading, and the bead's suggested
`makemigrations --merge --check` signal does **not** fail (exits 0). So this
adds an explicit, named gate that tells a developer to run `--merge`.

## Verification (empirical — the bead's completeness gate)

| Scenario | Command | Result |
|---|---|---|
| Two `0079`-style leaves off one parent | `check_migration_conflicts` | **exit 1** ✅ |
| Clean single-leaf graph | `check_migration_conflicts` | **exit 0** ✅ |
| Unmigrated model change | `makemigrations --check --dry-run` (existing) | **exit 1** ✅ |

Backend lint (`black`/`isort`/`flake8`) clean; new tests green on Postgres;
`manage.py check` clean; command registered.

## ⚠️ Action required (Ian) — branch protection

The CI gate only sees the conflict when CI evaluates a tree containing **both**
leaves. GitHub runs PR CI against the PR-merged-into-base ref, but a *stale* PR
merges against an old base. Enable, for `main`:

> Settings → Branches → rule for `main` → **"Require branches to be up to date
> before merging"**

That forces a PR adding `0079` to rebase onto a `main` that already has the
other `0079` (and re-run CI) before merge — which is what makes this gate fire.

Bead: op-yfrf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
