### PR TITLE
refactor(frontend): single "Print work order" button (unified OMR PDF) (op-3irz)

### DIFF
--- a/frontend/src/__tests__/pages/WorkOrderPage.test.tsx
+++ b/frontend/src/__tests__/pages/WorkOrderPage.test.tsx
@@ -201,19 +201,19 @@ describe('WorkOrderPage resilience (#457 R4)', () => {
     });
   });
 
-  it('offers a print button for the scan-to-complete (OMR) form variant (op-w4ju)', async () => {
+  it('offers a single print button for the unified work order (OMR) PDF (op-3irz)', async () => {
     mockWorkOrderAPI.getWorkOrder.mockResolvedValue(okResponse(buildWorkOrder()));
-    mockWorkOrderAPI.getOmrPdfUrl.mockReturnValue(
-      'http://localhost:8000/api/inventory/work-orders/wo-1/omr-pdf/',
+    mockWorkOrderAPI.getPdfUrl.mockReturnValue(
+      'http://localhost:8000/api/inventory/work-orders/wo-1/pdf/',
     );
 
     renderPage();
 
-    const scanBtn = await screen.findByLabelText('Print scan-to-complete form');
-    expect(scanBtn).toHaveAttribute(
+    const printBtn = await screen.findByLabelText('Print work order form');
+    expect(printBtn).toHaveAttribute(
       'href',
-      'http://localhost:8000/api/inventory/work-orders/wo-1/omr-pdf/',
+      'http://localhost:8000/api/inventory/work-orders/wo-1/pdf/',
     );
-    expect(mockWorkOrderAPI.getOmrPdfUrl).toHaveBeenCalledWith('wo-1');
+    expect(mockWorkOrderAPI.getPdfUrl).toHaveBeenCalledWith('wo-1');
   });
 });

--- a/frontend/src/__tests__/services/api.test.ts
+++ b/frontend/src/__tests__/services/api.test.ts
@@ -981,11 +981,4 @@ describe('API Service', () => {
       expect(url).toBe('http://localhost:8000/api/inventory/work-orders/abc-123/pdf/');
     });
   });
-
-  describe('workOrderAPI.getOmrPdfUrl targets the scan-to-complete endpoint', () => {
-    test('produces the omr-pdf URL prefixed by the resolved API base URL', () => {
-      const url = workOrderAPI.getOmrPdfUrl('abc-123');
-      expect(url).toBe('http://localhost:8000/api/inventory/work-orders/abc-123/omr-pdf/');
-    });
-  });
 });

