### PR TITLE
feat(frontend): retire an inventory item — badge, retire button, form toggle, show-retired filter (op-0u9f)

### DIFF
--- a/frontend/src/__tests__/pages/InventoryItemDetailPage.retire.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemDetailPage.retire.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * Tests for the Retire / Unretire action on InventoryItemDetailPage (op-jv7r):
+ * the hero button (label + icon toggle by is_retired, calls the retire/unretire
+ * API then reloads) and the Retired status badge.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { NotificationProvider } from '../../contexts/NotificationContext';
+import InventoryItemDetailPage from '../../pages/InventoryItemDetailPage';
+import * as api from '../../services/api';
+import { showError } from '../../utils/dialogs';
+
+vi.mock('../../services/api');
+
+vi.mock('../../utils/dialogs', async () => ({
+  showError: vi.fn(),
+}));
+
+vi.mock('qrcode.react', async () => ({
+  QRCodeSVG: () => <div data-testid="qr-code">QR Code</div>,
+}));
+
+vi.mock('recharts', async () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  LineChart: () => <div data-testid="line-chart" />,
+  Line: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  Tooltip: () => <div />,
+}));
+
+const mockNavigate = jest.fn();
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useNavigate: () => mockNavigate,
+}));
+
+const makeItem = (overrides: Record<string, unknown> = {}) => ({
+  id: 'test-id',
+  name: 'Test Item',
+  description: 'Test description',
+  sku: 'TEST-001',
+  category: 1,
+  category_name: 'Tools',
+  location: 'Shelf A',
+  current_stock: 10,
+  minimum_stock: 5,
+  reorder_quantity: 20,
+  unit_cost: '15.99',
+  supplier_name: 'Test Supplier',
+  needs_reorder: false,
+  has_pending_reorder: false,
+  is_active: true,
+  is_retired: false,
+  retired_at: null,
+  image: null,
+  thumbnail: null,
+  qr_code: null,
+  use_case_based_reorder: false,
+  minimum_cases: 0,
+  reorder_cases: 0,
+  current_cases: 0,
+  supplier: null,
+  supplier_sku: '',
+  supplier_url: '',
+  average_lead_time: 7,
+  notes: '',
+  total_value: '159.90',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+  ownership_type: 'space' as const,
+  owning_user: null,
+  owning_group: null,
+  reorder_status: '',
+  expected_delivery_date: null,
+  active_reorder_request: null,
+  is_hazardous: false,
+  msds_url: null,
+  nfpa_health_hazard: null,
+  nfpa_fire_hazard: null,
+  nfpa_instability_hazard: null,
+  nfpa_special_hazards: '',
+  nfpa_fire_diamond_display: '',
+  hazmat_compliance_status: '',
+  has_complete_nfpa_data: false,
+  last_counted_at: null,
+  days_since_last_count: null,
+  ...overrides,
+});
+
+const setupItem = (item: Record<string, unknown>) => {
+  (api.inventoryAPI.getItem as jest.Mock).mockResolvedValue({ data: item });
+  (api.inventoryAPI.getItemMetrics as jest.Mock).mockResolvedValue({ data: null });
+  (api.inventoryAPI.getUsageLogs as jest.Mock).mockResolvedValue({ data: { results: [] } });
+  (api.reorderAPI.listRequests as jest.Mock).mockResolvedValue({ data: { results: [] } });
+  (api.assetsAPI.listAssets as jest.Mock).mockResolvedValue({ data: { results: [] } });
+};
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <NotificationProvider>
+        <MemoryRouter initialEntries={['/inventory/items/test-id']}>
+          <Routes>
+            <Route path="/inventory/items/:id" element={<InventoryItemDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </NotificationProvider>
+    </MantineProvider>
+  );
+
+describe('InventoryItemDetailPage — retire / unretire', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows a "Retire" button (not the badge) for an active item', async () => {
+    setupItem(makeItem({ is_retired: false }));
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Test Item')).toBeInTheDocument());
+    expect(screen.getByTestId('retire-button')).toHaveTextContent('Retire');
+    // No Retired status badge for a non-retired item.
+    expect(screen.queryByText('Retired')).not.toBeInTheDocument();
+  });
+
+  it('retires an active item and reloads', async () => {
+    setupItem(makeItem({ is_retired: false }));
+    (api.inventoryAPI.retireItem as jest.Mock).mockResolvedValue({
+      data: makeItem({ is_retired: true, retired_at: '2026-07-10T00:00:00Z' }),
+    });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Test Item')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('retire-button'));
+
+    await waitFor(() => expect(api.inventoryAPI.retireItem).toHaveBeenCalledWith('test-id'));
+    expect(api.inventoryAPI.unretireItem).not.toHaveBeenCalled();
+    // The item is reloaded after retiring (initial load + reload).
+    await waitFor(() =>
+      expect((api.inventoryAPI.getItem as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(2)
+    );
+  });
+
+  it('shows the Retired badge + an "Unretire" button for a retired item', async () => {
+    setupItem(makeItem({ is_retired: true, retired_at: '2026-07-10T00:00:00Z' }));
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Test Item')).toBeInTheDocument());
+    expect(screen.getByText('Retired')).toBeInTheDocument();
+    expect(screen.getByTestId('retire-button')).toHaveTextContent('Unretire');
+  });
+
+  it('unretires a retired item and reloads', async () => {
+    setupItem(makeItem({ is_retired: true, retired_at: '2026-07-10T00:00:00Z' }));
+    (api.inventoryAPI.unretireItem as jest.Mock).mockResolvedValue({
+      data: makeItem({ is_retired: false }),
+    });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Test Item')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('retire-button'));
+
+    await waitFor(() => expect(api.inventoryAPI.unretireItem).toHaveBeenCalledWith('test-id'));
+    expect(api.inventoryAPI.retireItem).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an error when the retire action fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setupItem(makeItem({ is_retired: false }));
+    (api.inventoryAPI.retireItem as jest.Mock).mockRejectedValue(new Error('boom'));
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Test Item')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('retire-button'));
+
+    await waitFor(() =>
+      expect(showError).toHaveBeenCalledWith('Failed to update retirement status. Please try again.')
+    );
+    consoleError.mockRestore();
+  });
+});

