### PR TITLE
feat(frontend): asset report "Supplies Used" tab (op-ib81)

### DIFF
--- a/frontend/src/__tests__/pages/AssetReportPage.test.tsx
+++ b/frontend/src/__tests__/pages/AssetReportPage.test.tsx
@@ -8,7 +8,7 @@
  * readable "No data available" state rather than a blank panel or a crash.
  */
 import { MantineProvider } from '@mantine/core';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import AssetReportPage from '../../pages/AssetReportPage';
 import { reportsAPI } from '../../services/api';
@@ -64,5 +64,76 @@ describe('AssetReportPage resilience (#457 R4)', () => {
     await waitFor(() => {
       expect(screen.queryByText(/loading\.\.\./i)).not.toBeInTheDocument();
     });
+  });
+});
+
+describe('AssetReportPage Supplies Used tab (op-ib81)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Mount tab loads on render; keep it quiet so the panel under test is clean.
+    mockReportsAPI.getAssetAssetsByStatus.mockResolvedValue(okResponse([]));
+  });
+
+  it('loads and renders serialized + consumable rows when the tab is selected', async () => {
+    mockReportsAPI.getAssetSuppliesUsed.mockResolvedValue(
+      okResponse([
+        {
+          asset_id: 'a1',
+          asset_name: 'Laser Cutter',
+          source: 'serialized',
+          item_name: 'Lens Assembly',
+          serial_number: 'SN-1001',
+          action: 'install',
+          action_display: 'Installed',
+          used_at: '2026-06-01T10:00:00Z',
+          actor: 'alice',
+        },
+        {
+          asset_id: 'a1',
+          asset_name: 'Laser Cutter',
+          source: 'consumable',
+          item_name: 'Cutting Oil',
+          quantity: '2',
+          unit: 'L',
+          work_order_id: 'wo-9',
+          estimated_cost: '15.50',
+          used_at: '2026-06-05T12:00:00Z',
+        },
+      ]),
+    );
+
+    renderPage();
+
+    // Mantine Tabs keeps every panel mounted; the loader only fires once the
+    // Supplies Used tab is active, honoring the shared date range.
+    fireEvent.click(screen.getByRole('tab', { name: /supplies used/i }));
+
+    const panel = await screen.findByRole('tabpanel');
+    // Serialized row: serial number + human action, no cost column value.
+    expect(await within(panel).findByText('Lens Assembly')).toBeInTheDocument();
+    expect(within(panel).getByText('SN-1001')).toBeInTheDocument();
+    expect(within(panel).getByText('Installed')).toBeInTheDocument();
+    // Consumable row: qty+unit under Serial/Qty and a formatted cost.
+    expect(within(panel).getByText('Cutting Oil')).toBeInTheDocument();
+    expect(within(panel).getByText('2 L')).toBeInTheDocument();
+    expect(within(panel).getByText('$15.50')).toBeInTheDocument();
+
+    expect(mockReportsAPI.getAssetSuppliesUsed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        start_date: expect.any(String),
+        end_date: expect.any(String),
+      }),
+    );
+  });
+
+  it('shows a clear empty state on the tab when there are no rows', async () => {
+    mockReportsAPI.getAssetSuppliesUsed.mockResolvedValue(okResponse([]));
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('tab', { name: /supplies used/i }));
+
+    const panel = await screen.findByRole('tabpanel');
+    expect(await within(panel).findByText(/no supplies used in this period/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/services/api.test.ts
+++ b/frontend/src/__tests__/services/api.test.ts
@@ -909,6 +909,38 @@ describe('API Service', () => {
     });
   });
 
+  describe('Reports API', () => {
+    test('getAssetSuppliesUsed requests supplies_used with the date window', async () => {
+      mock.onGet('/inventory/reports/assets/supplies_used/').reply((config) => {
+        expect(config.params).toEqual({
+          start_date: '2026-06-01',
+          end_date: '2026-06-30',
+        });
+        return [
+          200,
+          [
+            {
+              asset_id: 'a1',
+              asset_name: 'Laser Cutter',
+              source: 'serialized',
+              item_name: 'Lens Assembly',
+              serial_number: 'SN-1001',
+              used_at: '2026-06-01T10:00:00Z',
+            },
+          ],
+        ];
+      });
+
+      const response = await reportsAPI.getAssetSuppliesUsed({
+        start_date: '2026-06-01',
+        end_date: '2026-06-30',
+      });
+
+      expect(response.data[0].source).toBe('serialized');
+      expect(response.data[0].serial_number).toBe('SN-1001');
+    });
+  });
+
   describe('resolveApiBaseUrl (deployment-configurable API base URL)', () => {
     const ORIGINAL_LOCATION = window.location;
 

--- a/frontend/src/pages/AssetReportPage.tsx
+++ b/frontend/src/pages/AssetReportPage.tsx
@@ -15,11 +15,12 @@ import {
 import { DatePickerInput, DatesRangeValue } from '@mantine/dates';
 import { IconDownload } from '@tabler/icons-react';
 import dayjs from 'dayjs';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { reportsAPI } from '../services/api';
 import {
   AssetAssetsByStatus,
   AssetMaintenanceDue,
+  AssetSuppliesUsed,
   AssetTco,
   AssetUtilization,
 } from '../types';
@@ -42,6 +43,7 @@ const AssetReportPage: React.FC = () => {
   const [maintenanceDue, setMaintenanceDue] = useState<AssetMaintenanceDue[]>([]);
   const [utilization, setUtilization] = useState<AssetUtilization[]>([]);
   const [tcoRows, setTcoRows] = useState<AssetTco[]>([]);
+  const [suppliesUsed, setSuppliesUsed] = useState<AssetSuppliesUsed[]>([]);
   const [dateRange, setDateRange] = useState<DatesRangeValue>(getDefaultDateRange);
   const [sortField, setSortField] = useState<SortField>('');
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
@@ -57,6 +59,8 @@ const AssetReportPage: React.FC = () => {
       loadUtilization();
     } else if (activeTab === 'tco') {
       loadTco();
+    } else if (activeTab === 'supplies_used') {
+      loadSuppliesUsed();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab, dateRange]);
@@ -113,6 +117,22 @@ const AssetReportPage: React.FC = () => {
     }
   };
 
+  const loadSuppliesUsed = async () => {
+    if (!dateRange[0] || !dateRange[1]) return;
+    try {
+      setLoading(true);
+      const response = await reportsAPI.getAssetSuppliesUsed({
+        start_date: dayjs(dateRange[0]).format('YYYY-MM-DD'),
+        end_date: dayjs(dateRange[1]).format('YYYY-MM-DD'),
+      });
+      setSuppliesUsed(response.data);
+    } catch (err) {
+      console.error('Error loading supplies used:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const handleSort = (field: SortField) => {
     if (sortField === field) {
       setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
@@ -122,26 +142,30 @@ const AssetReportPage: React.FC = () => {
     }
   };
 
-  const sortData = <T extends Record<string, any>>(data: T[]): T[] => {
-    const sorted = [...data];
-    if (!sortField) return sorted;
-    sorted.sort((a, b) => {
-      let aVal: any = a[sortField];
-      let bVal: any = b[sortField];
-      if (typeof aVal === 'string') {
-        aVal = aVal.toLowerCase();
-        bVal = bVal.toLowerCase();
-      }
-      if (aVal < bVal) return sortDirection === 'asc' ? -1 : 1;
-      if (aVal > bVal) return sortDirection === 'asc' ? 1 : -1;
-      return 0;
-    });
-    return sorted;
-  };
+  const sortData = useCallback(
+    <T extends Record<string, any>>(data: T[]): T[] => {
+      const sorted = [...data];
+      if (!sortField) return sorted;
+      sorted.sort((a, b) => {
+        let aVal: any = a[sortField];
+        let bVal: any = b[sortField];
+        if (typeof aVal === 'string') {
+          aVal = aVal.toLowerCase();
+          bVal = bVal.toLowerCase();
+        }
+        if (aVal < bVal) return sortDirection === 'asc' ? -1 : 1;
+        if (aVal > bVal) return sortDirection === 'asc' ? 1 : -1;
+        return 0;
+      });
+      return sorted;
+    },
+    [sortField, sortDirection],
+  );
 
-  const sortedAssetsByStatus = useMemo(() => sortData(assetsByStatus), [assetsByStatus, sortField, sortDirection]);
-  const sortedMaintenanceDue = useMemo(() => sortData(maintenanceDue), [maintenanceDue, sortField, sortDirection]);
-  const sortedUtilization = useMemo(() => sortData(utilization), [utilization, sortField, sortDirection]);
+  const sortedAssetsByStatus = useMemo(() => sortData(assetsByStatus), [assetsByStatus, sortData]);
+  const sortedMaintenanceDue = useMemo(() => sortData(maintenanceDue), [maintenanceDue, sortData]);
+  const sortedUtilization = useMemo(() => sortData(utilization), [utilization, sortData]);
+  const sortedSuppliesUsed = useMemo(() => sortData(suppliesUsed), [suppliesUsed, sortData]);
   const sortedTco = useMemo(() => {
     if (!sortField) {
       return [...tcoRows].sort(
@@ -193,6 +217,8 @@ const AssetReportPage: React.FC = () => {
       exportAssetReportToCSV(utilization, 'utilization');
     } else if (activeTab === 'tco') {
       exportAssetReportToCSV(tcoRows, 'tco');
+    } else if (activeTab === 'supplies_used') {
+      exportAssetReportToCSV(suppliesUsed, 'supplies_used');
     }
   };
 
@@ -231,6 +257,7 @@ const AssetReportPage: React.FC = () => {
           <Tabs.Tab value="maintenance_due">Maintenance Due</Tabs.Tab>
           <Tabs.Tab value="utilization">Utilization</Tabs.Tab>
           <Tabs.Tab value="tco">Total Cost of Ownership</Tabs.Tab>
+          <Tabs.Tab value="supplies_used">Supplies Used</Tabs.Tab>
         </Tabs.List>
 
         <Tabs.Panel value="assets_by_status" pt="md">
@@ -478,6 +505,99 @@ const AssetReportPage: React.FC = () => {
                           <Table.Td>${formatMoney(item.vendor_maintenance_cost)}</Table.Td>
                           <Table.Td>
                             <Text fw={600}>${formatMoney(item.total_maintenance_cost_90d)}</Text>
+                          </Table.Td>
+                        </Table.Tr>
+                      ))
+                    )}
+                  </Table.Tbody>
+                </Table>
+              </Table.ScrollContainer>
+            </Paper>
+          </Stack>
+        </Tabs.Panel>
+
+        <Tabs.Panel value="supplies_used" pt="md">
+          <Stack gap="md">
+            <Text size="sm" c="dimmed">
+              Supplies consumed per asset over the selected window. Serialized rows
+              are serial-numbered units put into service on / consumed by the asset;
+              consumable rows are bulk materials used while closing a preventive-
+              maintenance work order. Serial/Qty, Action, and Cost are blank where
+              they do not apply to that source.
+            </Text>
+            <Group>
+              <DatePickerInput
+                type="range"
+                label="Date Range"
+                placeholder="Select date range"
+                value={dateRange}
+                onChange={setDateRange}
+                allowSingleDateInRange
+                clearable
+                maxDate={new Date()}
+                style={{ minWidth: 280 }}
+              />
+            </Group>
+            <Paper withBorder>
+              <Table.ScrollContainer minWidth={1000}>
+                <Table highlightOnHover>
+                  <Table.Thead>
+                    <Table.Tr>
+                      <Table.Th style={{ cursor: 'pointer' }} onClick={() => handleSort('asset_name')}>
+                        Asset
+                      </Table.Th>
+                      <Table.Th style={{ cursor: 'pointer' }} onClick={() => handleSort('source')}>
+                        Source
+                      </Table.Th>
+                      <Table.Th style={{ cursor: 'pointer' }} onClick={() => handleSort('item_name')}>
+                        Item
+                      </Table.Th>
+                      <Table.Th>Serial/Qty</Table.Th>
+                      <Table.Th>Action</Table.Th>
+                      <Table.Th style={{ cursor: 'pointer' }} onClick={() => handleSort('used_at')}>
+                        Used At
+                      </Table.Th>
+                      <Table.Th>Cost</Table.Th>
+                    </Table.Tr>
+                  </Table.Thead>
+                  <Table.Tbody>
+                    {loading ? (
+                      <Table.Tr>
+                        <Table.Td colSpan={7} style={{ textAlign: 'center' }}>
+                          <Text>Loading...</Text>
+                        </Table.Td>
+                      </Table.Tr>
+                    ) : sortedSuppliesUsed.length === 0 ? (
+                      <Table.Tr>
+                        <Table.Td colSpan={7} style={{ textAlign: 'center' }}>
+                          <Text>No supplies used in this period</Text>
+                        </Table.Td>
+                      </Table.Tr>
+                    ) : (
+                      sortedSuppliesUsed.map((item, idx) => (
+                        <Table.Tr key={idx}>
+                          <Table.Td>{item.asset_name}</Table.Td>
+                          <Table.Td>
+                            {item.source === 'serialized' ? 'Serialized' : 'Consumable'}
+                          </Table.Td>
+                          <Table.Td>{item.item_name}</Table.Td>
+                          <Table.Td>
+                            {item.source === 'serialized'
+                              ? item.serial_number || '—'
+                              : [item.quantity, item.unit].filter(Boolean).join(' ') || '—'}
+                          </Table.Td>
+                          <Table.Td>
+                            {item.source === 'serialized'
+                              ? item.action_display || item.action || '—'
+                              : ''}
+                          </Table.Td>
+                          <Table.Td>
+                            {item.used_at ? new Date(item.used_at).toLocaleDateString() : '—'}
+                          </Table.Td>
+                          <Table.Td>
+                            {item.source === 'consumable' && item.estimated_cost != null
+                              ? `$${formatMoney(item.estimated_cost)}`
+                              : ''}
                           </Table.Td>
                         </Table.Tr>
                       ))

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2046,6 +2046,9 @@ export const reportsAPI = {
   getAssetTco: () =>
     api.get('/inventory/reports/assets/tco/'),
 
+  getAssetSuppliesUsed: (params?: DateRangeParams) =>
+    api.get('/inventory/reports/assets/supplies_used/', { params }),
+
   exportAssetReport: (type: 'assets_by_status' | 'maintenance_due' | 'utilization' | 'tco', params?: DateRangeParams) =>
     api.get('/inventory/reports/assets/export/', {
       params: { type, ...params },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1147,6 +1147,27 @@ export interface AssetTco {
   total_maintenance_cost_90d: string;
 }
 
+// One supply used on an asset over a date window. The backend merges two
+// sources into a single flat row list; common keys are always present and the
+// remaining keys are source-specific (see inventory/views.py supplies_used).
+export interface AssetSuppliesUsed {
+  asset_id: string;
+  asset_name: string;
+  source: 'serialized' | 'consumable';
+  item_name: string;
+  used_at: string;
+  // serialized only — a serial-numbered unit put into service on / consumed by the asset
+  serial_number?: string;
+  action?: string;
+  action_display?: string;
+  actor?: string | null;
+  // consumable only — a bulk material used while closing a PM work order
+  quantity?: string;
+  unit?: string;
+  work_order_id?: string;
+  estimated_cost?: string | null;
+}
+
 // Dashboard Widget Types
 export type WidgetType = 'low_stock' | 'pending_reorders' | 'asset_problems' | 'qr_scans' | 'deliveries';
 

--- a/frontend/src/utils/csvExport.ts
+++ b/frontend/src/utils/csvExport.ts
@@ -230,7 +230,7 @@ export function exportPurchasingReportToCSV(
  */
 export function exportAssetReportToCSV(
   data: any[],
-  reportType: 'assets_by_status' | 'maintenance_due' | 'utilization' | 'tco'
+  reportType: 'assets_by_status' | 'maintenance_due' | 'utilization' | 'tco' | 'supplies_used'
 ): void {
   let headers: string[] = [];
   let csvData: any[] = [];
@@ -289,6 +289,33 @@ export function exportAssetReportToCSV(
       'Unscheduled Maintenance Cost': item.unscheduled_maintenance_cost ?? '0.00',
       'Repair Cost': item.repair_cost ?? '0.00',
       'Total Cost of Ownership': item.tco ?? '0.00',
+    }));
+  } else if (reportType === 'supplies_used') {
+    // Union of both source shapes; source-specific columns are blank on rows
+    // where they do not apply (serialized has no qty/cost, consumable no serial).
+    headers = [
+      'Asset',
+      'Source',
+      'Item',
+      'Serial Number',
+      'Quantity',
+      'Unit',
+      'Action',
+      'Used At',
+      'Work Order',
+      'Estimated Cost',
+    ];
+    csvData = data.map((item) => ({
+      Asset: item.asset_name || '',
+      Source: item.source || '',
+      Item: item.item_name || '',
+      'Serial Number': item.serial_number || '',
+      Quantity: item.quantity ?? '',
+      Unit: item.unit || '',
+      Action: item.action_display || item.action || '',
+      'Used At': item.used_at || '',
+      'Work Order': item.work_order_id || '',
+      'Estimated Cost': item.estimated_cost != null ? `$${item.estimated_cost}` : '',
     }));
   }
 


### PR DESCRIPTION
## What
Web half of the asset-report Supplies-Used section (consumes the #872 backend endpoint). Adds a **"Supplies Used"** tab to `AssetReportPage`: a table of supplies consumed per asset (serialized usage + PM consumables), honoring the existing date range like the Utilization tab, with CSV export.

- `AssetReportPage.tsx`: new tab + `loadSuppliesUsed()` on the date range.
- `api.ts`: `getAssetSuppliesUsed({start_date, end_date})` → `/inventory/reports/assets/supplies_used/`.
- `csvExport.ts`: export branch for the new tab. Types added.

## Verification
- eslint: 0 errors.
- Tests: `AssetReportPage.test` (+73) + `api.test` (+32).

Parity pair: ScanTTY Supplies-Used tab (sc-08vk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)