### PR TITLE
fix(dashboard): isolate widget failures + un-blind swallowed widget-data 500s (op-8lhv)

### DIFF
--- a/backend/dashboard/tests/test_views.py
+++ b/backend/dashboard/tests/test_views.py
@@ -2,6 +2,8 @@
 Integration tests for dashboard API views.
 """
 
+from unittest import mock
+
 from django.contrib.auth import get_user_model
 
 import pytest
@@ -231,3 +233,41 @@ class TestDashboardWidgetDataViews:
         assert row["items_count"] == 1
         assert row["total_quantity"] == 3
         assert row["supplier_name"] == supplier.name
+
+    def test_widget_data_view_reports_swallowed_exception(self, authenticated_client):
+        """A widget-data view that 500s must report the exception before it returns.
+
+        The ``get_*_data`` views wrap their body in a broad ``except Exception``
+        that turns any failure into a standardized error envelope so one widget
+        can't 500 the whole dashboard request. That broad catch also swallowed
+        the traceback, so real failures never reached Sentry and we were blind
+        to why a widget 500s. Regression for op-8lhv: the handler must report
+        the exception (``sentry_sdk.capture_exception``) yet still emit the
+        standardized envelope unchanged.
+        """
+        from inventory.models import InventoryItem
+
+        client, _user = authenticated_client
+
+        with (
+            mock.patch("dashboard.views.sentry_sdk.capture_exception") as mock_capture,
+            mock.patch.object(
+                InventoryItem.objects,
+                "filter",
+                side_effect=RuntimeError("boom: missing column"),
+            ),
+        ):
+            response = client.get("/api/dashboard/widget-data/low-stock/")
+
+        # Standardized error envelope, unchanged shape, 500.
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        body = response.json()
+        assert body["error"]["code"] == "server_error"
+        assert "boom: missing column" in body["error"]["message"]
+
+        # The swallowed exception was reported to Sentry before the envelope
+        # was returned — the failure is no longer invisible.
+        mock_capture.assert_called_once()
+        reported = mock_capture.call_args[0][0]
+        assert isinstance(reported, RuntimeError)
+        assert str(reported) == "boom: missing column"

--- a/backend/dashboard/views.py
+++ b/backend/dashboard/views.py
@@ -2,11 +2,13 @@
 API views for dashboard configuration management.
 """
 
+import logging
 from datetime import datetime
 
 from django.http import JsonResponse
 from django.utils import timezone as dj_timezone
 
+import sentry_sdk
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
@@ -17,6 +19,28 @@ from config.api_errors import ErrorCode, error_response
 from .audit_feed import collect_events
 from .models import DashboardConfig, DashboardMessage, DashboardWidget
 from .serializers import DashboardWidgetSerializer
+
+logger = logging.getLogger(__name__)
+
+
+def _widget_data_server_error(exc):
+    """Report a swallowed widget-data exception, then return the standardized 500 envelope.
+
+    Every ``get_*_data`` widget view wraps its body in a broad ``except Exception``
+    and returns the standardized error envelope so a single failing widget can't
+    500 the whole dashboard request. That broad catch also swallows the traceback
+    before Django's default handler can report it, so the real failure never
+    reaches Sentry and we stay blind to why a widget 500s (op-8lhv). Capture the
+    exception to Sentry and log it here — BEFORE returning the envelope — so
+    swallowed widget-data 500s become visible without changing the response shape.
+    """
+    logger.exception("dashboard widget-data view failed")
+    sentry_sdk.capture_exception(exc)
+    return error_response(
+        ErrorCode.SERVER_ERROR,
+        str(exc),
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+    )
 
 
 @api_view(["GET"])
@@ -423,11 +447,7 @@ def get_low_stock_data(request):
         )
 
     except Exception as e:
-        return error_response(
-            ErrorCode.SERVER_ERROR,
-            str(e),
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
+        return _widget_data_server_error(e)
 
 
 @api_view(["GET"])
@@ -485,11 +505,7 @@ def get_pending_reorders_data(request):
         )
 
     except Exception as e:
-        return error_response(
-            ErrorCode.SERVER_ERROR,
-            str(e),
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
+        return _widget_data_server_error(e)
 
 
 @api_view(["GET"])
@@ -547,11 +563,7 @@ def get_asset_problems_data(request):
         )
 
     except Exception as e:
