### PR TITLE
feat(inventory): asset report "Supplies Used" tab — serialized usage + PM consumables (op-xr0p)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -1158,6 +1158,9 @@ views:
       maintenance_due:
         permission_classes:
         - IsAuthenticated
+      supplies_used:
+        permission_classes:
+        - IsAuthenticated
       tco:
         permission_classes:
         - IsAuthenticated

--- a/backend/inventory/tests/test_supplies_used.py
+++ b/backend/inventory/tests/test_supplies_used.py
@@ -1,0 +1,461 @@
+"""
+Tests for the Asset "Supplies Used" report endpoint.
+
+Covers ``AssetReportViewSet.supplies_used`` (serialized ComponentUsageEvent
+usage + consumable WorkOrderMaterialUsage from PM work orders, date-windowed)
+and its CSV ``export`` branch.
+"""
+
+import csv
+import io
+from datetime import timedelta
+from decimal import Decimal
+
+from django.utils import timezone
+
+import pytest
+from rest_framework import status
+
+from inventory.models import (
+    ComponentUsageEvent,
+    MaintenanceItem,
+    MaintenanceMaterial,
+    SerializedComponent,
+    WorkOrderMaterialUsage,
+)
+from inventory.tests.factories import AssetFactory, SerializedComponentFactory
+
+URL = "/api/inventory/reports/assets/supplies_used/"
+EXPORT_URL = "/api/inventory/reports/assets/export/"
+
+
+def _event(asset, *, action, at, item_name="Ball bearing", serial="SN-A", actor=None):
+    """Create a SerializedComponent + one ComponentUsageEvent tied to ``asset``."""
+    component = SerializedComponentFactory(item__name=item_name, serial_number=serial)
+    return ComponentUsageEvent.objects.create(
+        component=component,
+        asset=asset,
+        action=action,
+        at=at,
+        actor=actor,
+    )
+
+
+def _completed_pm_with_material(
+    asset,
+    *,
+    completed_at,
+    material_name="Motor oil",
+    quantity_planned=None,
+    cost_per_unit=None,
+    unit="qt",
+    was_used=True,
+    interval_days=90,
+):
+    """Create a MaintenanceItem + completed WorkOrder + one material-usage row."""
+    from inventory.models import WorkOrder
+
+    if quantity_planned is None:
+        quantity_planned = Decimal("3.00")
+    if cost_per_unit is None:
+        cost_per_unit = Decimal("2.50")
+
+    mi = MaintenanceItem.objects.create(
+        asset=asset,
+        title="Quarterly PM",
+        interval_days=interval_days,
+        estimated_cost=Decimal("0.00"),
+    )
+    wo = WorkOrder.objects.create(
+        maintenance_item=mi,
+        status=WorkOrder.STATUS_COMPLETED,
+        completed_at=completed_at,
+    )
+    material = MaintenanceMaterial.objects.create(
+        maintenance_item=mi,
+        name=material_name,
+        quantity=Decimal("1.00"),
+        estimated_cost_per_unit=cost_per_unit,
+    )
+    usage = WorkOrderMaterialUsage.objects.create(
+        work_order=wo,
+        material=material,
+        material_name=material_name,
+        quantity_planned=quantity_planned,
+        unit=unit,
+        was_used=was_used,
+    )
+    return mi, wo, usage
+
+
+def _rows_for_asset(data, asset):
+    return [row for row in data if row["asset_id"] == str(asset.id)]
+
+
+@pytest.mark.integration
+class TestSuppliesUsedAuth:
+    def test_requires_auth(self, api_client):
+        response = api_client.get(URL)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.integration
+class TestSuppliesUsedSerialized:
+    """Serialized usage rows come from ComponentUsageEvent (install/consume)."""
+
+    def test_install_and_consume_in_window_included(self, authenticated_client):
+        client, user = authenticated_client
+        asset = AssetFactory(name="Mill", asset_tag="A-1")
+        now = timezone.now()
+        _event(
+            asset,
+            action=SerializedComponent.ACTION_INSTALL,
+            at=now - timedelta(days=3),
+            item_name="Spindle bearing",
+            serial="SN-INST",
+            actor=user,
+        )
+        _event(
+            asset,
+            action=SerializedComponent.ACTION_CONSUME,
+            at=now - timedelta(days=4),
+            item_name="Cutting fluid pod",
+            serial="SN-CONS",
+        )
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+
+        rows = _rows_for_asset(response.data, asset)
+        assert len(rows) == 2
+        by_serial = {r["serial_number"]: r for r in rows}
+
+        install = by_serial["SN-INST"]
+        assert install["source"] == "serialized"
+        assert install["asset_name"] == "Mill"
+        assert install["item_name"] == "Spindle bearing"
+        assert install["action"] == "install"
+        assert install["action_display"] == "Install"
+        assert install["actor"] == user.username
+        assert "used_at" in install
+
+        consume = by_serial["SN-CONS"]
+        assert consume["action"] == "consume"
+        assert consume["action_display"] == "Consume"
+        # No actor recorded on this event.
+        assert consume["actor"] is None
+
+    def test_excludes_out_of_window(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Lathe", asset_tag="A-2")
+        now = timezone.now()
+        # 45 days ago — outside the default 30-day window.
+        _event(
+            asset,
+            action=SerializedComponent.ACTION_INSTALL,
+            at=now - timedelta(days=45),
+            serial="SN-OLD",
+        )
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert _rows_for_asset(response.data, asset) == []
+
+    @pytest.mark.parametrize(
+        "excluded_action",
+        [
+            SerializedComponent.ACTION_RECEIVE,
+            SerializedComponent.ACTION_REMOVE,
+            SerializedComponent.ACTION_RETIRE,
+            SerializedComponent.ACTION_DISPOSE,
+        ],
+    )
+    def test_excludes_non_install_consume_actions(self, authenticated_client, excluded_action):
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Router", asset_tag="A-3")
+        _event(
+            asset,
+            action=excluded_action,
+            at=timezone.now() - timedelta(days=2),
+            serial=f"SN-{excluded_action}",
+        )
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert _rows_for_asset(response.data, asset) == []
+
+    def test_excludes_events_without_asset(self, authenticated_client):
+        """A pure stock event (no asset) must not appear in any asset's rows."""
+        client, _ = authenticated_client
+        now = timezone.now()
+        component = SerializedComponentFactory(item__name="Loose bolt", serial_number="SN-STOCK")
+        ComponentUsageEvent.objects.create(
+            component=component,
+            asset=None,
+            action=SerializedComponent.ACTION_CONSUME,
+            at=now - timedelta(days=1),
+        )
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert all(row["source"] != "serialized" for row in response.data)
+
+
+@pytest.mark.integration
+class TestSuppliesUsedConsumable:
+    """Consumable rows come from was_used WorkOrderMaterialUsage on completed PMs."""
+
+    def test_used_material_in_window_included(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(name="HVAC", asset_tag="A-4")
+        _, wo, _ = _completed_pm_with_material(
+            asset,
+            completed_at=timezone.now() - timedelta(days=5),
+            material_name="Motor oil",
+            quantity_planned=Decimal("3.00"),
+            cost_per_unit=Decimal("2.50"),
+            unit="qt",
+        )
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+
+        rows = _rows_for_asset(response.data, asset)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["source"] == "consumable"
+        assert row["asset_name"] == "HVAC"
+        assert row["item_name"] == "Motor oil"
+        assert row["quantity"] == "3.00"
+        assert row["unit"] == "qt"
+        assert row["work_order_id"] == str(wo.id)
+        # 3.00 × 2.50 = 7.50
+        assert row["estimated_cost"] == "7.50"
+        assert "used_at" in row
+
+    def test_excludes_material_not_used(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Press", asset_tag="A-5")
+        _completed_pm_with_material(
+            asset,
+            completed_at=timezone.now() - timedelta(days=5),
+            was_used=False,
+        )
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert _rows_for_asset(response.data, asset) == []
+
+    def test_excludes_work_order_out_of_window(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Saw", asset_tag="A-6")
+        _completed_pm_with_material(
+            asset,
+            completed_at=timezone.now() - timedelta(days=45),
+        )
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert _rows_for_asset(response.data, asset) == []
+
+    def test_excludes_incomplete_work_order(self, authenticated_client):
+        """A work order with no completion date cannot be windowed → excluded."""
+        from inventory.models import WorkOrder
+
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Kiln", asset_tag="A-7")
+        mi = MaintenanceItem.objects.create(
+            asset=asset, title="PM", interval_days=30, estimated_cost=Decimal("0.00")
+        )
+        wo = WorkOrder.objects.create(
+            maintenance_item=mi,
+            status=WorkOrder.STATUS_OPEN,
+            completed_at=None,
+        )
+        material = MaintenanceMaterial.objects.create(
+            maintenance_item=mi,
+            name="Grease",
+            quantity=Decimal("1.00"),
+            estimated_cost_per_unit=Decimal("5.00"),
+        )
+        WorkOrderMaterialUsage.objects.create(
+            work_order=wo,
+            material=material,
+            material_name="Grease",
+            quantity_planned=Decimal("1.00"),
+            was_used=True,
+        )
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert _rows_for_asset(response.data, asset) == []
+
+    def test_estimated_cost_null_when_material_deleted(self, authenticated_client):
+        """material FK is SET_NULL; a used row with no material has no cost."""
+        from inventory.models import WorkOrder
+
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Compressor", asset_tag="A-8")
+        mi = MaintenanceItem.objects.create(
+            asset=asset, title="PM", interval_days=30, estimated_cost=Decimal("0.00")
+        )
+        wo = WorkOrder.objects.create(
+            maintenance_item=mi,
+            status=WorkOrder.STATUS_COMPLETED,
+            completed_at=timezone.now() - timedelta(days=2),
+        )
+        WorkOrderMaterialUsage.objects.create(
+            work_order=wo,
+            material=None,
+            material_name="Deleted filter",
+            quantity_planned=Decimal("2.00"),
+            was_used=True,
+        )
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+        rows = _rows_for_asset(response.data, asset)
+        assert len(rows) == 1
+        assert rows[0]["item_name"] == "Deleted filter"
+        assert rows[0]["quantity"] == "2.00"
+        assert rows[0]["estimated_cost"] is None
+
+
+@pytest.mark.integration
+class TestSuppliesUsedFilteringAndSorting:
+    def test_date_filter_honored(self, authenticated_client):
+        """Explicit start_date/end_date narrows to events inside the window."""
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Grinder", asset_tag="A-9")
+        now = timezone.now()
+        _event(
+            asset,
+            action=SerializedComponent.ACTION_INSTALL,
+            at=now - timedelta(days=2),
+            serial="SN-RECENT",
+        )
+        _event(
+            asset,
+            action=SerializedComponent.ACTION_INSTALL,
+            at=now - timedelta(days=20),
+            serial="SN-EARLIER",
+        )
+
+        # Window covering only the last 5 days.
+        start = (now - timedelta(days=5)).date().isoformat()
+        end = now.date().isoformat()
+        response = client.get(URL, {"start_date": start, "end_date": end})
+        assert response.status_code == status.HTTP_200_OK
+
+        serials = {r["serial_number"] for r in _rows_for_asset(response.data, asset)}
+        assert serials == {"SN-RECENT"}
+
+    def test_rows_sorted_by_asset_name_then_used_at(self, authenticated_client):
+        client, _ = authenticated_client
+        alpha = AssetFactory(name="Alpha", asset_tag="A-A")
+        beta = AssetFactory(name="Beta", asset_tag="A-B")
+        now = timezone.now()
+
+        # Alpha: a later event and an earlier event (should come out ascending).
+        _event(
+            alpha,
+            action=SerializedComponent.ACTION_INSTALL,
+            at=now - timedelta(days=2),
+            serial="SN-ALPHA-NEW",
+        )
+        _event(
+            alpha,
+            action=SerializedComponent.ACTION_CONSUME,
+            at=now - timedelta(days=8),
+            serial="SN-ALPHA-OLD",
+        )
+        _event(
+            beta,
+            action=SerializedComponent.ACTION_INSTALL,
+            at=now - timedelta(days=1),
+            serial="SN-BETA",
+        )
+
+        response = client.get(URL)
+        assert response.status_code == status.HTTP_200_OK
+
+        names = [r["asset_name"] for r in response.data]
+        # All Alpha rows precede all Beta rows.
+        assert names == sorted(names)
+        alpha_rows = _rows_for_asset(response.data, alpha)
+        used_at_values = [r["used_at"] for r in alpha_rows]
+        assert used_at_values == sorted(used_at_values)
+
+
+@pytest.mark.integration
+class TestSuppliesUsedExport:
+    def test_export_csv_contains_both_sources(self, authenticated_client):
+        client, user = authenticated_client
+        asset = AssetFactory(name="Exporter", asset_tag="A-X")
+        now = timezone.now()
+        _event(
+            asset,
+            action=SerializedComponent.ACTION_INSTALL,
+            at=now - timedelta(days=3),
+            item_name="Bearing",
+            serial="SN-EXP",
+            actor=user,
+        )
+        _completed_pm_with_material(
+            asset,
+            completed_at=now - timedelta(days=4),
+            material_name="Motor oil",
+            quantity_planned=Decimal("2.00"),
+            cost_per_unit=Decimal("4.00"),
+            unit="qt",
+        )
+
+        response = client.get(EXPORT_URL, {"type": "supplies_used"})
+        assert response.status_code == status.HTTP_200_OK
+        assert response["Content-Type"] == "text/csv"
+        assert "assets_supplies_used.csv" in response["Content-Disposition"]
+
+        reader = csv.DictReader(io.StringIO(response.content.decode("utf-8")))
+        assert reader.fieldnames == [
+            "asset_id",
+            "asset_name",
+            "source",
+            "item_name",
+            "serial_number",
+            "action",
+            "action_display",
+            "quantity",
+            "unit",
+            "used_at",
+            "work_order_id",
+            "estimated_cost",
+            "actor",
+        ]
+        rows = [r for r in reader if r["asset_id"] == str(asset.id)]
+        assert len(rows) == 2
+        by_source = {r["source"]: r for r in rows}
+
+        serialized = by_source["serialized"]
+        assert serialized["serial_number"] == "SN-EXP"
+        assert serialized["action"] == "install"
+        assert serialized["actor"] == user.username
+        # Consumable-only columns are blank on a serialized row.
+        assert serialized["quantity"] == ""
+        assert serialized["unit"] == ""
+        assert serialized["work_order_id"] == ""
+        assert serialized["estimated_cost"] == ""
+
+        consumable = by_source["consumable"]
+        assert consumable["item_name"] == "Motor oil"
+        assert consumable["quantity"] == "2.00"
+        assert consumable["unit"] == "qt"
+        assert consumable["estimated_cost"] == "8.00"
+        # Serialized-only columns are blank on a consumable row.
+        assert consumable["serial_number"] == ""
+        assert consumable["action"] == ""
+        assert consumable["actor"] == ""
+
+    def test_export_invalid_type_returns_error(self, authenticated_client):
+        client, _ = authenticated_client
+        response = client.get(EXPORT_URL, {"type": "not_a_report"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -5262,6 +5262,137 @@ class AssetReportViewSet(viewsets.ViewSet):
         serializer = AssetTcoReportSerializer(rows, many=True)
         return Response(serializer.data)
 
+    @staticmethod
+    def _supplies_window(request):
+        """Parse ``start_date``/``end_date`` query params for supplies_used.
+
+        Mirrors ``utilization``/``tco`` windowing: both params must be present
+        and valid ``YYYY-MM-DD`` strings, otherwise it falls back to the last
+        30 days. Returns ``(start_date, end_date)`` as ``date`` objects.
+        """
+        from datetime import datetime
+
+        start_date_str = request.query_params.get("start_date")
+        end_date_str = request.query_params.get("end_date")
+        if start_date_str and end_date_str:
+            try:
+                start_date = datetime.strptime(start_date_str, "%Y-%m-%d").date()
+                end_date = datetime.strptime(end_date_str, "%Y-%m-%d").date()
+                return start_date, end_date
+            except ValueError:
+                pass
+        start_date = (timezone.now() - timedelta(days=30)).date()
+        end_date = timezone.now().date()
+        return start_date, end_date
+
+    @action(detail=False, methods=["get"])
+    def supplies_used(self, request):
+        """Historical supplies used per asset over a date window.
+
+        Merges two sources into one flat, per-asset-labeled row list. Every row
+        carries the common keys ``asset_id``, ``asset_name``, ``source``,
+        ``item_name`` and ``used_at`` (ISO-8601); the remaining keys are
+        source-specific:
+
+        - ``source == "serialized"`` — a serial-numbered unit put into service
+          on, or consumed by, the asset. Sourced from ``ComponentUsageEvent``
+          rows tied to an asset with ``action`` in ``install``/``consume``,
+          windowed by the event timestamp ``at``. Extra keys: ``serial_number``,
+          ``action``, ``action_display``, ``actor``.
+        - ``source == "consumable"`` — a bulk maintenance material actually used
+          while closing a preventive-maintenance work order. Sourced from
+          ``WorkOrderMaterialUsage`` rows with ``was_used=True``, reached via
+          ``asset -> maintenance_items -> work_orders -> material_usage`` and
+          windowed by the work order's ``completed_at`` date (the same field
+          ``tco`` uses). Extra keys: ``quantity`` (planned qty), ``unit``,
+          ``work_order_id``, ``estimated_cost`` (``quantity`` ×
+          ``material.estimated_cost_per_unit``; null if the material was
+          deleted after the work order was created).
+
+        Query params ``start_date``/``end_date`` (``YYYY-MM-DD``) default to the
+        last 30 days. Rows are sorted by ``asset_name`` then ``used_at``.
+        """
+        from django.db.models import Prefetch
+
+        start_date, end_date = self._supplies_window(request)
+
+        rows = []
+
+        # Serialized usage: ComponentUsageEvent tied to an asset. Only install
+        # and consume count as "put into service on / used up by" the asset —
+        # receive/remove/retire/dispose are stock or teardown events.
+        events = ComponentUsageEvent.objects.filter(
+            asset__isnull=False,
+            action__in=[
+                SerializedComponent.ACTION_INSTALL,
+                SerializedComponent.ACTION_CONSUME,
+            ],
+            at__date__gte=start_date,
+            at__date__lte=end_date,
+        ).select_related("asset", "component", "component__item", "actor")
+        for event in events:
+            rows.append(
+                {
+                    "asset_id": str(event.asset_id),
+                    "asset_name": event.asset.name,
+                    "source": "serialized",
+                    "item_name": event.component.item.name,
+                    "serial_number": event.component.serial_number,
+                    "action": event.action,
+                    "action_display": event.get_action_display(),
+                    "used_at": event.at,
+                    "actor": event.actor.username if event.actor else None,
+                }
+            )
+
+        # Consumable usage: materials marked used on a completed PM work order.
+        # Reuse tco's asset -> maintenance_items -> work_orders -> material_usage
+        # prefetch traversal to avoid N+1.
+        assets = Asset.objects.all().prefetch_related(
+            Prefetch(
+                "maintenance_items__work_orders",
+                queryset=WorkOrder.objects.prefetch_related("material_usage__material"),
+            ),
+        )
+        for asset in assets:
+            for mi in asset.maintenance_items.all():
+                for wo in mi.work_orders.all():
+                    if wo.status != WorkOrder.STATUS_COMPLETED or wo.completed_at is None:
+                        continue
+                    completed_date = wo.completed_at.date()
+                    if not (start_date <= completed_date <= end_date):
+                        continue
+                    for usage in wo.material_usage.all():
+                        if not usage.was_used:
+                            continue
+                        estimated_cost = None
+                        if usage.material is not None:
+                            estimated_cost = str(
+                                (
+                                    usage.quantity_planned * usage.material.estimated_cost_per_unit
+                                ).quantize(Decimal("0.01"))
+                            )
+                        rows.append(
+                            {
+                                "asset_id": str(asset.id),
+                                "asset_name": asset.name,
+                                "source": "consumable",
+                                "item_name": usage.material_name,
+                                "quantity": str(usage.quantity_planned),
+                                "unit": usage.unit,
+                                "used_at": wo.completed_at,
+                                "work_order_id": str(wo.id),
+                                "estimated_cost": estimated_cost,
+                            }
+                        )
+
+        # Sort on the aware datetimes, then serialize used_at to ISO-8601.
+        rows.sort(key=lambda r: (r["asset_name"], r["used_at"]))
+        for row in rows:
+            row["used_at"] = row["used_at"].isoformat()
+
+        return Response(rows)
+
     @action(detail=False, methods=["get"])
     def export(self, request):
         """Export asset report data as CSV."""
@@ -5384,6 +5515,38 @@ class AssetReportViewSet(viewsets.ViewSet):
                         "repair_cost": row["repair_cost"],
                         "tco": row["tco"],
                     }
+                )
+
+            return response_obj
+        elif report_type == "supplies_used":
+            response = self.supplies_used(request)
+            data = response.data
+
+            response_obj = HttpResponse(content_type="text/csv")
+            response_obj["Content-Disposition"] = 'attachment; filename="assets_supplies_used.csv"'
+
+            # Union of both source shapes; source-specific columns are left
+            # blank on rows where they do not apply.
+            fieldnames = [
+                "asset_id",
+                "asset_name",
+                "source",
+                "item_name",
+                "serial_number",
+                "action",
+                "action_display",
+                "quantity",
+                "unit",
+                "used_at",
+                "work_order_id",
+                "estimated_cost",
+                "actor",
+            ]
+            writer = csv.DictWriter(response_obj, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in data:
+                writer.writerow(
+                    {key: ("" if row.get(key) is None else row.get(key)) for key in fieldnames}
                 )
 
             return response_obj


### PR DESCRIPTION
## What
New **Supplies Used** section for the asset report (owner ask). Adds a `supplies_used` `@action` on `AssetReportViewSet` that merges, per asset over a date window:
- **Serialized** — `ComponentUsageEvent` rows with action ∈ {install, consume} (units put into service / used up on the asset).
- **Consumables** — `WorkOrderMaterialUsage` where `was_used=True`, via `asset.maintenance_items → work_orders → material_usage` (the exact path TCO walks), windowed by work-order completion. Quantity is the planned amount (OMS records no measured actual); cost = quantity × `estimated_cost_per_unit`.

Also wires a `report_type == "supplies_used"` branch into the CSV `export()`.

## API (for the web + ScanTTY tabs)
`GET /inventory/reports/assets/supplies_used/?start_date&end_date` → JSON rows `{asset_id, asset_name, source, item_name, serial_number|quantity/unit, action, used_at, ...}`. See the action docstring for the exact shape.

## Verification
- No model change (`makemigrations --check` clean, no migration).
- `check_permission_matrix` → OK, 863 endpoints match (action registered).
- black / isort / flake8 clean. +461 lines of tests (serialized + consumable rows, date filter, CSV export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)