### PR TITLE
fix(labels): install DejaVu font in container so label text isn't tiny

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libzbar0 \
         libgl1 \
         libglib2.0-0 \
+        fonts-dejavu-core \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libzbar0 \
         libgl1 \
         libglib2.0-0 \
+        fonts-dejavu-core \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies

--- a/backend/maker_boxes/services/label_service.py
+++ b/backend/maker_boxes/services/label_service.py
@@ -56,6 +56,12 @@ NAME_GAP_INCHES = 0.15
 def _try_font(size: int) -> ImageFont.ImageFont:
     """Return the largest available bundled TrueType font, or PIL's default."""
     candidates: Iterable[str] = (
+        # Absolute paths first: Pillow does NOT resolve a bare filename against
+        # the system font dirs, so the bare names below fell through to
+        # load_default() (a fixed ~10px bitmap that ignores `size`) even when
+        # DejaVu was installed. DejaVu ships via fonts-dejavu-core (Dockerfile).
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
         "DejaVuSans-Bold.ttf",
         "DejaVuSans.ttf",
         "Arial Bold.ttf",
@@ -66,7 +72,12 @@ def _try_font(size: int) -> ImageFont.ImageFont:
             return ImageFont.truetype(name, size=size)
         except OSError:
             continue
-    return ImageFont.load_default()
+    # Last resort: a size-scaled default so text stays legible even with no
+    # TrueType font present (Pillow >= 10.1 honours size=).
+    try:
+        return ImageFont.load_default(size=size)
+    except TypeError:
+        return ImageFont.load_default()
 
 
 def _qr_payload(bin_id: str, username: str) -> str:

--- a/backend/project_storage/services/label_service.py
+++ b/backend/project_storage/services/label_service.py
@@ -52,6 +52,12 @@ EPSON_SIZE_PX = (576, 340)
 
 def _try_font(size: int) -> ImageFont.ImageFont:
     candidates: Iterable[str] = (
+        # Absolute paths first: Pillow does NOT resolve a bare filename against
+        # the system font dirs, so the bare names below fell through to
+        # load_default() (a fixed ~10px bitmap that ignores `size`) even when
+        # DejaVu was installed. DejaVu ships via fonts-dejavu-core (Dockerfile).
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
         "DejaVuSans-Bold.ttf",
         "DejaVuSans.ttf",
         "Arial Bold.ttf",
@@ -62,7 +68,12 @@ def _try_font(size: int) -> ImageFont.ImageFont:
             return ImageFont.truetype(name, size=size)
         except OSError:
             continue
-    return ImageFont.load_default()
+    # Last resort: a size-scaled default so text stays legible even with no
+    # TrueType font present (Pillow >= 10.1 honours size=).
+    try:
+        return ImageFont.load_default(size=size)
+    except TypeError:
+        return ImageFont.load_default()
 
 
 def _build_qr_image(value: str, target_px: int) -> Image.Image:


### PR DESCRIPTION
## Root cause
The label text is small **in everything** because the container has **no fonts installed at all** — confirmed on the running prod container:
- `/usr/share/fonts/truetype/dejavu/` → No such file or directory
- `find /usr/share/fonts -name "*.ttf"` → empty · `dpkg -l | grep font` → nothing

Every renderer calls `ImageFont.truetype(".../DejaVuSans.ttf", size)`; the file is absent, so Pillow silently falls back to `ImageFont.load_default()` — a fixed ~8px bitmap that **ignores the requested size**. So all the size math (incl. #822's bumps) had no visible effect.

**Proof:** `truetype(60)` renders "Wk32" at **47px**; `load_default()` at **8px**.

## Fix
1. `apt-get install fonts-dejavu-core` in `backend/Dockerfile` + `Dockerfile.prod` — the open-source font the code already references. The full-path loaders (asset tags, Brother ESC/P, donations QR, forgekey e-paper) start working immediately.
2. `project_storage` + `maker_boxes` label services loaded DejaVu by **bare filename**, which Pillow won't resolve against the system font dirs (so they'd fall back even with the font present) — point them at `/usr/share/fonts/truetype/dejavu/…`, with a size-scaled `load_default()` as the last resort.

Fixes tiny text across **all** label types. Visual confirmation after deploy: any printed label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)