### PR TITLE
fix(dashboard): correct invalid deliveries widget prefetch (fixes dashboard crash)

### DIFF
--- a/backend/dashboard/tests/test_views.py
+++ b/backend/dashboard/tests/test_views.py
@@ -175,30 +175,59 @@ class TestDashboardWidgetDataViews:
         assert "daily_scans" in data
 
     def test_get_deliveries_data(self, authenticated_client):
-        """Test getting deliveries data."""
+        """Deliveries widget returns 200 for a delivery that HAS items.
+
+        Regression (prod 500 -> whole-dashboard crash): get_deliveries_data
+        used prefetch_related("items__purchase_order_item__item"), but
+        PurchaseOrderItem has no "item" relation. Django only validates that
+        trailing segment once level-2 (the DeliveryItems) yields objects, so a
+        delivery WITH items raised ValueError while a delivery without items did
+        not. The previous version of this test created a delivery with no items
+        and thus never traversed far enough to catch it.
+        """
         client, user = authenticated_client
         from datetime import timedelta
+        from decimal import Decimal
 
         from django.utils import timezone
 
         from inventory.tests.factories import SupplierFactory
-        from reorder_queue.models import OrderDelivery, PurchaseOrder
+        from reorder_queue.models import (
+            DeliveryItem,
+            OrderDelivery,
+            PurchaseOrder,
+            PurchaseOrderItem,
+        )
 
-        # Create a purchase order and delivery
         supplier = SupplierFactory()
         po = PurchaseOrder.objects.create(
             supplier=supplier, status=PurchaseOrder.SENT, created_by=user
         )
-        OrderDelivery.objects.create(
+        # Freeform line item (no item_supplier / asset needed).
+        po_item = PurchaseOrderItem.objects.create(
+            purchase_order=po,
+            description="Freeform widget",
+            quantity_ordered=5,
+            unit_cost_ordered=Decimal("1.00"),
+        )
+        delivery = OrderDelivery.objects.create(
             purchase_order=po,
             delivery_date=timezone.now() - timedelta(days=1),
             received_by=user,
+        )
+        DeliveryItem.objects.create(
+            delivery=delivery,
+            purchase_order_item=po_item,
+            quantity_received=3,
         )
 
         response = client.get("/api/dashboard/widget-data/deliveries/")
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert "count" in data
-        assert "deliveries" in data
-        assert len(data["deliveries"]) >= 0
+        assert data["count"] == 1
+        assert len(data["deliveries"]) == 1
+        row = data["deliveries"][0]
+        assert row["items_count"] == 1
+        assert row["total_quantity"] == 3
+        assert row["supplier_name"] == supplier.name

--- a/backend/dashboard/views.py
+++ b/backend/dashboard/views.py
@@ -657,7 +657,7 @@ def get_deliveries_data(request):
         deliveries = (
             OrderDelivery.objects.filter(delivery_date__gte=thirty_days_ago)
             .select_related("purchase_order__supplier", "received_by")
-            .prefetch_related("items__purchase_order_item__item")
+            .prefetch_related("items")
             .order_by("-delivery_date")[:50]
         )
 


### PR DESCRIPTION
## 🐛 The bug (live prod: logged-in `/dashboard` → "Something went wrong")

Diagnosed from self-hosted Sentry (frontend group 43, culprit `/dashboard`) + read-only inspection on the OMS host.

`get_deliveries_data` runs:
```python
.prefetch_related("items__purchase_order_item__item")   # invalid
```
`PurchaseOrderItem` has **no `item` relation** (its relations: `serialized_components, deliveries, audit_events, purchase_order, item_supplier, asset, voided_by`). Django only validates that trailing segment once level-2 (the `DeliveryItem`s) yields objects, so `/api/dashboard/widget-data/deliveries/` raises:
```
ValueError: 'items__purchase_order_item__item' does not resolve to an item
that supports prefetching — this is an invalid parameter to prefetch_related().
```
…and returns **500 whenever a delivery in the last 30 days has ≥1 item**. Prod had exactly one such delivery, created 07-08 21:19Z — matching the crash onset.

The frontend deliveries widget then renders that 500's `{code, message}` error body directly as a JSX child → **React #31** → the whole dashboard trips its error boundary.

## The fix

The loop never uses the prefetched item — only `delivery.items`. So prefetch `"items"` (still useful for `items.count()` and the quantity sum) and drop the invalid tail. One line.

## Verified

- **Read-only on prod** (Django 6.0.6): original path raises the `ValueError`; corrected query returns `rows=1 OK`.
- **No migration drift** — confirmed zero unapplied migrations on prod (ruled out as a cause).
- **Regression test** strengthened to create a delivery *with* an item (the prior test created none, so it never traversed far enough). `pytest -k test_get_deliveries_data` → **1 passed**.

## Not in this PR (tracked in op-8lhv)
Per-widget error boundaries (so one widget can't wholesale-crash the dashboard) + `capture_exception` in the `get_*_data` `except` handlers (they currently swallow exceptions, which is why this was invisible in the backend Sentry project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)