### PR TITLE
feat(frontend): serialized expiration_date + available/on-hand + batch scan-receive (op-n4pi)

### DIFF
--- a/frontend/src/__tests__/components/AssetSerializedComponentsSection.test.tsx
+++ b/frontend/src/__tests__/components/AssetSerializedComponentsSection.test.tsx
@@ -3,7 +3,7 @@
  * "serial history" surface on the asset detail page.
  */
 import { MantineProvider } from '@mantine/core';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 
 import AssetSerializedComponentsSection from '../../components/inventory/AssetSerializedComponentsSection';
 import {
@@ -34,6 +34,7 @@ const buildUnit = (overrides: Partial<SerializedComponent> = {}): SerializedComp
   item_sku: 'BLD-1',
   serial_number: 'SN-INSTALLED',
   lot: '',
+  expiration_date: null,
   status: 'installed',
   status_display: 'Installed',
   tracking_mode: 'reusable',
@@ -100,6 +101,16 @@ describe('AssetSerializedComponentsSection', () => {
     });
     // History is every serial this machine has used (?asset=).
     expect(mockAPI.listUsageEvents).toHaveBeenCalledWith({ asset: ASSET_ID });
+  });
+
+  it('shows the expiration date for an installed unit in the Expires column', async () => {
+    mockAPI.list.mockResolvedValue(paginated([buildUnit({ expiration_date: '2027-03-15' })]));
+    mockAPI.listUsageEvents.mockResolvedValue(paginated([]));
+
+    renderSection();
+
+    const installed = await screen.findByTestId('asset-serialized-installed');
+    expect(within(installed).getByText('Mar 15, 2027')).toBeInTheDocument();
   });
 
   it('renders nothing when the asset has no serialized history at all', async () => {

--- a/frontend/src/__tests__/components/SerializedComponentsPanel.test.tsx
+++ b/frontend/src/__tests__/components/SerializedComponentsPanel.test.tsx
@@ -20,6 +20,7 @@ vi.mock('../../services/api', async () => {
     serializedComponentsAPI: {
       list: jest.fn(),
       create: jest.fn(),
+      scanReceive: jest.fn(),
       receive: jest.fn(),
       install: jest.fn(),
       remove: jest.fn(),
@@ -46,6 +47,7 @@ const buildUnit = (overrides: Partial<SerializedComponent> = {}): SerializedComp
   item_sku: 'BLD-1',
   serial_number: 'SN-0001',
   lot: '',
+  expiration_date: null,
   status: 'received',
   status_display: 'Received',
   tracking_mode: 'consumable',
@@ -134,9 +136,49 @@ describe('SerializedComponentsPanel', () => {
         item: ITEM_ID,
         serial_number: 'SN-9999',
         lot: undefined,
+        // No expiry set on the form → the optional field is left undefined.
+        expiration_date: undefined,
       }),
     );
     expect(await screen.findByText('SN-9999')).toBeInTheDocument();
+  });
+
+  it('renders a unit expiration date in the Expires column', async () => {
+    mockAPI.list.mockResolvedValue(listResponse([buildUnit({ expiration_date: '2027-03-15' })]));
+    renderPanel();
+
+    expect(await screen.findByText('SN-0001')).toBeInTheDocument();
+    // Formatted for display (date-only, no UTC off-by-one).
+    expect(screen.getByText('Mar 15, 2027')).toBeInTheDocument();
+  });
+
+  it('shows the available / on-hand / installed stock summary when provided', async () => {
+    mockAPI.list.mockResolvedValue(listResponse([buildUnit()]));
+    render(
+      <MantineProvider>
+        <SerializedComponentsPanel
+          itemId={ITEM_ID}
+          trackingMode="consumable"
+          serializedStock={{ available: 4, on_hand: 6, installed: 2 }}
+        />
+      </MantineProvider>,
+    );
+
+    const summary = await screen.findByTestId('serialized-stock-summary');
+    expect(within(summary).getByTestId('serialized-stock-available')).toHaveTextContent('4');
+    expect(within(summary).getByTestId('serialized-stock-on-hand')).toHaveTextContent('6');
+    expect(within(summary).getByTestId('serialized-stock-installed')).toHaveTextContent('2');
+  });
+
+  it('opens the scan-driven batch receive modal from the header', async () => {
+    mockAPI.list.mockResolvedValue(listResponse([]));
+    renderPanel();
+    await screen.findByText('No serialized units recorded for this item yet.');
+
+    fireEvent.click(screen.getByTestId('serialized-scan-receive-open'));
+
+    expect(await screen.findByTestId('serialized-scan-receive-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('scan-receive-serial')).toBeInTheDocument();
   });
 
   it('shows an enable-tracking CTA (not a dead panel) when the item is not serialized', async () => {

--- a/frontend/src/__tests__/components/SerializedForecastPanel.test.tsx
+++ b/frontend/src/__tests__/components/SerializedForecastPanel.test.tsx
@@ -3,7 +3,7 @@
  * low-stock report surfaced on the inventory + purchasing overviews.
  */
 import { MantineProvider } from '@mantine/core';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import SerializedForecastPanel from '../../components/inventory/SerializedForecastPanel';
 import { reportsAPI, SerializedForecastRow } from '../../services/api';
@@ -26,8 +26,11 @@ const buildRow = (overrides: Partial<SerializedForecastRow> = {}): SerializedFor
   sku: 'BLD-1',
   category_name: 'Consumables',
   serial_tracking_mode: 'consumable',
-  available_stock: 3,
-  current_stock: 3,
+  available: 3,
+  on_hand: 5,
+  installed: 2,
+  available_stock: 5,
+  current_stock: 5,
   window_days: 90,
   units_depleted_in_window: 9,
   avg_daily_use: 0.1,
@@ -113,6 +116,21 @@ describe('SerializedForecastPanel', () => {
         low_stock_only: true,
       }),
     );
+  });
+
+  it('shows available (reorder driver) and on-hand as distinct columns', async () => {
+    // Distinct, collision-free numbers (reorder_point is 3, avg_daily_use 0.1,
+    // stockout "30 d" — 7 and 9 appear only as available / on-hand).
+    mockReports.getSerializedForecast.mockResolvedValue({
+      data: [buildRow({ available: 7, on_hand: 9, installed: 2 })],
+    } as never);
+    renderPanel();
+
+    const row = await screen.findByTestId('serialized-forecast-row-item-1');
+    expect(within(row).getByText('7')).toBeInTheDocument();
+    expect(within(row).getByText('9')).toBeInTheDocument();
+    // A legend spells out that reorder follows available, not on-hand.
+    expect(screen.getByTestId('serialized-forecast-legend')).toBeInTheDocument();
   });
 
   it('invokes onSelectItem when a row is clicked', async () => {

--- a/frontend/src/__tests__/components/SerializedScanReceiveModal.test.tsx
+++ b/frontend/src/__tests__/components/SerializedScanReceiveModal.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * Tests for SerializedScanReceiveModal (op-n4pi) — the scan-driven batch
+ * receive surface. Covers: each Enter calls scan_receive against the batch
+ * item/lot/expiry; new-vs-duplicate is surfaced from the `created` flag;
+ * undo-last disposes the most recent newly-received unit; backend errors show
+ * inline; and closing a non-empty batch notifies the launcher to refresh.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+
+import SerializedScanReceiveModal from '../../components/inventory/SerializedScanReceiveModal';
+import { serializedComponentsAPI } from '../../services/api';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    serializedComponentsAPI: {
+      scanReceive: jest.fn(),
+      dispose: jest.fn(),
+    },
+  };
+});
+
+const mockAPI = serializedComponentsAPI as jest.Mocked<typeof serializedComponentsAPI>;
+
+const ITEM = { id: 'item-1', name: 'Cutting blade' };
+
+const scanResult = (overrides: { id?: string; serial_number: string; created: boolean }) =>
+  ({
+    data: {
+      id: overrides.id ?? 'unit-1',
+      item: ITEM.id,
+      serial_number: overrides.serial_number,
+      lot: '',
+      expiration_date: null,
+      status: 'in_stock',
+      created: overrides.created,
+    },
+  }) as never;
+
+const renderModal = (props: Partial<React.ComponentProps<typeof SerializedScanReceiveModal>> = {}) => {
+  const onClose = props.onClose ?? vi.fn();
+  const onReceived = props.onReceived ?? vi.fn();
+  render(
+    <MantineProvider>
+      <SerializedScanReceiveModal
+        opened
+        onClose={onClose}
+        item={ITEM}
+        onReceived={onReceived}
+        {...props}
+      />
+    </MantineProvider>,
+  );
+  return { onClose, onReceived };
+};
+
+const scan = (serial: string) => {
+  fireEvent.change(screen.getByTestId('scan-receive-serial'), {
+    target: { value: serial },
+  });
+  fireEvent.submit(screen.getByTestId('scan-receive-form'));
+};
+
+describe('SerializedScanReceiveModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('receives a scanned serial against the batch item and marks it new', async () => {
+    mockAPI.scanReceive.mockResolvedValue(scanResult({ serial_number: 'SN-1', created: true }));
+    renderModal();
+
+    scan('SN-1');
+
+    await waitFor(() =>
+      expect(mockAPI.scanReceive).toHaveBeenCalledWith({
+        item: 'item-1',
+        serial_number: 'SN-1',
+        lot: undefined,
+        expiration_date: undefined,
+      }),
+    );
+
+    const log = await screen.findByTestId('scan-receive-log');
+    expect(within(log).getByText('SN-1')).toBeInTheDocument();
+    expect(within(log).getByText('New')).toBeInTheDocument();
+    expect(screen.getByTestId('scan-receive-new-count')).toHaveTextContent('1 new');
+    // Input is cleared for the next scan.
+    expect(screen.getByTestId('scan-receive-serial')).toHaveValue('');
+  });
+
+  it('applies the batch lot to every scan', async () => {
+    mockAPI.scanReceive.mockResolvedValue(scanResult({ serial_number: 'SN-1', created: true }));
+    renderModal();
+
+    fireEvent.change(screen.getByTestId('scan-receive-lot'), { target: { value: 'LOT-9' } });
+    scan('SN-1');
+
+    await waitFor(() =>
+      expect(mockAPI.scanReceive).toHaveBeenCalledWith(
+        expect.objectContaining({ item: 'item-1', serial_number: 'SN-1', lot: 'LOT-9' }),
+      ),
+    );
+  });
+
+  it('flags an idempotent re-scan as a duplicate rather than an error', async () => {
+    mockAPI.scanReceive.mockResolvedValue(scanResult({ serial_number: 'SN-DUP', created: false }));
+    renderModal();
+
+    scan('SN-DUP');
+
+    const log = await screen.findByTestId('scan-receive-log');
+    expect(await within(log).findByText('Duplicate')).toBeInTheDocument();
+    expect(screen.getByTestId('scan-receive-dup-count')).toHaveTextContent('1 duplicate');
+    expect(screen.getByTestId('scan-receive-new-count')).toHaveTextContent('0 new');
+  });
+
+  it('undoes the last newly-received unit by disposing it', async () => {
+    mockAPI.scanReceive.mockResolvedValue(
+      scanResult({ id: 'unit-77', serial_number: 'SN-7', created: true }),
+    );
+    mockAPI.dispose.mockResolvedValue({ data: { id: 'unit-77' } } as never);
+    renderModal();
+
+    scan('SN-7');
+    await screen.findByText('SN-7');
+
+    fireEvent.click(screen.getByTestId('scan-receive-undo'));
+
+    await waitFor(() =>
+      expect(mockAPI.dispose).toHaveBeenCalledWith('unit-77', {
+        disposal_reason: 'Undo scan-receive (batch)',
+      }),
+    );
+    // The entry is struck through / marked undone and the new-count drops to 0.
+    expect(await screen.findByText('Undone')).toBeInTheDocument();
+    expect(screen.getByTestId('scan-receive-new-count')).toHaveTextContent('0 new');
+  });
+
+  it('does not offer undo when nothing new has been received', async () => {
+    renderModal();
+    expect(screen.getByTestId('scan-receive-undo')).toBeDisabled();
+  });
+
+  it('surfaces a backend error inline', async () => {
+    mockAPI.scanReceive.mockRejectedValue({
+      response: { data: { detail: 'Item is not serialized.' } },
+    });
+    renderModal();
+
+    scan('SN-BAD');
+
+    expect(await screen.findByTestId('scan-receive-error')).toHaveTextContent(
+      'Item is not serialized.',
+    );
+  });
+
+  it('notifies the launcher to refresh once on close when the batch received something', async () => {
+    mockAPI.scanReceive.mockResolvedValue(scanResult({ serial_number: 'SN-1', created: true }));
+    const { onClose, onReceived } = renderModal();
+
+    scan('SN-1');
+    await screen.findByText('SN-1');
+
+    fireEvent.click(screen.getByTestId('scan-receive-done'));
+
+    expect(onReceived).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refresh on close when nothing was received', async () => {
+    const { onClose, onReceived } = renderModal();
+
+    fireEvent.click(screen.getByTestId('scan-receive-done'));
+
+    expect(onReceived).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/__tests__/services/api.test.ts
+++ b/frontend/src/__tests__/services/api.test.ts
@@ -2,7 +2,7 @@
  * Tests for API service
  */
 import MockAdapter from 'axios-mock-adapter';
-import api, { assetPartsAPI, assetsAPI, authAPI, checklistsAPI, inventoryAPI, purchaseOrderAPI, reorderAPI, resolveApiBaseUrl, workOrderAPI } from '../../services/api';
+import api, { assetPartsAPI, assetsAPI, authAPI, checklistsAPI, inventoryAPI, purchaseOrderAPI, reorderAPI, reportsAPI, resolveApiBaseUrl, serializedComponentsAPI, workOrderAPI } from '../../services/api';
 
 describe('API Service', () => {
   let mock: MockAdapter;
@@ -820,6 +820,92 @@ describe('API Service', () => {
       const response = await assetPartsAPI.markReplaced('1', 'SN-XYZ');
 
       expect(response.data.replacement_serial_number).toBe('SN-XYZ');
+    });
+  });
+
+  describe('Serialized Components API', () => {
+    test('scanReceive posts item/serial/lot/expiration and returns the created flag (201)', async () => {
+      const mockUnit = {
+        id: 'unit-1',
+        item: 'item-1',
+        serial_number: 'SN-1',
+        lot: 'LOT-A',
+        expiration_date: '2027-01-31',
+        status: 'in_stock',
+        created: true,
+      };
+
+      mock.onPost('/inventory/serialized-components/scan_receive/').reply((config) => {
+        expect(JSON.parse(config.data)).toEqual({
+          item: 'item-1',
+          serial_number: 'SN-1',
+          lot: 'LOT-A',
+          expiration_date: '2027-01-31',
+        });
+        return [201, mockUnit];
+      });
+
+      const response = await serializedComponentsAPI.scanReceive({
+        item: 'item-1',
+        serial_number: 'SN-1',
+        lot: 'LOT-A',
+        expiration_date: '2027-01-31',
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.data.created).toBe(true);
+      expect(response.data.serial_number).toBe('SN-1');
+    });
+
+    test('scanReceive surfaces an idempotent re-scan (created:false, HTTP 200)', async () => {
+      mock.onPost('/inventory/serialized-components/scan_receive/').reply(200, {
+        id: 'unit-1',
+        item: 'item-1',
+        serial_number: 'SN-1',
+        created: false,
+      });
+
+      const response = await serializedComponentsAPI.scanReceive({
+        item: 'item-1',
+        serial_number: 'SN-1',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.data.created).toBe(false);
+    });
+
+    test('create forwards an optional expiration_date', async () => {
+      mock.onPost('/inventory/serialized-components/').reply((config) => {
+        expect(JSON.parse(config.data)).toEqual({
+          item: 'item-1',
+          serial_number: 'SN-2',
+          expiration_date: '2026-12-01',
+        });
+        return [201, { id: 'unit-2', serial_number: 'SN-2', expiration_date: '2026-12-01' }];
+      });
+
+      const response = await serializedComponentsAPI.create({
+        item: 'item-1',
+        serial_number: 'SN-2',
+        expiration_date: '2026-12-01',
+      });
+
+      expect(response.data.expiration_date).toBe('2026-12-01');
+    });
+
+    test('getSerializedForecast passes window + low-stock params and carries available/on_hand', async () => {
+      mock.onGet('/inventory/reports/inventory/serialized_forecast/').reply((config) => {
+        expect(config.params).toEqual({ window_days: 60, low_stock_only: true });
+        return [200, [{ item_id: 'i1', available: 2, on_hand: 5, installed: 3 }]];
+      });
+
+      const response = await reportsAPI.getSerializedForecast({
+        window_days: 60,
+        low_stock_only: true,
+      });
+
+      expect(response.data[0].available).toBe(2);
+      expect(response.data[0].on_hand).toBe(5);
     });
   });
 

--- a/frontend/src/components/inventory/AssetSerializedComponentsSection.tsx
+++ b/frontend/src/components/inventory/AssetSerializedComponentsSection.tsx
@@ -13,6 +13,7 @@
  * import + one JSX line.
  */
 import { Badge, Group, Loader, Table, Text, Title } from '@mantine/core';
+import dayjs from 'dayjs';
 import React, { useEffect, useMemo, useState } from 'react';
 
 import {
@@ -37,6 +38,10 @@ const fmtDateTime = (iso: string | null): string =>
         minute: '2-digit',
       })
     : '—';
+
+// expiration_date is a calendar date ("YYYY-MM-DD"); parse it as local (dayjs)
+// rather than `new Date(...)` to avoid a UTC-midnight off-by-one-day shift.
+const fmtDate = (d: string | null): string => (d ? dayjs(d).format('MMM D, YYYY') : '—');
 
 const AssetSerializedComponentsSection: React.FC<Props> = ({ assetId }) => {
   const [installed, setInstalled] = useState<SerializedComponent[]>([]);
@@ -117,6 +122,7 @@ const AssetSerializedComponentsSection: React.FC<Props> = ({ assetId }) => {
             <Table.Tr>
               <Table.Th>Serial</Table.Th>
               <Table.Th>Component</Table.Th>
+              <Table.Th>Expires</Table.Th>
               <Table.Th>Status</Table.Th>
               <Table.Th>Installed</Table.Th>
             </Table.Tr>
@@ -128,6 +134,7 @@ const AssetSerializedComponentsSection: React.FC<Props> = ({ assetId }) => {
                   <Text fw={500}>{unit.serial_number}</Text>
                 </Table.Td>
                 <Table.Td>{unit.item_name}</Table.Td>
+                <Table.Td>{fmtDate(unit.expiration_date)}</Table.Td>
                 <Table.Td>
                   <Badge color={serializedStatusColor(unit.status)} variant="light">
                     {unit.status_display}

--- a/frontend/src/components/inventory/SerializedComponentsPanel.tsx
+++ b/frontend/src/components/inventory/SerializedComponentsPanel.tsx
@@ -28,7 +28,9 @@ import {
   TextInput,
   Title,
 } from '@mantine/core';
-import { IconChevronDown, IconChevronRight, IconPlus } from '@tabler/icons-react';
+import { DateInput } from '@mantine/dates';
+import { IconChevronDown, IconChevronRight, IconPlus, IconScan } from '@tabler/icons-react';
+import dayjs from 'dayjs';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
@@ -46,11 +48,27 @@ import {
   serializedActionLabel,
   serializedStatusColor,
 } from '../../utils/serializedComponents';
+import SerializedScanReceiveModal from './SerializedScanReceiveModal';
 
 interface Props {
   itemId: string;
+  /** Owning item's name, shown in the batch scan-receive modal title. */
+  itemName?: string;
   /** Owning item's tracking mode, shown as context in the header. */
   trackingMode?: SerializedTrackingMode;
+  /**
+   * Display-only {available, on_hand, installed} split for the item, rendered
+   * as a header summary. Read straight off the item-detail payload
+   * (`item.serialized_stock`); null/undefined hides the summary. `available`
+   * (= on_hand − installed) is what drives reorder — units installed in an
+   * asset reduce available but not on-hand.
+   */
+  serializedStock?: { available: number; on_hand: number; installed: number } | null;
+  /**
+   * Invoked after units are received / mutated so the parent can refresh the
+   * item and hand a fresh `serializedStock` back down.
+   */
+  onStockChanged?: () => void;
   /**
    * Whether the owning item is flagged `is_serialized`. When false the panel
    * shows a discoverable "turn this on" call-to-action instead of a dead,
@@ -74,9 +92,14 @@ const fmtDateTime = (iso: string | null): string =>
       })
     : '—';
 
+const fmtDate = (d: string | null): string => (d ? dayjs(d).format('MMM D, YYYY') : '—');
+
 const SerializedComponentsPanel: React.FC<Props> = ({
   itemId,
+  itemName,
   trackingMode,
+  serializedStock,
+  onStockChanged,
   isSerialized = true,
   onEnableTracking,
 }) => {
@@ -95,7 +118,11 @@ const SerializedComponentsPanel: React.FC<Props> = ({
   const [showAdd, setShowAdd] = useState(false);
   const [newSerial, setNewSerial] = useState('');
   const [newLot, setNewLot] = useState('');
+  const [newExpiration, setNewExpiration] = useState<string | null>(null);
   const [adding, setAdding] = useState(false);
+
+  // Scan-driven batch receive modal.
+  const [scanOpen, setScanOpen] = useState(false);
 
   // Install modal.
   const [installUnit, setInstallUnit] = useState<SerializedComponent | null>(null);
@@ -172,6 +199,9 @@ const SerializedComponentsPanel: React.FC<Props> = ({
       try {
         const res = await serializedComponentsAPI[action](unit.id);
         if (res?.data) replaceUnit(res.data);
+        // A lifecycle transition (receive/install/remove/…) shifts the
+        // available/on-hand/installed split — let the parent refresh it.
+        onStockChanged?.();
         if (expandedId === unit.id) {
           refreshHistory(unit.id);
         }
@@ -181,7 +211,7 @@ const SerializedComponentsPanel: React.FC<Props> = ({
         setBusyId(null);
       }
     },
-    [expandedId, refreshHistory, replaceUnit],
+    [expandedId, refreshHistory, replaceUnit, onStockChanged],
   );
 
   const openInstall = useCallback(
@@ -210,6 +240,7 @@ const SerializedComponentsPanel: React.FC<Props> = ({
     try {
       const res = await serializedComponentsAPI.install(installUnit.id, { asset: selectedAssetId });
       if (res?.data) replaceUnit(res.data);
+      onStockChanged?.();
       if (expandedId === installUnit.id) refreshHistory(installUnit.id);
       setInstallUnit(null);
     } catch (err) {
@@ -217,7 +248,7 @@ const SerializedComponentsPanel: React.FC<Props> = ({
     } finally {
       setBusyId(null);
     }
-  }, [installUnit, selectedAssetId, expandedId, refreshHistory, replaceUnit]);
+  }, [installUnit, selectedAssetId, expandedId, refreshHistory, replaceUnit, onStockChanged]);
 
   const submitDispose = useCallback(async () => {
     if (!disposeUnit || !disposalReason.trim()) return;
@@ -228,6 +259,7 @@ const SerializedComponentsPanel: React.FC<Props> = ({
         disposal_reason: disposalReason.trim(),
       });
       if (res?.data) replaceUnit(res.data);
+      onStockChanged?.();
       if (expandedId === disposeUnit.id) refreshHistory(disposeUnit.id);
       setDisposeUnit(null);
       setDisposalReason('');
@@ -236,7 +268,7 @@ const SerializedComponentsPanel: React.FC<Props> = ({
     } finally {
       setBusyId(null);
     }
-  }, [disposeUnit, disposalReason, expandedId, refreshHistory, replaceUnit]);
+  }, [disposeUnit, disposalReason, expandedId, refreshHistory, replaceUnit, onStockChanged]);
 
   const handleAction = useCallback(
     (unit: SerializedComponent, action: SerializedComponentAction) => {
@@ -262,20 +294,23 @@ const SerializedComponentsPanel: React.FC<Props> = ({
         item: itemId,
         serial_number: serial,
         lot: newLot.trim() || undefined,
+        expiration_date: newExpiration || undefined,
       });
       if (res?.data) {
         setUnits((prev) => [res.data, ...prev]);
         setTotal((prev) => prev + 1);
+        onStockChanged?.();
       }
       setNewSerial('');
       setNewLot('');
+      setNewExpiration(null);
       setShowAdd(false);
     } catch (err) {
       setError(extractErrorMessage(err, 'Could not add unit.'));
     } finally {
       setAdding(false);
     }
-  }, [itemId, newSerial, newLot]);
+  }, [itemId, newSerial, newLot, newExpiration, onStockChanged]);
 
   const assetOptions = useMemo(
     () =>
@@ -329,16 +364,62 @@ const SerializedComponentsPanel: React.FC<Props> = ({
             </Badge>
           )}
         </Group>
-        <Button
-          size="xs"
-          variant="light"
-          leftSection={<IconPlus size={14} />}
-          onClick={() => setShowAdd((v) => !v)}
-          data-testid="serialized-add-toggle"
-        >
-          {showAdd ? 'Cancel' : 'Add unit'}
-        </Button>
+        <Group gap="xs">
+          <Button
+            size="xs"
+            variant="light"
+            leftSection={<IconScan size={14} />}
+            onClick={() => setScanOpen(true)}
+            data-testid="serialized-scan-receive-open"
+          >
+            Receive serials
+          </Button>
+          <Button
+            size="xs"
+            variant="light"
+            leftSection={<IconPlus size={14} />}
+            onClick={() => setShowAdd((v) => !v)}
+            data-testid="serialized-add-toggle"
+          >
+            {showAdd ? 'Cancel' : 'Add unit'}
+          </Button>
+        </Group>
       </Group>
+
+      {/* Available / on-hand split (display-only). `available` drives reorder;
+          installed units reduce available but remain on-hand. */}
+      {serializedStock && (
+        <Group gap="xl" mb="sm" data-testid="serialized-stock-summary">
+          <div>
+            <Text size="xs" c="dimmed">
+              Available
+            </Text>
+            <Text fw={600} data-testid="serialized-stock-available">
+              {serializedStock.available}
+            </Text>
+          </div>
+          <div>
+            <Text size="xs" c="dimmed">
+              On-hand
+            </Text>
+            <Text fw={600} data-testid="serialized-stock-on-hand">
+              {serializedStock.on_hand}
+            </Text>
+          </div>
+          <div>
+            <Text size="xs" c="dimmed">
+              Installed
+            </Text>
+            <Text fw={600} data-testid="serialized-stock-installed">
+              {serializedStock.installed}
+            </Text>
+          </div>
+          <Text size="xs" c="dimmed" maw={280}>
+            Reorder is driven by <b>available</b> — units installed in an asset
+            reduce available but not on-hand.
+          </Text>
+        </Group>
+      )}
 
       {error && (
         <Alert color="red" mb="sm" onClose={() => setError(null)} withCloseButton>
@@ -363,6 +444,15 @@ const SerializedComponentsPanel: React.FC<Props> = ({
               value={newLot}
               onChange={(e) => setNewLot(e.currentTarget.value)}
               data-testid="serialized-add-lot"
+              style={{ flex: 1 }}
+            />
+            <DateInput
+              label="Expires (optional)"
+              placeholder="Shelf-life date"
+              value={newExpiration}
+              onChange={setNewExpiration}
+              clearable
+              data-testid="serialized-add-expiration"
               style={{ flex: 1 }}
             />
             <Button
@@ -390,6 +480,7 @@ const SerializedComponentsPanel: React.FC<Props> = ({
               <Table.Th w={40} />
               <Table.Th>Serial</Table.Th>
               <Table.Th>Lot</Table.Th>
+              <Table.Th>Expires</Table.Th>
               <Table.Th>Status</Table.Th>
               <Table.Th>Installed in</Table.Th>
               <Table.Th>Actions</Table.Th>
@@ -421,6 +512,7 @@ const SerializedComponentsPanel: React.FC<Props> = ({
                       <Text fw={500}>{unit.serial_number}</Text>
                     </Table.Td>
                     <Table.Td>{unit.lot || '—'}</Table.Td>
+                    <Table.Td>{fmtDate(unit.expiration_date)}</Table.Td>
                     <Table.Td>
                       <Badge color={serializedStatusColor(unit.status)} variant="light">
                         {unit.status_display}
@@ -452,7 +544,7 @@ const SerializedComponentsPanel: React.FC<Props> = ({
                     </Table.Td>
                   </Table.Tr>
                   <Table.Tr>
-                    <Table.Td colSpan={6} p={0} style={{ border: isExpanded ? undefined : 'none' }}>
+                    <Table.Td colSpan={7} p={0} style={{ border: isExpanded ? undefined : 'none' }}>
                       <Collapse in={isExpanded}>
                         <div style={{ padding: '0.5rem 1rem 1rem 3rem' }}>
                           {historyLoadingId === unit.id ? (
@@ -575,6 +667,17 @@ const SerializedComponentsPanel: React.FC<Props> = ({
           </Group>
         </Stack>
       </Modal>
+
+      {/* Scan-driven batch receive — keyboard-wedge-friendly bulk intake. */}
+      <SerializedScanReceiveModal
+        opened={scanOpen}
+        onClose={() => setScanOpen(false)}
+        item={{ id: itemId, name: itemName ?? 'this item' }}
+        onReceived={() => {
+          load();
+          onStockChanged?.();
+        }}
+      />
     </Paper>
   );
 };

--- a/frontend/src/components/inventory/SerializedForecastPanel.tsx
+++ b/frontend/src/components/inventory/SerializedForecastPanel.tsx
@@ -125,13 +125,14 @@ const SerializedForecastPanel: React.FC<Props> = ({
             : 'No serialized items to forecast yet.'}
         </Text>
       ) : (
-        <Table.ScrollContainer minWidth={720}>
+        <Table.ScrollContainer minWidth={800}>
           <Table highlightOnHover verticalSpacing="xs">
             <Table.Thead>
               <Table.Tr>
                 <Table.Th>Item</Table.Th>
                 <Table.Th>Mode</Table.Th>
                 <Table.Th ta="right">Available</Table.Th>
+                <Table.Th ta="right">On-hand</Table.Th>
                 <Table.Th ta="right">Avg/day</Table.Th>
                 <Table.Th ta="right">Stockout</Table.Th>
                 <Table.Th ta="right">Reorder pt</Table.Th>
@@ -160,7 +161,12 @@ const SerializedForecastPanel: React.FC<Props> = ({
                     </Text>
                   </Table.Td>
                   <Table.Td tt="capitalize">{row.serial_tracking_mode}</Table.Td>
-                  <Table.Td ta="right">{row.available_stock}</Table.Td>
+                  <Table.Td ta="right" fw={600}>
+                    {row.available}
+                  </Table.Td>
+                  <Table.Td ta="right" c="dimmed">
+                    {row.on_hand}
+                  </Table.Td>
                   <Table.Td ta="right">{row.avg_daily_use}</Table.Td>
                   <Table.Td ta="right">{fmtDays(row.days_until_stockout)}</Table.Td>
                   <Table.Td ta="right">{row.reorder_point}</Table.Td>
@@ -180,6 +186,13 @@ const SerializedForecastPanel: React.FC<Props> = ({
             </Table.Tbody>
           </Table>
         </Table.ScrollContainer>
+      )}
+
+      {!loading && !error && rows.length > 0 && (
+        <Text size="xs" c="dimmed" mt="xs" data-testid="serialized-forecast-legend">
+          Reorder is driven by <b>available</b> (on-hand minus units installed in
+          an asset), not on-hand.
+        </Text>
       )}
     </Paper>
   );

--- a/frontend/src/components/inventory/SerializedScanReceiveModal.tsx
+++ b/frontend/src/components/inventory/SerializedScanReceiveModal.tsx
@@ -1,0 +1,309 @@
+/**
+ * SerializedScanReceiveModal — scan-driven batch receive for a serialized
+ * InventoryItem (op-n4pi). Web parity with the ScanTTY batch-scan surface.
+ *
+ * The item is fixed for the batch (the modal is launched from that item's
+ * serialized-units panel). Staff set an optional batch `lot` + `expiration_date`
+ * that apply to every scan, then fire serials one after another into a
+ * keyboard-wedge-friendly input: it autofocuses, submits on Enter, and clears +
+ * refocuses so a handheld scanner can rattle through a box of units untouched.
+ *
+ * Each scan calls the idempotent `scan_receive` endpoint (get-or-create-and-
+ * receive), so a double-scanned serial is tolerated and surfaced as a
+ * "Duplicate" rather than an error. A running log shows new-vs-duplicate with a
+ * count, and "Undo last" disposes the most recent newly-received unit. Backend
+ * errors surface inline via the standard extractErrorMessage path.
+ */
+import {
+  Alert,
+  Badge,
+  Button,
+  Divider,
+  Group,
+  Modal,
+  ScrollArea,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+} from '@mantine/core';
+import { DateInput } from '@mantine/dates';
+import { IconArrowBackUp } from '@tabler/icons-react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { serializedComponentsAPI } from '../../services/api';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
+
+interface ReceivedEntry {
+  /** Unique per scan event (a serial can be scanned more than once). */
+  key: string;
+  componentId: string;
+  serialNumber: string;
+  /** True when this scan minted+received a new unit; false on a re-scan. */
+  created: boolean;
+  /** True once "Undo last" has disposed the underlying unit. */
+  undone: boolean;
+}
+
+interface Props {
+  opened: boolean;
+  onClose: () => void;
+  /** The serialized item every scan in this batch is received against. */
+  item: { id: string; name: string };
+  /**
+   * Called once on close when the batch received anything, so the launching
+   * panel can refresh its units list + available/on-hand header.
+   */
+  onReceived?: () => void;
+}
+
+const SerializedScanReceiveModal: React.FC<Props> = ({
+  opened,
+  onClose,
+  item,
+  onReceived,
+}) => {
+  // Batch settings — applied to every scan in this session.
+  const [lot, setLot] = useState('');
+  const [expiration, setExpiration] = useState<string | null>(null);
+
+  const [serial, setSerial] = useState('');
+  const [received, setReceived] = useState<ReceivedEntry[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [undoing, setUndoing] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const scanSeq = useRef(0);
+
+  // Focus the scan field when the modal opens so a wedge scanner fires straight
+  // in without a click.
+  useEffect(() => {
+    if (opened) inputRef.current?.focus();
+  }, [opened]);
+
+  const handleScan = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      const sn = serial.trim();
+      if (!sn) return;
+      // Clear + refocus immediately so the next scan can land while this one is
+      // still in flight (scanners fire faster than the round-trip).
+      setSerial('');
+      inputRef.current?.focus();
+      setError(null);
+      setBusy(true);
+      const seq = (scanSeq.current += 1);
+      try {
+        const res = await serializedComponentsAPI.scanReceive({
+          item: item.id,
+          serial_number: sn,
+          lot: lot.trim() || undefined,
+          expiration_date: expiration || undefined,
+        });
+        const data = res?.data;
+        if (data) {
+          setReceived((prev) => [
+            {
+              key: `${seq}-${data.id}`,
+              componentId: data.id,
+              serialNumber: data.serial_number,
+              created: data.created,
+              undone: false,
+            },
+            ...prev,
+          ]);
+        }
+      } catch (err) {
+        setError(extractErrorMessage(err, `Could not receive ${sn}.`));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [serial, lot, expiration, item.id],
+  );
+
+  // Undo targets the most recent *newly-received* unit that has not already
+  // been undone — a re-scan (duplicate) created nothing here, so undoing it
+  // must never dispose pre-existing inventory.
+  const lastUndoable = received.find((r) => r.created && !r.undone);
+
+  const handleUndo = useCallback(async () => {
+    if (!lastUndoable) return;
+    setUndoing(true);
+    setError(null);
+    try {
+      await serializedComponentsAPI.dispose(lastUndoable.componentId, {
+        disposal_reason: 'Undo scan-receive (batch)',
+      });
+      setReceived((prev) =>
+        prev.map((r) => (r.key === lastUndoable.key ? { ...r, undone: true } : r)),
+      );
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Could not undo the last received unit.'));
+    } finally {
+      setUndoing(false);
+      inputRef.current?.focus();
+    }
+  }, [lastUndoable]);
+
+  const handleClose = useCallback(() => {
+    // A batch that received (or undid) anything changed server state — let the
+    // launching panel refresh once, on close, rather than per keystroke.
+    if (received.length > 0) onReceived?.();
+    setSerial('');
+    setError(null);
+    setReceived([]);
+    setLot('');
+    setExpiration(null);
+    onClose();
+  }, [received.length, onReceived, onClose]);
+
+  const newCount = received.filter((r) => r.created && !r.undone).length;
+  const dupCount = received.filter((r) => !r.created).length;
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={handleClose}
+      title={`Receive serials — ${item.name}`}
+      size="lg"
+      centered
+      data-testid="serialized-scan-receive-modal"
+    >
+      <Stack gap="sm">
+        <Text size="sm" c="dimmed">
+          Set an optional lot / expiry for the batch, then scan or type each
+          serial and press Enter. Serials are received against{' '}
+          <Text span fw={500}>
+            {item.name}
+          </Text>
+          . Re-scanning a serial is safe — it shows as a duplicate rather than an
+          error.
+        </Text>
+
+        <Group grow align="flex-start">
+          <TextInput
+            label="Lot (optional)"
+            placeholder="Batch / lot"
+            value={lot}
+            onChange={(e) => setLot(e.currentTarget.value)}
+            data-testid="scan-receive-lot"
+          />
+          <DateInput
+            label="Expires (optional)"
+            placeholder="Batch expiry"
+            value={expiration}
+            onChange={setExpiration}
+            clearable
+            data-testid="scan-receive-expiration"
+          />
+        </Group>
+
+        <form onSubmit={handleScan} data-testid="scan-receive-form">
+          <TextInput
+            ref={inputRef}
+            label="Scan serial"
+            placeholder="Scan or type a serial, then Enter"
+            value={serial}
+            onChange={(e) => setSerial(e.currentTarget.value)}
+            data-autofocus
+            data-testid="scan-receive-serial"
+            rightSection={busy ? <Text size="xs" c="dimmed">…</Text> : undefined}
+          />
+        </form>
+
+        {error && (
+          <Alert
+            color="red"
+            withCloseButton
+            onClose={() => setError(null)}
+            data-testid="scan-receive-error"
+          >
+            {error}
+          </Alert>
+        )}
+
+        <Divider />
+
+        <Group justify="space-between" align="center">
+          <Group gap="xs">
+            <Badge color="green" variant="light" data-testid="scan-receive-new-count">
+              {newCount} new
+            </Badge>
+            <Badge color="gray" variant="light" data-testid="scan-receive-dup-count">
+              {dupCount} duplicate
+            </Badge>
+          </Group>
+          <Button
+            size="xs"
+            variant="light"
+            color="red"
+            leftSection={<IconArrowBackUp size={14} />}
+            onClick={handleUndo}
+            disabled={!lastUndoable}
+            loading={undoing}
+            data-testid="scan-receive-undo"
+          >
+            Undo last
+          </Button>
+        </Group>
+
+        {received.length === 0 ? (
+          <Text c="dimmed" size="sm" data-testid="scan-receive-empty">
+            No serials received yet.
+          </Text>
+        ) : (
+          <ScrollArea.Autosize mah={260}>
+            <Table verticalSpacing="xs" fz="sm" data-testid="scan-receive-log">
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Serial</Table.Th>
+                  <Table.Th>Result</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {received.map((entry) => (
+                  <Table.Tr key={entry.key} data-testid="scan-receive-entry">
+                    <Table.Td>
+                      <Text
+                        fw={500}
+                        td={entry.undone ? 'line-through' : undefined}
+                        c={entry.undone ? 'dimmed' : undefined}
+                      >
+                        {entry.serialNumber}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      {entry.undone ? (
+                        <Badge color="red" variant="light">
+                          Undone
+                        </Badge>
+                      ) : entry.created ? (
+                        <Badge color="green" variant="light">
+                          New
+                        </Badge>
+                      ) : (
+                        <Badge color="gray" variant="light">
+                          Duplicate
+                        </Badge>
+                      )}
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          </ScrollArea.Autosize>
+        )}
+
+        <Group justify="flex-end">
+          <Button onClick={handleClose} data-testid="scan-receive-done">
+            Done
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+};
+
+export default SerializedScanReceiveModal;

--- a/frontend/src/pages/InventoryItemDetailPage.tsx
+++ b/frontend/src/pages/InventoryItemDetailPage.tsx
@@ -630,7 +630,10 @@ const InventoryItemDetailPage: React.FC = () => {
         <Tabs.Panel value="serialized-units" pt="md">
           <SerializedComponentsPanel
             itemId={item.id}
+            itemName={item.name}
             trackingMode={item.serial_tracking_mode}
+            serializedStock={item.serialized_stock}
+            onStockChanged={loadData}
             isSerialized={item.is_serialized ?? false}
             onEnableTracking={() => navigate(`/inventory/items/${item.id}/edit`)}
           />

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -720,6 +720,9 @@ export interface SerializedComponent {
   item_sku: string;
   serial_number: string;
   lot: string;
+  // Optional shelf-life date (record/display only — no forecast/alert effect).
+  // ISO calendar date "YYYY-MM-DD" as returned by the DRF DateField, or null.
+  expiration_date: string | null;
   status: SerializedComponentStatus;
   status_display: string;
   tracking_mode: SerializedTrackingMode;
@@ -739,6 +742,13 @@ export interface SerializedComponent {
 // A lifecycle action returns the updated unit plus the event it logged.
 export interface SerializedComponentActionResult extends SerializedComponent {
   event: ComponentUsageEvent;
+}
+
+// scan_receive returns the (created-or-existing) unit plus a `created` flag:
+// true when this scan minted+received a new unit (HTTP 201), false on an
+// idempotent re-scan of the same (item, serial_number) pair (HTTP 200).
+export interface SerializedComponentScanResult extends SerializedComponent {
+  created: boolean;
 }
 
 interface Paginated<T> {
@@ -765,9 +775,26 @@ export const serializedComponentsAPI = {
     item: string;
     serial_number: string;
     lot?: string;
+    expiration_date?: string | null;
     provenance_delivery_item?: number | null;
     provenance_purchase_order_item?: number | null;
   }) => api.post<SerializedComponent>('/inventory/serialized-components/', data),
+
+  // Scan-driven batch receive: idempotent get-or-create-and-receive by
+  // (item, serial_number). A first scan mints the unit and applies `receive`
+  // (201 `created:true`); a re-scan resolves to the existing unit without a
+  // unique-constraint 400 (200 `created:false`). Drives the web + ScanTTY
+  // batch-scan surfaces.
+  scanReceive: (data: {
+    item: string;
+    serial_number: string;
+    lot?: string;
+    expiration_date?: string | null;
+  }) =>
+    api.post<SerializedComponentScanResult>(
+      '/inventory/serialized-components/scan_receive/',
+      data,
+    ),
 
   // Lifecycle actions — each returns the updated unit plus the logged event.
   receive: (id: string, data?: { notes?: string }) =>
@@ -817,6 +844,13 @@ export interface SerializedForecastRow {
   sku: string;
   category_name: string | null;
   serial_tracking_mode: SerializedTrackingMode;
+  // Serialized stock split. `available` (= on_hand − installed) is what drives
+  // the reorder math; `on_hand` counts every physically-present unit including
+  // those currently installed in an asset. `available_stock` is a
+  // backward-compatible alias of `on_hand`.
+  available: number;
+  on_hand: number;
+  installed: number;
   available_stock: number;
   current_stock: number;
   window_days: number;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -161,6 +161,15 @@ export interface InventoryItem {
   // matches `SerializedTrackingMode` in services/api.ts.)
   is_serialized?: boolean;
   serial_tracking_mode?: 'consumable' | 'reusable';
+  // Display-only serialized stock split, present on the item-detail (retrieve)
+  // payload for serialized items and null otherwise. `available` = on_hand −
+  // installed; `on_hand` counts every physically-present unit. Does not touch
+  // the aggregate `current_stock` / generic reorder path.
+  serialized_stock?: {
+    available: number;
+    on_hand: number;
+    installed: number;
+  } | null;
   // Reorder status and tracking
   reorder_status: string;
   has_pending_reorder: boolean;


### PR DESCRIPTION
## What
Web half of the serialized enhancement (consumes the #870 backend API). All three asks:
- **expiration_date** — a Mantine `DateInput` ("Expires") on the Add-unit form in `SerializedComponentsPanel`, an "Expires" column in the units table, and read-only display in `AssetSerializedComponentsSection`.
- **available / on-hand** — surfaced on the panel header + `SerializedForecastPanel` (available = on-hand − installed; installed no longer counts as available for reorder).
- **Batch scan-receive** — new `SerializedScanReceiveModal`: pick a serialized item, set optional batch expiry/lot, rapid-fire scan serials → each calls the idempotent `scan_receive` endpoint; running list with new-vs-duplicate, count, and undo-last. Keyboard-wedge friendly (autofocus + submit-on-Enter + refocus).
- `api.ts` methods (`scanReceive`, expiration_date on create) + TS types.

## Verification
- eslint: 0 errors.
- Tests: new `SerializedScanReceiveModal.test.tsx` (+182) + panel/forecast/api test updates.

Pairs with ScanTTY #96 (batch-scan-serials). Parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)