--- a/frontend/src/__tests__/pages/InventoryItemFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemFormPage.test.tsx
@@ -614,4 +614,90 @@ describe('InventoryItemFormPage', () => {
     expect(formData.get('is_serialized')).toBe('true');
     expect(formData.get('serial_tracking_mode')).toBe('reusable');
   });
+
+  // ---- op-jv7r: retire toggle ----
+
+  it('renders the Retired switch', async () => {
+    renderCreatePage();
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(/Retired/i).length).toBeGreaterThan(0);
+    });
+  });
+
+  it('sends is_retired=false by default', async () => {
+    (api.inventoryAPI.createItem as jest.Mock).mockResolvedValue({
+      data: { ...mockItem, id: 'new-id' },
+    });
+
+    renderCreatePage();
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(/Name/i).length).toBeGreaterThan(0);
+    });
+    fillRequiredFields();
+    fireEvent.click(screen.getByText('Create Item'));
+
+    await waitFor(() => {
+      expect(api.inventoryAPI.createItem).toHaveBeenCalled();
+    });
+
+    const formData = (api.inventoryAPI.createItem as jest.Mock).mock.calls[0][0] as FormData;
+    expect(formData.get('is_retired')).toBe('false');
+  });
+
+  it('includes is_retired=true in the create payload when toggled on', async () => {
+    (api.inventoryAPI.createItem as jest.Mock).mockResolvedValue({
+      data: { ...mockItem, id: 'new-id' },
+    });
+
+    renderCreatePage();
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(/Name/i).length).toBeGreaterThan(0);
+    });
+    fillRequiredFields();
+
+    fireEvent.click(screen.getAllByLabelText(/Retired/i)[0]);
+    fireEvent.click(screen.getByText('Create Item'));
+
+    await waitFor(() => {
+      expect(api.inventoryAPI.createItem).toHaveBeenCalled();
+    });
+
+    const formData = (api.inventoryAPI.createItem as jest.Mock).mock.calls[0][0] as FormData;
+    expect(formData.get('is_retired')).toBe('true');
+  });
+
+  it('hydrates is_retired in edit mode and includes it on update', async () => {
+    (api.inventoryAPI.getItem as jest.Mock).mockResolvedValue({
+      data: { ...mockItem, is_retired: true, retired_at: '2026-07-10T00:00:00Z' },
+    });
+    (api.inventoryAPI.updateItem as jest.Mock).mockResolvedValue({ data: mockItem });
+
+    render(
+      <MantineProvider env="test">
+        <MemoryRouter initialEntries={['/inventory/items/test-id/edit']}>
+          <Routes>
+            <Route path="/inventory/items/:id/edit" element={<InventoryItemFormPage />} />
+          </Routes>
+        </MemoryRouter>
+      </MantineProvider>
+    );
+
+    // The Retired switch hydrates on from the fetched item.
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Test Item')).toBeInTheDocument();
+    });
+    expect((screen.getAllByLabelText(/Retired/i)[0] as HTMLInputElement).checked).toBe(true);
+
+    fireEvent.click(screen.getByText('Save Changes'));
+
+    await waitFor(() => {
+      expect(api.inventoryAPI.updateItem).toHaveBeenCalled();
+    });
+
+    const formData = (api.inventoryAPI.updateItem as jest.Mock).mock.calls[0][1] as FormData;
+    expect(formData.get('is_retired')).toBe('true');
+  });
 });