-        return error_response(
-            ErrorCode.SERVER_ERROR,
-            str(e),
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
+        return _widget_data_server_error(e)
 
 
 @api_view(["GET"])
@@ -630,11 +642,7 @@ def get_qr_scans_data(request):
         )
 
     except Exception as e:
-        return error_response(
-            ErrorCode.SERVER_ERROR,
-            str(e),
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
+        return _widget_data_server_error(e)
 
 
 @api_view(["GET"])
@@ -691,11 +699,7 @@ def get_deliveries_data(request):
         )
 
     except Exception as e:
-        return error_response(
-            ErrorCode.SERVER_ERROR,
-            str(e),
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
+        return _widget_data_server_error(e)
 
 
 def _parse_audit_feed_dt(value):

--- a/frontend/src/__tests__/components/DashboardWidgetResilience.test.tsx
+++ b/frontend/src/__tests__/components/DashboardWidgetResilience.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Dashboard widget resilience tests (op-8lhv).
+ *
+ * One widget-data endpoint 500'ing used to blank the whole dashboard via two
+ * independent defects:
+ *   1. Widgets stored the raw `{code, message}` error envelope in state and
+ *      rendered it as a JSX child, throwing React #31.
+ *   2. There was no per-widget error isolation, so that throw bubbled to the
+ *      app-level boundary and took down the entire page.
+ *
+ * These tests lock in the fixes: a 500 surfaces a friendly per-widget string,
+ * and a widget that crashes at render is isolated so its siblings keep
+ * rendering.
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import DashboardWidget from '../../components/dashboard/DashboardWidget';
+import DeliveriesWidget from '../../components/dashboard/DeliveriesWidget';
+import WidgetErrorBoundary from '../../components/dashboard/WidgetErrorBoundary';
+import { dashboardAPI } from '../../services/api';
+
+vi.mock('../../services/api', () => ({
+  dashboardAPI: {
+    getDeliveriesData: vi.fn(),
+  },
+}));
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <MantineProvider>
+      <BrowserRouter>{ui}</BrowserRouter>
+    </MantineProvider>
+  );
+
+// The standardized 500 envelope the backend emits from error_response(): axios
+// rejects with this shape on the deliveries endpoint.
+const serverErrorEnvelope = {
+  response: {
+    status: 500,
+    data: { error: { code: 'server_error', message: 'Internal server error.' } },
+  },
+};
+
+describe('Dashboard widget resilience (op-8lhv)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a friendly string (not the raw {code,message} object) when a widget fetch 500s', async () => {
+    vi.mocked(dashboardAPI.getDeliveriesData).mockRejectedValueOnce(serverErrorEnvelope);
+
+    renderWithProviders(<DeliveriesWidget />);
+
+    // The widget surfaces the envelope's message as a string. If it rendered the
+    // raw {code,message} object it would throw React #31 before this resolves.
+    await waitFor(() => {
+      expect(screen.getByText('Internal server error.')).toBeInTheDocument();
+    });
+    // The widget itself is still on screen — the failure is contained to its own
+    // per-widget error state, not a blank page.
+    expect(screen.getByText('Recent Deliveries')).toBeInTheDocument();
+  });
+
+  it('isolates a crashing widget so sibling widgets keep rendering', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const Boom: React.FC = () => {
+      throw new Error('kaboom');
+    };
+
+    renderWithProviders(
+      <>
+        <WidgetErrorBoundary title="Recent Deliveries">
+          <Boom />
+        </WidgetErrorBoundary>
+        <WidgetErrorBoundary title="Low Stock">
+          <div>healthy widget content</div>
+        </WidgetErrorBoundary>
+      </>
+    );
+
+    // The crashed widget shows its compact fallback...
+    expect(screen.getByText(/couldn't load/i)).toBeInTheDocument();
+    // ...and the sibling still renders. One widget did not take down the rest.
+    expect(screen.getByText('healthy widget content')).toBeInTheDocument();
+
+    consoleError.mockRestore();
+  });
+
+  it('coerces a {code,message} object error to a string instead of throwing React #31', () => {
+    // Defense-in-depth: even if a widget forwards the raw envelope object, the
+    // shared base component must never render it as a JSX child.
+    const envelope = { code: 'server_error', message: 'Internal server error.' };
+
+    expect(() =>
+      renderWithProviders(
+        <DashboardWidget title="Recent Deliveries" error={envelope as unknown as string}>
+          <div>content</div>
+        </DashboardWidget>
+      )
+    ).not.toThrow();
+
+    expect(screen.getByText('Internal server error.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/AssetProblemsWidget.tsx
+++ b/frontend/src/components/dashboard/AssetProblemsWidget.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { dashboardAPI } from '../../services/api';
 import { AssetProblemsData } from '../../types';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
 import DashboardWidget from './DashboardWidget';
 
 const AssetProblemsWidget: React.FC = () => {
@@ -28,7 +29,7 @@ const AssetProblemsWidget: React.FC = () => {
       const response = await dashboardAPI.getAssetProblemsData();
       setData(response.data);
     } catch (err: any) {
-      setError(err.response?.data?.error || 'Failed to load asset problems');
+      setError(extractErrorMessage(err, 'Failed to load asset problems'));
       console.error('Error loading asset problems:', err);
     } finally {
       setLoading(false);

--- a/frontend/src/components/dashboard/DashboardWidget.tsx
+++ b/frontend/src/components/dashboard/DashboardWidget.tsx
@@ -15,6 +15,32 @@ interface DashboardWidgetProps {
   className?: string;
 }
 
+/**
+ * Coerce whatever lands in the `error` prop to a safe, renderable string.
+ *
+ * The standardized API error envelope is an object (`{code, message}`). If a
+ * widget ever forwards that object instead of a string, rendering it as a JSX
+ * child throws React #31 — which, before the per-widget error boundary existed,
+ * blanked the entire dashboard (op-8lhv). This base component is the single
+ * funnel every widget's error passes through, so guard here: never render a raw
+ * object as a child.
+ */
+function normalizeErrorText(error: unknown): string | undefined {
+  if (!error) {
+    return undefined;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === 'string' && message.trim() !== '') {
+      return message;
+    }
+  }
+  return 'Something went wrong loading this widget.';
+}
+
 const DashboardWidget: React.FC<DashboardWidgetProps> = ({
   title,
   loading = false,
@@ -22,6 +48,7 @@ const DashboardWidget: React.FC<DashboardWidgetProps> = ({
   children,
   className = '',
 }) => {
+  const errorText = normalizeErrorText(error);
   return (
     <Card className={`dashboard-widget ${className}`} shadow="sm" padding="md" radius="md" withBorder>
       <div className="dashboard-widget-header">
@@ -38,14 +65,14 @@ const DashboardWidget: React.FC<DashboardWidgetProps> = ({
             <Loader size="sm" />
           </div>
         )}
-        {error && (
+        {errorText && (
           <div className="dashboard-widget-error">
             <Text c="red" size="sm">
-              {error}
+              {errorText}
             </Text>
           </div>
         )}
-        {!loading && !error && children}
+        {!loading && !errorText && children}
       </div>
     </Card>
   );

--- a/frontend/src/components/dashboard/DeliveriesWidget.tsx
+++ b/frontend/src/components/dashboard/DeliveriesWidget.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { dashboardAPI } from '../../services/api';
 import { DeliveriesData } from '../../types';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
 import DashboardWidget from './DashboardWidget';
 
 const DeliveriesWidget: React.FC = () => {
@@ -28,7 +29,7 @@ const DeliveriesWidget: React.FC = () => {
       const response = await dashboardAPI.getDeliveriesData();
       setData(response.data);
     } catch (err: any) {
-      setError(err.response?.data?.error || 'Failed to load deliveries data');
+      setError(extractErrorMessage(err, 'Failed to load deliveries data'));
       console.error('Error loading deliveries data:', err);
     } finally {
       setLoading(false);

--- a/frontend/src/components/dashboard/LowStockWidget.tsx
+++ b/frontend/src/components/dashboard/LowStockWidget.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { dashboardAPI } from '../../services/api';
 import { LowStockData } from '../../types';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
 import DashboardWidget from './DashboardWidget';
 
 const LowStockWidget: React.FC = () => {
@@ -29,7 +30,7 @@ const LowStockWidget: React.FC = () => {
       const response = await dashboardAPI.getLowStockData();
       setData(response.data);
     } catch (err: any) {
-      setError(err.response?.data?.error || 'Failed to load low stock data');
+      setError(extractErrorMessage(err, 'Failed to load low stock data'));
       console.error('Error loading low stock data:', err);
     } finally {
       setLoading(false);

--- a/frontend/src/components/dashboard/PendingReordersWidget.tsx
+++ b/frontend/src/components/dashboard/PendingReordersWidget.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { dashboardAPI } from '../../services/api';
 import { PendingReordersData } from '../../types';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
 import DashboardWidget from './DashboardWidget';
 
 const PendingReordersWidget: React.FC = () => {
@@ -28,7 +29,7 @@ const PendingReordersWidget: React.FC = () => {
       const response = await dashboardAPI.getPendingReordersData();
       setData(response.data);
     } catch (err: any) {
-      setError(err.response?.data?.error || 'Failed to load pending reorders');
+      setError(extractErrorMessage(err, 'Failed to load pending reorders'));
       console.error('Error loading pending reorders:', err);
     } finally {
       setLoading(false);

--- a/frontend/src/components/dashboard/QRScansWidget.tsx
+++ b/frontend/src/components/dashboard/QRScansWidget.tsx
@@ -6,6 +6,7 @@ import { Badge, ScrollArea, Text } from '@mantine/core';
 import React, { useEffect, useState } from 'react';
 import { dashboardAPI } from '../../services/api';
 import { QRScansData } from '../../types';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
 import DashboardWidget from './DashboardWidget';
 
 const QRScansWidget: React.FC = () => {
@@ -26,7 +27,7 @@ const QRScansWidget: React.FC = () => {
       const response = await dashboardAPI.getQRScansData();
       setData(response.data);
     } catch (err: any) {
-      setError(err.response?.data?.error || 'Failed to load QR scan data');
+      setError(extractErrorMessage(err, 'Failed to load QR scan data'));
       console.error('Error loading QR scan data:', err);
     } finally {
       setLoading(false);

--- a/frontend/src/components/dashboard/WidgetErrorBoundary.tsx
+++ b/frontend/src/components/dashboard/WidgetErrorBoundary.tsx
@@ -1,0 +1,61 @@
+/**
+ * Per-widget error boundary.
+ *
+ * The dashboard renders each widget independently. A single widget that throws
+ * during render — e.g. React #31 when an unexpected error-object shape reaches
+ * JSX, or any other downstream render bug — must degrade to a compact
+ * "couldn't load" card for THAT widget only. Without this, the error bubbles to
+ * the app-level ErrorBoundary in App.tsx and blanks the entire page with the
+ * global "Something went wrong" screen: one widget takes down the whole
+ * dashboard (op-8lhv).
+ *
+ * Errors are still reported to Sentry (mirroring the app-level boundary) so
+ * isolating a widget failure does not cost us observability.
+ */
+import { Card, Text } from '@mantine/core';
+import * as Sentry from '@sentry/react';
+import React from 'react';
+
+interface WidgetErrorBoundaryProps {
+  /** Human-readable widget name, shown in the fallback so the user knows what failed. */
+  title?: string;
+  children: React.ReactNode;
+}
+
+class WidgetErrorBoundary extends React.Component<
+  WidgetErrorBoundaryProps,
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('Dashboard widget crashed:', error, info);
+    // Report with the React component stack as context. No-op when Sentry.init
+    // wasn't called (VITE_SENTRY_DSN unset), matching the app-level boundary.
+    Sentry.captureException(error, {
+      contexts: { react: { componentStack: info.componentStack ?? '' } },
+    });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Card shadow="sm" padding="md" radius="md" withBorder role="alert">
+          <Text fw={600} size="sm">
+            {this.props.title ?? 'Widget'}
+          </Text>
+          <Text c="red" size="sm" mt="xs">
+            This widget couldn&apos;t load. The rest of the dashboard is unaffected.
+          </Text>
+        </Card>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default WidgetErrorBoundary;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -13,10 +13,22 @@ import DeliveriesWidget from '../components/dashboard/DeliveriesWidget';
 import LowStockWidget from '../components/dashboard/LowStockWidget';
 import PendingReordersWidget from '../components/dashboard/PendingReordersWidget';
 import QRScansWidget from '../components/dashboard/QRScansWidget';
+import WidgetErrorBoundary from '../components/dashboard/WidgetErrorBoundary';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import { dashboardAPI } from '../services/api';
 import '../styles/DashboardPage.css';
 import { DashboardWidget as DashboardWidgetType } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+// Human-readable titles for the per-widget error-boundary fallback, so a
+// crashed widget still tells the user which panel failed.
+const WIDGET_TITLES: Record<string, string> = {
+  low_stock: 'Low Stock',
+  pending_reorders: 'Pending Reorders',
+  asset_problems: 'Asset Problems',
+  qr_scans: 'QR Scans',
+  deliveries: 'Recent Deliveries',
+};
 
 const DashboardPage: React.FC = () => {
   const [widgets, setWidgets] = useState<DashboardWidgetType[]>([]);
@@ -59,7 +71,10 @@ const DashboardPage: React.FC = () => {
         : (payload as { results?: DashboardWidgetType[] } | null)?.results ?? [];
       setWidgets(list);
     } catch (err: any) {
-      setError(err.response?.data?.error || 'Failed to load dashboard widgets');
+      // Never store the raw error envelope object ({code,message}) in error
+      // state — it would render as a JSX child and throw React #31. Always
+      // resolve to a string (op-8lhv).
+      setError(extractErrorMessage(err, 'Failed to load dashboard widgets'));
       console.error('Error loading widgets:', err);
     } finally {
       setLoading(false);
@@ -115,24 +130,34 @@ const DashboardPage: React.FC = () => {
       return null;
     }
 
-    const widgetProps = {
-      key: widget.id,
-    };
-
+    let inner: React.ReactNode;
     switch (widget.widget_type) {
       case 'low_stock':
-        return <LowStockWidget {...widgetProps} />;
+        inner = <LowStockWidget />;
+        break;
       case 'pending_reorders':
-        return <PendingReordersWidget {...widgetProps} />;
+        inner = <PendingReordersWidget />;
+        break;
       case 'asset_problems':
-        return <AssetProblemsWidget {...widgetProps} />;
+        inner = <AssetProblemsWidget />;
+        break;
       case 'qr_scans':
-        return <QRScansWidget {...widgetProps} />;
+        inner = <QRScansWidget />;
+        break;
       case 'deliveries':
-        return <DeliveriesWidget {...widgetProps} />;
+        inner = <DeliveriesWidget />;
+        break;
       default:
         return null;
     }
+
+    // Isolate each widget: a render crash in one widget shows a compact
+    // per-widget fallback instead of bubbling to the app-level error boundary
+    // and blanking the whole dashboard (op-8lhv). The list key lives on the
+    // wrapping <div> in the grid below.
+    return (
+      <WidgetErrorBoundary title={WIDGET_TITLES[widget.widget_type]}>{inner}</WidgetErrorBoundary>
+    );
   };
 
   const getLayout = (): LayoutItem[] => {


### PR DESCRIPTION
## What
Durable dashboard resilience + observability hardening (op-8lhv), complementing the #867 root-cause fix. Two independent defects let a single widget's 500 crash the **entire** dashboard *and* kept us blind to why:

1. **No per-widget isolation (the user-facing crash).** Each dashboard widget now renders inside its own `WidgetErrorBoundary`, so a single widget failure shows a compact per-widget "couldn't load" state instead of tripping the global boundary and blanking the whole page. Widgets also never render a raw error/response object as a JSX child — the `{code, message}` envelope that caused the React #31 crash.

2. **Swallowed 500s were invisible (the observability gap).** Every `get_*_data` widget view wraps its body in a broad `except Exception` that returns the standardized error envelope so one widget can't 500 the whole request — but that catch also swallowed the traceback before Django could report it, so real failures never reached Sentry (the backend project had zero deliveries errors despite the prod 500s). A new `_widget_data_server_error(exc)` helper captures to Sentry + logs, then returns the same envelope unchanged. All 5 widget handlers (low-stock, pending-reorders, asset-problems, qr-scans, **deliveries**) route through it.

## Why
The prod dashboard crash (#867, invalid deliveries prefetch) took down the whole page because of defect 1, and was slow to diagnose because of defect 2. #867 fixed that specific bug; this makes the dashboard resilient to the *next* one and ensures it's visible in Sentry.

## Tests
- Backend: `test_widget_data_view_reports_swallowed_exception` — a widget-data 500 calls `sentry_sdk.capture_exception` before returning the unchanged envelope.
- Frontend: `DashboardWidgetResilience.test.tsx` — a throwing widget renders its own error state without crashing siblings.

## Notes
Rebased onto current `main`. Resolved one test conflict with #867 by keeping #867's strengthened deliveries assertions **and** adding op-8lhv's new swallowed-exception test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)