--- a/frontend/src/pages/WorkOrderPage.tsx
+++ b/frontend/src/pages/WorkOrderPage.tsx
@@ -118,7 +118,7 @@ const WorkOrderPage: React.FC = () => {
 
   // AC-3: validation prompt state.
   const [validationOpen, setValidationOpen] = useState(false);
-  const [validationKind, setValidationKind] = useState<'finalize' | 'pdf' | 'omr-pdf'>('finalize');
+  const [validationKind, setValidationKind] = useState<'finalize' | 'pdf'>('finalize');
   const [ackElectrical, setAckElectrical] = useState(false);
   const [ackLoto, setAckLoto] = useState(false);
   const [ackRequired, setAckRequired] = useState(false);
@@ -219,12 +219,12 @@ const WorkOrderPage: React.FC = () => {
         // Re-attempt finalization now that the gate is open.
         await handleStatusChange('completed');
       } else {
-        // Open the requested PDF variant in a new tab now that the gate is open.
-        const url =
-          validationKind === 'omr-pdf'
-            ? workOrderAPI.getOmrPdfUrl(workOrder.id)
-            : workOrderAPI.getPdfUrl(workOrder.id);
-        window.open(url, '_blank', 'noopener,noreferrer');
+        // Open the work order PDF in a new tab now that the gate is open.
+        window.open(
+          workOrderAPI.getPdfUrl(workOrder.id),
+          '_blank',
+          'noopener,noreferrer',
+        );
       }
     } catch (err: unknown) {
       const e = err as { response?: { data?: { detail?: string } } };
@@ -242,20 +242,6 @@ const WorkOrderPage: React.FC = () => {
     if (!workOrder?.validation?.is_complete) {
       e.preventDefault();
       setValidationKind('pdf');
-      setAckElectrical(false);
-      setAckLoto(false);
-      setAckRequired(false);
-      setValidationNotes('');
-      setValidationOpen(true);
-    }
-  };
-
-  const handlePrintOmrPdf = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    // Same validation gate as the standard PDF; on success the anchor href
-    // opens the OMR variant, otherwise the modal drives validate-then-open.
-    if (!workOrder?.validation?.is_complete) {
-      e.preventDefault();
-      setValidationKind('omr-pdf');
       setAckElectrical(false);
       setAckLoto(false);
       setAckRequired(false);
@@ -508,37 +494,21 @@ const WorkOrderPage: React.FC = () => {
               </Text>
             )}
           </Box>
-          <Stack gap="xs">
-            <Tooltip label="Print PDF">
-              <ActionIcon
-                variant="light"
-                color="gray"
-                size="lg"
-                component="a"
-                href={workOrderAPI.getPdfUrl(workOrder.id)}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={handlePrintPdf}
-              >
-                <IconFileText size={20} />
-              </ActionIcon>
-            </Tooltip>
-            <Tooltip label="Print scan-to-complete form">
-              <ActionIcon
-                variant="light"
-                color="gray"
-                size="lg"
-                component="a"
-                href={workOrderAPI.getOmrPdfUrl(workOrder.id)}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={handlePrintOmrPdf}
-                aria-label="Print scan-to-complete form"
-              >
-                <IconScan size={20} />
-              </ActionIcon>
-            </Tooltip>
-          </Stack>
+          <Tooltip label="Print work order form">
+            <ActionIcon
+              variant="light"
+              color="gray"
+              size="lg"
+              component="a"
+              href={workOrderAPI.getPdfUrl(workOrder.id)}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handlePrintPdf}
+              aria-label="Print work order form"
+            >
+              <IconFileText size={20} />
+            </ActionIcon>
+          </Tooltip>
         </Group>
 
         {/* Status selector */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1283,11 +1283,11 @@ export const workOrderAPI = {
   updateWorkOrder: (id: string, data: Partial<WorkOrder>) =>
     api.patch<WorkOrder>(`/inventory/work-orders/${id}/`, data),
 
+  // The work order PDF is the OMR "scan-to-complete" form: a printable form
+  // with corner fiducials that can be filled by hand and scanned back in.
+  // Backend unified /pdf/ onto this variant (op-8mjw); /omr-pdf/ is a
+  // deprecated alias, so the web uses the single /pdf/ endpoint.
   getPdfUrl: (id: string) => `${API_BASE_URL}/inventory/work-orders/${id}/pdf/`,
-
-  // OMR "scan-to-complete" form variant: printable form with corner fiducials
-  // that can be filled by hand and scanned back in (op-w4ju).
-  getOmrPdfUrl: (id: string) => `${API_BASE_URL}/inventory/work-orders/${id}/omr-pdf/`,
 
   generateWorkOrder: (maintenanceItemId: string, data?: { due_date?: string; notes?: string }) =>
     api.post<WorkOrder>(`/inventory/maintenance-items/${maintenanceItemId}/generate_work_order/`, data || {}),


### PR DESCRIPTION
## What
Follow-on to #873 (backend unified the WO PDF on the OMR route). The WorkOrder page had two print buttons (`pdf` + `omr-pdf`); now that both endpoints return the same OMR PDF, this collapses them into **one** "Print work order" button (calls `/pdf/`) and removes the now-redundant `omr-pdf` api method + its `validationKind` branch.

## Verification
- eslint: 0 errors.
- Tests updated (WorkOrderPage.test, api.test — drop the omr-pdf assertions). Net −70/+33.

Backend counterpart: #873 (keeps `/omr-pdf/` as a deprecated alias, so no 404 window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)