--- a/frontend/src/__tests__/pages/InventoryListPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryListPage.test.tsx
@@ -50,6 +50,8 @@ describe('InventoryListPage', () => {
       needs_reorder: false,
       has_pending_reorder: false,
       is_active: true,
+      is_retired: false,
+      retired_at: null,
       description: 'Test description',
       image: null,
       thumbnail: null,
@@ -97,6 +99,8 @@ describe('InventoryListPage', () => {
       needs_reorder: true,
       has_pending_reorder: false,
       is_active: true,
+      is_retired: false,
+      retired_at: null,
       description: 'Low stock item',
       image: null,
       thumbnail: null,
@@ -260,6 +264,49 @@ describe('InventoryListPage', () => {
         expect.objectContaining({ low_stock: true, page: 1 })
       );
     });
+  });
+
+  it('requests include_retired when the Show Retired filter is selected', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item 1')).toBeInTheDocument();
+    });
+    (api.inventoryAPI.listItems as jest.Mock).mockClear();
+
+    const retiredSelect = screen.getByPlaceholderText('Retired');
+    fireEvent.click(retiredSelect);
+    const option = await screen.findByRole('option', { name: 'Show Retired' });
+    fireEvent.click(option);
+
+    await waitFor(() => {
+      expect(api.inventoryAPI.listItems).toHaveBeenCalledWith(
+        expect.objectContaining({ include_retired: true, page: 1 })
+      );
+    });
+  });
+
+  it('renders a Retired badge for retired items', async () => {
+    (api.inventoryAPI.listItems as jest.Mock).mockResolvedValue(
+      fullPage([{ ...mockItems[0], is_retired: true }])
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item 1')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Retired')).toBeInTheDocument();
+  });
+
+  it('does not render a Retired badge for non-retired items', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item 1')).toBeInTheDocument();
+    });
+    // Neither seed item is retired (is_retired is absent/falsy).
+    expect(screen.queryByText('Retired')).not.toBeInTheDocument();
   });
 
   it('requests server-side sorting when a column header is clicked', async () => {

--- a/frontend/src/pages/InventoryItemDetailPage.tsx
+++ b/frontend/src/pages/InventoryItemDetailPage.tsx
@@ -21,7 +21,7 @@ import {
     Textarea,
     Title,
 } from '@mantine/core';
-import { IconClipboardCheck, IconEdit, IconQrcode } from '@tabler/icons-react';
+import { IconArchive, IconArchiveOff, IconClipboardCheck, IconEdit, IconQrcode } from '@tabler/icons-react';
 import { QRCodeSVG } from 'qrcode.react';
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -175,6 +175,7 @@ const InventoryItemDetailPage: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<string | null>('overview');
   const [cycleCountOpen, setCycleCountOpen] = useState(false);
+  const [retiring, setRetiring] = useState(false);
 
   useEffect(() => {
     if (id) {
@@ -246,6 +247,28 @@ const InventoryItemDetailPage: React.FC = () => {
     }
   };
 
+  // Retire / un-retire (op-jv7r). Mirrors handleGenerateQR: call the action
+  // then reload so the badge + button label reflect the new state. Toggles by
+  // the item's current is_retired.
+  const handleToggleRetire = async () => {
+    if (!id || !item) return;
+
+    try {
+      setRetiring(true);
+      if (item.is_retired) {
+        await inventoryAPI.unretireItem(id);
+      } else {
+        await inventoryAPI.retireItem(id);
+      }
+      await loadData();
+    } catch (err) {
+      console.error('Error updating retirement status:', err);
+      showError('Failed to update retirement status. Please try again.');
+    } finally {
+      setRetiring(false);
+    }
+  };
+
   if (loading) {
     return (
       <WorkspacePage
@@ -291,6 +314,18 @@ const InventoryItemDetailPage: React.FC = () => {
             </Button>
             <Button
               variant="default"
+              color={item.is_retired ? undefined : 'orange'}
+              leftSection={
+                item.is_retired ? <IconArchiveOff size={16} /> : <IconArchive size={16} />
+              }
+              onClick={handleToggleRetire}
+              loading={retiring}
+              data-testid="retire-button"
+            >
+              {item.is_retired ? 'Unretire' : 'Retire'}
+            </Button>
+            <Button
+              variant="default"
               leftSection={<IconQrcode size={16} />}
               onClick={handleGenerateQR}
             >
@@ -311,6 +346,7 @@ const InventoryItemDetailPage: React.FC = () => {
         {item.needs_reorder && <Badge color="red">Low Stock</Badge>}
         {item.has_pending_reorder && <Badge color="blue">Reorder Pending</Badge>}
         {!item.is_active && <Badge color="gray">Inactive</Badge>}
+        {item.is_retired && <Badge color="orange">Retired</Badge>}
         {item.is_hazardous && <Badge color="orange">Hazardous Material</Badge>}
         {item.is_serialized && <Badge color="grape">Serialized</Badge>}
       </Group>

--- a/frontend/src/pages/InventoryItemFormPage.tsx
+++ b/frontend/src/pages/InventoryItemFormPage.tsx
@@ -75,6 +75,7 @@ const InventoryItemFormPage: React.FC = () => {
       is_serialized: false,
       serial_tracking_mode: null,
       is_active: true,
+      is_retired: false,
       notes: '',
     },
   });
@@ -145,6 +146,7 @@ const InventoryItemFormPage: React.FC = () => {
         is_serialized: item.is_serialized ?? false,
         serial_tracking_mode: item.serial_tracking_mode ?? null,
         is_active: item.is_active,
+        is_retired: item.is_retired ?? false,
         notes: item.notes || '',
         image_url: item.image ? (item.image.startsWith('http') ? item.image : '') : '',
       });
@@ -589,6 +591,14 @@ const InventoryItemFormPage: React.FC = () => {
                           label="Active"
                           checked={watch('is_active')}
                           onChange={(e) => setValue('is_active', e.currentTarget.checked)}
+                        />
+                      </div>
+                      <div>
+                        <Switch
+                          label="Retired"
+                          description="Phased out: never flagged for reorder; hidden from the list once stock hits 0."
+                          checked={watch('is_retired')}
+                          onChange={(e) => setValue('is_retired', e.currentTarget.checked)}
                         />
                       </div>
                     </>

--- a/frontend/src/pages/InventoryListPage.tsx
+++ b/frontend/src/pages/InventoryListPage.tsx
@@ -56,6 +56,7 @@ const InventoryListPage: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [selectedLocation, setSelectedLocation] = useState<string | null>(null);
   const [lowStockFilter, setLowStockFilter] = useState<string | null>(null);
+  const [showRetired, setShowRetired] = useState<string | null>(null);
   const [sortField, setSortField] = useState<SortField>('name');
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
   const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
@@ -111,6 +112,10 @@ const InventoryListPage: React.FC = () => {
     } else if (lowStockFilter === 'false') {
       params.low_stock = false;
     }
+    // Retired-and-empty items are hidden by default; opt in to see them.
+    if (showRetired === 'true') {
+      params.include_retired = true;
+    }
     return params;
   };
 
@@ -132,7 +137,7 @@ const InventoryListPage: React.FC = () => {
     };
     loadFirstPage();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedSearch, selectedCategory, selectedLocation, lowStockFilter, sortField, sortDirection]);
+  }, [debouncedSearch, selectedCategory, selectedLocation, lowStockFilter, showRetired, sortField, sortDirection]);
 
   const loadMore = async () => {
     if (loadingMore || loading || !hasMore) {
@@ -372,6 +377,16 @@ const InventoryListPage: React.FC = () => {
               onChange={(value) => setLowStockFilter(value || null)}
               clearable
             />
+            <Select
+              placeholder="Retired"
+              data={[
+                { value: '', label: 'Hide Retired' },
+                { value: 'true', label: 'Show Retired' },
+              ]}
+              value={showRetired || ''}
+              onChange={(value) => setShowRetired(value || null)}
+              clearable
+            />
           </Group>
 
           {/* Bulk Actions */}
@@ -526,6 +541,7 @@ const InventoryListPage: React.FC = () => {
                       {item.needs_reorder && <Badge color="red" size="sm">Low Stock</Badge>}
                       {item.has_pending_reorder && <Badge color="blue" size="sm">Reorder Pending</Badge>}
                       {!item.is_active && <Badge color="gray" size="sm">Inactive</Badge>}
+                      {item.is_retired && <Badge color="orange" size="sm">Retired</Badge>}
                       {item.is_serialized && <Badge color="grape" size="sm">Serialized</Badge>}
                     </Group>
                   </Table.Td>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -224,6 +224,9 @@ export const inventoryAPI = {
     low_stock?: boolean;
     owning_group?: number;
     is_active?: boolean;
+    // Retired items with stock are always listed; retired-and-empty items are
+    // hidden by default. Pass include_retired=true to surface them (op-jv7r).
+    include_retired?: boolean;
     ordering?: string;
     page?: number;
     page_size?: number;
@@ -249,6 +252,15 @@ export const inventoryAPI = {
 
   generateQR: (id: string) =>
     api.post(`/inventory/items/${id}/generate_qr/`),
+
+  // Retire / un-retire an item (op-jv7r). Retiring phases the item out: it is
+  // never flagged for reorder and auto-hides from the list once stock hits 0.
+  // Both actions return the refreshed item payload (with is_retired/retired_at).
+  retireItem: (id: string) =>
+    api.post<InventoryItem>(`/inventory/items/${id}/retire/`),
+
+  unretireItem: (id: string) =>
+    api.post<InventoryItem>(`/inventory/items/${id}/unretire/`),
 
   logUsage: (id: string, quantity: number, notes?: string) =>
     api.post(`/inventory/items/${id}/log_usage/`, {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -145,6 +145,12 @@ export interface InventoryItem {
   average_lead_time: number;
   qr_code: string | null;
   is_active: boolean;
+  // Retirement (op-jv7r). A retired item is never flagged for reorder and is
+  // auto-hidden from the default list once its stock hits 0. `is_retired` is
+  // writable (item form/admin toggle); `retired_at` is a read-only audit stamp
+  // set by the retire/unretire actions.
+  is_retired: boolean;
+  retired_at: string | null;
   notes: string;
   needs_reorder: boolean;
   total_value: string;

--- a/frontend/src/utils/formSchemas.ts
+++ b/frontend/src/utils/formSchemas.ts
@@ -127,6 +127,9 @@ export const inventoryItemSchema = z
 
     // Other
     is_active: z.boolean().default(true),
+    // Retirement (op-jv7r): must be in the schema or the resolver strips it
+    // from the submit payload.
+    is_retired: z.boolean().default(false),
     notes: z.string().optional(),
   })
   .refine(


### PR DESCRIPTION
## What
Web half of the retire feature (consumes #878). Mirrors the existing `is_active`/`is_serialized` pattern:
- **Retired badge** in `InventoryListPage` + the item-detail status strip.
- **Retire / Unretire button** on the item-detail hero (toggles by `is_retired`).
- **`is_retired` toggle** in the item form (+ Zod schema).
- **"Show retired" filter** in the list — passes `include_retired=true` so drawn-down retired items can be revealed (they auto-hide at 0 stock by default).
- `api.ts` `retireItem`/`unretireItem` + `include_retired` list param; `is_retired` on the `InventoryItem` type.

## Verification
- eslint: 0 errors.
- +316 lines of tests (detail retire flow, form toggle, list badge/filter).

Parity pair: ScanTTY #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)