### PR TITLE
refactor(inventory,reorder_queue): convert *_CHOICES to nested TextChoices (#889)

### DIFF
--- a/backend/analytics/services/aggregation.py
+++ b/backend/analytics/services/aggregation.py
@@ -61,7 +61,7 @@ def value_summary(period_start: date, period_end: date) -> ValueSummary:
     start_dt, end_dt = _aware_range(period_start, period_end)
 
     completed_wos = WorkOrder.objects.filter(
-        status=WorkOrder.STATUS_COMPLETED,
+        status=WorkOrder.Status.COMPLETED,
         completed_at__gte=start_dt,
         completed_at__lt=end_dt,
     )
@@ -112,7 +112,7 @@ def wo_volume(period_start: date, period_end: date, bucket: str = "month") -> li
 
     qs = (
         WorkOrder.objects.filter(
-            status=WorkOrder.STATUS_COMPLETED,
+            status=WorkOrder.Status.COMPLETED,
             completed_at__gte=start_dt,
             completed_at__lt=end_dt,
         )
@@ -129,7 +129,7 @@ def top_users(period_start: date, period_end: date, limit: int = 10) -> list[dic
     start_dt, end_dt = _aware_range(period_start, period_end)
     qs = (
         WorkOrder.objects.filter(
-            status=WorkOrder.STATUS_COMPLETED,
+            status=WorkOrder.Status.COMPLETED,
             completed_at__gte=start_dt,
             completed_at__lt=end_dt,
         )
@@ -171,7 +171,7 @@ def utilization(period_start: date, period_end: date) -> list[dict]:
             window_wo_count=Count(
                 "maintenance_items__work_orders",
                 filter=Q(
-                    maintenance_items__work_orders__status=WorkOrder.STATUS_COMPLETED,
+                    maintenance_items__work_orders__status=WorkOrder.Status.COMPLETED,
                     maintenance_items__work_orders__completed_at__gte=start_dt,
                     maintenance_items__work_orders__completed_at__lt=end_dt,
                 ),
@@ -205,7 +205,7 @@ def category_spend(period_start: date, period_end: date) -> list[dict]:
 
     internal_rows = (
         WorkOrder.objects.filter(
-            status=WorkOrder.STATUS_COMPLETED,
+            status=WorkOrder.Status.COMPLETED,
             completed_at__gte=start_dt,
             completed_at__lt=end_dt,
         )

--- a/backend/analytics/services/forecast.py
+++ b/backend/analytics/services/forecast.py
@@ -38,7 +38,7 @@ class ForecastEntry(TypedDict):
     due_reason: str  # "hours" | "days" | "both"
 
 
-_EXCLUDED_STATUSES = (Asset.RETIRED, Asset.LOST, Asset.DONATED_OUT)
+_EXCLUDED_STATUSES = (Asset.Status.RETIRED, Asset.Status.LOST, Asset.Status.DONATED_OUT)
 
 
 def maintenance_forecast(now: datetime | None = None) -> list[ForecastEntry]:

--- a/backend/analytics/tests/test_aggregation.py
+++ b/backend/analytics/tests/test_aggregation.py
@@ -49,7 +49,7 @@ def _make_completed_wo(
     return WorkOrder.objects.create(
         maintenance_item=item,
         due_date=completed_at.date(),
-        status=WorkOrder.STATUS_COMPLETED,
+        status=WorkOrder.Status.COMPLETED,
         completed_at=completed_at,
         estimated_external_cost=estimated_external_cost,
         assigned_to=assigned_to,
@@ -132,7 +132,7 @@ class TestValueSummary:
         item = MaintenanceItem.objects.create(asset=asset, title="X", interval_days=30)
         WorkOrder.objects.create(
             maintenance_item=item,
-            status=WorkOrder.STATUS_OPEN,
+            status=WorkOrder.Status.OPEN,
             completed_at=_aware(date(2026, 4, 15)),
             estimated_external_cost=Decimal("999.00"),
         )

--- a/backend/analytics/tests/test_forecast.py
+++ b/backend/analytics/tests/test_forecast.py
@@ -17,7 +17,7 @@ def _complete_wo(asset, completed_at: datetime):
     item = MaintenanceItem.objects.create(asset=asset, title="Service", interval_days=30)
     return WorkOrder.objects.create(
         maintenance_item=item,
-        status=WorkOrder.STATUS_COMPLETED,
+        status=WorkOrder.Status.COMPLETED,
         completed_at=completed_at,
         due_date=completed_at.date(),
     )

--- a/backend/analytics/tests/test_views.py
+++ b/backend/analytics/tests/test_views.py
@@ -133,7 +133,7 @@ class TestPulseCache:
         item = MaintenanceItem.objects.create(asset=asset, title="X", interval_days=30)
         WorkOrder.objects.create(
             maintenance_item=item,
-            status=WorkOrder.STATUS_COMPLETED,
+            status=WorkOrder.Status.COMPLETED,
             completed_at=timezone.make_aware(
                 datetime.combine(last_month_start + timedelta(days=5), datetime.min.time()),
                 timezone.get_current_timezone(),

--- a/backend/config/tests/test_task_idempotency.py
+++ b/backend/config/tests/test_task_idempotency.py
@@ -92,7 +92,7 @@ class TestWebhookPayloadIsDeduplicatable:
         WebHook.objects.create(
             name="dedup target",
             url="https://example.com/hook",
-            event_type=WebHook.REORDER_REQUEST_CREATED,
+            event_type=WebHook.EventType.REORDER_REQUEST_CREATED,
             is_active=True,
         )
 
@@ -107,8 +107,8 @@ class TestWebhookPayloadIsDeduplicatable:
             "data": {"id": 42, "item_name": "rags"},
         }
 
-        send_webhook_notification.run(WebHook.REORDER_REQUEST_CREATED, payload)
-        send_webhook_notification.run(WebHook.REORDER_REQUEST_CREATED, payload)
+        send_webhook_notification.run(WebHook.EventType.REORDER_REQUEST_CREATED, payload)
+        send_webhook_notification.run(WebHook.EventType.REORDER_REQUEST_CREATED, payload)
 
         assert mock_post.call_count == 2
         bodies = [call.kwargs.get("data") for call in mock_post.call_args_list]
@@ -126,12 +126,12 @@ class TestWebhookPayloadIsDeduplicatable:
         webhook = WebHook.objects.create(
             name="deactivated",
             url="https://example.com/hook",
-            event_type=WebHook.REORDER_REQUEST_CREATED,
+            event_type=WebHook.EventType.REORDER_REQUEST_CREATED,
             is_active=False,
         )
 
         send_webhook_notification.run(
-            WebHook.REORDER_REQUEST_CREATED, {"event": "x", "data": {"id": 1}}
+            WebHook.EventType.REORDER_REQUEST_CREATED, {"event": "x", "data": {"id": 1}}
         )
         webhook.refresh_from_db()
         assert webhook.success_count == 0

--- a/backend/dashboard/tests/test_audit_feed_integration.py
+++ b/backend/dashboard/tests/test_audit_feed_integration.py
@@ -94,7 +94,7 @@ def _make_webhook(**overrides) -> WebHook:
     defaults = {
         "name": "Audit Webhook",
         "url": "https://example.com/audit-webhook",
-        "event_type": WebHook.REORDER_REQUEST_CREATED,
+        "event_type": WebHook.EventType.REORDER_REQUEST_CREATED,
         "is_active": True,
         "secret": "initial-shared-secret",
     }
@@ -125,11 +125,11 @@ def _seed_one_event_per_domain(actor) -> dict:
     supplier = SupplierFactory()
     purchase_order = PurchaseOrder.objects.create(
         supplier=supplier,
-        status=PurchaseOrder.VOIDED,
+        status=PurchaseOrder.Status.VOIDED,
         created_by=actor,
     )
     po_event = record_po_audit(
-        action=PurchaseOrderAuditEvent.ACTION_PO_VOID,
+        action=PurchaseOrderAuditEvent.Action.PO_VOID,
         actor=actor,
         purchase_order=purchase_order,
         notes="audit feed integration test",
@@ -139,7 +139,7 @@ def _seed_one_event_per_domain(actor) -> dict:
     # carries before/after values we can assert against later.
     webhook = _make_webhook(name="Before Name")
     webhook_event = record_webhook_audit(
-        action=WebhookAuditEvent.ACTION_WEBHOOK_UPDATE,
+        action=WebhookAuditEvent.Action.WEBHOOK_UPDATE,
         actor=actor,
         webhook=webhook,
         metadata={
@@ -167,10 +167,10 @@ def _seed_one_event_per_domain(actor) -> dict:
     problem = LocationProblem.objects.create(
         location=location,
         description="Audit feed integration problem",
-        status=LocationProblem.REPORTED,
+        status=LocationProblem.Status.REPORTED,
     )
     maintenance_event = record_maintenance_audit(
-        action=MaintenanceAuditEvent.ACTION_LOCATION_PROBLEM_RESOLVE,
+        action=MaintenanceAuditEvent.Action.LOCATION_PROBLEM_RESOLVE,
         actor=actor,
         location_problem=problem,
         notes="resolved",
@@ -352,11 +352,11 @@ class TestAuditRowSurvivesEntityDeletion:
 
         purchase_order = PurchaseOrder.objects.create(
             supplier=SupplierFactory(),
-            status=PurchaseOrder.VOIDED,
+            status=PurchaseOrder.Status.VOIDED,
             created_by=actor,
         )
         event = record_po_audit(
-            action=PurchaseOrderAuditEvent.ACTION_PO_VOID,
+            action=PurchaseOrderAuditEvent.Action.PO_VOID,
             actor=actor,
             purchase_order=purchase_order,
         )
@@ -370,7 +370,7 @@ class TestAuditRowSurvivesEntityDeletion:
     def test_webhook_audit_survives_webhook_delete(self, actor):
         webhook = _make_webhook()
         event = record_webhook_audit(
-            action=WebhookAuditEvent.ACTION_WEBHOOK_DELETE,
+            action=WebhookAuditEvent.Action.WEBHOOK_DELETE,
             actor=actor,
             webhook=webhook,
             metadata={
@@ -410,10 +410,10 @@ class TestAuditRowSurvivesEntityDeletion:
         problem = LocationProblem.objects.create(
             location=LocationFactory(),
             description="Survival problem",
-            status=LocationProblem.REPORTED,
+            status=LocationProblem.Status.REPORTED,
         )
         event = record_maintenance_audit(
-            action=MaintenanceAuditEvent.ACTION_LOCATION_PROBLEM_RESOLVE,
+            action=MaintenanceAuditEvent.Action.LOCATION_PROBLEM_RESOLVE,
             actor=actor,
             location_problem=problem,
         )
@@ -495,14 +495,14 @@ class TestAuditFeedRedactsSecrets:
         # here we mirror it via the helper so the assertion is about what
         # gets stored, independent of the view).
         record_webhook_audit(
-            action=WebhookAuditEvent.ACTION_WEBHOOK_SECRET_ROTATE,
+            action=WebhookAuditEvent.Action.WEBHOOK_SECRET_ROTATE,
             actor=actor,
             webhook=webhook,
         )
         # Force a config update that would have leaked secret if the diff
         # helper had not excluded it.
         record_webhook_audit(
-            action=WebhookAuditEvent.ACTION_WEBHOOK_UPDATE,
+            action=WebhookAuditEvent.Action.WEBHOOK_UPDATE,
             actor=actor,
             webhook=webhook,
             metadata={"changes": {"name": {"before": "x", "after": "y"}}},
@@ -517,7 +517,7 @@ class TestAuditFeedRedactsSecrets:
         # The rotate row should be present so reviewers can see the rotation
         # happened, just without the value.
         actions = {event["action"] for event in response.data["events"]}
-        assert WebhookAuditEvent.ACTION_WEBHOOK_SECRET_ROTATE in actions
+        assert WebhookAuditEvent.Action.WEBHOOK_SECRET_ROTATE in actions
 
     def test_feed_response_never_includes_logo_or_favicon_binary(self, admin_client, actor):
         """The settings audit explicitly summarizes file fields by filename

--- a/backend/dashboard/tests/test_views.py
+++ b/backend/dashboard/tests/test_views.py
@@ -230,7 +230,7 @@ class TestDashboardWidgetDataViews:
 
         supplier = SupplierFactory()
         po = PurchaseOrder.objects.create(
-            supplier=supplier, status=PurchaseOrder.SENT, created_by=user
+            supplier=supplier, status=PurchaseOrder.Status.SENT, created_by=user
         )
         # Freeform line item (no item_supplier / asset needed).
         po_item = PurchaseOrderItem.objects.create(

--- a/backend/forgekey/services/indicator.py
+++ b/backend/forgekey/services/indicator.py
@@ -199,7 +199,7 @@ def derive_asset_status(asset) -> str:
 
     if (
         mode_value == OperationalMode.MODE_MAINTENANCE
-        or asset.status != asset.ACTIVE
+        or asset.status != asset.Status.ACTIVE
         or _has_offline_primary_device(asset)
     ):
         return IndicatorStatus.UNAVAILABLE

--- a/backend/forgekey/tests/test_indicator.py
+++ b/backend/forgekey/tests/test_indicator.py
@@ -164,7 +164,7 @@ class TestPresentationMapping:
 # ---------------------------------------------------------------------------
 class TestDeriveAssetStatus:
     def test_default_active_asset_is_available(self):
-        asset = AssetFactory(status=Asset.ACTIVE)
+        asset = AssetFactory(status=Asset.Status.ACTIVE)
         assert derive_asset_status(asset) == IndicatorStatus.AVAILABLE
 
     def test_open_usage_is_in_use(self):
@@ -198,17 +198,17 @@ class TestDeriveAssetStatus:
         assert derive_asset_status(asset) == IndicatorStatus.UNAVAILABLE
 
     def test_non_active_asset_is_unavailable(self):
-        asset = AssetFactory(status=Asset.MAINTENANCE)
+        asset = AssetFactory(status=Asset.Status.MAINTENANCE)
         assert derive_asset_status(asset) == IndicatorStatus.UNAVAILABLE
 
     def test_offline_primary_device_is_unavailable(self):
-        asset = AssetFactory(status=Asset.ACTIVE)
+        asset = AssetFactory(status=Asset.Status.ACTIVE)
         offline = ESP32DeviceFactory(is_online=False)
         AssetDeviceFactory(asset=asset, device=offline, is_primary=True)
         assert derive_asset_status(asset) == IndicatorStatus.UNAVAILABLE
 
     def test_online_primary_device_stays_available(self):
-        asset = AssetFactory(status=Asset.ACTIVE)
+        asset = AssetFactory(status=Asset.Status.ACTIVE)
         online = ESP32DeviceFactory(is_online=True)
         AssetDeviceFactory(asset=asset, device=online, is_primary=True)
         assert derive_asset_status(asset) == IndicatorStatus.AVAILABLE
@@ -233,7 +233,7 @@ class TestDeriveAssetStatus:
 
     def test_precedence_usage_beats_unavailable(self):
         # in_use (step 3) wins over a non-ACTIVE status (step 4).
-        asset = AssetFactory(status=Asset.MAINTENANCE)
+        asset = AssetFactory(status=Asset.Status.MAINTENANCE)
         DeviceUsageFactory(asset=asset, ended_at=None)
         assert derive_asset_status(asset) == IndicatorStatus.IN_USE
 
@@ -639,7 +639,7 @@ class TestSignals:
         binding = IndicatorBindingFactory()
         sync_indicator(binding, force=True)  # prime last_presentation = available
         mock_publish.reset_mock()
-        binding.asset.status = Asset.MAINTENANCE
+        binding.asset.status = Asset.Status.MAINTENANCE
         binding.asset.save()
         assert mock_publish.called
         assert _last_payload(mock_publish)["color"] == "red"  # unavailable
@@ -678,7 +678,7 @@ class TestSignals:
 # ---------------------------------------------------------------------------
 class TestDeviceTransition:
     def test_sync_bindings_for_device_targets_asset(self, mock_publish):
-        asset = AssetFactory(status=Asset.ACTIVE)
+        asset = AssetFactory(status=Asset.Status.ACTIVE)
         control = ESP32DeviceFactory(is_online=False)
         AssetDeviceFactory(asset=asset, device=control, is_primary=True)
         binding = IndicatorBindingFactory(asset=asset)
@@ -695,7 +695,7 @@ class TestDeviceTransition:
         assert mock_publish.called
 
     def test_webhook_task_transition_resyncs(self, mock_publish):
-        asset = AssetFactory(status=Asset.ACTIVE)
+        asset = AssetFactory(status=Asset.Status.ACTIVE)
         control = ESP32DeviceFactory(mac_address="AA:BB:CC:DD:EE:01", is_online=False)
         AssetDeviceFactory(asset=asset, device=control, is_primary=True)
         binding = IndicatorBindingFactory(asset=asset)
@@ -707,7 +707,7 @@ class TestDeviceTransition:
         assert binding.last_status == IndicatorStatus.AVAILABLE
 
     def test_consumer_transition_resyncs(self, mock_publish):
-        asset = AssetFactory(status=Asset.ACTIVE)
+        asset = AssetFactory(status=Asset.Status.ACTIVE)
         control = ESP32DeviceFactory(mac_address="AA:BB:CC:DD:EE:02", is_online=False)
         AssetDeviceFactory(asset=asset, device=control, is_primary=True)
         binding = IndicatorBindingFactory(asset=asset)

--- a/backend/inventory/admin.py
+++ b/backend/inventory/admin.py
@@ -1719,8 +1719,8 @@ class AssetProblemAdmin(admin.ModelAdmin):
         from django.utils import timezone
 
         count = 0
-        for problem in queryset.filter(status=AssetProblem.REPORTED):
-            problem.status = AssetProblem.RESOLVED
+        for problem in queryset.filter(status=AssetProblem.Status.REPORTED):
+            problem.status = AssetProblem.Status.RESOLVED
             problem.resolved_at = timezone.now()
             problem.save()
             count += 1
@@ -1734,7 +1734,7 @@ class AssetProblemAdmin(admin.ModelAdmin):
     @admin.action(description="Mark selected as closed")
     def mark_closed(self, request, queryset):
         """Mark selected problems as closed."""
-        count = queryset.update(status=AssetProblem.CLOSED)
+        count = queryset.update(status=AssetProblem.Status.CLOSED)
         self.message_user(
             request,
             f"{count} problem(s) marked as closed.",

--- a/backend/inventory/models/asset.py
+++ b/backend/inventory/models/asset.py
@@ -93,23 +93,14 @@ class Asset(models.Model):
     """
 
     # Status choices
-    IMPLEMENTING = "implementing"
-    TESTING = "testing"
-    ACTIVE = "active"
-    MAINTENANCE = "maintenance"
-    RETIRED = "retired"
-    LOST = "lost"
-    DONATED_OUT = "donated_out"
-
-    STATUS_CHOICES = [
-        (IMPLEMENTING, "Implementing"),
-        (TESTING, "Testing"),
-        (ACTIVE, "Active"),
-        (MAINTENANCE, "Under Maintenance"),
-        (RETIRED, "Retired"),
-        (LOST, "Lost"),
-        (DONATED_OUT, "Donated Out"),
-    ]
+    class Status(models.TextChoices):
+        IMPLEMENTING = "implementing", "Implementing"
+        TESTING = "testing", "Testing"
+        ACTIVE = "active", "Active"
+        MAINTENANCE = "maintenance", "Under Maintenance"
+        RETIRED = "retired", "Retired"
+        LOST = "lost", "Lost"
+        DONATED_OUT = "donated_out", "Donated Out"
 
     # Note: Operational status, lockout, and authorization fields have been moved to the forgekey app
 
@@ -232,23 +223,14 @@ class Asset(models.Model):
     )
 
     # Power & electrical tracking
-    WIRING_120V_PLUG = "120v_plug"
-    WIRING_240V_PLUG = "240v_plug"
-    WIRING_HARDWIRED = "hardwired"
-    WIRING_BATTERY = "battery"
-    WIRING_PNEUMATIC = "pneumatic"
-    WIRING_NONE = "none"
-    WIRING_UNKNOWN = "unknown"
-
-    WIRING_TYPE_CHOICES = [
-        (WIRING_120V_PLUG, "120V Plug"),
-        (WIRING_240V_PLUG, "240V Plug"),
-        (WIRING_HARDWIRED, "Hardwired"),
-        (WIRING_BATTERY, "Battery"),
-        (WIRING_PNEUMATIC, "Pneumatic / non-electric"),
-        (WIRING_NONE, "No power required"),
-        (WIRING_UNKNOWN, "Unknown"),
-    ]
+    class WiringType(models.TextChoices):
+        PLUG_120V = "120v_plug", "120V Plug"
+        PLUG_240V = "240v_plug", "240V Plug"
+        HARDWIRED = "hardwired", "Hardwired"
+        BATTERY = "battery", "Battery"
+        PNEUMATIC = "pneumatic", "Pneumatic / non-electric"
+        NONE = "none", "No power required"
+        UNKNOWN = "unknown", "Unknown"
 
     power_draw_watts = models.DecimalField(
         max_digits=10,
@@ -259,8 +241,8 @@ class Asset(models.Model):
     )
     wiring_type = models.CharField(
         max_length=20,
-        choices=WIRING_TYPE_CHOICES,
-        default=WIRING_UNKNOWN,
+        choices=WiringType.choices,
+        default=WiringType.UNKNOWN,
         blank=True,
         help_text="How this asset is wired or supplied with power.",
     )
@@ -340,23 +322,14 @@ class Asset(models.Model):
     )
 
     # Interlock tracking
-    INTERLOCK_NONE = "none"
-    INTERLOCK_FORGEKEY = "forgekey"
-    INTERLOCK_KEY_SWITCH = "key_switch"
-    INTERLOCK_E_STOP = "e_stop"
-    INTERLOCK_CONTACTOR = "contactor"
-    INTERLOCK_OTHER = "other"
-    INTERLOCK_UNKNOWN = "unknown"
-
-    INTERLOCK_TYPE_CHOICES = [
-        (INTERLOCK_NONE, "None"),
-        (INTERLOCK_FORGEKEY, "ForgeKey-controlled"),
-        (INTERLOCK_KEY_SWITCH, "Key switch"),
-        (INTERLOCK_E_STOP, "E-Stop"),
-        (INTERLOCK_CONTACTOR, "Contactor / relay"),
-        (INTERLOCK_OTHER, "Other"),
-        (INTERLOCK_UNKNOWN, "Unknown"),
-    ]
+    class InterlockType(models.TextChoices):
+        NONE = "none", "None"
+        FORGEKEY = "forgekey", "ForgeKey-controlled"
+        KEY_SWITCH = "key_switch", "Key switch"
+        E_STOP = "e_stop", "E-Stop"
+        CONTACTOR = "contactor", "Contactor / relay"
+        OTHER = "other", "Other"
+        UNKNOWN = "unknown", "Unknown"
 
     has_interlock = models.BooleanField(
         default=False,
@@ -364,8 +337,8 @@ class Asset(models.Model):
     )
     interlock_type = models.CharField(
         max_length=20,
-        choices=INTERLOCK_TYPE_CHOICES,
-        default=INTERLOCK_UNKNOWN,
+        choices=InterlockType.choices,
+        default=InterlockType.UNKNOWN,
         blank=True,
         help_text="How the interlock is implemented.",
     )
@@ -376,30 +349,20 @@ class Asset(models.Model):
     )
 
     # Lockout / Tagout tracking
-    LOCKOUT_LOTO = "loto"
-    LOCKOUT_PLUG = "plug_lockout"
-    LOCKOUT_BREAKER = "breaker_lockout"
-    LOCKOUT_KEY = "key_lockout"
-    LOCKOUT_VALVE = "valve_lockout"
-    LOCKOUT_FORGEKEY = "forgekey"
-    LOCKOUT_NONE = "none"
-    LOCKOUT_UNKNOWN = "unknown"
-
-    LOCKOUT_TYPE_CHOICES = [
-        (LOCKOUT_LOTO, "LOTO (Lockout / Tagout)"),
-        (LOCKOUT_PLUG, "Plug lockout"),
-        (LOCKOUT_BREAKER, "Breaker lockout"),
-        (LOCKOUT_KEY, "Key lockout"),
-        (LOCKOUT_VALVE, "Valve lockout"),
-        (LOCKOUT_FORGEKEY, "ForgeKey-managed"),
-        (LOCKOUT_NONE, "None"),
-        (LOCKOUT_UNKNOWN, "Unknown"),
-    ]
+    class LockoutType(models.TextChoices):
+        LOTO = "loto", "LOTO (Lockout / Tagout)"
+        PLUG = "plug_lockout", "Plug lockout"
+        BREAKER = "breaker_lockout", "Breaker lockout"
+        KEY = "key_lockout", "Key lockout"
+        VALVE = "valve_lockout", "Valve lockout"
+        FORGEKEY = "forgekey", "ForgeKey-managed"
+        NONE = "none", "None"
+        UNKNOWN = "unknown", "Unknown"
 
     lockout_type = models.CharField(
         max_length=20,
-        choices=LOCKOUT_TYPE_CHOICES,
-        default=LOCKOUT_UNKNOWN,
+        choices=LockoutType.choices,
+        default=LockoutType.UNKNOWN,
         blank=True,
         help_text="How the asset is locked out for service.",
     )
@@ -462,8 +425,8 @@ class Asset(models.Model):
     # Status and condition
     status = models.CharField(
         max_length=20,
-        choices=STATUS_CHOICES,
-        default=ACTIVE,
+        choices=Status.choices,
+        default=Status.ACTIVE,
         help_text="Current status of the asset",
     )
     condition_notes = models.TextField(
@@ -472,20 +435,15 @@ class Asset(models.Model):
     )
 
     # Ownership - can be owned by User, Group, or Space (makerspace itself)
-    OWNERSHIP_TYPE_USER = "user"
-    OWNERSHIP_TYPE_GROUP = "group"
-    OWNERSHIP_TYPE_SPACE = "space"
-
-    OWNERSHIP_TYPE_CHOICES = [
-        (OWNERSHIP_TYPE_USER, "User"),
-        (OWNERSHIP_TYPE_GROUP, "Group"),
-        (OWNERSHIP_TYPE_SPACE, "Space"),
-    ]
+    class OwnershipType(models.TextChoices):
+        USER = "user", "User"
+        GROUP = "group", "Group"
+        SPACE = "space", "Space"
 
     ownership_type = models.CharField(
         max_length=10,
-        choices=OWNERSHIP_TYPE_CHOICES,
-        default=OWNERSHIP_TYPE_SPACE,
+        choices=OwnershipType.choices,
+        default=OwnershipType.SPACE,
         help_text="Type of ownership for this asset",
     )
     owning_user = models.ForeignKey(
@@ -652,11 +610,11 @@ class Asset(models.Model):
             return False
 
         # Active assets can be operated by anyone (subject to other permissions)
-        if self.status == self.ACTIVE:
+        if self.status == self.Status.ACTIVE:
             return True
 
         # Implementing and Testing status assets have restricted access
-        if self.status in [self.IMPLEMENTING, self.TESTING]:
+        if self.status in [self.Status.IMPLEMENTING, self.Status.TESTING]:
             # Check for COO
             try:
                 coo_group = Group.objects.get(name="COO")
@@ -696,9 +654,9 @@ class Asset(models.Model):
         configured to control its power, or if the asset is explicitly marked
         as ForgeKey-controlled via interlock_type / lockout_type.
         """
-        if self.interlock_type == self.INTERLOCK_FORGEKEY:
+        if self.interlock_type == self.InterlockType.FORGEKEY:
             return True
-        if self.lockout_type == self.LOCKOUT_FORGEKEY:
+        if self.lockout_type == self.LockoutType.FORGEKEY:
             return True
         try:
             return self.forgekey_devices.exists()
@@ -935,17 +893,11 @@ class AssetProblem(models.Model):
     """
 
     # Problem status choices
-    REPORTED = "reported"
-    IN_PROGRESS = "in_progress"
-    RESOLVED = "resolved"
-    CLOSED = "closed"
-
-    STATUS_CHOICES = [
-        (REPORTED, "Reported"),
-        (IN_PROGRESS, "In Progress"),
-        (RESOLVED, "Resolved"),
-        (CLOSED, "Closed"),
-    ]
+    class Status(models.TextChoices):
+        REPORTED = "reported", "Reported"
+        IN_PROGRESS = "in_progress", "In Progress"
+        RESOLVED = "resolved", "Resolved"
+        CLOSED = "closed", "Closed"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     asset = models.ForeignKey(
@@ -981,8 +933,8 @@ class AssetProblem(models.Model):
     )
     status = models.CharField(
         max_length=20,
-        choices=STATUS_CHOICES,
-        default=REPORTED,
+        choices=Status.choices,
+        default=Status.REPORTED,
         help_text="Current status of the problem report",
     )
     resolution_notes = models.TextField(
@@ -1059,23 +1011,17 @@ class AssetDocument(models.Model):
     False so it drops out of the "current" view.
     """
 
-    MANUAL = "manual"
-    CAD_SOURCE = "cad_source"
-    WIRING_DIAGRAM = "wiring_diagram"
-    CUT_SHEET_SPEC = "cut_sheet_spec"
-    CUT_READY_TEMPLATE = "cut_ready_template"
-    PHOTO = "photo"
-    OTHER = "other"
-
-    CATEGORY_CHOICES = [
-        (MANUAL, "Manual / Documentation"),
-        (CAD_SOURCE, "CAD Source"),
-        (WIRING_DIAGRAM, "Wiring Diagram"),
-        (CUT_SHEET_SPEC, "Cut Sheet / Spec"),
-        (CUT_READY_TEMPLATE, "Cut-Ready Template (DXF/SVG/G-code/STL)"),
-        (PHOTO, "Photo"),
-        (OTHER, "Other"),
-    ]
+    class Category(models.TextChoices):
+        MANUAL = "manual", "Manual / Documentation"
+        CAD_SOURCE = "cad_source", "CAD Source"
+        WIRING_DIAGRAM = "wiring_diagram", "Wiring Diagram"
+        CUT_SHEET_SPEC = "cut_sheet_spec", "Cut Sheet / Spec"
+        CUT_READY_TEMPLATE = (
+            "cut_ready_template",
+            "Cut-Ready Template (DXF/SVG/G-code/STL)",
+        )
+        PHOTO = "photo", "Photo"
+        OTHER = "other", "Other"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     asset = models.ForeignKey(
@@ -1093,8 +1039,8 @@ class AssetDocument(models.Model):
     )
     category = models.CharField(
         max_length=20,
-        choices=CATEGORY_CHOICES,
-        default=OTHER,
+        choices=Category.choices,
+        default=Category.OTHER,
         help_text="What kind of document this is",
     )
     title = models.CharField(
@@ -1164,29 +1110,17 @@ class AssetMeter(models.Model):
     source of truth (:class:`AssetMeterReading`).
     """
 
-    RUNTIME_HOURS = "runtime_hours"
-    VOLUME_GALLONS = "volume_gallons"
-    CYCLES = "cycles"
-    KWH = "kwh"
-    GENERIC_COUNT = "generic_count"
+    class MeterType(models.TextChoices):
+        RUNTIME_HOURS = "runtime_hours", "Runtime hours"
+        VOLUME_GALLONS = "volume_gallons", "Volume (gallons)"
+        CYCLES = "cycles", "Cycles"
+        KWH = "kwh", "Energy (kWh)"
+        GENERIC_COUNT = "generic_count", "Generic count"
 
-    METER_TYPE_CHOICES = [
-        (RUNTIME_HOURS, "Runtime hours"),
-        (VOLUME_GALLONS, "Volume (gallons)"),
-        (CYCLES, "Cycles"),
-        (KWH, "Energy (kWh)"),
-        (GENERIC_COUNT, "Generic count"),
-    ]
-
-    SOURCE_AUTO_SESSION = "auto_session"
-    SOURCE_AUTO_TELEMETRY = "auto_telemetry"
-    SOURCE_MANUAL = "manual"
-
-    SOURCE_CHOICES = [
-        (SOURCE_AUTO_SESSION, "Auto — usage sessions"),
-        (SOURCE_AUTO_TELEMETRY, "Auto — telemetry"),
-        (SOURCE_MANUAL, "Manual entry"),
-    ]
+    class Source(models.TextChoices):
+        AUTO_SESSION = "auto_session", "Auto — usage sessions"
+        AUTO_TELEMETRY = "auto_telemetry", "Auto — telemetry"
+        MANUAL = "manual", "Manual entry"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     asset = models.ForeignKey(
@@ -1201,8 +1135,8 @@ class AssetMeter(models.Model):
     )
     meter_type = models.CharField(
         max_length=20,
-        choices=METER_TYPE_CHOICES,
-        default=GENERIC_COUNT,
+        choices=MeterType.choices,
+        default=MeterType.GENERIC_COUNT,
         help_text="What this meter measures",
     )
     unit = models.CharField(
@@ -1212,8 +1146,8 @@ class AssetMeter(models.Model):
     )
     source = models.CharField(
         max_length=20,
-        choices=SOURCE_CHOICES,
-        default=SOURCE_MANUAL,
+        choices=Source.choices,
+        default=Source.MANUAL,
         help_text="How this meter advances — auto rollup or manual entry",
     )
     current_value = models.DecimalField(
@@ -1268,17 +1202,11 @@ class AssetMeterReading(models.Model):
     ``value_after = current_value + d``.
     """
 
-    SOURCE_AUTO_SESSION = "auto_session"
-    SOURCE_AUTO_TELEMETRY = "auto_telemetry"
-    SOURCE_MANUAL = "manual"
-    SOURCE_MANUAL_ADJUST = "manual_adjust"
-
-    SOURCE_CHOICES = [
-        (SOURCE_AUTO_SESSION, "Auto — usage sessions"),
-        (SOURCE_AUTO_TELEMETRY, "Auto — telemetry"),
-        (SOURCE_MANUAL, "Manual entry"),
-        (SOURCE_MANUAL_ADJUST, "Manual correction"),
-    ]
+    class Source(models.TextChoices):
+        AUTO_SESSION = "auto_session", "Auto — usage sessions"
+        AUTO_TELEMETRY = "auto_telemetry", "Auto — telemetry"
+        MANUAL = "manual", "Manual entry"
+        MANUAL_ADJUST = "manual_adjust", "Manual correction"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     meter = models.ForeignKey(
@@ -1289,7 +1217,7 @@ class AssetMeterReading(models.Model):
     )
     source = models.CharField(
         max_length=20,
-        choices=SOURCE_CHOICES,
+        choices=Source.choices,
         help_text="What produced this reading",
     )
     delta = models.DecimalField(

--- a/backend/inventory/models/core.py
+++ b/backend/inventory/models/core.py
@@ -81,42 +81,31 @@ class Supplier(models.Model):
     """
 
     # Supplier type choices
-    LOCAL = "local"
-    ONLINE = "online"
-    NATIONAL = "national"
-
-    SUPPLIER_TYPE_CHOICES = [
-        (LOCAL, "Local"),
-        (ONLINE, "Online"),
-        (NATIONAL, "National"),
-    ]
+    class SupplierType(models.TextChoices):
+        LOCAL = "local", "Local"
+        ONLINE = "online", "Online"
+        NATIONAL = "national", "National"
 
     # Ordering adapter — selects the artifact the order-pad export emits for this
     # supplier (op-svpq). ``none``/``generic_csv`` produce the vendor-agnostic
     # part#,qty pad; ``amazon`` produces an add-to-cart URL; ``hdsupply`` produces
     # a Part Number,Quantity CSV for HD Supply's Saved-List / Quick Order pad.
-    ADAPTER_NONE = "none"
-    ADAPTER_GENERIC_CSV = "generic_csv"
-    ADAPTER_AMAZON = "amazon"
-    ADAPTER_HDSUPPLY = "hdsupply"
-
-    ORDERING_ADAPTER_CHOICES = [
-        (ADAPTER_NONE, "None (generic part#,qty pad)"),
-        (ADAPTER_GENERIC_CSV, "Generic CSV (part#,qty pad)"),
-        (ADAPTER_AMAZON, "Amazon (add-to-cart URL)"),
-        (ADAPTER_HDSUPPLY, "HD Supply (Part#,Qty CSV)"),
-    ]
+    class OrderingAdapter(models.TextChoices):
+        NONE = "none", "None (generic part#,qty pad)"
+        GENERIC_CSV = "generic_csv", "Generic CSV (part#,qty pad)"
+        AMAZON = "amazon", "Amazon (add-to-cart URL)"
+        HDSUPPLY = "hdsupply", "HD Supply (Part#,Qty CSV)"
 
     name = models.CharField(max_length=200)
     supplier_type = models.CharField(
         max_length=20,
-        choices=SUPPLIER_TYPE_CHOICES,
+        choices=SupplierType.choices,
         help_text="Classification of supplier by distribution type",
     )
     ordering_adapter = models.CharField(
         max_length=20,
-        choices=ORDERING_ADAPTER_CHOICES,
-        default=ADAPTER_NONE,
+        choices=OrderingAdapter.choices,
+        default=OrderingAdapter.NONE,
         help_text=(
             "How the order-pad export builds an order for this supplier: a "
             "generic part#,qty pad, an Amazon add-to-cart URL, or an HD Supply "
@@ -341,20 +330,15 @@ class InventoryItem(models.Model):
     )
 
     # Ownership - can be owned by User, Group (SIG), or Space (makerspace itself)
-    OWNERSHIP_TYPE_USER = "user"
-    OWNERSHIP_TYPE_GROUP = "group"
-    OWNERSHIP_TYPE_SPACE = "space"
-
-    OWNERSHIP_TYPE_CHOICES = [
-        (OWNERSHIP_TYPE_USER, "User"),
-        (OWNERSHIP_TYPE_GROUP, "Group"),
-        (OWNERSHIP_TYPE_SPACE, "Space"),
-    ]
+    class OwnershipType(models.TextChoices):
+        USER = "user", "User"
+        GROUP = "group", "Group"
+        SPACE = "space", "Space"
 
     ownership_type = models.CharField(
         max_length=10,
-        choices=OWNERSHIP_TYPE_CHOICES,
-        default=OWNERSHIP_TYPE_SPACE,
+        choices=OwnershipType.choices,
+        default=OwnershipType.SPACE,
         help_text="Type of ownership for this inventory item",
     )
     owning_user = models.ForeignKey(
@@ -378,13 +362,9 @@ class InventoryItem(models.Model):
     # Aggregate stock (current_stock) still applies; when is_serialized is set,
     # individual physical units are additionally tracked as SerializedComponent
     # records that move through a lifecycle branched on serial_tracking_mode.
-    SERIAL_TRACKING_CONSUMABLE = "consumable"
-    SERIAL_TRACKING_REUSABLE = "reusable"
-
-    SERIAL_TRACKING_MODE_CHOICES = [
-        (SERIAL_TRACKING_CONSUMABLE, "Consumable"),
-        (SERIAL_TRACKING_REUSABLE, "Reusable"),
-    ]
+    class SerialTrackingMode(models.TextChoices):
+        CONSUMABLE = "consumable", "Consumable"
+        REUSABLE = "reusable", "Reusable"
 
     is_serialized = models.BooleanField(
         default=False,
@@ -392,8 +372,8 @@ class InventoryItem(models.Model):
     )
     serial_tracking_mode = models.CharField(
         max_length=20,
-        choices=SERIAL_TRACKING_MODE_CHOICES,
-        default=SERIAL_TRACKING_CONSUMABLE,
+        choices=SerialTrackingMode.choices,
+        default=SerialTrackingMode.CONSUMABLE,
         help_text=(
             "Consumable components are used up "
             "(received -> in_stock -> installed -> consumed -> disposed); "
@@ -948,11 +928,10 @@ class PriceHistory(models.Model):
     allowing for trend analysis and price tracking over time.
     """
 
-    CHANGE_TYPE_CHOICES = [
-        ("created", "Initial Price"),
-        ("updated", "Price Update"),
-        ("supplier_changed", "Supplier Info Changed"),
-    ]
+    class ChangeType(models.TextChoices):
+        CREATED = "created", "Initial Price"
+        UPDATED = "updated", "Price Update"
+        SUPPLIER_CHANGED = "supplier_changed", "Supplier Info Changed"
 
     item_supplier = models.ForeignKey(
         "ItemSupplier", on_delete=models.CASCADE, related_name="price_history"
@@ -977,8 +956,8 @@ class PriceHistory(models.Model):
     )
     change_type = models.CharField(
         max_length=20,
-        choices=CHANGE_TYPE_CHOICES,
-        default="updated",
+        choices=ChangeType.choices,
+        default=ChangeType.UPDATED,
         help_text="Type of change that triggered this history record",
     )
     recorded_at = models.DateTimeField(auto_now_add=True)
@@ -1043,23 +1022,14 @@ class StockReconciliation(models.Model):
     are new rows with reason='miscounted', never edits to existing rows.
     """
 
-    REASON_LOST = "lost"
-    REASON_DAMAGED = "damaged"
-    REASON_MISCOUNTED = "miscounted"
-    REASON_USED_WITHOUT_SCAN = "used_without_scan"
-    REASON_FOUND = "found"
-    REASON_VISION_SUPPLY_CHECK = "vision_supply_check"
-    REASON_OTHER = "other"
-
-    REASON_CHOICES = [
-        (REASON_LOST, "Lost"),
-        (REASON_DAMAGED, "Damaged"),
-        (REASON_MISCOUNTED, "Miscounted"),
-        (REASON_USED_WITHOUT_SCAN, "Used without scanning"),
-        (REASON_FOUND, "Found (positive delta)"),
-        (REASON_VISION_SUPPLY_CHECK, "Vision supply check"),
-        (REASON_OTHER, "Other"),
-    ]
+    class ReasonCode(models.TextChoices):
+        LOST = "lost", "Lost"
+        DAMAGED = "damaged", "Damaged"
+        MISCOUNTED = "miscounted", "Miscounted"
+        USED_WITHOUT_SCAN = "used_without_scan", "Used without scanning"
+        FOUND = "found", "Found (positive delta)"
+        VISION_SUPPLY_CHECK = "vision_supply_check", "Vision supply check"
+        OTHER = "other", "Other"
 
     item = models.ForeignKey(
         "InventoryItem",
@@ -1069,7 +1039,7 @@ class StockReconciliation(models.Model):
     projected_count = models.IntegerField(help_text="current_stock at the time of reconciliation")
     actual_count = models.IntegerField(help_text="Physically counted quantity")
     delta = models.IntegerField(help_text="actual_count - projected_count (signed)")
-    reason = models.CharField(max_length=32, choices=REASON_CHOICES)
+    reason = models.CharField(max_length=32, choices=ReasonCode.choices)
     notes = models.TextField(blank=True)
     reconciled_by = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -1119,58 +1089,41 @@ class SerializedComponent(models.Model):
     """
 
     # Lifecycle status choices
-    RECEIVED = "received"
-    IN_STOCK = "in_stock"
-    INSTALLED = "installed"
-    REMOVED = "removed"
-    CONSUMED = "consumed"
-    RETIRED = "retired"
-    DISPOSED = "disposed"
-
-    STATUS_CHOICES = [
-        (RECEIVED, "Received"),
-        (IN_STOCK, "In Stock"),
-        (INSTALLED, "Installed"),
-        (REMOVED, "Removed"),
-        (CONSUMED, "Consumed"),
-        (RETIRED, "Retired"),
-        (DISPOSED, "Disposed"),
-    ]
+    class Status(models.TextChoices):
+        RECEIVED = "received", "Received"
+        IN_STOCK = "in_stock", "In Stock"
+        INSTALLED = "installed", "Installed"
+        REMOVED = "removed", "Removed"
+        CONSUMED = "consumed", "Consumed"
+        RETIRED = "retired", "Retired"
+        DISPOSED = "disposed", "Disposed"
 
     # Lifecycle action choices (also used by ComponentUsageEvent.action)
-    ACTION_RECEIVE = "receive"
-    ACTION_INSTALL = "install"
-    ACTION_REMOVE = "remove"
-    ACTION_CONSUME = "consume"
-    ACTION_RETIRE = "retire"
-    ACTION_DISPOSE = "dispose"
-
-    ACTION_CHOICES = [
-        (ACTION_RECEIVE, "Receive"),
-        (ACTION_INSTALL, "Install"),
-        (ACTION_REMOVE, "Remove"),
-        (ACTION_CONSUME, "Consume"),
-        (ACTION_RETIRE, "Retire"),
-        (ACTION_DISPOSE, "Dispose"),
-    ]
+    class Action(models.TextChoices):
+        RECEIVE = "receive", "Receive"
+        INSTALL = "install", "Install"
+        REMOVE = "remove", "Remove"
+        CONSUME = "consume", "Consume"
+        RETIRE = "retire", "Retire"
+        DISPOSE = "dispose", "Dispose"
 
     # (current_status, action) -> resulting_status, keyed by tracking mode.
     _TRANSITIONS = {
-        InventoryItem.SERIAL_TRACKING_CONSUMABLE: {
-            (RECEIVED, ACTION_RECEIVE): IN_STOCK,
-            (IN_STOCK, ACTION_INSTALL): INSTALLED,
-            (INSTALLED, ACTION_CONSUME): CONSUMED,
-            (CONSUMED, ACTION_DISPOSE): DISPOSED,
+        InventoryItem.SerialTrackingMode.CONSUMABLE: {
+            (Status.RECEIVED, Action.RECEIVE): Status.IN_STOCK,
+            (Status.IN_STOCK, Action.INSTALL): Status.INSTALLED,
+            (Status.INSTALLED, Action.CONSUME): Status.CONSUMED,
+            (Status.CONSUMED, Action.DISPOSE): Status.DISPOSED,
         },
-        InventoryItem.SERIAL_TRACKING_REUSABLE: {
-            (RECEIVED, ACTION_RECEIVE): IN_STOCK,
-            (IN_STOCK, ACTION_INSTALL): INSTALLED,
-            (INSTALLED, ACTION_REMOVE): REMOVED,
-            (REMOVED, ACTION_INSTALL): INSTALLED,
-            (IN_STOCK, ACTION_RETIRE): RETIRED,
-            (INSTALLED, ACTION_RETIRE): RETIRED,
-            (REMOVED, ACTION_RETIRE): RETIRED,
-            (RETIRED, ACTION_DISPOSE): DISPOSED,
+        InventoryItem.SerialTrackingMode.REUSABLE: {
+            (Status.RECEIVED, Action.RECEIVE): Status.IN_STOCK,
+            (Status.IN_STOCK, Action.INSTALL): Status.INSTALLED,
+            (Status.INSTALLED, Action.REMOVE): Status.REMOVED,
+            (Status.REMOVED, Action.INSTALL): Status.INSTALLED,
+            (Status.IN_STOCK, Action.RETIRE): Status.RETIRED,
+            (Status.INSTALLED, Action.RETIRE): Status.RETIRED,
+            (Status.REMOVED, Action.RETIRE): Status.RETIRED,
+            (Status.RETIRED, Action.DISPOSE): Status.DISPOSED,
         },
     }
 
@@ -1201,8 +1154,8 @@ class SerializedComponent(models.Model):
     )
     status = models.CharField(
         max_length=20,
-        choices=STATUS_CHOICES,
-        default=RECEIVED,
+        choices=Status.choices,
+        default=Status.RECEIVED,
         help_text="Current lifecycle status of this unit",
     )
     installed_in_asset = models.ForeignKey(
@@ -1314,25 +1267,25 @@ class SerializedComponent(models.Model):
         now = at or timezone.now()
         event_asset = None
 
-        if action == self.ACTION_RECEIVE:
+        if action == self.Action.RECEIVE:
             if not self.received_at:
                 self.received_at = now
-        elif action == self.ACTION_INSTALL:
+        elif action == self.Action.INSTALL:
             if asset is None:
                 raise ValidationError("An asset is required to install a component.")
             self.installed_in_asset = asset
             self.installed_at = now
             event_asset = asset
-        elif action == self.ACTION_REMOVE:
+        elif action == self.Action.REMOVE:
             event_asset = self.installed_in_asset
             self.installed_in_asset = None
-        elif action == self.ACTION_CONSUME:
+        elif action == self.Action.CONSUME:
             event_asset = self.installed_in_asset
             self.installed_in_asset = None
-        elif action == self.ACTION_RETIRE:
+        elif action == self.Action.RETIRE:
             event_asset = self.installed_in_asset
             self.installed_in_asset = None
-        elif action == self.ACTION_DISPOSE:
+        elif action == self.Action.DISPOSE:
             if not disposal_reason:
                 raise ValidationError("A disposal reason is required to dispose a component.")
             self.disposal_reason = disposal_reason
@@ -1379,7 +1332,7 @@ class ComponentUsageEvent(models.Model):
     )
     action = models.CharField(
         max_length=20,
-        choices=SerializedComponent.ACTION_CHOICES,
+        choices=SerializedComponent.Action.choices,
         help_text="The lifecycle action performed",
     )
     at = models.DateTimeField(

--- a/backend/inventory/models/fixtures.py
+++ b/backend/inventory/models/fixtures.py
@@ -61,7 +61,7 @@ class Fixture(models.Model):
     @property
     def pending_requests_count(self) -> int:
         """Count of pending refill requests for this fixture."""
-        return self.refill_requests.filter(status="pending").count()
+        return self.refill_requests.filter(status=FixtureRefillRequest.Status.PENDING).count()
 
 
 class FixtureRefillRequest(models.Model):
@@ -71,12 +71,11 @@ class FixtureRefillRequest(models.Model):
     Created when someone scans a fixture's QR code to report it needs refilling.
     """
 
-    STATUS_CHOICES = [
-        ("pending", "Pending"),
-        ("in_progress", "In Progress"),
-        ("completed", "Completed"),
-        ("cancelled", "Cancelled"),
-    ]
+    class Status(models.TextChoices):
+        PENDING = "pending", "Pending"
+        IN_PROGRESS = "in_progress", "In Progress"
+        COMPLETED = "completed", "Completed"
+        CANCELLED = "cancelled", "Cancelled"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     fixture = models.ForeignKey(
@@ -87,8 +86,8 @@ class FixtureRefillRequest(models.Model):
     )
     status = models.CharField(
         max_length=20,
-        choices=STATUS_CHOICES,
-        default="pending",
+        choices=Status.choices,
+        default=Status.PENDING,
         help_text="Current status of this refill request",
     )
     requested_at = models.DateTimeField(auto_now_add=True)

--- a/backend/inventory/models/location_problem.py
+++ b/backend/inventory/models/location_problem.py
@@ -17,29 +17,17 @@ class LocationProblem(models.Model):
     when work is scheduled.
     """
 
-    REPORTED = "reported"
-    IN_PROGRESS = "in_progress"
-    RESOLVED = "resolved"
-    CLOSED = "closed"
+    class Status(models.TextChoices):
+        REPORTED = "reported", "Reported"
+        IN_PROGRESS = "in_progress", "In Progress"
+        RESOLVED = "resolved", "Resolved"
+        CLOSED = "closed", "Closed"
 
-    STATUS_CHOICES = [
-        (REPORTED, "Reported"),
-        (IN_PROGRESS, "In Progress"),
-        (RESOLVED, "Resolved"),
-        (CLOSED, "Closed"),
-    ]
-
-    SEVERITY_LOW = "low"
-    SEVERITY_MEDIUM = "medium"
-    SEVERITY_HIGH = "high"
-    SEVERITY_URGENT = "urgent"
-
-    SEVERITY_CHOICES = [
-        (SEVERITY_LOW, "Low"),
-        (SEVERITY_MEDIUM, "Medium"),
-        (SEVERITY_HIGH, "High"),
-        (SEVERITY_URGENT, "Urgent"),
-    ]
+    class Severity(models.TextChoices):
+        LOW = "low", "Low"
+        MEDIUM = "medium", "Medium"
+        HIGH = "high", "High"
+        URGENT = "urgent", "Urgent"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     location = models.ForeignKey(
@@ -56,13 +44,13 @@ class LocationProblem(models.Model):
     description = models.TextField(help_text="Description of the problem or issue")
     status = models.CharField(
         max_length=20,
-        choices=STATUS_CHOICES,
-        default=REPORTED,
+        choices=Status.choices,
+        default=Status.REPORTED,
     )
     severity = models.CharField(
         max_length=10,
-        choices=SEVERITY_CHOICES,
-        default=SEVERITY_MEDIUM,
+        choices=Severity.choices,
+        default=Severity.MEDIUM,
     )
     photo = models.ImageField(
         upload_to="location_problems/%Y/%m/",

--- a/backend/inventory/models/maintenance.py
+++ b/backend/inventory/models/maintenance.py
@@ -391,17 +391,11 @@ class WorkOrder(models.Model):
     maintenance history.
     """
 
-    STATUS_OPEN = "open"
-    STATUS_IN_PROGRESS = "in_progress"
-    STATUS_BLOCKED = "blocked"
-    STATUS_COMPLETED = "completed"
-
-    STATUS_CHOICES = [
-        (STATUS_OPEN, "Open"),
-        (STATUS_IN_PROGRESS, "In Progress"),
-        (STATUS_BLOCKED, "Blocked"),
-        (STATUS_COMPLETED, "Completed"),
-    ]
+    class Status(models.TextChoices):
+        OPEN = "open", "Open"
+        IN_PROGRESS = "in_progress", "In Progress"
+        BLOCKED = "blocked", "Blocked"
+        COMPLETED = "completed", "Completed"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     maintenance_item = models.ForeignKey(
@@ -429,8 +423,8 @@ class WorkOrder(models.Model):
     )
     status = models.CharField(
         max_length=20,
-        choices=STATUS_CHOICES,
-        default=STATUS_OPEN,
+        choices=Status.choices,
+        default=Status.OPEN,
         help_text="Current status of this work order",
     )
     due_date = models.DateField(
@@ -496,7 +490,7 @@ class WorkOrder(models.Model):
         """Return True if this open work order is past its due date."""
         from django.utils import timezone
 
-        if self.status == self.STATUS_COMPLETED:
+        if self.status == self.Status.COMPLETED:
             return False
         if not self.due_date:
             return False
@@ -777,43 +771,27 @@ class WorkOrderSubmission(models.Model):
     history.
     """
 
-    STATUS_RECEIVED = "received"
-    STATUS_APPLIED = "applied"
-    STATUS_FAILED = "failed"
-    STATUS_PENDING_REVIEW = "pending_review"
+    class Status(models.TextChoices):
+        RECEIVED = "received", "Received"
+        APPLIED = "applied", "Applied"
+        FAILED = "failed", "Failed"
+        PENDING_REVIEW = "pending_review", "Pending review"
 
-    STATUS_CHOICES = [
-        (STATUS_RECEIVED, "Received"),
-        (STATUS_APPLIED, "Applied"),
-        (STATUS_FAILED, "Failed"),
-        (STATUS_PENDING_REVIEW, "Pending review"),
-    ]
+    class Source(models.TextChoices):
+        EMAIL = "email", "Email"
+        MANUAL = "manual", "Manual"
+        SCAN = "scan", "Scan (OMR)"
 
-    SOURCE_EMAIL = "email"
-    SOURCE_MANUAL = "manual"
-    SOURCE_SCAN = "scan"
-
-    SOURCE_CHOICES = [
-        (SOURCE_EMAIL, "Email"),
-        (SOURCE_MANUAL, "Manual"),
-        (SOURCE_SCAN, "Scan (OMR)"),
-    ]
-
-    KIND_PM_COMPLETION = "pm_completion"
-    KIND_THIRD_PARTY_WO = "third_party_wo"
-    KIND_LOCATION_PROBLEM = "location_problem"
-
-    KIND_CHOICES = [
-        (KIND_PM_COMPLETION, "PM completion"),
-        (KIND_THIRD_PARTY_WO, "Third-party WO"),
-        (KIND_LOCATION_PROBLEM, "Location Problem Report"),
-    ]
+    class Kind(models.TextChoices):
+        PM_COMPLETION = "pm_completion", "PM completion"
+        THIRD_PARTY_WO = "third_party_wo", "Third-party WO"
+        LOCATION_PROBLEM = "location_problem", "Location Problem Report"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     kind = models.CharField(
         max_length=20,
-        choices=KIND_CHOICES,
-        default=KIND_PM_COMPLETION,
+        choices=Kind.choices,
+        default=Kind.PM_COMPLETION,
         help_text=(
             "Discriminates which ingest pipeline to run: pm_completion routes to "
             "WorkOrder updates; third_party_wo routes to ThirdPartyWorkOrder."
@@ -852,13 +830,13 @@ class WorkOrderSubmission(models.Model):
     )
     status = models.CharField(
         max_length=20,
-        choices=STATUS_CHOICES,
-        default=STATUS_RECEIVED,
+        choices=Status.choices,
+        default=Status.RECEIVED,
     )
     source = models.CharField(
         max_length=20,
-        choices=SOURCE_CHOICES,
-        default=SOURCE_EMAIL,
+        choices=Source.choices,
+        default=Source.EMAIL,
         help_text="How this submission entered the system (email webhook vs manual upload)",
     )
     submitted_by = models.ForeignKey(
@@ -913,15 +891,10 @@ class MaintenanceAuditEvent(models.Model):
     eventual unified review surface (#359) can join cleanly.
     """
 
-    ACTION_WO_CREATE = "wo_create"
-    ACTION_WO_COMPLETE = "wo_complete"
-    ACTION_LOCATION_PROBLEM_RESOLVE = "location_problem_resolve"
-
-    ACTION_CHOICES = [
-        (ACTION_WO_CREATE, "Work order created"),
-        (ACTION_WO_COMPLETE, "Work order completed"),
-        (ACTION_LOCATION_PROBLEM_RESOLVE, "Location problem resolved"),
-    ]
+    class Action(models.TextChoices):
+        WO_CREATE = "wo_create", "Work order created"
+        WO_COMPLETE = "wo_complete", "Work order completed"
+        LOCATION_PROBLEM_RESOLVE = "location_problem_resolve", "Location problem resolved"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     created_at = models.DateTimeField(auto_now_add=True)
@@ -933,7 +906,7 @@ class MaintenanceAuditEvent(models.Model):
         related_name="maintenance_audit_actions",
         help_text="User who performed the action; null for system-initiated events.",
     )
-    action = models.CharField(max_length=32, choices=ACTION_CHOICES)
+    action = models.CharField(max_length=32, choices=Action.choices)
     work_order = models.ForeignKey(
         "WorkOrder",
         on_delete=models.SET_NULL,

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -82,7 +82,7 @@ class SupplierSerializer(serializers.ModelSerializer):
             from reorder_queue.models import PurchaseOrder
 
             result = PurchaseOrder.objects.filter(
-                supplier=obj, status=PurchaseOrder.RECEIVED, actual_total__isnull=False
+                supplier=obj, status=PurchaseOrder.Status.RECEIVED, actual_total__isnull=False
             ).aggregate(total=Sum("actual_total"))["total"] or Decimal("0.00")
             return str(result)
         except (ImportError, TypeError):
@@ -1190,7 +1190,7 @@ class AssetSerializer(serializers.ModelSerializer):
 
     def get_owning_group_name(self, obj):
         """Return owning group name, or 'Logistics' if owned by space."""
-        if obj.ownership_type == obj.OWNERSHIP_TYPE_SPACE:
+        if obj.ownership_type == obj.OwnershipType.SPACE:
             return "Logistics"
         if obj.owning_group:
             return obj.owning_group.name
@@ -1198,7 +1198,7 @@ class AssetSerializer(serializers.ModelSerializer):
 
     def get_owning_user_name(self, obj):
         """Return owning user name, or 'COO' if owned by space."""
-        if obj.ownership_type == obj.OWNERSHIP_TYPE_SPACE:
+        if obj.ownership_type == obj.OwnershipType.SPACE:
             return "COO"
         if obj.owning_user:
             return obj.owning_user.username
@@ -1221,7 +1221,7 @@ class AssetSerializer(serializers.ModelSerializer):
             return True
 
         # Check if user can operate assets in Implementing/Testing status
-        if obj.status in [obj.IMPLEMENTING, obj.TESTING]:
+        if obj.status in [obj.Status.IMPLEMENTING, obj.Status.TESTING]:
             return obj.can_user_operate(user)
 
         # Check if user's groups are in groups_can_enable
@@ -2092,7 +2092,7 @@ class StockReconciliationRowSerializer(serializers.Serializer):
 
     item_id = serializers.UUIDField()
     actual_count = serializers.IntegerField(min_value=0)
-    reason = serializers.ChoiceField(choices=StockReconciliation.REASON_CHOICES)
+    reason = serializers.ChoiceField(choices=StockReconciliation.ReasonCode.choices)
     notes = serializers.CharField(required=False, allow_blank=True, default="")
     skip_reorder = serializers.BooleanField(required=False, default=False)
 

--- a/backend/inventory/services/component_forecast.py
+++ b/backend/inventory/services/component_forecast.py
@@ -53,13 +53,13 @@ DEFAULT_WINDOW_DAYS = 90
 
 # Statuses that mean a unit has permanently left the usable pool, per mode.
 _DEPLETED_STATUSES = {
-    InventoryItem.SERIAL_TRACKING_CONSUMABLE: {
-        SerializedComponent.CONSUMED,
-        SerializedComponent.DISPOSED,
+    InventoryItem.SerialTrackingMode.CONSUMABLE: {
+        SerializedComponent.Status.CONSUMED,
+        SerializedComponent.Status.DISPOSED,
     },
-    InventoryItem.SERIAL_TRACKING_REUSABLE: {
-        SerializedComponent.RETIRED,
-        SerializedComponent.DISPOSED,
+    InventoryItem.SerialTrackingMode.REUSABLE: {
+        SerializedComponent.Status.RETIRED,
+        SerializedComponent.Status.DISPOSED,
     },
 }
 
@@ -68,10 +68,10 @@ _DEPLETED_STATUSES = {
 # depletion already happened at ``consume`` — counting ``dispose`` too would
 # double-count a single unit, so consumables only count ``consume``.
 _DEPLETING_ACTIONS = {
-    InventoryItem.SERIAL_TRACKING_CONSUMABLE: [SerializedComponent.ACTION_CONSUME],
-    InventoryItem.SERIAL_TRACKING_REUSABLE: [
-        SerializedComponent.ACTION_RETIRE,
-        SerializedComponent.ACTION_DISPOSE,
+    InventoryItem.SerialTrackingMode.CONSUMABLE: [SerializedComponent.Action.CONSUME],
+    InventoryItem.SerialTrackingMode.REUSABLE: [
+        SerializedComponent.Action.RETIRE,
+        SerializedComponent.Action.DISPOSE,
     ],
 }
 
@@ -145,7 +145,7 @@ def _stock_split_by_item(items: list[InventoryItem]) -> dict[Any, dict[str, int]
         depleted = _DEPLETED_STATUSES.get(item.serial_tracking_mode, set())
         per_status = counts.get(item.id, {})
         on_hand = sum(n for status, n in per_status.items() if status not in depleted)
-        installed = per_status.get(SerializedComponent.INSTALLED, 0)
+        installed = per_status.get(SerializedComponent.Status.INSTALLED, 0)
         split[item.id] = {
             "on_hand": on_hand,
             "installed": installed,
@@ -170,16 +170,16 @@ def _depletion_counts(items: list[InventoryItem], window_start, now) -> dict[Any
     inside the same window from counting twice.
     """
     consumable_ids = [
-        i.id for i in items if i.serial_tracking_mode == InventoryItem.SERIAL_TRACKING_CONSUMABLE
+        i.id for i in items if i.serial_tracking_mode == InventoryItem.SerialTrackingMode.CONSUMABLE
     ]
     reusable_ids = [
-        i.id for i in items if i.serial_tracking_mode == InventoryItem.SERIAL_TRACKING_REUSABLE
+        i.id for i in items if i.serial_tracking_mode == InventoryItem.SerialTrackingMode.REUSABLE
     ]
 
     depleted: dict[Any, int] = {}
     for item_ids, mode in (
-        (consumable_ids, InventoryItem.SERIAL_TRACKING_CONSUMABLE),
-        (reusable_ids, InventoryItem.SERIAL_TRACKING_REUSABLE),
+        (consumable_ids, InventoryItem.SerialTrackingMode.CONSUMABLE),
+        (reusable_ids, InventoryItem.SerialTrackingMode.REUSABLE),
     ):
         if not item_ids:
             continue

--- a/backend/inventory/services/item_metrics.py
+++ b/backend/inventory/services/item_metrics.py
@@ -24,16 +24,16 @@ from reorder_queue.models import PurchaseOrder, PurchaseOrderItem
 # PO statuses that count as "on order" (QOO): units committed on a live PO that
 # has been sent but not fully received, voided, or cancelled.
 ON_ORDER_STATUSES = (
-    PurchaseOrder.SENT,
-    PurchaseOrder.CONFIRMED,
-    PurchaseOrder.PARTIALLY_RECEIVED,
+    PurchaseOrder.Status.SENT,
+    PurchaseOrder.Status.CONFIRMED,
+    PurchaseOrder.Status.PARTIALLY_RECEIVED,
 )
 
 # Work-order statuses that keep a material "committed" (QC).
 OPEN_WO_STATUSES = (
-    WorkOrder.STATUS_OPEN,
-    WorkOrder.STATUS_IN_PROGRESS,
-    WorkOrder.STATUS_BLOCKED,
+    WorkOrder.Status.OPEN,
+    WorkOrder.Status.IN_PROGRESS,
+    WorkOrder.Status.BLOCKED,
 )
 
 
@@ -91,7 +91,7 @@ def compute_item_metrics_batch(items):
             PurchaseOrderItem.objects.filter(
                 item_supplier__item_id__in=item_ids,
                 is_voided=False,
-                purchase_order__status=PurchaseOrder.PARTIALLY_RECEIVED,
+                purchase_order__status=PurchaseOrder.Status.PARTIALLY_RECEIVED,
                 quantity_received__lt=F("quantity_ordered"),
             )
             .values("item_supplier__item")

--- a/backend/inventory/services/meter_sources.py
+++ b/backend/inventory/services/meter_sources.py
@@ -112,7 +112,7 @@ class SessionRuntimeAdapter(MeterSourceAdapter):
     re-run is exactly-once.
     """
 
-    source_slug = AssetMeter.SOURCE_AUTO_SESSION
+    source_slug = AssetMeter.Source.AUTO_SESSION
 
     def pull(self, meter: AssetMeter, now: datetime) -> List[ReadingSpec]:
         # Lazy import: inventory must not migrate/import against forgekey at
@@ -138,7 +138,7 @@ class SessionRuntimeAdapter(MeterSourceAdapter):
             # watermark so we don't re-scan them forever.
             return [
                 ReadingSpec(
-                    source=AssetMeterReading.SOURCE_AUTO_SESSION,
+                    source=AssetMeterReading.Source.AUTO_SESSION,
                     observed_at=max_ended,
                     delta=Decimal("0"),
                     is_estimated=False,
@@ -150,7 +150,7 @@ class SessionRuntimeAdapter(MeterSourceAdapter):
         delta_hours = (Decimal(total_seconds) / Decimal(3600)).quantize(Decimal("0.0001"))
         return [
             ReadingSpec(
-                source=AssetMeterReading.SOURCE_AUTO_SESSION,
+                source=AssetMeterReading.Source.AUTO_SESSION,
                 observed_at=max_ended,
                 delta=delta_hours,
                 is_estimated=False,
@@ -169,7 +169,7 @@ class TelemetryCounterAdapter(MeterSourceAdapter):
     :func:`apply_reading` directly, e.g.::
 
         spec = ReadingSpec(
-            source=AssetMeterReading.SOURCE_AUTO_TELEMETRY,
+            source=AssetMeterReading.Source.AUTO_TELEMETRY,
             observed_at=sensor_ts,
             delta=gallons_since_last,          # or absolute=cumulative_counter
             is_estimated=False,
@@ -180,7 +180,7 @@ class TelemetryCounterAdapter(MeterSourceAdapter):
     Nothing is pulled on the schedule, so ``pull()`` returns ``[]``.
     """
 
-    source_slug = AssetMeter.SOURCE_AUTO_TELEMETRY
+    source_slug = AssetMeter.Source.AUTO_TELEMETRY
 
     def pull(self, meter: AssetMeter, now: datetime) -> List[ReadingSpec]:
         return []
@@ -189,15 +189,15 @@ class TelemetryCounterAdapter(MeterSourceAdapter):
 class ManualAdapter(MeterSourceAdapter):
     """manual (PUSH): readings come from the record-reading / adjust API actions."""
 
-    source_slug = AssetMeter.SOURCE_MANUAL
+    source_slug = AssetMeter.Source.MANUAL
 
     def pull(self, meter: AssetMeter, now: datetime) -> List[ReadingSpec]:
         return []
 
 
-register_meter_source(AssetMeter.SOURCE_AUTO_SESSION, SessionRuntimeAdapter())
-register_meter_source(AssetMeter.SOURCE_AUTO_TELEMETRY, TelemetryCounterAdapter())
-register_meter_source(AssetMeter.SOURCE_MANUAL, ManualAdapter())
+register_meter_source(AssetMeter.Source.AUTO_SESSION, SessionRuntimeAdapter())
+register_meter_source(AssetMeter.Source.AUTO_TELEMETRY, TelemetryCounterAdapter())
+register_meter_source(AssetMeter.Source.MANUAL, ManualAdapter())
 
 
 def apply_reading(
@@ -250,7 +250,7 @@ def apply_reading(
             update_fields.append("rollup_watermark_at")
         locked.save(update_fields=update_fields)
 
-        if locked.meter_type == AssetMeter.RUNTIME_HOURS:
+        if locked.meter_type == AssetMeter.MeterType.RUNTIME_HOURS:
             increment = int(delta)
             if increment > 0:
                 Asset.objects.filter(pk=locked.asset_id).update(

--- a/backend/inventory/services/work_order_context.py
+++ b/backend/inventory/services/work_order_context.py
@@ -47,8 +47,8 @@ def _build_electrical_rows(asset: "Asset") -> list[list[str]]:
     rows: list[list[str]] = []
 
     if asset.wiring_type and asset.wiring_type not in (
-        asset.WIRING_NONE,
-        asset.WIRING_UNKNOWN,
+        asset.WiringType.NONE,
+        asset.WiringType.UNKNOWN,
         "",
     ):
         rows.append(["Wiring", asset.get_wiring_type_display()])
@@ -144,7 +144,7 @@ def _real_lockout(asset: "Asset") -> bool:
     """True iff the asset has a meaningful lockout requirement to display."""
     return bool(
         asset.lockout_type
-        and asset.lockout_type not in (asset.LOCKOUT_NONE, asset.LOCKOUT_UNKNOWN, "")
+        and asset.lockout_type not in (asset.LockoutType.NONE, asset.LockoutType.UNKNOWN, "")
     )
 
 

--- a/backend/inventory/services/work_order_ingest.py
+++ b/backend/inventory/services/work_order_ingest.py
@@ -316,14 +316,14 @@ def apply_submission(submission: WorkOrderSubmission) -> WorkOrderSubmission:
     # human review. Only PM-completion scans use OMR; 3PWO/LOCPROB keep their
     # existing QR/text handlers.
     if (
-        submission.source == WorkOrderSubmission.SOURCE_SCAN
-        and submission.kind == WorkOrderSubmission.KIND_PM_COMPLETION
+        submission.source == WorkOrderSubmission.Source.SCAN
+        and submission.kind == WorkOrderSubmission.Kind.PM_COMPLETION
     ):
         return _apply_omr_submission(submission, pdf_bytes)
 
-    if submission.kind == WorkOrderSubmission.KIND_THIRD_PARTY_WO:
+    if submission.kind == WorkOrderSubmission.Kind.THIRD_PARTY_WO:
         return _apply_third_party_submission(submission, pdf_bytes)
-    if submission.kind == WorkOrderSubmission.KIND_LOCATION_PROBLEM:
+    if submission.kind == WorkOrderSubmission.Kind.LOCATION_PROBLEM:
         return _apply_location_problem_submission(submission, pdf_bytes)
     return _apply_pm_submission(submission, pdf_bytes)
 
@@ -335,7 +335,7 @@ def _apply_pm_submission(submission: WorkOrderSubmission, pdf_bytes: bytes) -> W
         parsed = parse_work_order_pdf(pdf_bytes)
     except Exception as exc:  # noqa: BLE001 - defensive: malformed PDF
         logger.exception("Failed to parse work order submission %s", submission.id)
-        submission.status = WorkOrderSubmission.STATUS_FAILED
+        submission.status = WorkOrderSubmission.Status.FAILED
         submission.parse_error = f"Failed to parse PDF: {exc}"
         submission.save(update_fields=["status", "parse_error"])
         return submission
@@ -344,7 +344,7 @@ def _apply_pm_submission(submission: WorkOrderSubmission, pdf_bytes: bytes) -> W
 
     work_order, err = _resolve_work_order(submission, parsed)
     if err:
-        submission.status = WorkOrderSubmission.STATUS_FAILED
+        submission.status = WorkOrderSubmission.Status.FAILED
         submission.parse_error = err
         submission.save(update_fields=["status", "parse_error", "parsed_fields"])
         return submission
@@ -403,12 +403,12 @@ def _apply_pm_submission(submission: WorkOrderSubmission, pdf_bytes: bytes) -> W
 
     wo_became_complete = False
     if required_total > 0 and required_done >= required_total:
-        if work_order.status != WorkOrder.STATUS_COMPLETED:
-            work_order.status = WorkOrder.STATUS_COMPLETED
+        if work_order.status != WorkOrder.Status.COMPLETED:
+            work_order.status = WorkOrder.Status.COMPLETED
             work_order.completed_at = now
             wo_became_complete = True
-    elif applied_tasks > 0 and work_order.status == WorkOrder.STATUS_OPEN:
-        work_order.status = WorkOrder.STATUS_IN_PROGRESS
+    elif applied_tasks > 0 and work_order.status == WorkOrder.Status.OPEN:
+        work_order.status = WorkOrder.Status.IN_PROGRESS
 
     work_order.save()
 
@@ -447,9 +447,9 @@ def _apply_pm_submission(submission: WorkOrderSubmission, pdf_bytes: bytes) -> W
     # human review rather than marked applied — the digital UI surfaces the
     # pending list for accept/reject.
     if queue_cv:
-        submission.status = WorkOrderSubmission.STATUS_PENDING_REVIEW
+        submission.status = WorkOrderSubmission.Status.PENDING_REVIEW
     else:
-        submission.status = WorkOrderSubmission.STATUS_APPLIED
+        submission.status = WorkOrderSubmission.Status.APPLIED
     submission.parse_error = ""
     submission.save(
         update_fields=[
@@ -590,10 +590,10 @@ def omr_confirm_completion(
     required_done = work_order.task_completions.filter(is_required=True, is_completed=True).count()
     if not (required_total > 0 and required_done >= required_total):
         return False
-    if work_order.status == WorkOrder.STATUS_COMPLETED:
+    if work_order.status == WorkOrder.Status.COMPLETED:
         return False
     now = timezone.now()
-    work_order.status = WorkOrder.STATUS_COMPLETED
+    work_order.status = WorkOrder.Status.COMPLETED
     work_order.completed_at = now
     work_order.save(update_fields=["status", "completed_at", "updated_at"])
     item = work_order.maintenance_item
@@ -612,7 +612,7 @@ def omr_confirm_completion(
 
 def _omr_fail(submission: WorkOrderSubmission, message: str) -> WorkOrderSubmission:
     """Unrecoverable scan (no WO id / WO missing): mark FAILED."""
-    submission.status = WorkOrderSubmission.STATUS_FAILED
+    submission.status = WorkOrderSubmission.Status.FAILED
     submission.parse_error = message
     submission.save(update_fields=["status", "parse_error", "work_order"])
     return submission
@@ -624,7 +624,7 @@ def _omr_review(
     """Recoverable scan problem (bad alignment / template drift / no template):
     hold for human review with an explanatory message and apply nothing."""
     submission.work_order = work_order
-    submission.status = WorkOrderSubmission.STATUS_PENDING_REVIEW
+    submission.status = WorkOrderSubmission.Status.PENDING_REVIEW
     submission.parse_error = message
     submission.pending_changes = []
     submission.save(update_fields=["status", "parse_error", "work_order", "pending_changes"])
@@ -710,8 +710,8 @@ def _apply_omr_submission(submission: WorkOrderSubmission, raw_bytes: bytes) -> 
         )
 
     # Progress is allowed (OPEN → IN_PROGRESS); COMPLETED is NOT — never here.
-    if applied and work_order.status == WorkOrder.STATUS_OPEN:
-        work_order.status = WorkOrder.STATUS_IN_PROGRESS
+    if applied and work_order.status == WorkOrder.Status.OPEN:
+        work_order.status = WorkOrder.Status.IN_PROGRESS
         work_order.save(update_fields=["status"])
 
     base = f"/api/inventory/work-orders/{work_order.id}/submissions/{submission.id}/mark-crop/"
@@ -740,7 +740,7 @@ def _apply_omr_submission(submission: WorkOrderSubmission, raw_bytes: bytes) -> 
     }
     # A scan ALWAYS ends in review — the human confirms the marks (and any WO
     # completion) on screen. Never auto-applied, never auto-closed.
-    submission.status = WorkOrderSubmission.STATUS_PENDING_REVIEW
+    submission.status = WorkOrderSubmission.Status.PENDING_REVIEW
     submission.parse_error = ""
     submission.save(
         update_fields=["status", "work_order", "parsed_fields", "parse_error", "pending_changes"]
@@ -999,24 +999,24 @@ def detect_submission_kind(pdf_bytes: bytes, subject: str = "") -> str:
     """
     subject_norm = (subject or "").lstrip().upper()
     if subject_norm.startswith(THIRD_PARTY_SUBJECT_PREFIX):
-        return WorkOrderSubmission.KIND_THIRD_PARTY_WO
+        return WorkOrderSubmission.Kind.THIRD_PARTY_WO
     if subject_norm.startswith(LOCATION_PROBLEM_SUBJECT_PREFIX):
-        return WorkOrderSubmission.KIND_LOCATION_PROBLEM
+        return WorkOrderSubmission.Kind.LOCATION_PROBLEM
     try:
         reader = PdfReader(io.BytesIO(pdf_bytes))
         fields = reader.get_fields() or {}
         if "third_party_work_order_id" in fields:
-            return WorkOrderSubmission.KIND_THIRD_PARTY_WO
+            return WorkOrderSubmission.Kind.THIRD_PARTY_WO
         if "location_problem_report" in fields or "location_id" in fields:
-            return WorkOrderSubmission.KIND_LOCATION_PROBLEM
+            return WorkOrderSubmission.Kind.LOCATION_PROBLEM
     except Exception:  # noqa: BLE001  # nosec B110 - malformed PDFs default to PM path
         pass
     text = _pdf_text(pdf_bytes)
     if LOCATION_PROBLEM_HEADER_RE.search(text):
-        return WorkOrderSubmission.KIND_LOCATION_PROBLEM
+        return WorkOrderSubmission.Kind.LOCATION_PROBLEM
     if THIRD_PARTY_HEADER_RE.search(text):
-        return WorkOrderSubmission.KIND_THIRD_PARTY_WO
-    return WorkOrderSubmission.KIND_PM_COMPLETION
+        return WorkOrderSubmission.Kind.THIRD_PARTY_WO
+    return WorkOrderSubmission.Kind.PM_COMPLETION
 
 
 def _looks_like_qr_payload(image_bytes: bytes) -> bool:
@@ -1069,7 +1069,7 @@ def _apply_third_party_submission(
         parsed = parse_third_party_wo_pdf(pdf_bytes)
     except Exception as exc:  # noqa: BLE001 - defensive: malformed PDF
         logger.exception("Failed to parse third-party WO submission %s", submission.id)
-        submission.status = WorkOrderSubmission.STATUS_FAILED
+        submission.status = WorkOrderSubmission.Status.FAILED
         submission.parse_error = f"Failed to parse PDF: {exc}"
         submission.save(update_fields=["status", "parse_error"])
         return submission
@@ -1085,7 +1085,7 @@ def _apply_third_party_submission(
             if errors
             else "Could not find a Third-Party Work Order ID marker in the PDF."
         )
-        submission.status = WorkOrderSubmission.STATUS_FAILED
+        submission.status = WorkOrderSubmission.Status.FAILED
         submission.parse_error = msg
         submission.save(update_fields=["status", "parse_error", "parsed_fields"])
         return submission
@@ -1093,7 +1093,7 @@ def _apply_third_party_submission(
     try:
         tpwo = ThirdPartyWorkOrder.objects.get(id=tpwo_id)
     except ThirdPartyWorkOrder.DoesNotExist:
-        submission.status = WorkOrderSubmission.STATUS_FAILED
+        submission.status = WorkOrderSubmission.Status.FAILED
         submission.parse_error = f"Third-party work order {tpwo_id} not found."
         submission.save(update_fields=["status", "parse_error", "parsed_fields"])
         return submission
@@ -1200,7 +1200,7 @@ def _apply_third_party_submission(
             submission.id,
         )
 
-    submission.status = WorkOrderSubmission.STATUS_APPLIED
+    submission.status = WorkOrderSubmission.Status.APPLIED
     submission.parse_error = ""
     submission.save(
         update_fields=["status", "third_party_work_order", "parsed_fields", "parse_error"]
@@ -1287,7 +1287,7 @@ def _apply_location_problem_submission(
 
     location_id = parsed.get("location_id")
     if not location_id:
-        submission.status = WorkOrderSubmission.STATUS_FAILED
+        submission.status = WorkOrderSubmission.Status.FAILED
         submission.parse_error = (
             "Could not extract a Location ID from the form. "
             "Tried: AcroForm location_id, Location ID text, QR location:<id>."
@@ -1298,15 +1298,15 @@ def _apply_location_problem_submission(
     try:
         location = Location.objects.get(id=location_id)
     except Location.DoesNotExist:
-        submission.status = WorkOrderSubmission.STATUS_FAILED
+        submission.status = WorkOrderSubmission.Status.FAILED
         submission.parse_error = f"Location {location_id} not found."
         submission.save(update_fields=["status", "parse_error", "parsed_fields"])
         return submission
 
-    severity = parsed.get("severity") or LocationProblem.SEVERITY_MEDIUM
-    valid_severities = {choice for choice, _ in LocationProblem.SEVERITY_CHOICES}
+    severity = parsed.get("severity") or LocationProblem.Severity.MEDIUM
+    valid_severities = {choice for choice, _ in LocationProblem.Severity.choices}
     if severity not in valid_severities:
-        severity = LocationProblem.SEVERITY_MEDIUM
+        severity = LocationProblem.Severity.MEDIUM
 
     description = parsed.get("description") or "Reported via paper Location Problem Report"
 
@@ -1316,7 +1316,7 @@ def _apply_location_problem_submission(
             description=description,
             severity=severity,
             reported_by=submission.from_email or "",
-            status=LocationProblem.REPORTED,
+            status=LocationProblem.Status.REPORTED,
         )
         problem.paper_form_attachment.save(
             f"locprob-{problem.id}-paper.pdf",
@@ -1325,7 +1325,7 @@ def _apply_location_problem_submission(
         )
         submission.location_problem = problem
 
-    submission.status = WorkOrderSubmission.STATUS_APPLIED
+    submission.status = WorkOrderSubmission.Status.APPLIED
     submission.parse_error = ""
     submission.save(update_fields=["status", "location_problem", "parsed_fields", "parse_error"])
     return submission

--- a/backend/inventory/tasks.py
+++ b/backend/inventory/tasks.py
@@ -131,7 +131,7 @@ def update_average_lead_times():
         # For now, we'll update based on all reorders for the item
         completed_reorders = ReorderRequest.objects.filter(
             item=item_supplier.item,
-            status="received",
+            status=ReorderRequest.Status.RECEIVED,
             ordered_at__isnull=False,
             actual_delivery__isnull=False,
             ordered_at__gte=six_months_ago,

--- a/backend/inventory/tests/factories.py
+++ b/backend/inventory/tests/factories.py
@@ -46,7 +46,9 @@ class SupplierFactory(DjangoModelFactory):
         model = Supplier
 
     name = factory.Sequence(lambda n: f"supplier-{n}")
-    supplier_type = factory.Iterator([Supplier.LOCAL, Supplier.ONLINE, Supplier.NATIONAL])
+    supplier_type = factory.Iterator(
+        [Supplier.SupplierType.LOCAL, Supplier.SupplierType.ONLINE, Supplier.SupplierType.NATIONAL]
+    )
     website = Faker("url")
     notes = Faker("text", max_nb_chars=200)
 
@@ -242,7 +244,7 @@ class AssetFactory(DjangoModelFactory):
     category = SubFactory(CategoryFactory)
     location = SubFactory(LocationFactory)
     manufacturer = SubFactory(SupplierFactory)
-    status = Asset.ACTIVE
+    status = Asset.Status.ACTIVE
     is_active = True
     is_chargeable = False
 
@@ -303,14 +305,14 @@ class AssetProblemFactory(DjangoModelFactory):
     part = None  # Optional, can be set explicitly in tests
     reported_by = Faker("user_name")
     description = Faker("text", max_nb_chars=200)
-    status = AssetProblem.REPORTED
+    status = AssetProblem.Status.REPORTED
     resolution_notes = ""
 
 
 class SerializedComponentFactory(DjangoModelFactory):
     """Factory for SerializedComponent instances (consumable-mode by default).
 
-    Pass ``item__serial_tracking_mode=InventoryItem.SERIAL_TRACKING_REUSABLE``
+    Pass ``item__serial_tracking_mode=InventoryItem.SerialTrackingMode.REUSABLE``
     to build a reusable-mode component.
     """
 
@@ -320,8 +322,8 @@ class SerializedComponentFactory(DjangoModelFactory):
     item = SubFactory(
         InventoryItemFactory,
         is_serialized=True,
-        serial_tracking_mode=InventoryItem.SERIAL_TRACKING_CONSUMABLE,
+        serial_tracking_mode=InventoryItem.SerialTrackingMode.CONSUMABLE,
     )
     serial_number = factory.Sequence(lambda n: f"SN-{n:06d}")
     lot = ""
-    status = SerializedComponent.RECEIVED
+    status = SerializedComponent.Status.RECEIVED

--- a/backend/inventory/tests/test_asset_document.py
+++ b/backend/inventory/tests/test_asset_document.py
@@ -61,7 +61,7 @@ def _isolated_media(settings, tmp_path):
 def _make_document(asset, **kwargs):
     """Create an AssetDocument row directly (used to seed list/supersede setup)."""
     kwargs.setdefault("title", "Seed doc")
-    kwargs.setdefault("category", AssetDocument.MANUAL)
+    kwargs.setdefault("category", AssetDocument.Category.MANUAL)
     kwargs.setdefault("file", _make_file())
     return AssetDocument.objects.create(asset=asset, **kwargs)
 
@@ -80,7 +80,7 @@ class TestAssetDocumentUpload:
             data={
                 "asset": str(asset.id),
                 "file": _make_file(name="lathe-manual.pdf"),
-                "category": AssetDocument.MANUAL,
+                "category": AssetDocument.Category.MANUAL,
                 "title": "Lathe Manual",
                 "description": "Operator's guide",
             },
@@ -90,7 +90,7 @@ class TestAssetDocumentUpload:
         assert resp.status_code == status.HTTP_201_CREATED, resp.content
         body = resp.json()
         assert body["title"] == "Lathe Manual"
-        assert body["category"] == "manual"
+        assert body["category"] == AssetDocument.Category.MANUAL
         assert body["category_display"] == "Manual / Documentation"
         assert body["version"] == 1
         assert body["is_current"] is True
@@ -120,13 +120,13 @@ class TestAssetDocumentUpload:
                     content=b"0\nSECTION\n2\nHEADER\n",
                     content_type="application/dxf",
                 ),
-                "category": AssetDocument.CUT_READY_TEMPLATE,
+                "category": AssetDocument.Category.CUT_READY_TEMPLATE,
                 "title": "Front panel DXF",
             },
             format="multipart",
         )
         assert resp.status_code == status.HTTP_201_CREATED, resp.content
-        assert resp.json()["category"] == "cut_ready_template"
+        assert resp.json()["category"] == AssetDocument.Category.CUT_READY_TEMPLATE
 
     def test_upload_requires_title_and_file(self):
         asset = AssetFactory()
@@ -153,12 +153,12 @@ class TestAssetDocumentListFilters:
 
     def test_list_filtered_by_category(self):
         asset = AssetFactory()
-        _make_document(asset, title="Manual", category=AssetDocument.MANUAL)
-        _make_document(asset, title="Wiring", category=AssetDocument.WIRING_DIAGRAM)
+        _make_document(asset, title="Manual", category=AssetDocument.Category.MANUAL)
+        _make_document(asset, title="Wiring", category=AssetDocument.Category.WIRING_DIAGRAM)
 
         client = APIClient()
         resp = client.get(
-            LIST_URL, {"asset": str(asset.id), "category": AssetDocument.WIRING_DIAGRAM}
+            LIST_URL, {"asset": str(asset.id), "category": AssetDocument.Category.WIRING_DIAGRAM}
         )
         assert resp.status_code == status.HTTP_200_OK
         results = _results(resp)
@@ -190,7 +190,7 @@ class TestAssetDocumentSupersede:
             data={
                 "asset": str(asset.id),
                 "file": _make_file(name="v1.pdf"),
-                "category": AssetDocument.MANUAL,
+                "category": AssetDocument.Category.MANUAL,
                 "title": "Manual",
             },
             format="multipart",
@@ -210,7 +210,7 @@ class TestAssetDocumentSupersede:
         assert v2["supersedes"] == v1_id
         # Title/category inherited from the prior version when not overridden.
         assert v2["title"] == "Manual"
-        assert v2["category"] == "manual"
+        assert v2["category"] == AssetDocument.Category.MANUAL
 
         v1 = AssetDocument.objects.get(id=v1_id)
         assert v1.is_current is False
@@ -223,7 +223,7 @@ class TestAssetDocumentSupersede:
     def test_create_with_supersedes_bumps_version_and_flips(self):
         """The create endpoint also supports 'upload a new version of <doc>'."""
         asset = AssetFactory()
-        prior = _make_document(asset, title="Manual", category=AssetDocument.MANUAL)
+        prior = _make_document(asset, title="Manual", category=AssetDocument.Category.MANUAL)
         client = APIClient()
         client.force_authenticate(user=_member_user())
 
@@ -232,7 +232,7 @@ class TestAssetDocumentSupersede:
             data={
                 "asset": str(asset.id),
                 "file": _make_file(name="v2.pdf"),
-                "category": AssetDocument.MANUAL,
+                "category": AssetDocument.Category.MANUAL,
                 "title": "Manual v2",
                 "supersedes": str(prior.id),
             },
@@ -274,7 +274,7 @@ class TestAssetDocumentSupersede:
             data={
                 "asset": str(asset_a.id),
                 "file": _make_file(),
-                "category": AssetDocument.MANUAL,
+                "category": AssetDocument.Category.MANUAL,
                 "title": "cross-asset",
                 "supersedes": str(prior_b.id),
             },
@@ -303,7 +303,7 @@ class TestAssetDocumentPermissionsAndDelete:
             data={
                 "asset": str(asset.id),
                 "file": _make_file(),
-                "category": AssetDocument.MANUAL,
+                "category": AssetDocument.Category.MANUAL,
                 "title": "unauth",
             },
             format="multipart",

--- a/backend/inventory/tests/test_asset_meters.py
+++ b/backend/inventory/tests/test_asset_meters.py
@@ -50,8 +50,8 @@ def _client(user=None):
 
 def _meter(asset, **kwargs):
     kwargs.setdefault("name", "Runtime")
-    kwargs.setdefault("meter_type", AssetMeter.RUNTIME_HOURS)
-    kwargs.setdefault("source", AssetMeter.SOURCE_MANUAL)
+    kwargs.setdefault("meter_type", AssetMeter.MeterType.RUNTIME_HOURS)
+    kwargs.setdefault("source", AssetMeter.Source.MANUAL)
     kwargs.setdefault("unit", "hours")
     return AssetMeter.objects.create(asset=asset, **kwargs)
 
@@ -75,12 +75,12 @@ def _adjust_url(meter):
 class TestAssetMeterModels:
     def test_create_meter_defaults(self):
         asset = AssetFactory()
-        meter = _meter(asset, name="Spindle", meter_type=AssetMeter.RUNTIME_HOURS)
+        meter = _meter(asset, name="Spindle", meter_type=AssetMeter.MeterType.RUNTIME_HOURS)
         assert meter.current_value == Decimal("0")
         assert meter.current_is_estimated is False
         assert meter.rollup_watermark_at is None
         assert meter.is_active is True
-        assert meter.source == AssetMeter.SOURCE_MANUAL
+        assert meter.source == AssetMeter.Source.MANUAL
 
     def test_unique_together_asset_name(self):
         asset = AssetFactory()
@@ -101,7 +101,7 @@ class TestAssetMeterModels:
         apply_reading(
             meter,
             ReadingSpec(
-                source=AssetMeterReading.SOURCE_MANUAL,
+                source=AssetMeterReading.Source.MANUAL,
                 observed_at=timezone.now(),
                 absolute=Decimal("5"),
             ),
@@ -109,7 +109,7 @@ class TestAssetMeterModels:
         apply_reading(
             meter,
             ReadingSpec(
-                source=AssetMeterReading.SOURCE_MANUAL,
+                source=AssetMeterReading.Source.MANUAL,
                 observed_at=timezone.now(),
                 delta=Decimal("3"),
             ),
@@ -124,11 +124,11 @@ class TestAssetMeterModels:
 class TestApplyReading:
     def test_absolute_reading_sets_value_and_delta(self):
         asset = AssetFactory()
-        meter = _meter(asset, meter_type=AssetMeter.VOLUME_GALLONS, unit="gallons")
+        meter = _meter(asset, meter_type=AssetMeter.MeterType.VOLUME_GALLONS, unit="gallons")
         reading = apply_reading(
             meter,
             ReadingSpec(
-                source=AssetMeterReading.SOURCE_MANUAL,
+                source=AssetMeterReading.Source.MANUAL,
                 observed_at=timezone.now(),
                 absolute=Decimal("100"),
             ),
@@ -140,13 +140,13 @@ class TestApplyReading:
 
     def test_delta_reading_adds_to_current(self):
         asset = AssetFactory()
-        meter = _meter(asset, meter_type=AssetMeter.VOLUME_GALLONS, unit="gallons")
+        meter = _meter(asset, meter_type=AssetMeter.MeterType.VOLUME_GALLONS, unit="gallons")
         meter.current_value = Decimal("100")
         meter.save(update_fields=["current_value"])
         reading = apply_reading(
             meter,
             ReadingSpec(
-                source=AssetMeterReading.SOURCE_MANUAL,
+                source=AssetMeterReading.Source.MANUAL,
                 observed_at=timezone.now(),
                 delta=Decimal("25"),
             ),
@@ -157,11 +157,11 @@ class TestApplyReading:
 
     def test_absolute_then_delta_compose(self):
         asset = AssetFactory()
-        meter = _meter(asset, meter_type=AssetMeter.CYCLES, unit="cycles")
+        meter = _meter(asset, meter_type=AssetMeter.MeterType.CYCLES, unit="cycles")
         apply_reading(
             meter,
             ReadingSpec(
-                source=AssetMeterReading.SOURCE_MANUAL,
+                source=AssetMeterReading.Source.MANUAL,
                 observed_at=timezone.now(),
                 absolute=Decimal("40"),
             ),
@@ -169,7 +169,7 @@ class TestApplyReading:
         r2 = apply_reading(
             meter,
             ReadingSpec(
-                source=AssetMeterReading.SOURCE_MANUAL,
+                source=AssetMeterReading.Source.MANUAL,
                 observed_at=timezone.now(),
                 delta=Decimal("-10"),
             ),
@@ -179,11 +179,11 @@ class TestApplyReading:
 
     def test_estimated_flag_propagates_to_meter(self):
         asset = AssetFactory()
-        meter = _meter(asset, meter_type=AssetMeter.VOLUME_GALLONS, unit="gallons")
+        meter = _meter(asset, meter_type=AssetMeter.MeterType.VOLUME_GALLONS, unit="gallons")
         apply_reading(
             meter,
             ReadingSpec(
-                source=AssetMeterReading.SOURCE_MANUAL,
+                source=AssetMeterReading.Source.MANUAL,
                 observed_at=timezone.now(),
                 absolute=Decimal("12"),
                 is_estimated=True,
@@ -194,10 +194,10 @@ class TestApplyReading:
 
     def test_spec_requires_exactly_one_of_delta_absolute(self):
         with pytest.raises(ValueError):
-            ReadingSpec(source="manual", observed_at=timezone.now())
+            ReadingSpec(source=AssetMeterReading.Source.MANUAL, observed_at=timezone.now())
         with pytest.raises(ValueError):
             ReadingSpec(
-                source="manual",
+                source=AssetMeterReading.Source.MANUAL,
                 observed_at=timezone.now(),
                 delta=Decimal("1"),
                 absolute=Decimal("1"),
@@ -210,7 +210,7 @@ class TestApplyReading:
 class TestSessionRuntimeRollup:
     def test_sums_ended_sessions_into_hours(self):
         asset = AssetFactory(hours_used=0)
-        meter = _meter(asset, source=AssetMeter.SOURCE_AUTO_SESSION)
+        meter = _meter(asset, source=AssetMeter.Source.AUTO_SESSION)
         now = timezone.now()
         _ended_session(asset, 3600, now - timedelta(minutes=30))  # 1.0h
         _ended_session(asset, 1800, now - timedelta(minutes=10))  # 0.5h
@@ -222,14 +222,14 @@ class TestSessionRuntimeRollup:
         readings = meter.readings.all()
         assert readings.count() == 1
         reading = readings.first()
-        assert reading.source == AssetMeterReading.SOURCE_AUTO_SESSION
+        assert reading.source == AssetMeterReading.Source.AUTO_SESSION
         assert reading.is_estimated is False
         assert reading.delta == Decimal("1.5000")
         assert "device_usage x2" in reading.source_ref
 
     def test_ignores_in_flight_sessions(self):
         asset = AssetFactory()
-        meter = _meter(asset, source=AssetMeter.SOURCE_AUTO_SESSION)
+        meter = _meter(asset, source=AssetMeter.Source.AUTO_SESSION)
         now = timezone.now()
         _ended_session(asset, 3600, now - timedelta(minutes=5))
         # In-flight: ended_at + duration not set (as before end_session()).
@@ -242,7 +242,7 @@ class TestSessionRuntimeRollup:
 
     def test_watermark_advances_to_latest_ended(self):
         asset = AssetFactory()
-        meter = _meter(asset, source=AssetMeter.SOURCE_AUTO_SESSION)
+        meter = _meter(asset, source=AssetMeter.Source.AUTO_SESSION)
         now = timezone.now()
         latest = now - timedelta(minutes=1)
         _ended_session(asset, 600, now - timedelta(minutes=20))
@@ -255,7 +255,7 @@ class TestSessionRuntimeRollup:
 
     def test_rollup_is_idempotent(self):
         asset = AssetFactory(hours_used=0)
-        meter = _meter(asset, source=AssetMeter.SOURCE_AUTO_SESSION)
+        meter = _meter(asset, source=AssetMeter.Source.AUTO_SESSION)
         now = timezone.now()
         _ended_session(asset, 7200, now - timedelta(minutes=15))  # 2.0h
 
@@ -270,7 +270,7 @@ class TestSessionRuntimeRollup:
 
     def test_only_new_sessions_after_watermark_are_counted(self):
         asset = AssetFactory()
-        meter = _meter(asset, source=AssetMeter.SOURCE_AUTO_SESSION)
+        meter = _meter(asset, source=AssetMeter.Source.AUTO_SESSION)
         now = timezone.now()
         _ended_session(asset, 3600, now - timedelta(minutes=30))
         run_rollup(now)
@@ -287,7 +287,7 @@ class TestSessionRuntimeRollup:
 
     def test_no_sessions_writes_no_reading(self):
         asset = AssetFactory()
-        meter = _meter(asset, source=AssetMeter.SOURCE_AUTO_SESSION)
+        meter = _meter(asset, source=AssetMeter.Source.AUTO_SESSION)
         run_rollup(timezone.now())
         meter.refresh_from_db()
         assert meter.readings.count() == 0
@@ -297,8 +297,8 @@ class TestSessionRuntimeRollup:
         asset = AssetFactory(hours_used=10)
         _meter(
             asset,
-            source=AssetMeter.SOURCE_AUTO_SESSION,
-            meter_type=AssetMeter.RUNTIME_HOURS,
+            source=AssetMeter.Source.AUTO_SESSION,
+            meter_type=AssetMeter.MeterType.RUNTIME_HOURS,
         )
         now = timezone.now()
         _ended_session(asset, 7200, now - timedelta(minutes=5))  # 2.0h
@@ -312,8 +312,8 @@ class TestSessionRuntimeRollup:
         asset = AssetFactory(hours_used=5)
         _meter(
             asset,
-            source=AssetMeter.SOURCE_AUTO_SESSION,
-            meter_type=AssetMeter.VOLUME_GALLONS,
+            source=AssetMeter.Source.AUTO_SESSION,
+            meter_type=AssetMeter.MeterType.VOLUME_GALLONS,
             unit="gallons",
         )
         # A gallons meter should never touch hours_used, even from a session.
@@ -325,7 +325,7 @@ class TestSessionRuntimeRollup:
         # A sub-second session ends with duration_seconds=0. It adds nothing but
         # must still advance the watermark so it isn't rescanned forever.
         asset = AssetFactory(hours_used=0)
-        meter = _meter(asset, source=AssetMeter.SOURCE_AUTO_SESSION)
+        meter = _meter(asset, source=AssetMeter.Source.AUTO_SESSION)
         ended = timezone.now() - timedelta(minutes=1)
         _ended_session(asset, 0, ended)
 
@@ -346,7 +346,7 @@ class TestSessionRuntimeRollup:
 class TestRunRollupDispatch:
     def test_skips_inactive_meters(self):
         asset = AssetFactory()
-        meter = _meter(asset, source=AssetMeter.SOURCE_AUTO_SESSION, is_active=False)
+        meter = _meter(asset, source=AssetMeter.Source.AUTO_SESSION, is_active=False)
         _ended_session(asset, 3600, timezone.now())
         run_rollup(timezone.now())
         meter.refresh_from_db()
@@ -355,8 +355,8 @@ class TestRunRollupDispatch:
 
     def test_manual_and_telemetry_are_push_no_ops(self):
         asset = AssetFactory()
-        manual = _meter(asset, name="Manual", source=AssetMeter.SOURCE_MANUAL)
-        telem = _meter(asset, name="Telemetry", source=AssetMeter.SOURCE_AUTO_TELEMETRY)
+        manual = _meter(asset, name="Manual", source=AssetMeter.Source.MANUAL)
+        telem = _meter(asset, name="Telemetry", source=AssetMeter.Source.AUTO_TELEMETRY)
         # Sessions exist, but only auto_session pulls them.
         _ended_session(asset, 3600, timezone.now())
 
@@ -388,7 +388,7 @@ class TestManualEntryAPI:
 
     def test_record_reading_absolute(self):
         asset = AssetFactory()
-        meter = _meter(asset, meter_type=AssetMeter.VOLUME_GALLONS, unit="gallons")
+        meter = _meter(asset, meter_type=AssetMeter.MeterType.VOLUME_GALLONS, unit="gallons")
         resp = self.client.post(
             _record_url(meter),
             data={"value": 500, "is_absolute": True},
@@ -397,14 +397,14 @@ class TestManualEntryAPI:
         assert resp.status_code == 201
         body = resp.json()
         assert Decimal(body["meter"]["current_value"]) == Decimal("500")
-        assert body["reading"]["source"] == AssetMeterReading.SOURCE_MANUAL
+        assert body["reading"]["source"] == AssetMeterReading.Source.MANUAL
         meter.refresh_from_db()
         assert meter.current_value == Decimal("500")
         assert meter.readings.first().recorded_by == self.staff
 
     def test_record_reading_delta(self):
         asset = AssetFactory()
-        meter = _meter(asset, meter_type=AssetMeter.VOLUME_GALLONS, unit="gallons")
+        meter = _meter(asset, meter_type=AssetMeter.MeterType.VOLUME_GALLONS, unit="gallons")
         meter.current_value = Decimal("500")
         meter.save(update_fields=["current_value"])
         resp = self.client.post(
@@ -417,7 +417,7 @@ class TestManualEntryAPI:
 
     def test_record_reading_estimated(self):
         asset = AssetFactory()
-        meter = _meter(asset, meter_type=AssetMeter.VOLUME_GALLONS, unit="gallons")
+        meter = _meter(asset, meter_type=AssetMeter.MeterType.VOLUME_GALLONS, unit="gallons")
         resp = self.client.post(
             _record_url(meter),
             data={"value": 42, "is_absolute": True, "is_estimated": True},
@@ -436,7 +436,7 @@ class TestManualEntryAPI:
 
     def test_record_reading_on_runtime_meter_dual_writes(self):
         asset = AssetFactory(hours_used=0)
-        meter = _meter(asset, meter_type=AssetMeter.RUNTIME_HOURS, unit="hours")
+        meter = _meter(asset, meter_type=AssetMeter.MeterType.RUNTIME_HOURS, unit="hours")
         resp = self.client.post(
             _record_url(meter),
             data={"value": 8, "is_absolute": True},
@@ -448,7 +448,7 @@ class TestManualEntryAPI:
 
     def test_adjust_sets_target_with_reason(self):
         asset = AssetFactory()
-        meter = _meter(asset, meter_type=AssetMeter.VOLUME_GALLONS, unit="gallons")
+        meter = _meter(asset, meter_type=AssetMeter.MeterType.VOLUME_GALLONS, unit="gallons")
         meter.current_value = Decimal("100")
         meter.save(update_fields=["current_value"])
         resp = self.client.post(
@@ -459,7 +459,7 @@ class TestManualEntryAPI:
         assert resp.status_code == 201
         body = resp.json()
         assert Decimal(body["meter"]["current_value"]) == Decimal("90")
-        assert body["reading"]["source"] == AssetMeterReading.SOURCE_MANUAL_ADJUST
+        assert body["reading"]["source"] == AssetMeterReading.Source.MANUAL_ADJUST
         assert body["reading"]["notes"] == "physical recount"
         assert Decimal(body["reading"]["delta"]) == Decimal("-10")
 
@@ -520,7 +520,7 @@ class TestMeterPermissions:
 
     def test_meter_create_requires_staff(self):
         asset = AssetFactory()
-        payload = {"asset": str(asset.id), "name": "New", "meter_type": "cycles"}
+        payload = {"asset": str(asset.id), "name": "New", "meter_type": AssetMeter.MeterType.CYCLES}
         assert (
             _client(_user("vol3"))
             .post("/api/inventory/asset-meters/", data=payload, format="json")
@@ -539,7 +539,7 @@ class TestMeterPermissions:
         apply_reading(
             meter,
             ReadingSpec(
-                source=AssetMeterReading.SOURCE_MANUAL,
+                source=AssetMeterReading.Source.MANUAL,
                 observed_at=timezone.now(),
                 absolute=Decimal("1"),
             ),
@@ -557,7 +557,7 @@ class TestMeterPermissions:
 class TestAssetDetailEmbedsMeters:
     def test_asset_detail_includes_meters(self):
         asset = AssetFactory()
-        _meter(asset, name="Runtime", meter_type=AssetMeter.RUNTIME_HOURS, unit="hours")
+        _meter(asset, name="Runtime", meter_type=AssetMeter.MeterType.RUNTIME_HOURS, unit="hours")
         resp = _client(_user("viewer")).get(f"/api/inventory/assets/{asset.id}/")
         assert resp.status_code == 200
         meters = resp.json()["meters"]

--- a/backend/inventory/tests/test_asset_power_tracking.py
+++ b/backend/inventory/tests/test_asset_power_tracking.py
@@ -42,10 +42,10 @@ class TestAssetPowerFields:
         asset = AssetFactory()
         asset.refresh_from_db()
         assert asset.power_draw_watts is None
-        assert asset.wiring_type == Asset.WIRING_UNKNOWN
+        assert asset.wiring_type == Asset.WiringType.UNKNOWN
         assert asset.has_interlock is False
-        assert asset.interlock_type == Asset.INTERLOCK_UNKNOWN
-        assert asset.lockout_type == Asset.LOCKOUT_UNKNOWN
+        assert asset.interlock_type == Asset.InterlockType.UNKNOWN
+        assert asset.lockout_type == Asset.LockoutType.UNKNOWN
         assert asset.has_network_drop is False
         assert asset.suite == ""
         assert asset.electrical_box == ""
@@ -58,14 +58,14 @@ class TestAssetPowerFields:
     def test_full_power_record_persists(self):
         asset = AssetFactory(
             power_draw_watts=Decimal("1800.00"),
-            wiring_type=Asset.WIRING_240V_PLUG,
+            wiring_type=Asset.WiringType.PLUG_240V,
             suite="North Bay",
             electrical_box="Panel A",
             breaker_location="A-12",
             has_interlock=True,
-            interlock_type=Asset.INTERLOCK_KEY_SWITCH,
+            interlock_type=Asset.InterlockType.KEY_SWITCH,
             interlock_responsible="Wood Shop SIG Lead",
-            lockout_type=Asset.LOCKOUT_BREAKER,
+            lockout_type=Asset.LockoutType.BREAKER,
             lockout_instructions="1. Open panel A. 2. Throw breaker A-12. 3. Apply LOTO tag.",
             lockout_responsible="Logistics on duty",
             has_network_drop=True,
@@ -74,7 +74,7 @@ class TestAssetPowerFields:
         asset.full_clean()
         asset.refresh_from_db()
         assert asset.power_draw_watts == Decimal("1800.00")
-        assert asset.wiring_type == Asset.WIRING_240V_PLUG
+        assert asset.wiring_type == Asset.WiringType.PLUG_240V
         assert asset.has_interlock is True
         assert asset.interlock_responsible == "Wood Shop SIG Lead"
         assert asset.lockout_instructions.startswith("1. Open panel A.")
@@ -90,25 +90,25 @@ class TestAssetPowerSerializer:
     def test_serializer_round_trips_power_fields(self):
         asset = AssetFactory(
             power_draw_watts=Decimal("750.50"),
-            wiring_type=Asset.WIRING_120V_PLUG,
+            wiring_type=Asset.WiringType.PLUG_120V,
             suite="Suite 200",
             electrical_box="Sub-panel B",
             breaker_location="B-7",
             has_interlock=True,
-            interlock_type=Asset.INTERLOCK_E_STOP,
-            lockout_type=Asset.LOCKOUT_PLUG,
+            interlock_type=Asset.InterlockType.E_STOP,
+            lockout_type=Asset.LockoutType.PLUG,
             lockout_instructions="Unplug at outlet O-14, apply plug lockout, tag.",
             has_network_drop=False,
         )
         data = AssetSerializer(asset).data
         assert Decimal(str(data["power_draw_watts"])) == Decimal("750.50")
-        assert data["wiring_type"] == Asset.WIRING_120V_PLUG
+        assert data["wiring_type"] == Asset.WiringType.PLUG_120V
         assert data["suite"] == "Suite 200"
         assert data["electrical_box"] == "Sub-panel B"
         assert data["breaker_location"] == "B-7"
         assert data["has_interlock"] is True
-        assert data["interlock_type"] == Asset.INTERLOCK_E_STOP
-        assert data["lockout_type"] == Asset.LOCKOUT_PLUG
+        assert data["interlock_type"] == Asset.InterlockType.E_STOP
+        assert data["lockout_type"] == Asset.LockoutType.PLUG
         assert "Unplug at outlet O-14" in data["lockout_instructions"]
         assert data["has_network_drop"] is False
         assert data["is_forgekey_managed"] is False
@@ -118,12 +118,12 @@ class TestAssetPowerSerializer:
         payload = {
             "name": asset.name,
             "power_draw_watts": "1200.00",
-            "wiring_type": Asset.WIRING_HARDWIRED,
+            "wiring_type": Asset.WiringType.HARDWIRED,
             "suite": "Main Floor",
             "breaker_location": "Main-3",
             "has_interlock": True,
-            "interlock_type": Asset.INTERLOCK_CONTACTOR,
-            "lockout_type": Asset.LOCKOUT_LOTO,
+            "interlock_type": Asset.InterlockType.CONTACTOR,
+            "lockout_type": Asset.LockoutType.LOTO,
             "lockout_instructions": "LOTO at main breaker.",
         }
         serializer = AssetSerializer(asset, data=payload, partial=True)
@@ -131,9 +131,9 @@ class TestAssetPowerSerializer:
         serializer.save()
         asset.refresh_from_db()
         assert asset.power_draw_watts == Decimal("1200.00")
-        assert asset.wiring_type == Asset.WIRING_HARDWIRED
+        assert asset.wiring_type == Asset.WiringType.HARDWIRED
         assert asset.suite == "Main Floor"
-        assert asset.lockout_type == Asset.LOCKOUT_LOTO
+        assert asset.lockout_type == Asset.LockoutType.LOTO
         assert asset.has_interlock is True
 
 
@@ -144,11 +144,11 @@ class TestAssetPowerSerializer:
 
 class TestIsForgekeyManaged:
     def test_explicit_interlock_type_marks_managed(self):
-        asset = AssetFactory(interlock_type=Asset.INTERLOCK_FORGEKEY)
+        asset = AssetFactory(interlock_type=Asset.InterlockType.FORGEKEY)
         assert asset.is_forgekey_managed is True
 
     def test_explicit_lockout_type_marks_managed(self):
-        asset = AssetFactory(lockout_type=Asset.LOCKOUT_FORGEKEY)
+        asset = AssetFactory(lockout_type=Asset.LockoutType.FORGEKEY)
         assert asset.is_forgekey_managed is True
 
     def test_unmanaged_asset_returns_false(self):
@@ -185,14 +185,14 @@ class TestElectricalRowsHelper:
 
     def test_rows_include_breaker_and_lockout(self):
         asset = AssetFactory(
-            wiring_type=Asset.WIRING_240V_PLUG,
+            wiring_type=Asset.WiringType.PLUG_240V,
             power_draw_watts=Decimal("3000"),
             suite="North Bay",
             electrical_box="Panel A",
             breaker_location="A-12",
             has_interlock=True,
-            interlock_type=Asset.INTERLOCK_KEY_SWITCH,
-            lockout_type=Asset.LOCKOUT_BREAKER,
+            interlock_type=Asset.InterlockType.KEY_SWITCH,
+            lockout_type=Asset.LockoutType.BREAKER,
             lockout_responsible="Logistics",
         )
         rows = _build_electrical_rows(asset)
@@ -213,7 +213,7 @@ class TestElectricalRowsHelper:
         # "Circuit" row.
         from electrical_circuits.models import PowerBreaker, PowerPanel
 
-        asset = AssetFactory(wiring_type=Asset.WIRING_120V_PLUG)
+        asset = AssetFactory(wiring_type=Asset.WiringType.PLUG_120V)
         panel = PowerPanel.objects.create(location=asset.location, name="Panel Z")
         breaker = PowerBreaker.objects.create(panel=panel, position="7", amperage=15)
         # Write-through the compat setter; no breaker_location is set.
@@ -267,11 +267,11 @@ class TestWorkOrderPdfElectricalSection:
         asset = AssetFactory(
             name="CNC Router",
             power_draw_watts=Decimal("2400"),
-            wiring_type=Asset.WIRING_240V_PLUG,
+            wiring_type=Asset.WiringType.PLUG_240V,
             suite="North Bay",
             electrical_box="Panel A",
             breaker_location="A-12",
-            lockout_type=Asset.LOCKOUT_BREAKER,
+            lockout_type=Asset.LockoutType.BREAKER,
             lockout_instructions="LOTO breaker A-12 before service.",
             lockout_responsible="Wood Shop SIG Lead",
         )
@@ -287,10 +287,10 @@ class TestWorkOrderPdfElectricalSection:
     def test_pdf_marks_forgekey_managed_assets(self):
         asset = AssetFactory(
             name="Laser Cutter",
-            wiring_type=Asset.WIRING_240V_PLUG,
+            wiring_type=Asset.WiringType.PLUG_240V,
             breaker_location="B-3",
-            interlock_type=Asset.INTERLOCK_FORGEKEY,
-            lockout_type=Asset.LOCKOUT_FORGEKEY,
+            interlock_type=Asset.InterlockType.FORGEKEY,
+            lockout_type=Asset.LockoutType.FORGEKEY,
         )
         wo = _make_work_order(asset)
         text = _pdf_text(generate_work_order_pdf(wo, base_url="http://example.com"))
@@ -299,12 +299,12 @@ class TestWorkOrderPdfElectricalSection:
     def test_pdf_marks_non_forgekey_asset_with_responsible_party(self):
         asset = AssetFactory(
             name="Old Drill Press",
-            wiring_type=Asset.WIRING_120V_PLUG,
+            wiring_type=Asset.WiringType.PLUG_120V,
             breaker_location="C-7",
             has_interlock=True,
-            interlock_type=Asset.INTERLOCK_KEY_SWITCH,
+            interlock_type=Asset.InterlockType.KEY_SWITCH,
             interlock_responsible="Metal Shop SIG",
-            lockout_type=Asset.LOCKOUT_PLUG,
+            lockout_type=Asset.LockoutType.PLUG,
             lockout_responsible="Metal Shop SIG",
         )
         wo = _make_work_order(asset)

--- a/backend/inventory/tests/test_asset_problem_filter.py
+++ b/backend/inventory/tests/test_asset_problem_filter.py
@@ -48,10 +48,10 @@ class TestAssetProblemFiltering:
     def test_filter_by_status(self):
         """``?status=`` narrows to problems in that status."""
         asset = AssetFactory()
-        reported = AssetProblemFactory(asset=asset, status=AssetProblem.REPORTED)
-        resolved = AssetProblemFactory(asset=asset, status=AssetProblem.RESOLVED)
+        reported = AssetProblemFactory(asset=asset, status=AssetProblem.Status.REPORTED)
+        resolved = AssetProblemFactory(asset=asset, status=AssetProblem.Status.RESOLVED)
 
-        resp = APIClient().get(LIST_URL, {"status": AssetProblem.RESOLVED})
+        resp = APIClient().get(LIST_URL, {"status": AssetProblem.Status.RESOLVED})
 
         ids = _ids(resp)
         assert str(resolved.id) in ids
@@ -74,12 +74,12 @@ class TestAssetProblemFiltering:
         """Filters combine: ``?asset=A&status=reported`` intersects both."""
         asset_a = AssetFactory()
         asset_b = AssetFactory()
-        target = AssetProblemFactory(asset=asset_a, status=AssetProblem.REPORTED)
-        AssetProblemFactory(asset=asset_a, status=AssetProblem.RESOLVED)
-        AssetProblemFactory(asset=asset_b, status=AssetProblem.REPORTED)
+        target = AssetProblemFactory(asset=asset_a, status=AssetProblem.Status.REPORTED)
+        AssetProblemFactory(asset=asset_a, status=AssetProblem.Status.RESOLVED)
+        AssetProblemFactory(asset=asset_b, status=AssetProblem.Status.REPORTED)
 
         resp = APIClient().get(
-            LIST_URL, {"asset": str(asset_a.id), "status": AssetProblem.REPORTED}
+            LIST_URL, {"asset": str(asset_a.id), "status": AssetProblem.Status.REPORTED}
         )
 
         ids = _ids(resp)

--- a/backend/inventory/tests/test_audit_events.py
+++ b/backend/inventory/tests/test_audit_events.py
@@ -47,7 +47,7 @@ def _maintenance_item():
     )
 
 
-def _work_order(*, status: str = WorkOrder.STATUS_OPEN, notes: str = "") -> WorkOrder:
+def _work_order(*, status: str = WorkOrder.Status.OPEN, notes: str = "") -> WorkOrder:
     item = _maintenance_item()
     return WorkOrder.objects.create(
         maintenance_item=item,
@@ -85,7 +85,7 @@ def test_wo_create_records_audit_event():
     assert response.status_code == status.HTTP_201_CREATED, response.content
 
     work_order = WorkOrder.objects.get(pk=response.json()["id"])
-    event = MaintenanceAuditEvent.objects.get(action=MaintenanceAuditEvent.ACTION_WO_CREATE)
+    event = MaintenanceAuditEvent.objects.get(action=MaintenanceAuditEvent.Action.WO_CREATE)
     assert event.actor == user
     assert event.work_order == work_order
     assert event.location_problem is None
@@ -95,21 +95,21 @@ def test_wo_create_records_audit_event():
 def test_wo_complete_records_audit_event_on_status_transition():
     user = _staff_user("wo-complete-user")
     client = _api_client(user)
-    work_order = _work_order(status=WorkOrder.STATUS_OPEN)
+    work_order = _work_order(status=WorkOrder.Status.OPEN)
     _complete_validation(work_order, user)
 
     response = client.patch(
         reverse("workorder-detail", kwargs={"pk": work_order.pk}),
-        {"status": WorkOrder.STATUS_COMPLETED},
+        {"status": WorkOrder.Status.COMPLETED},
         format="json",
     )
 
     assert response.status_code == status.HTTP_200_OK, response.content
 
-    event = MaintenanceAuditEvent.objects.get(action=MaintenanceAuditEvent.ACTION_WO_COMPLETE)
+    event = MaintenanceAuditEvent.objects.get(action=MaintenanceAuditEvent.Action.WO_COMPLETE)
     assert event.actor == user
     assert event.work_order == work_order
-    assert event.metadata["previous_status"] == WorkOrder.STATUS_OPEN
+    assert event.metadata["previous_status"] == WorkOrder.Status.OPEN
 
 
 def test_wo_update_without_status_change_no_complete_audit():
@@ -126,7 +126,7 @@ def test_wo_update_without_status_change_no_complete_audit():
     assert response.status_code == status.HTTP_200_OK, response.content
     assert (
         MaintenanceAuditEvent.objects.filter(
-            action=MaintenanceAuditEvent.ACTION_WO_COMPLETE,
+            action=MaintenanceAuditEvent.Action.WO_COMPLETE,
             work_order=work_order,
         ).count()
         == 0
@@ -136,18 +136,18 @@ def test_wo_update_without_status_change_no_complete_audit():
 def test_wo_already_completed_update_no_duplicate_audit():
     user = _staff_user("wo-completed-user")
     client = _api_client(user)
-    work_order = _work_order(status=WorkOrder.STATUS_COMPLETED)
+    work_order = _work_order(status=WorkOrder.Status.COMPLETED)
 
     response = client.patch(
         reverse("workorder-detail", kwargs={"pk": work_order.pk}),
-        {"status": WorkOrder.STATUS_COMPLETED},
+        {"status": WorkOrder.Status.COMPLETED},
         format="json",
     )
 
     assert response.status_code == status.HTTP_200_OK, response.content
     assert (
         MaintenanceAuditEvent.objects.filter(
-            action=MaintenanceAuditEvent.ACTION_WO_COMPLETE,
+            action=MaintenanceAuditEvent.Action.WO_COMPLETE,
             work_order=work_order,
         ).count()
         == 0
@@ -161,8 +161,8 @@ def test_location_problem_resolve_records_audit_event():
     problem = LocationProblem.objects.create(
         location=location,
         description="Standing water by the sink",
-        severity=LocationProblem.SEVERITY_HIGH,
-        status=LocationProblem.REPORTED,
+        severity=LocationProblem.Severity.HIGH,
+        status=LocationProblem.Status.REPORTED,
     )
 
     response = client.post(
@@ -174,15 +174,15 @@ def test_location_problem_resolve_records_audit_event():
     assert response.status_code == status.HTTP_200_OK, response.content
 
     problem.refresh_from_db()
-    assert problem.status == LocationProblem.RESOLVED
+    assert problem.status == LocationProblem.Status.RESOLVED
 
     event = MaintenanceAuditEvent.objects.get(
-        action=MaintenanceAuditEvent.ACTION_LOCATION_PROBLEM_RESOLVE
+        action=MaintenanceAuditEvent.Action.LOCATION_PROBLEM_RESOLVE
     )
     assert event.actor == user
     assert event.location_problem == problem
     assert event.notes == "swept and dried"
-    assert event.metadata["new_status"] == LocationProblem.RESOLVED
+    assert event.metadata["new_status"] == LocationProblem.Status.RESOLVED
     assert event.metadata["severity"] == problem.severity
 
 
@@ -192,7 +192,7 @@ def test_location_problem_resolve_invalid_status_no_audit():
     problem = LocationProblem.objects.create(
         location=LocationFactory(),
         description="Broken latch",
-        status=LocationProblem.REPORTED,
+        status=LocationProblem.Status.REPORTED,
     )
 
     response = client.post(
@@ -204,7 +204,7 @@ def test_location_problem_resolve_invalid_status_no_audit():
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
         MaintenanceAuditEvent.objects.filter(
-            action=MaintenanceAuditEvent.ACTION_LOCATION_PROBLEM_RESOLVE,
+            action=MaintenanceAuditEvent.Action.LOCATION_PROBLEM_RESOLVE,
             location_problem=problem,
         ).count()
         == 0
@@ -215,7 +215,7 @@ def test_record_event_with_anonymous_actor_creates_row_with_null_actor():
     work_order = _work_order()
 
     event = record_event(
-        action=MaintenanceAuditEvent.ACTION_WO_CREATE,
+        action=MaintenanceAuditEvent.Action.WO_CREATE,
         actor=None,
         work_order=work_order,
     )
@@ -228,7 +228,7 @@ def test_record_event_accepts_either_entity_only():
     work_order = _work_order()
 
     event = record_event(
-        action=MaintenanceAuditEvent.ACTION_WO_CREATE,
+        action=MaintenanceAuditEvent.Action.WO_CREATE,
         work_order=work_order,
     )
 

--- a/backend/inventory/tests/test_component_forecast.py
+++ b/backend/inventory/tests/test_component_forecast.py
@@ -74,20 +74,20 @@ class TestBuildComponentForecast:
         installed unit stays *on hand* (physically present) but is no longer
         *available* to install; the depletion rate ignores receive/install."""
         now = timezone.now()
-        item = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=0)
+        item = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=0)
 
         # On hand: 6 on the shelf + 1 installed (not yet consumed) = 7.
-        _components(item, SerializedComponent.IN_STOCK, 6, "stock")
-        installed = _components(item, SerializedComponent.INSTALLED, 1, "inst")
+        _components(item, SerializedComponent.Status.IN_STOCK, 6, "stock")
+        installed = _components(item, SerializedComponent.Status.INSTALLED, 1, "inst")
 
         # Depleted: 4 consumed units, each with a consume event inside the window.
-        consumed = _components(item, SerializedComponent.CONSUMED, 4, "used")
+        consumed = _components(item, SerializedComponent.Status.CONSUMED, 4, "used")
         for i, comp in enumerate(consumed):
-            _event(comp, SerializedComponent.ACTION_CONSUME, days_ago=i + 1, now=now)
+            _event(comp, SerializedComponent.Action.CONSUME, days_ago=i + 1, now=now)
 
         # Noise the rate must ignore: receive/install events in the window.
-        _event(installed[0], SerializedComponent.ACTION_RECEIVE, days_ago=3, now=now)
-        _event(installed[0], SerializedComponent.ACTION_INSTALL, days_ago=2, now=now)
+        _event(installed[0], SerializedComponent.Action.RECEIVE, days_ago=3, now=now)
+        _event(installed[0], SerializedComponent.Action.INSTALL, days_ago=2, now=now)
 
         row = _row_for(build_component_forecast(now=now), item)
 
@@ -103,22 +103,22 @@ class TestBuildComponentForecast:
         does. Installed and removed units are both *on hand*, but only removed
         (and in-stock) units are *available* — installed ones are not."""
         now = timezone.now()
-        item = _serialized_item(InventoryItem.SERIAL_TRACKING_REUSABLE, minimum_stock=0)
+        item = _serialized_item(InventoryItem.SerialTrackingMode.REUSABLE, minimum_stock=0)
 
         # On hand: 5 in stock + 2 installed + 1 removed = 8 (reuse states count).
-        in_stock = _components(item, SerializedComponent.IN_STOCK, 5, "stock")
-        installed = _components(item, SerializedComponent.INSTALLED, 2, "inst")
-        removed = _components(item, SerializedComponent.REMOVED, 1, "rem")
+        in_stock = _components(item, SerializedComponent.Status.IN_STOCK, 5, "stock")
+        installed = _components(item, SerializedComponent.Status.INSTALLED, 2, "inst")
+        removed = _components(item, SerializedComponent.Status.REMOVED, 1, "rem")
 
         # Depleted: 3 retired units with retire events in the window.
-        retired = _components(item, SerializedComponent.RETIRED, 3, "ret")
+        retired = _components(item, SerializedComponent.Status.RETIRED, 3, "ret")
         for i, comp in enumerate(retired):
-            _event(comp, SerializedComponent.ACTION_RETIRE, days_ago=i + 1, now=now)
+            _event(comp, SerializedComponent.Action.RETIRE, days_ago=i + 1, now=now)
 
         # Reuse-cycle noise that must NOT be counted as depletion.
-        _event(installed[0], SerializedComponent.ACTION_INSTALL, days_ago=4, now=now)
-        _event(removed[0], SerializedComponent.ACTION_REMOVE, days_ago=3, now=now)
-        _event(in_stock[0], SerializedComponent.ACTION_RECEIVE, days_ago=2, now=now)
+        _event(installed[0], SerializedComponent.Action.INSTALL, days_ago=4, now=now)
+        _event(removed[0], SerializedComponent.Action.REMOVE, days_ago=3, now=now)
+        _event(in_stock[0], SerializedComponent.Action.RECEIVE, days_ago=2, now=now)
 
         row = _row_for(build_component_forecast(now=now), item)
 
@@ -133,17 +133,17 @@ class TestBuildComponentForecast:
         """A reusable unit retired *and* disposed inside the window is one
         depletion, not two."""
         now = timezone.now()
-        item = _serialized_item(InventoryItem.SERIAL_TRACKING_REUSABLE, minimum_stock=0)
-        _components(item, SerializedComponent.IN_STOCK, 2, "stock")
+        item = _serialized_item(InventoryItem.SerialTrackingMode.REUSABLE, minimum_stock=0)
+        _components(item, SerializedComponent.Status.IN_STOCK, 2, "stock")
 
-        retired = _components(item, SerializedComponent.RETIRED, 2, "ret")
+        retired = _components(item, SerializedComponent.Status.RETIRED, 2, "ret")
         for i, comp in enumerate(retired):
-            _event(comp, SerializedComponent.ACTION_RETIRE, days_ago=i + 1, now=now)
+            _event(comp, SerializedComponent.Action.RETIRE, days_ago=i + 1, now=now)
 
         # One unit that has both a retire and a dispose event within the window.
-        disposed = _components(item, SerializedComponent.DISPOSED, 1, "disp")[0]
-        _event(disposed, SerializedComponent.ACTION_RETIRE, days_ago=6, now=now)
-        _event(disposed, SerializedComponent.ACTION_DISPOSE, days_ago=5, now=now)
+        disposed = _components(item, SerializedComponent.Status.DISPOSED, 1, "disp")[0]
+        _event(disposed, SerializedComponent.Action.RETIRE, days_ago=6, now=now)
+        _event(disposed, SerializedComponent.Action.DISPOSE, days_ago=5, now=now)
 
         row = _row_for(build_component_forecast(now=now), item)
 
@@ -154,14 +154,14 @@ class TestBuildComponentForecast:
         now = timezone.now()
         user = User.objects.create_user(username="lt-user", password="x")
         item = _serialized_item(
-            InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=2, current_stock=10
+            InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=2, current_stock=10
         )
         _add_lead_time_log(item, user, actual_days=10)
 
-        _components(item, SerializedComponent.IN_STOCK, 10, "stock")  # available = 10
-        consumed = _components(item, SerializedComponent.CONSUMED, 9, "used")
+        _components(item, SerializedComponent.Status.IN_STOCK, 10, "stock")  # available = 10
+        consumed = _components(item, SerializedComponent.Status.CONSUMED, 9, "used")
         for i, comp in enumerate(consumed):
-            _event(comp, SerializedComponent.ACTION_CONSUME, days_ago=i + 1, now=now)
+            _event(comp, SerializedComponent.Action.CONSUME, days_ago=i + 1, now=now)
 
         row = _row_for(build_component_forecast(now=now), item)
 
@@ -182,14 +182,14 @@ class TestBuildComponentForecast:
         now = timezone.now()
         user = User.objects.create_user(username="ls-user", password="x")
 
-        low = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=5)
+        low = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=5)
         _add_lead_time_log(low, user, actual_days=10)
-        _components(low, SerializedComponent.IN_STOCK, 2, "low")  # available = 2
-        for i, comp in enumerate(_components(low, SerializedComponent.CONSUMED, 18, "lu")):
-            _event(comp, SerializedComponent.ACTION_CONSUME, days_ago=(i % 80) + 1, now=now)
+        _components(low, SerializedComponent.Status.IN_STOCK, 2, "low")  # available = 2
+        for i, comp in enumerate(_components(low, SerializedComponent.Status.CONSUMED, 18, "lu")):
+            _event(comp, SerializedComponent.Action.CONSUME, days_ago=(i % 80) + 1, now=now)
 
-        healthy = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=0)
-        _components(healthy, SerializedComponent.IN_STOCK, 50, "hs")
+        healthy = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=0)
+        _components(healthy, SerializedComponent.Status.IN_STOCK, 50, "hs")
 
         all_rows = build_component_forecast(now=now)
         low_row = _row_for(all_rows, low)
@@ -209,10 +209,10 @@ class TestBuildComponentForecast:
         never flagged needs_reorder no matter how low its available stock is."""
         now = timezone.now()
         retired = _serialized_item(
-            InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=5, is_retired=True
+            InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=5, is_retired=True
         )
         # Available (1) is under minimum, so an active item here would flag.
-        _components(retired, SerializedComponent.IN_STOCK, 1, "ret")
+        _components(retired, SerializedComponent.Status.IN_STOCK, 1, "ret")
 
         rows = build_component_forecast(now=now)
         assert all(r["item_id"] != str(retired.id) for r in rows)
@@ -220,17 +220,17 @@ class TestBuildComponentForecast:
     def test_lead_time_falls_back_to_supplier_estimate(self):
         now = timezone.now()
         item = _serialized_item(
-            InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=0, average_lead_time=7
+            InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=0, average_lead_time=7
         )
-        _components(item, SerializedComponent.IN_STOCK, 3, "stock")
+        _components(item, SerializedComponent.Status.IN_STOCK, 3, "stock")
 
         row = _row_for(build_component_forecast(now=now), item)
         assert row["lead_time_days"] == 7.0
 
     def test_zero_depletion_has_no_stockout_date(self):
         now = timezone.now()
-        item = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=4)
-        _components(item, SerializedComponent.IN_STOCK, 3, "stock")
+        item = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=4)
+        _components(item, SerializedComponent.Status.IN_STOCK, 3, "stock")
 
         row = _row_for(build_component_forecast(now=now), item)
         assert row["avg_daily_use"] == 0.0
@@ -242,11 +242,11 @@ class TestBuildComponentForecast:
 
     def test_events_outside_window_are_ignored(self):
         now = timezone.now()
-        item = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=0)
-        _components(item, SerializedComponent.IN_STOCK, 5, "stock")
-        old = _components(item, SerializedComponent.CONSUMED, 3, "old")
+        item = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=0)
+        _components(item, SerializedComponent.Status.IN_STOCK, 5, "stock")
+        old = _components(item, SerializedComponent.Status.CONSUMED, 3, "old")
         for i, comp in enumerate(old):
-            _event(comp, SerializedComponent.ACTION_CONSUME, days_ago=200 + i, now=now)
+            _event(comp, SerializedComponent.Action.CONSUME, days_ago=200 + i, now=now)
 
         row = _row_for(build_component_forecast(now=now, window_days=90), item)
         assert row["units_depleted_in_window"] == 0
@@ -254,11 +254,11 @@ class TestBuildComponentForecast:
 
     def test_window_days_param_changes_rate(self):
         now = timezone.now()
-        item = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=0)
-        _components(item, SerializedComponent.IN_STOCK, 10, "stock")
-        consumed = _components(item, SerializedComponent.CONSUMED, 10, "used")
+        item = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=0)
+        _components(item, SerializedComponent.Status.IN_STOCK, 10, "stock")
+        consumed = _components(item, SerializedComponent.Status.CONSUMED, 10, "used")
         for i, comp in enumerate(consumed):
-            _event(comp, SerializedComponent.ACTION_CONSUME, days_ago=i + 1, now=now)
+            _event(comp, SerializedComponent.Action.CONSUME, days_ago=i + 1, now=now)
 
         row = _row_for(build_component_forecast(now=now, window_days=10), item)
         # All 10 consume events fall within the tighter 10-day window.
@@ -267,11 +267,11 @@ class TestBuildComponentForecast:
 
     def test_excludes_non_serialized_and_inactive_items(self):
         now = timezone.now()
-        serialized = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE)
-        _components(serialized, SerializedComponent.IN_STOCK, 1, "stock")
+        serialized = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE)
+        _components(serialized, SerializedComponent.Status.IN_STOCK, 1, "stock")
 
         plain = InventoryItemFactory(is_serialized=False)
-        inactive = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE, is_active=False)
+        inactive = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE, is_active=False)
 
         ids = {r["item_id"] for r in build_component_forecast(now=now)}
         assert str(serialized.id) in ids
@@ -282,9 +282,9 @@ class TestBuildComponentForecast:
         """Installing a consumable unit moves it out of ``available`` while it
         stays ``on_hand`` (physically present) until it is consumed."""
         now = timezone.now()
-        item = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=0)
-        _components(item, SerializedComponent.IN_STOCK, 4, "stock")
-        _components(item, SerializedComponent.INSTALLED, 3, "inst")
+        item = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=0)
+        _components(item, SerializedComponent.Status.IN_STOCK, 4, "stock")
+        _components(item, SerializedComponent.Status.INSTALLED, 3, "inst")
 
         row = _row_for(build_component_forecast(now=now), item)
         assert row["on_hand"] == 7  # 4 in_stock + 3 installed
@@ -295,9 +295,9 @@ class TestBuildComponentForecast:
         """A consumed unit is depleted: it counts toward neither on_hand nor
         available (only the 2 in-stock units remain)."""
         now = timezone.now()
-        item = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=0)
-        _components(item, SerializedComponent.IN_STOCK, 2, "stock")
-        _components(item, SerializedComponent.CONSUMED, 5, "used")
+        item = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=0)
+        _components(item, SerializedComponent.Status.IN_STOCK, 2, "stock")
+        _components(item, SerializedComponent.Status.CONSUMED, 5, "used")
 
         row = _row_for(build_component_forecast(now=now), item)
         assert row["on_hand"] == 2
@@ -308,9 +308,9 @@ class TestBuildComponentForecast:
         """A reusable unit that has been *removed* from its asset returns to the
         available pool, while installed units do not."""
         now = timezone.now()
-        item = _serialized_item(InventoryItem.SERIAL_TRACKING_REUSABLE, minimum_stock=0)
-        _components(item, SerializedComponent.INSTALLED, 2, "inst")
-        _components(item, SerializedComponent.REMOVED, 3, "rem")
+        item = _serialized_item(InventoryItem.SerialTrackingMode.REUSABLE, minimum_stock=0)
+        _components(item, SerializedComponent.Status.INSTALLED, 2, "inst")
+        _components(item, SerializedComponent.Status.REMOVED, 3, "rem")
 
         row = _row_for(build_component_forecast(now=now), item)
         assert row["on_hand"] == 5  # installed + removed are both present
@@ -322,9 +322,9 @@ class TestBuildComponentForecast:
         (lowering available without lowering on_hand) can push an item to its
         reorder point even with no depletion history."""
         now = timezone.now()
-        item = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=3)
-        _components(item, SerializedComponent.IN_STOCK, 2, "stock")
-        _components(item, SerializedComponent.INSTALLED, 4, "inst")
+        item = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=3)
+        _components(item, SerializedComponent.Status.IN_STOCK, 2, "stock")
+        _components(item, SerializedComponent.Status.INSTALLED, 4, "inst")
 
         row = _row_for(build_component_forecast(now=now), item)
         assert row["on_hand"] == 6
@@ -338,12 +338,12 @@ class TestBuildComponentForecast:
         """Runway is measured against ``available``: installed units do not
         extend the projected stockout."""
         now = timezone.now()
-        item = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=0)
-        _components(item, SerializedComponent.IN_STOCK, 5, "stock")
-        _components(item, SerializedComponent.INSTALLED, 5, "inst")
-        consumed = _components(item, SerializedComponent.CONSUMED, 9, "used")
+        item = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=0)
+        _components(item, SerializedComponent.Status.IN_STOCK, 5, "stock")
+        _components(item, SerializedComponent.Status.INSTALLED, 5, "inst")
+        consumed = _components(item, SerializedComponent.Status.CONSUMED, 9, "used")
         for i, comp in enumerate(consumed):
-            _event(comp, SerializedComponent.ACTION_CONSUME, days_ago=i + 1, now=now)
+            _event(comp, SerializedComponent.Action.CONSUME, days_ago=i + 1, now=now)
 
         row = _row_for(build_component_forecast(now=now), item)
         assert row["on_hand"] == 10
@@ -360,17 +360,17 @@ class TestSerializedForecastEndpoint:
 
     def test_returns_forecast_rows(self, authenticated_client):
         client, _ = authenticated_client
-        item = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=0)
-        _components(item, SerializedComponent.IN_STOCK, 4, "stock")
-        consumed = _components(item, SerializedComponent.CONSUMED, 9, "used")
+        item = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=0)
+        _components(item, SerializedComponent.Status.IN_STOCK, 4, "stock")
+        consumed = _components(item, SerializedComponent.Status.CONSUMED, 9, "used")
         now = timezone.now()
         for i, comp in enumerate(consumed):
-            _event(comp, SerializedComponent.ACTION_CONSUME, days_ago=i + 1, now=now)
+            _event(comp, SerializedComponent.Action.CONSUME, days_ago=i + 1, now=now)
 
         response = client.get(FORECAST_URL)
         assert response.status_code == status.HTTP_200_OK
         row = _row_for(response.data, item)
-        assert row["serial_tracking_mode"] == InventoryItem.SERIAL_TRACKING_CONSUMABLE
+        assert row["serial_tracking_mode"] == InventoryItem.SerialTrackingMode.CONSUMABLE
         assert row["available_stock"] == 4
         assert row["on_hand"] == 4
         assert row["available"] == 4
@@ -381,13 +381,13 @@ class TestSerializedForecastEndpoint:
         client, _ = authenticated_client
         now = timezone.now()
 
-        low = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=10)
-        _components(low, SerializedComponent.IN_STOCK, 1, "low")
-        for i, comp in enumerate(_components(low, SerializedComponent.CONSUMED, 5, "lu")):
-            _event(comp, SerializedComponent.ACTION_CONSUME, days_ago=i + 1, now=now)
+        low = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=10)
+        _components(low, SerializedComponent.Status.IN_STOCK, 1, "low")
+        for i, comp in enumerate(_components(low, SerializedComponent.Status.CONSUMED, 5, "lu")):
+            _event(comp, SerializedComponent.Action.CONSUME, days_ago=i + 1, now=now)
 
-        healthy = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=0)
-        _components(healthy, SerializedComponent.IN_STOCK, 100, "hs")
+        healthy = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=0)
+        _components(healthy, SerializedComponent.Status.IN_STOCK, 100, "hs")
 
         response = client.get(FORECAST_URL, {"low_stock_only": "true"})
         assert response.status_code == status.HTTP_200_OK
@@ -399,13 +399,13 @@ class TestSerializedForecastEndpoint:
         """End-to-end: real lifecycle transitions (which write ComponentUsageEvent
         rows) drive the depletion rate."""
         client, _ = authenticated_client
-        item = _serialized_item(InventoryItem.SERIAL_TRACKING_CONSUMABLE, minimum_stock=0)
+        item = _serialized_item(InventoryItem.SerialTrackingMode.CONSUMABLE, minimum_stock=0)
 
         # One unit consumed via the real lifecycle API path.
         component = SerializedComponent.objects.create(item=item, serial_number="LC-1")
-        component.apply_action(SerializedComponent.ACTION_RECEIVE)
+        component.apply_action(SerializedComponent.Action.RECEIVE)
         # Keep a couple of spare units available on the shelf.
-        _components(item, SerializedComponent.IN_STOCK, 3, "spare")
+        _components(item, SerializedComponent.Status.IN_STOCK, 3, "spare")
 
         response = client.get(FORECAST_URL)
         assert response.status_code == status.HTTP_200_OK

--- a/backend/inventory/tests/test_costing.py
+++ b/backend/inventory/tests/test_costing.py
@@ -16,7 +16,9 @@ class TestNewCostingLogic:
     def test_trash_bag_example(self):
         """Test the specific example from the user: 50-count box for $40.49."""
 
-        supplier = Supplier.objects.create(name="Office Supply Co", supplier_type=Supplier.ONLINE)
+        supplier = Supplier.objects.create(
+            name="Office Supply Co", supplier_type=Supplier.SupplierType.ONLINE
+        )
         item = InventoryItem.objects.create(
             name="Trash Bags",
             description="Heavy-duty 13-gallon trash bags",
@@ -44,7 +46,9 @@ class TestNewCostingLogic:
     def test_cost_calculation_precision(self):
         """Test that cost calculations maintain proper decimal precision."""
 
-        supplier = Supplier.objects.create(name="Hardware Store", supplier_type=Supplier.LOCAL)
+        supplier = Supplier.objects.create(
+            name="Hardware Store", supplier_type=Supplier.SupplierType.LOCAL
+        )
         item = InventoryItem.objects.create(
             name="Screws",
             description="Phillips head screws #8",
@@ -68,7 +72,9 @@ class TestNewCostingLogic:
     def test_inventory_item_total_value_with_new_costing(self):
         """Test that inventory value calculations work correctly with new costing."""
 
-        supplier = Supplier.objects.create(name="Electronics Shop", supplier_type=Supplier.ONLINE)
+        supplier = Supplier.objects.create(
+            name="Electronics Shop", supplier_type=Supplier.SupplierType.ONLINE
+        )
         item = InventoryItem.objects.create(
             name="Resistors",
             description="1K ohm resistors",
@@ -93,7 +99,9 @@ class TestNewCostingLogic:
     def test_updating_package_cost_recalculates_unit_cost(self):
         """Test that updating package cost recalculates unit cost."""
 
-        supplier = Supplier.objects.create(name="Tool Supply", supplier_type=Supplier.LOCAL)
+        supplier = Supplier.objects.create(
+            name="Tool Supply", supplier_type=Supplier.SupplierType.LOCAL
+        )
         item = InventoryItem.objects.create(
             name="Drill Bits",
             description="HSS drill bit set",
@@ -123,7 +131,9 @@ class TestNewCostingLogic:
     def test_edge_case_quantity_per_package_change(self):
         """Test that changing quantity per package recalculates unit cost."""
 
-        supplier = Supplier.objects.create(name="Bulk Supplier", supplier_type=Supplier.ONLINE)
+        supplier = Supplier.objects.create(
+            name="Bulk Supplier", supplier_type=Supplier.SupplierType.ONLINE
+        )
         item = InventoryItem.objects.create(
             name="Cable Ties",
             description="4-inch cable ties",

--- a/backend/inventory/tests/test_cycle_count.py
+++ b/backend/inventory/tests/test_cycle_count.py
@@ -77,7 +77,11 @@ class TestCycleCountAction:
         client, _ = staff_client
         response = client.post(
             _cycle_count_url(item.id),
-            {"counted_qty": 18, "reason": "miscounted", "skip_reorder": True},
+            {
+                "counted_qty": 18,
+                "reason": StockReconciliation.ReasonCode.MISCOUNTED,
+                "skip_reorder": True,
+            },
             format="json",
         )
         assert response.status_code == status.HTTP_201_CREATED, response.data
@@ -91,7 +95,11 @@ class TestCycleCountAction:
         before = timezone.now()
         response = client.post(
             _cycle_count_url(item.id),
-            {"counted_qty": 18, "reason": "miscounted", "skip_reorder": True},
+            {
+                "counted_qty": 18,
+                "reason": StockReconciliation.ReasonCode.MISCOUNTED,
+                "skip_reorder": True,
+            },
             format="json",
         )
         assert response.status_code == status.HTTP_201_CREATED
@@ -105,7 +113,11 @@ class TestCycleCountAction:
         client, user = staff_client
         response = client.post(
             _cycle_count_url(item.id),
-            {"counted_qty": 15, "reason": "lost", "skip_reorder": True},
+            {
+                "counted_qty": 15,
+                "reason": StockReconciliation.ReasonCode.LOST,
+                "skip_reorder": True,
+            },
             format="json",
         )
         assert response.status_code == status.HTTP_201_CREATED
@@ -115,21 +127,24 @@ class TestCycleCountAction:
         assert rec.projected_count == 20
         assert rec.actual_count == 15
         assert rec.delta == -5
-        assert rec.reason == "lost"
+        assert rec.reason == StockReconciliation.ReasonCode.LOST
         assert rec.reconciled_by_id == user.id
         # Response echoes the audit row.
         assert response.data["reconciliation"]["id"] == rec.id
         assert response.data["reconciliation"]["projected_count"] == 20
         assert response.data["reconciliation"]["actual_count"] == 15
         assert response.data["reconciliation"]["delta"] == -5
-        assert response.data["reconciliation"]["reason"] == "lost"
+        assert response.data["reconciliation"]["reason"] == StockReconciliation.ReasonCode.LOST
         assert response.data["reconciliation"]["reconciled_by"] == user.id
 
     def test_auto_reorder_on_low_stock(self, staff_client, low_item):
         client, _ = staff_client
         response = client.post(
             _cycle_count_url(low_item.id),
-            {"counted_qty": 3, "reason": "used_without_scan"},  # <= minimum_stock (10)
+            {
+                "counted_qty": 3,
+                "reason": StockReconciliation.ReasonCode.USED_WITHOUT_SCAN,
+            },  # <= minimum_stock (10)
             format="json",
         )
         assert response.status_code == status.HTTP_201_CREATED
@@ -143,7 +158,11 @@ class TestCycleCountAction:
         client, _ = staff_client
         response = client.post(
             _cycle_count_url(low_item.id),
-            {"counted_qty": 2, "reason": "used_without_scan", "skip_reorder": True},
+            {
+                "counted_qty": 2,
+                "reason": StockReconciliation.ReasonCode.USED_WITHOUT_SCAN,
+                "skip_reorder": True,
+            },
             format="json",
         )
         assert response.status_code == status.HTTP_201_CREATED
@@ -157,7 +176,7 @@ class TestCycleCountAction:
         client.force_authenticate(user=regular)
         response = client.post(
             _cycle_count_url(item.id),
-            {"counted_qty": 15, "reason": "miscounted"},
+            {"counted_qty": 15, "reason": StockReconciliation.ReasonCode.MISCOUNTED},
             format="json",
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -169,7 +188,7 @@ class TestCycleCountAction:
     def test_anonymous_rejected(self, item):
         response = APIClient().post(
             _cycle_count_url(item.id),
-            {"counted_qty": 15, "reason": "miscounted"},
+            {"counted_qty": 15, "reason": StockReconciliation.ReasonCode.MISCOUNTED},
             format="json",
         )
         assert response.status_code in (
@@ -189,7 +208,11 @@ class TestCycleCountAction:
         client.force_authenticate(user=sig_admin)
         response = client.post(
             _cycle_count_url(item.id),
-            {"counted_qty": 18, "reason": "miscounted", "skip_reorder": True},
+            {
+                "counted_qty": 18,
+                "reason": StockReconciliation.ReasonCode.MISCOUNTED,
+                "skip_reorder": True,
+            },
             format="json",
         )
         assert response.status_code == status.HTTP_201_CREATED
@@ -212,7 +235,7 @@ class TestCycleCountAction:
         client, _ = staff_client
         response = client.post(
             _cycle_count_url(item.id),
-            {"reason": "miscounted"},
+            {"reason": StockReconciliation.ReasonCode.MISCOUNTED},
             format="json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -222,7 +245,7 @@ class TestCycleCountAction:
         client, _ = staff_client
         response = client.post(
             _cycle_count_url(item.id),
-            {"counted_qty": -1, "reason": "miscounted"},
+            {"counted_qty": -1, "reason": StockReconciliation.ReasonCode.MISCOUNTED},
             format="json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -262,7 +285,11 @@ class TestDaysSinceLastCount:
         client, _ = staff_client
         client.post(
             _cycle_count_url(item.id),
-            {"counted_qty": 12, "reason": "miscounted", "skip_reorder": True},
+            {
+                "counted_qty": 12,
+                "reason": StockReconciliation.ReasonCode.MISCOUNTED,
+                "skip_reorder": True,
+            },
             format="json",
         )
         response = client.get(_item_detail_url(item.id))

--- a/backend/inventory/tests/test_inventory_list_metrics.py
+++ b/backend/inventory/tests/test_inventory_list_metrics.py
@@ -66,7 +66,7 @@ def _open_po_line(
     *,
     quantity_ordered,
     quantity_received=0,
-    po_status=PurchaseOrder.SENT,
+    po_status=PurchaseOrder.Status.SENT,
     unit_cost_ordered=_DEFAULT_PO_UNIT_COST,
 ):
     """Create a PurchaseOrder + single line for ``item``'s primary supplier."""
@@ -125,14 +125,14 @@ class TestListMetricsValues:
         asset = AssetFactory()
         # Item A: on order + in transit + committed against 20 on hand.
         a = InventoryItemFactory(image=None, current_stock=20, reorder_quantity=5)
-        _open_po_line(a, quantity_ordered=8, po_status=PurchaseOrder.SENT)
+        _open_po_line(a, quantity_ordered=8, po_status=PurchaseOrder.Status.SENT)
         _open_po_line(
             a,
             quantity_ordered=10,
             quantity_received=4,
-            po_status=PurchaseOrder.PARTIALLY_RECEIVED,
+            po_status=PurchaseOrder.Status.PARTIALLY_RECEIVED,
         )
-        _commit_material(a, asset, quantity="3", wo_statuses=[WorkOrder.STATUS_OPEN])
+        _commit_material(a, asset, quantity="3", wo_statuses=[WorkOrder.Status.OPEN])
         # Item B: no PO / work-order activity at all.
         b = InventoryItemFactory(image=None, current_stock=3, reorder_quantity=1)
 
@@ -159,7 +159,7 @@ class TestListMetricsValues:
             item,
             asset,
             quantity="4",
-            wo_statuses=[WorkOrder.STATUS_OPEN, WorkOrder.STATUS_IN_PROGRESS],
+            wo_statuses=[WorkOrder.Status.OPEN, WorkOrder.Status.IN_PROGRESS],
         )
 
         results = _results(api_client.get(_list_url(with_metrics=True)))
@@ -193,7 +193,7 @@ class TestListMetricsValues:
         _open_po_line(
             item,
             quantity_ordered=6,
-            po_status=PurchaseOrder.CONFIRMED,
+            po_status=PurchaseOrder.Status.CONFIRMED,
             unit_cost_ordered=Decimal("4.0000"),
         )
 
@@ -215,8 +215,8 @@ def _count_queries(api_client, url):
 def _make_active_item(asset):
     """An item with a PO line and a committed material, so the aggregates hit rows."""
     item = InventoryItemFactory(image=None, current_stock=15, reorder_quantity=2)
-    _open_po_line(item, quantity_ordered=5, po_status=PurchaseOrder.SENT)
-    _commit_material(item, asset, quantity="1", wo_statuses=[WorkOrder.STATUS_OPEN])
+    _open_po_line(item, quantity_ordered=5, po_status=PurchaseOrder.Status.SENT)
+    _commit_material(item, asset, quantity="1", wo_statuses=[WorkOrder.Status.OPEN])
     return item
 
 

--- a/backend/inventory/tests/test_inventory_metrics.py
+++ b/backend/inventory/tests/test_inventory_metrics.py
@@ -115,29 +115,33 @@ class TestQuantityOnOrder:
         user = UserFactory()
 
         # Counted — the three open statuses.
-        _po_line(item, po_status=PurchaseOrder.SENT, quantity_ordered=5, created_by=user)
-        _po_line(item, po_status=PurchaseOrder.CONFIRMED, quantity_ordered=7, created_by=user)
+        _po_line(item, po_status=PurchaseOrder.Status.SENT, quantity_ordered=5, created_by=user)
+        _po_line(
+            item, po_status=PurchaseOrder.Status.CONFIRMED, quantity_ordered=7, created_by=user
+        )
         _po_line(
             item,
-            po_status=PurchaseOrder.PARTIALLY_RECEIVED,
+            po_status=PurchaseOrder.Status.PARTIALLY_RECEIVED,
             quantity_ordered=10,
             quantity_received=4,
             created_by=user,
         )
         # Not counted — draft / received / cancelled.
-        _po_line(item, po_status=PurchaseOrder.DRAFT, quantity_ordered=100, created_by=user)
+        _po_line(item, po_status=PurchaseOrder.Status.DRAFT, quantity_ordered=100, created_by=user)
         _po_line(
             item,
-            po_status=PurchaseOrder.RECEIVED,
+            po_status=PurchaseOrder.Status.RECEIVED,
             quantity_ordered=100,
             quantity_received=100,
             created_by=user,
         )
-        _po_line(item, po_status=PurchaseOrder.CANCELLED, quantity_ordered=100, created_by=user)
+        _po_line(
+            item, po_status=PurchaseOrder.Status.CANCELLED, quantity_ordered=100, created_by=user
+        )
         # Not counted — a voided line on an otherwise-open PO.
         _po_line(
             item,
-            po_status=PurchaseOrder.SENT,
+            po_status=PurchaseOrder.Status.SENT,
             quantity_ordered=100,
             is_voided=True,
             created_by=user,
@@ -164,7 +168,7 @@ class TestQuantityInTransit:
         # Partially received: 10 ordered, 4 received -> 6 in transit.
         _po_line(
             item,
-            po_status=PurchaseOrder.PARTIALLY_RECEIVED,
+            po_status=PurchaseOrder.Status.PARTIALLY_RECEIVED,
             quantity_ordered=10,
             quantity_received=4,
             created_by=user,
@@ -172,13 +176,13 @@ class TestQuantityInTransit:
         # A fully-received line on a partial PO contributes nothing in transit.
         _po_line(
             item,
-            po_status=PurchaseOrder.PARTIALLY_RECEIVED,
+            po_status=PurchaseOrder.Status.PARTIALLY_RECEIVED,
             quantity_ordered=8,
             quantity_received=8,
             created_by=user,
         )
         # A plain sent line is on order but not yet in transit.
-        _po_line(item, po_status=PurchaseOrder.SENT, quantity_ordered=5, created_by=user)
+        _po_line(item, po_status=PurchaseOrder.Status.SENT, quantity_ordered=5, created_by=user)
 
         data = api_client.get(_metrics_url(item)).json()
 
@@ -193,11 +197,11 @@ class TestQuantityCommittedAndAvailable:
         item = InventoryItemFactory(image=None, current_stock=20, reorder_quantity=1)
         asset = AssetFactory()
 
-        _committed_material(item, asset, quantity="3", wo_statuses=[WorkOrder.STATUS_OPEN])
-        _committed_material(item, asset, quantity="2", wo_statuses=[WorkOrder.STATUS_IN_PROGRESS])
-        _committed_material(item, asset, quantity="1", wo_statuses=[WorkOrder.STATUS_BLOCKED])
+        _committed_material(item, asset, quantity="3", wo_statuses=[WorkOrder.Status.OPEN])
+        _committed_material(item, asset, quantity="2", wo_statuses=[WorkOrder.Status.IN_PROGRESS])
+        _committed_material(item, asset, quantity="1", wo_statuses=[WorkOrder.Status.BLOCKED])
         # Completed work order -> not committed.
-        _committed_material(item, asset, quantity="100", wo_statuses=[WorkOrder.STATUS_COMPLETED])
+        _committed_material(item, asset, quantity="100", wo_statuses=[WorkOrder.Status.COMPLETED])
         # Material with no work order at all -> not committed.
         _committed_material(item, asset, quantity="50", wo_statuses=[])
 
@@ -215,7 +219,7 @@ class TestQuantityCommittedAndAvailable:
             item,
             asset,
             quantity="4",
-            wo_statuses=[WorkOrder.STATUS_OPEN, WorkOrder.STATUS_IN_PROGRESS],
+            wo_statuses=[WorkOrder.Status.OPEN, WorkOrder.Status.IN_PROGRESS],
         )
 
         data = api_client.get(_metrics_url(item)).json()
@@ -227,7 +231,7 @@ class TestQuantityCommittedAndAvailable:
         item = InventoryItemFactory(image=None, current_stock=1, reorder_quantity=1)
         asset = AssetFactory()
 
-        _committed_material(item, asset, quantity="5", wo_statuses=[WorkOrder.STATUS_OPEN])
+        _committed_material(item, asset, quantity="5", wo_statuses=[WorkOrder.Status.OPEN])
 
         data = api_client.get(_metrics_url(item)).json()
 
@@ -256,7 +260,7 @@ class TestCostAndTrend:
         item = InventoryItemFactory(image=None, reorder_quantity=1, unit_cost=current)
         _po_line(
             item,
-            po_status=PurchaseOrder.RECEIVED,
+            po_status=PurchaseOrder.Status.RECEIVED,
             quantity_ordered=1,
             quantity_received=1,
             unit_cost_ordered=last_po,
@@ -272,14 +276,14 @@ class TestCostAndTrend:
         item = InventoryItemFactory(image=None, reorder_quantity=1, unit_cost=Decimal("5.00"))
         older = _po_line(
             item,
-            po_status=PurchaseOrder.RECEIVED,
+            po_status=PurchaseOrder.Status.RECEIVED,
             quantity_ordered=1,
             quantity_received=1,
             unit_cost_ordered=Decimal("9.0000"),
         )
         newer = _po_line(
             item,
-            po_status=PurchaseOrder.RECEIVED,
+            po_status=PurchaseOrder.Status.RECEIVED,
             quantity_ordered=1,
             quantity_received=1,
             unit_cost_ordered=Decimal("4.0000"),

--- a/backend/inventory/tests/test_location_problem.py
+++ b/backend/inventory/tests/test_location_problem.py
@@ -125,15 +125,15 @@ class TestLocationProblemReporting:
             f"/api/inventory/locations/{location.id}/report_problem/",
             {
                 "description": "Light is flickering and buzzing.",
-                "severity": "high",
+                "severity": LocationProblem.Severity.HIGH,
             },
             format="multipart",
         )
         assert resp.status_code == 201, resp.content
         body = resp.json()
         assert body["location"] == location.id
-        assert body["status"] == LocationProblem.REPORTED
-        assert body["severity"] == "high"
+        assert body["status"] == LocationProblem.Status.REPORTED
+        assert body["severity"] == LocationProblem.Severity.HIGH
         assert LocationProblem.objects.filter(location=location).count() == 1
 
     def test_report_problem_anonymous_allowed(self, db, location):
@@ -146,13 +146,13 @@ class TestLocationProblemReporting:
         assert resp.status_code == 201, resp.content
         problem = LocationProblem.objects.get()
         assert problem.reported_by == ""
-        assert problem.severity == LocationProblem.SEVERITY_MEDIUM
+        assert problem.severity == LocationProblem.Severity.MEDIUM
 
     def test_report_problem_requires_description(self, admin_client, location):
         client, _ = admin_client
         resp = client.post(
             f"/api/inventory/locations/{location.id}/report_problem/",
-            {"severity": "low"},
+            {"severity": LocationProblem.Severity.LOW},
             format="multipart",
         )
         assert resp.status_code == 400
@@ -165,7 +165,7 @@ class TestPromoteToWorkOrder:
         problem = LocationProblem.objects.create(
             location=location,
             description="Drain backed up",
-            severity=LocationProblem.SEVERITY_HIGH,
+            severity=LocationProblem.Severity.HIGH,
         )
         resp = client.post(
             f"/api/inventory/location-problems/{problem.id}/promote-standard/",
@@ -177,7 +177,7 @@ class TestPromoteToWorkOrder:
         problem.refresh_from_db()
         assert problem.work_order is not None
         wo = problem.work_order
-        assert problem.status == LocationProblem.IN_PROGRESS
+        assert problem.status == LocationProblem.Status.IN_PROGRESS
         assert wo.maintenance_item_id == maintenance_item.id
         assert wo.notes == "Drain backed up"
         # Reverse relation: WorkOrder -> location_problems
@@ -205,7 +205,7 @@ class TestPromoteToThirdPartyWorkOrder:
         problem = LocationProblem.objects.create(
             location=location,
             description="HVAC making grinding noise.",
-            severity=LocationProblem.SEVERITY_URGENT,
+            severity=LocationProblem.Severity.URGENT,
         )
         # Attach a fake photo so the copy path is exercised.
         problem.photo.save("photo.png", ContentFile(_png_bytes()), save=True)
@@ -226,7 +226,7 @@ class TestPromoteToThirdPartyWorkOrder:
         assert tpwo.title == "HVAC grinding investigation"
         assert tpwo.location_id == location.id
         assert tpwo.notes == "HVAC making grinding noise."
-        assert problem.status == LocationProblem.IN_PROGRESS
+        assert problem.status == LocationProblem.Status.IN_PROGRESS
         # Photo was copied to TPWO attachments
         assert tpwo.attachments.filter(kind="photo").count() == 1
 
@@ -262,14 +262,14 @@ class TestUnionedActiveMaintenanceList:
 
         # Open LocationProblem (no WO promotion yet)
         lp = LocationProblem.objects.create(
-            location=location, description="Tile cracked", severity="medium"
+            location=location, description="Tile cracked", severity=LocationProblem.Severity.MEDIUM
         )
 
         # Closed LocationProblem (should NOT appear)
         LocationProblem.objects.create(
             location=location,
             description="Old issue",
-            status=LocationProblem.CLOSED,
+            status=LocationProblem.Status.CLOSED,
         )
 
         resp = client.get("/api/inventory/maintenance/active/")
@@ -290,11 +290,11 @@ class TestPaperFormIngestion:
     def test_detect_kind_by_subject(self, location):
         # Even with empty PDF bytes the subject should route correctly.
         kind = detect_submission_kind(b"", subject="[LOCPROB] leaky faucet")
-        assert kind == WorkOrderSubmission.KIND_LOCATION_PROBLEM
+        assert kind == WorkOrderSubmission.Kind.LOCATION_PROBLEM
 
     def test_detect_kind_by_header_text(self, location):
         pdf = _build_location_problem_pdf(location_id=location.id)
-        assert detect_submission_kind(pdf) == WorkOrderSubmission.KIND_LOCATION_PROBLEM
+        assert detect_submission_kind(pdf) == WorkOrderSubmission.Kind.LOCATION_PROBLEM
 
     def test_paper_form_ingestion_creates_location_problem(self, location):
         pdf_bytes = _build_location_problem_pdf(
@@ -303,14 +303,14 @@ class TestPaperFormIngestion:
             description="Sink overflowing - water on floor",
         )
         submission = WorkOrderSubmission.objects.create(
-            kind=WorkOrderSubmission.KIND_LOCATION_PROBLEM,
+            kind=WorkOrderSubmission.Kind.LOCATION_PROBLEM,
             from_email="reporter@example.com",
             subject="[LOCPROB] urgent leak",
         )
         submission.attachment.save("form.pdf", ContentFile(pdf_bytes), save=True)
 
         result = _apply_location_problem_submission(submission, pdf_bytes)
-        assert result.status == WorkOrderSubmission.STATUS_APPLIED
+        assert result.status == WorkOrderSubmission.Status.APPLIED
         problem = result.location_problem
         assert problem is not None
         assert problem.location_id == location.id
@@ -320,11 +320,11 @@ class TestPaperFormIngestion:
     def test_paper_form_ingestion_unknown_location_fails(self, db):
         pdf_bytes = _build_location_problem_pdf(location_id=999999)
         submission = WorkOrderSubmission.objects.create(
-            kind=WorkOrderSubmission.KIND_LOCATION_PROBLEM,
+            kind=WorkOrderSubmission.Kind.LOCATION_PROBLEM,
         )
         submission.attachment.save("f.pdf", ContentFile(pdf_bytes), save=True)
         result = _apply_location_problem_submission(submission, pdf_bytes)
-        assert result.status == WorkOrderSubmission.STATUS_FAILED
+        assert result.status == WorkOrderSubmission.Status.FAILED
         assert "999999" in result.parse_error
 
 
@@ -339,7 +339,10 @@ class TestLogisticsAlertFanOut:
         client = APIClient()
         resp = client.post(
             f"/api/inventory/locations/{location.id}/report_problem/",
-            {"description": "Ceiling leaking onto CNC", "severity": "urgent"},
+            {
+                "description": "Ceiling leaking onto CNC",
+                "severity": LocationProblem.Severity.URGENT,
+            },
             format="multipart",
         )
         assert resp.status_code == 201, resp.content
@@ -357,7 +360,7 @@ class TestLogisticsAlertFanOut:
         client = APIClient()
         resp = client.post(
             f"/api/inventory/locations/{location.id}/report_problem/",
-            {"description": "Light bulb burned out", "severity": "low"},
+            {"description": "Light bulb burned out", "severity": LocationProblem.Severity.LOW},
             format="multipart",
         )
         assert resp.status_code == 201
@@ -370,7 +373,7 @@ class TestLogisticsAlertFanOut:
         client = APIClient()
         resp = client.post(
             f"/api/inventory/locations/{location.id}/report_problem/",
-            {"description": "Major leak", "severity": "high"},
+            {"description": "Major leak", "severity": LocationProblem.Severity.HIGH},
             format="multipart",
         )
         assert resp.status_code == 201
@@ -389,7 +392,7 @@ class TestLogisticsAlertFanOut:
         client = APIClient()
         resp = client.post(
             f"/api/inventory/locations/{location.id}/report_problem/",
-            {"description": "Door wont latch", "severity": "medium"},
+            {"description": "Door wont latch", "severity": LocationProblem.Severity.MEDIUM},
             format="multipart",
         )
         assert resp.status_code == 201
@@ -405,7 +408,7 @@ class TestLogisticsAlertFanOut:
         problem = LocationProblem.objects.create(
             location=location,
             description="Roof leak",
-            severity=LocationProblem.SEVERITY_URGENT,
+            severity=LocationProblem.Severity.URGENT,
             reported_by="alice",
         )
         # No active webhooks: the task short-circuits but still validates the
@@ -418,7 +421,7 @@ class TestLogisticsAlertFanOut:
         WebHook.objects.create(
             name="Logistics LP",
             url="https://example.test/lp",
-            event_type=WebHook.LOCATION_PROBLEM_REPORTED,
+            event_type=WebHook.EventType.LOCATION_PROBLEM_REPORTED,
         )
         # send_webhook_notification posts to the URL, which we don't want in a
         # unit test. Stub it via patching at the module level.
@@ -433,7 +436,7 @@ class TestLogisticsAlertFanOut:
         event_type, payload = mocked.call_args.args
         assert event_type == "location_problem_reported"
         assert payload["data"]["id"] == str(problem.id)
-        assert payload["data"]["severity"] == "urgent"
+        assert payload["data"]["severity"] == LocationProblem.Severity.URGENT
         assert payload["data"]["location_name"] == location.name
 
 
@@ -447,7 +450,7 @@ class TestLogisticsDashboardLocationProblems:
         LocationProblem.objects.create(
             location=location,
             description="Tile cracked",
-            severity=LocationProblem.SEVERITY_LOW,
+            severity=LocationProblem.Severity.LOW,
         )
         resp = client.get("/api/reorders/analytics/logistics_dashboard/")
         assert resp.status_code == 200, resp.content
@@ -461,7 +464,7 @@ class TestLogisticsDashboardLocationProblems:
         LocationProblem.objects.create(
             location=location,
             description="Ceiling leak",
-            severity=LocationProblem.SEVERITY_URGENT,
+            severity=LocationProblem.Severity.URGENT,
         )
         resp = client.get("/api/reorders/analytics/logistics_dashboard/")
         assert resp.status_code == 200, resp.content
@@ -474,8 +477,8 @@ class TestLogisticsDashboardLocationProblems:
         LocationProblem.objects.create(
             location=location,
             description="Old leak",
-            severity=LocationProblem.SEVERITY_URGENT,
-            status=LocationProblem.RESOLVED,
+            severity=LocationProblem.Severity.URGENT,
+            status=LocationProblem.Status.RESOLVED,
         )
         resp = client.get("/api/reorders/analytics/logistics_dashboard/")
         assert resp.status_code == 200

--- a/backend/inventory/tests/test_maintenance_dashboard.py
+++ b/backend/inventory/tests/test_maintenance_dashboard.py
@@ -19,7 +19,7 @@ URL = "/api/inventory/maintenance/dashboard/"
 def _completed_wo(maintenance_item, completed_at, *, created_at=None):
     wo = WorkOrder.objects.create(
         maintenance_item=maintenance_item,
-        status=WorkOrder.STATUS_COMPLETED,
+        status=WorkOrder.Status.COMPLETED,
         completed_at=completed_at,
     )
     if created_at is not None:
@@ -105,14 +105,14 @@ class TestMaintenanceDashboard:
         )
         open_wo = WorkOrder.objects.create(
             maintenance_item=unscheduled_item,
-            status=WorkOrder.STATUS_OPEN,
+            status=WorkOrder.Status.OPEN,
         )
         # A completed WO should NOT show as unscheduled.
         _completed_wo(unscheduled_item, completed_at=timezone.now())
         # An open WO on a scheduled item should NOT show in unscheduled.
         WorkOrder.objects.create(
             maintenance_item=scheduled_item,
-            status=WorkOrder.STATUS_OPEN,
+            status=WorkOrder.Status.OPEN,
         )
 
         response = client.get(URL)
@@ -124,7 +124,7 @@ class TestMaintenanceDashboard:
         assert row["workorder_id"] == str(open_wo.id)
         assert row["asset_name"] == "Mill-B"
         assert row["problem"] == "Belt replacement"
-        assert row["status"] == WorkOrder.STATUS_OPEN
+        assert row["status"] == WorkOrder.Status.OPEN
 
     def test_cost_per_period_buckets_match_completed_at(self, authenticated_client):
         """today ⊆ this_week ⊆ this_month ⊆ this_year ⊆ all_time, anchored on

--- a/backend/inventory/tests/test_models.py
+++ b/backend/inventory/tests/test_models.py
@@ -24,9 +24,9 @@ class TestSupplierModel:
 
     def test_supplier_creation(self):
         """Test creating a supplier instance."""
-        supplier = SupplierFactory(supplier_type="local")
+        supplier = SupplierFactory(supplier_type=Supplier.SupplierType.LOCAL)
         assert supplier.name is not None
-        assert supplier.supplier_type == "local"
+        assert supplier.supplier_type == Supplier.SupplierType.LOCAL
         assert str(supplier) == supplier.name
 
     def test_supplier_ordering(self):
@@ -178,7 +178,9 @@ class TestItemSupplierModel:
     def test_package_cost_auto_calculation(self):
         """Unit cost should be auto-calculated from package cost and quantity."""
 
-        supplier = Supplier.objects.create(name="Bulk Supplies", supplier_type=Supplier.LOCAL)
+        supplier = Supplier.objects.create(
+            name="Bulk Supplies", supplier_type=Supplier.SupplierType.LOCAL
+        )
         item = InventoryItem.objects.create(
             name="Zip Ties",
             description="Standard 4-inch zip ties",
@@ -202,7 +204,9 @@ class TestItemSupplierModel:
     def test_backward_compatibility_unit_cost_entry(self):
         """Legacy unit cost entry should still work and calculate package cost."""
 
-        supplier = Supplier.objects.create(name="Local Shop", supplier_type=Supplier.LOCAL)
+        supplier = Supplier.objects.create(
+            name="Local Shop", supplier_type=Supplier.SupplierType.LOCAL
+        )
         item = InventoryItem.objects.create(
             name="Painter's Tape",
             description="Blue painter's tape roll",
@@ -226,7 +230,9 @@ class TestItemSupplierModel:
     def test_no_pricing_data(self):
         """When no pricing is provided, both fields should be None."""
 
-        supplier = Supplier.objects.create(name="Local Shop", supplier_type=Supplier.LOCAL)
+        supplier = Supplier.objects.create(
+            name="Local Shop", supplier_type=Supplier.SupplierType.LOCAL
+        )
         item = InventoryItem.objects.create(
             name="Painter's Tape",
             description="Blue painter's tape roll",
@@ -251,7 +257,7 @@ class TestItemSupplierModel:
         """Each supplier relationship should store UPCs for package and individual units."""
 
         supplier = Supplier.objects.create(
-            name="Warehouse Supplier", supplier_type=Supplier.NATIONAL
+            name="Warehouse Supplier", supplier_type=Supplier.SupplierType.NATIONAL
         )
         item = InventoryItem.objects.create(
             name="Nitrile Gloves",

--- a/backend/inventory/tests/test_reconciliation.py
+++ b/backend/inventory/tests/test_reconciliation.py
@@ -71,7 +71,7 @@ class TestBatchReconcile:
                 {
                     "item_id": str(item.id),
                     "actual_count": 18,
-                    "reason": "miscounted",
+                    "reason": StockReconciliation.ReasonCode.MISCOUNTED,
                     "notes": "off by two",
                     "skip_reorder": True,
                 }
@@ -89,7 +89,7 @@ class TestBatchReconcile:
                 {
                     "item_id": str(item.id),
                     "actual_count": 15,
-                    "reason": "lost",
+                    "reason": StockReconciliation.ReasonCode.LOST,
                     "skip_reorder": True,
                 }
             ]
@@ -102,7 +102,7 @@ class TestBatchReconcile:
         assert rec.projected_count == 20
         assert rec.actual_count == 15
         assert rec.delta == -5
-        assert rec.reason == "lost"
+        assert rec.reason == StockReconciliation.ReasonCode.LOST
         assert rec.reconciled_by_id == user.id
 
     def test_auto_reorder_on_low_stock(self, staff_client, low_item):
@@ -112,7 +112,7 @@ class TestBatchReconcile:
                 {
                     "item_id": str(low_item.id),
                     "actual_count": 3,  # <= minimum_stock (10)
-                    "reason": "used_without_scan",
+                    "reason": StockReconciliation.ReasonCode.USED_WITHOUT_SCAN,
                 }
             ]
         }
@@ -132,7 +132,7 @@ class TestBatchReconcile:
                 {
                     "item_id": str(low_item.id),
                     "actual_count": 2,
-                    "reason": "used_without_scan",
+                    "reason": StockReconciliation.ReasonCode.USED_WITHOUT_SCAN,
                     "skip_reorder": True,
                 }
             ]
@@ -159,7 +159,7 @@ class TestBatchReconcile:
                 {
                     "item_id": str(retired.id),
                     "actual_count": 1,  # well under minimum_stock (10)
-                    "reason": "used_without_scan",
+                    "reason": StockReconciliation.ReasonCode.USED_WITHOUT_SCAN,
                 }
             ]
         }
@@ -179,7 +179,7 @@ class TestBatchReconcile:
                 {
                     "item_id": str(item.id),
                     "actual_count": 15,
-                    "reason": "miscounted",
+                    "reason": StockReconciliation.ReasonCode.MISCOUNTED,
                     "skip_reorder": True,
                 }
             ]
@@ -202,7 +202,7 @@ class TestBatchReconcile:
                 {
                     "item_id": str(item.id),
                     "actual_count": 18,
-                    "reason": "miscounted",
+                    "reason": StockReconciliation.ReasonCode.MISCOUNTED,
                     "skip_reorder": True,
                 }
             ]
@@ -223,7 +223,7 @@ class TestBatchReconcile:
                 {
                     "item_id": str(item.id),
                     "actual_count": 19,
-                    "reason": "miscounted",
+                    "reason": StockReconciliation.ReasonCode.MISCOUNTED,
                     "skip_reorder": True,
                 }
             ]
@@ -252,13 +252,13 @@ class TestBatchReconcile:
                 {
                     "item_id": str(low_item.id),
                     "actual_count": 1,
-                    "reason": "used_without_scan",
+                    "reason": StockReconciliation.ReasonCode.USED_WITHOUT_SCAN,
                     "skip_reorder": True,
                 },
                 {
                     "item_id": str(item.id),  # not SIG admin for this one
                     "actual_count": 5,
-                    "reason": "miscounted",
+                    "reason": StockReconciliation.ReasonCode.MISCOUNTED,
                     "skip_reorder": True,
                 },
             ]
@@ -296,7 +296,7 @@ class TestReconciliationList:
             projected_count=20,
             actual_count=18,
             delta=-2,
-            reason="miscounted",
+            reason=StockReconciliation.ReasonCode.MISCOUNTED,
             reconciled_by=user,
         )
         response = client.get(LIST_URL)

--- a/backend/inventory/tests/test_serialized_component_admin.py
+++ b/backend/inventory/tests/test_serialized_component_admin.py
@@ -24,7 +24,7 @@ class SerializedComponentAdminSmokeTest(TestCase):
         cls.component = SerializedComponentFactory(item=cls.item)
         cls.event = ComponentUsageEvent.objects.create(
             component=cls.component,
-            action=SerializedComponent.ACTION_RECEIVE,
+            action=SerializedComponent.Action.RECEIVE,
         )
 
     def setUp(self):

--- a/backend/inventory/tests/test_serialized_component_api.py
+++ b/backend/inventory/tests/test_serialized_component_api.py
@@ -45,7 +45,7 @@ def _action_url(component, name):
 def consumable_item():
     return InventoryItemFactory(
         is_serialized=True,
-        serial_tracking_mode=InventoryItem.SERIAL_TRACKING_CONSUMABLE,
+        serial_tracking_mode=InventoryItem.SerialTrackingMode.CONSUMABLE,
     )
 
 
@@ -53,7 +53,7 @@ def consumable_item():
 def reusable_item():
     return InventoryItemFactory(
         is_serialized=True,
-        serial_tracking_mode=InventoryItem.SERIAL_TRACKING_REUSABLE,
+        serial_tracking_mode=InventoryItem.SerialTrackingMode.REUSABLE,
     )
 
 
@@ -87,9 +87,9 @@ class TestSerializedComponentCreate:
             format="json",
         )
         assert resp.status_code == 201
-        assert resp.data["status"] == SerializedComponent.RECEIVED
-        assert resp.data["tracking_mode"] == InventoryItem.SERIAL_TRACKING_CONSUMABLE
-        assert resp.data["available_actions"] == [SerializedComponent.ACTION_RECEIVE]
+        assert resp.data["status"] == SerializedComponent.Status.RECEIVED
+        assert resp.data["tracking_mode"] == InventoryItem.SerialTrackingMode.CONSUMABLE
+        assert resp.data["available_actions"] == [SerializedComponent.Action.RECEIVE]
 
     def test_cannot_create_for_non_serialized_item(self):
         plain_item = InventoryItemFactory(is_serialized=False)
@@ -121,8 +121,8 @@ class TestSerializedComponentLifecycleApi:
 
         r1 = client.post(_action_url(component, "receive"), data={}, format="json")
         assert r1.status_code == 200
-        assert r1.data["status"] == SerializedComponent.IN_STOCK
-        assert r1.data["event"]["action"] == SerializedComponent.ACTION_RECEIVE
+        assert r1.data["status"] == SerializedComponent.Status.IN_STOCK
+        assert r1.data["event"]["action"] == SerializedComponent.Action.RECEIVE
 
         r2 = client.post(
             _action_url(component, "install"),
@@ -130,12 +130,12 @@ class TestSerializedComponentLifecycleApi:
             format="json",
         )
         assert r2.status_code == 200
-        assert r2.data["status"] == SerializedComponent.INSTALLED
+        assert r2.data["status"] == SerializedComponent.Status.INSTALLED
         assert str(r2.data["installed_in_asset"]) == str(asset.id)
 
         r3 = client.post(_action_url(component, "consume"), data={}, format="json")
         assert r3.status_code == 200
-        assert r3.data["status"] == SerializedComponent.CONSUMED
+        assert r3.data["status"] == SerializedComponent.Status.CONSUMED
         assert r3.data["installed_in_asset"] is None
 
         r4 = client.post(
@@ -144,7 +144,7 @@ class TestSerializedComponentLifecycleApi:
             format="json",
         )
         assert r4.status_code == 200
-        assert r4.data["status"] == SerializedComponent.DISPOSED
+        assert r4.data["status"] == SerializedComponent.Status.DISPOSED
 
         component.refresh_from_db()
         assert component.usage_events.count() == 4
@@ -189,7 +189,7 @@ class TestSerializedComponentLifecycleApi:
         resp = client.post(_action_url(component, "consume"), data={}, format="json")
         assert resp.status_code == 400
         component.refresh_from_db()
-        assert component.status == SerializedComponent.RECEIVED
+        assert component.status == SerializedComponent.Status.RECEIVED
 
     def test_dispose_requires_reason(self, consumable_item):
         client = _client(_user("staff7", is_staff=True))
@@ -224,7 +224,7 @@ class TestSerializedComponentLifecycleApi:
         )
         r_remove = client.post(_action_url(component, "remove"), data={}, format="json")
         assert r_remove.status_code == 200
-        assert r_remove.data["status"] == SerializedComponent.REMOVED
+        assert r_remove.data["status"] == SerializedComponent.Status.REMOVED
         assert r_remove.data["installed_in_asset"] is None
 
         r_reinstall = client.post(
@@ -233,7 +233,7 @@ class TestSerializedComponentLifecycleApi:
             format="json",
         )
         assert r_reinstall.status_code == 200
-        assert r_reinstall.data["status"] == SerializedComponent.INSTALLED
+        assert r_reinstall.data["status"] == SerializedComponent.Status.INSTALLED
 
     def test_reusable_retire_from_installed_clears_current_asset(self, reusable_item):
         client = _client(_user("staff8b", is_staff=True))
@@ -249,7 +249,7 @@ class TestSerializedComponentLifecycleApi:
         resp = client.post(_action_url(component, "retire"), data={}, format="json")
 
         assert resp.status_code == 200
-        assert resp.data["status"] == SerializedComponent.RETIRED
+        assert resp.data["status"] == SerializedComponent.Status.RETIRED
         assert resp.data["installed_in_asset"] is None
 
 
@@ -259,22 +259,22 @@ class TestSerializedComponentFilters:
         other_item = InventoryItemFactory(is_serialized=True)
         c1 = SerializedComponentFactory(item=consumable_item)
         SerializedComponentFactory(item=other_item)
-        c1.apply_action(SerializedComponent.ACTION_RECEIVE)  # -> in_stock
+        c1.apply_action(SerializedComponent.Action.RECEIVE)  # -> in_stock
 
         client = _client(_user("member2"))
 
         by_item = client.get(LIST_URL, {"item": str(consumable_item.id)})
         assert by_item.data["count"] == 1
 
-        by_status = client.get(LIST_URL, {"status": SerializedComponent.IN_STOCK})
+        by_status = client.get(LIST_URL, {"status": SerializedComponent.Status.IN_STOCK})
         assert by_status.data["count"] == 1
         assert by_status.data["results"][0]["id"] == str(c1.id)
 
     def test_filter_by_installed_in_asset(self, consumable_item):
         asset = AssetFactory()
         component = SerializedComponentFactory(item=consumable_item)
-        component.apply_action(SerializedComponent.ACTION_RECEIVE)
-        component.apply_action(SerializedComponent.ACTION_INSTALL, asset=asset)
+        component.apply_action(SerializedComponent.Action.RECEIVE)
+        component.apply_action(SerializedComponent.Action.INSTALL, asset=asset)
         SerializedComponentFactory(item=consumable_item)  # not installed
 
         resp = _client(_user("member4")).get(LIST_URL, {"installed_in_asset": str(asset.id)})
@@ -289,13 +289,13 @@ class TestInventoryItemSerializesSerialConfig:
     def test_item_detail_exposes_serial_fields(self):
         item = InventoryItemFactory(
             is_serialized=True,
-            serial_tracking_mode=InventoryItem.SERIAL_TRACKING_REUSABLE,
+            serial_tracking_mode=InventoryItem.SerialTrackingMode.REUSABLE,
         )
         url = reverse("inventoryitem-detail", kwargs={"pk": item.pk})
         resp = _client(_user("member7")).get(url)
         assert resp.status_code == 200
         assert resp.data["is_serialized"] is True
-        assert resp.data["serial_tracking_mode"] == InventoryItem.SERIAL_TRACKING_REUSABLE
+        assert resp.data["serial_tracking_mode"] == InventoryItem.SerialTrackingMode.REUSABLE
 
     def test_serial_fields_are_writable(self):
         """Serialization config is editable through the item serializer (op-5tc).
@@ -309,31 +309,31 @@ class TestInventoryItemSerializesSerialConfig:
             url,
             data={
                 "is_serialized": True,
-                "serial_tracking_mode": InventoryItem.SERIAL_TRACKING_REUSABLE,
+                "serial_tracking_mode": InventoryItem.SerialTrackingMode.REUSABLE,
             },
             format="json",
         )
         assert resp.status_code == 200
         item.refresh_from_db()
         assert item.is_serialized is True
-        assert item.serial_tracking_mode == InventoryItem.SERIAL_TRACKING_REUSABLE
+        assert item.serial_tracking_mode == InventoryItem.SerialTrackingMode.REUSABLE
 
 
 @pytest.mark.integration
 class TestComponentUsageEventApi:
     def test_events_are_listed_and_filterable(self, consumable_item):
         component = SerializedComponentFactory(item=consumable_item)
-        component.apply_action(SerializedComponent.ACTION_RECEIVE)
+        component.apply_action(SerializedComponent.Action.RECEIVE)
 
         url = reverse("component-usage-event-list")
         resp = _client(_user("member3")).get(url, {"component": str(component.id)})
         assert resp.status_code == 200
         assert resp.data["count"] == 1
-        assert resp.data["results"][0]["action"] == SerializedComponent.ACTION_RECEIVE
+        assert resp.data["results"][0]["action"] == SerializedComponent.Action.RECEIVE
 
     def test_events_list_without_filter(self, consumable_item):
         component = SerializedComponentFactory(item=consumable_item)
-        component.apply_action(SerializedComponent.ACTION_RECEIVE)
+        component.apply_action(SerializedComponent.Action.RECEIVE)
         url = reverse("component-usage-event-list")
         resp = _client(_user("member5")).get(url)
         assert resp.status_code == 200
@@ -345,12 +345,12 @@ class TestComponentUsageEventApi:
         other_asset = AssetFactory()
 
         used_here = SerializedComponentFactory(item=consumable_item)
-        used_here.apply_action(SerializedComponent.ACTION_RECEIVE)
-        used_here.apply_action(SerializedComponent.ACTION_INSTALL, asset=asset)
+        used_here.apply_action(SerializedComponent.Action.RECEIVE)
+        used_here.apply_action(SerializedComponent.Action.INSTALL, asset=asset)
 
         used_elsewhere = SerializedComponentFactory(item=consumable_item)
-        used_elsewhere.apply_action(SerializedComponent.ACTION_RECEIVE)
-        used_elsewhere.apply_action(SerializedComponent.ACTION_INSTALL, asset=other_asset)
+        used_elsewhere.apply_action(SerializedComponent.Action.RECEIVE)
+        used_elsewhere.apply_action(SerializedComponent.Action.INSTALL, asset=other_asset)
 
         url = reverse("component-usage-event-list")
         resp = _client(_user("member6")).get(url, {"asset": str(asset.id)})
@@ -359,7 +359,7 @@ class TestComponentUsageEventApi:
         # receive events (asset=None) and the other machine's event are excluded.
         assert resp.data["count"] == 1
         assert str(resp.data["results"][0]["component"]) == str(used_here.id)
-        assert resp.data["results"][0]["action"] == SerializedComponent.ACTION_INSTALL
+        assert resp.data["results"][0]["action"] == SerializedComponent.Action.INSTALL
 
     def test_events_are_read_only(self, consumable_item):
         component = SerializedComponentFactory(item=consumable_item)
@@ -450,13 +450,13 @@ class TestScanReceive:
         assert resp.status_code == 201
         assert resp.data["created"] is True
         # scan = received -> receive applied -> lands in_stock (available).
-        assert resp.data["status"] == SerializedComponent.IN_STOCK
+        assert resp.data["status"] == SerializedComponent.Status.IN_STOCK
         assert resp.data["lot"] == "L9"
 
         unit = SerializedComponent.objects.get(item=consumable_item, serial_number="SCAN-1")
-        assert unit.status == SerializedComponent.IN_STOCK
+        assert unit.status == SerializedComponent.Status.IN_STOCK
         assert unit.received_at is not None
-        assert unit.usage_events.filter(action=SerializedComponent.ACTION_RECEIVE).count() == 1
+        assert unit.usage_events.filter(action=SerializedComponent.Action.RECEIVE).count() == 1
 
     def test_rescan_is_idempotent(self, consumable_item):
         client = _client(_user("scan-staff2", is_staff=True))
@@ -476,7 +476,7 @@ class TestScanReceive:
         units = SerializedComponent.objects.filter(item=consumable_item, serial_number="DUP-1")
         assert units.count() == 1
         assert (
-            units.first().usage_events.filter(action=SerializedComponent.ACTION_RECEIVE).count()
+            units.first().usage_events.filter(action=SerializedComponent.Action.RECEIVE).count()
             == 1
         )
 
@@ -525,7 +525,7 @@ class TestScanReceive:
             format="json",
         )
         assert resp.status_code == 201
-        assert resp.data["status"] == SerializedComponent.IN_STOCK
+        assert resp.data["status"] == SerializedComponent.Status.IN_STOCK
 
     def test_volunteer_cannot_scan_receive(self, consumable_item):
         resp = _client(_user("scan-vol")).post(
@@ -554,18 +554,18 @@ class TestItemDetailSerializedStock:
             SerializedComponent.objects.create(
                 item=consumable_item,
                 serial_number=f"ss-stock-{i}",
-                status=SerializedComponent.IN_STOCK,
+                status=SerializedComponent.Status.IN_STOCK,
             )
         for i in range(2):
             SerializedComponent.objects.create(
                 item=consumable_item,
                 serial_number=f"ss-inst-{i}",
-                status=SerializedComponent.INSTALLED,
+                status=SerializedComponent.Status.INSTALLED,
             )
         SerializedComponent.objects.create(
             item=consumable_item,
             serial_number="ss-consumed",
-            status=SerializedComponent.CONSUMED,
+            status=SerializedComponent.Status.CONSUMED,
         )
 
         url = reverse("inventoryitem-detail", kwargs={"pk": consumable_item.pk})

--- a/backend/inventory/tests/test_serialized_component_models.py
+++ b/backend/inventory/tests/test_serialized_component_models.py
@@ -21,14 +21,14 @@ pytestmark = pytest.mark.django_db
 def _consumable_item():
     return InventoryItemFactory(
         is_serialized=True,
-        serial_tracking_mode=InventoryItem.SERIAL_TRACKING_CONSUMABLE,
+        serial_tracking_mode=InventoryItem.SerialTrackingMode.CONSUMABLE,
     )
 
 
 def _reusable_item():
     return InventoryItemFactory(
         is_serialized=True,
-        serial_tracking_mode=InventoryItem.SERIAL_TRACKING_REUSABLE,
+        serial_tracking_mode=InventoryItem.SerialTrackingMode.REUSABLE,
     )
 
 
@@ -37,28 +37,28 @@ class TestSerializedComponentBasics:
     def test_defaults_to_received_and_derives_mode(self):
         item = _consumable_item()
         component = SerializedComponent.objects.create(item=item, serial_number="ABC-1")
-        assert component.status == SerializedComponent.RECEIVED
-        assert component.tracking_mode == InventoryItem.SERIAL_TRACKING_CONSUMABLE
+        assert component.status == SerializedComponent.Status.RECEIVED
+        assert component.tracking_mode == InventoryItem.SerialTrackingMode.CONSUMABLE
         assert str(component) == "ABC-1 (Received)"
 
     def test_available_actions_reflect_status_and_mode(self):
         consumable = SerializedComponentFactory()
-        assert consumable.available_actions == [SerializedComponent.ACTION_RECEIVE]
+        assert consumable.available_actions == [SerializedComponent.Action.RECEIVE]
 
         reusable = SerializedComponentFactory(
-            item__serial_tracking_mode=InventoryItem.SERIAL_TRACKING_REUSABLE
+            item__serial_tracking_mode=InventoryItem.SerialTrackingMode.REUSABLE
         )
-        reusable.status = SerializedComponent.INSTALLED
+        reusable.status = SerializedComponent.Status.INSTALLED
         # reusable installed unit can be removed or retired
         assert set(reusable.available_actions) == {
-            SerializedComponent.ACTION_REMOVE,
-            SerializedComponent.ACTION_RETIRE,
+            SerializedComponent.Action.REMOVE,
+            SerializedComponent.Action.RETIRE,
         }
 
     def test_can_apply_reflects_transition_table(self):
         component = SerializedComponentFactory()
-        assert component.can_apply(SerializedComponent.ACTION_RECEIVE) is True
-        assert component.can_apply(SerializedComponent.ACTION_CONSUME) is False
+        assert component.can_apply(SerializedComponent.Action.RECEIVE) is True
+        assert component.can_apply(SerializedComponent.Action.CONSUME) is False
 
     def test_unique_serial_per_item(self):
         item = _consumable_item()
@@ -75,78 +75,78 @@ class TestConsumableLifecycle:
         component = SerializedComponentFactory()
         asset = AssetFactory()
 
-        component.apply_action(SerializedComponent.ACTION_RECEIVE)
-        assert component.status == SerializedComponent.IN_STOCK
+        component.apply_action(SerializedComponent.Action.RECEIVE)
+        assert component.status == SerializedComponent.Status.IN_STOCK
         assert component.received_at is not None
 
-        component.apply_action(SerializedComponent.ACTION_INSTALL, asset=asset)
-        assert component.status == SerializedComponent.INSTALLED
+        component.apply_action(SerializedComponent.Action.INSTALL, asset=asset)
+        assert component.status == SerializedComponent.Status.INSTALLED
         assert component.installed_in_asset_id == asset.id
         assert component.installed_at is not None
 
-        consume_event = component.apply_action(SerializedComponent.ACTION_CONSUME)
-        assert component.status == SerializedComponent.CONSUMED
+        consume_event = component.apply_action(SerializedComponent.Action.CONSUME)
+        assert component.status == SerializedComponent.Status.CONSUMED
         assert component.installed_in_asset is None
         assert consume_event.asset_id == asset.id
 
-        component.apply_action(SerializedComponent.ACTION_DISPOSE, disposal_reason="used up")
-        assert component.status == SerializedComponent.DISPOSED
+        component.apply_action(SerializedComponent.Action.DISPOSE, disposal_reason="used up")
+        assert component.status == SerializedComponent.Status.DISPOSED
         assert component.disposal_reason == "used up"
         assert component.disposed_at is not None
 
         # One event per transition, in order.
         events = list(component.usage_events.order_by("at", "created_at"))
         assert [e.action for e in events] == [
-            SerializedComponent.ACTION_RECEIVE,
-            SerializedComponent.ACTION_INSTALL,
-            SerializedComponent.ACTION_CONSUME,
-            SerializedComponent.ACTION_DISPOSE,
+            SerializedComponent.Action.RECEIVE,
+            SerializedComponent.Action.INSTALL,
+            SerializedComponent.Action.CONSUME,
+            SerializedComponent.Action.DISPOSE,
         ]
 
     def test_cannot_remove_or_retire_consumable(self):
         component = SerializedComponentFactory()
-        component.apply_action(SerializedComponent.ACTION_RECEIVE)
-        component.apply_action(SerializedComponent.ACTION_INSTALL, asset=AssetFactory())
+        component.apply_action(SerializedComponent.Action.RECEIVE)
+        component.apply_action(SerializedComponent.Action.INSTALL, asset=AssetFactory())
         with pytest.raises(ValidationError):
-            component.apply_action(SerializedComponent.ACTION_REMOVE)
+            component.apply_action(SerializedComponent.Action.REMOVE)
         with pytest.raises(ValidationError):
-            component.apply_action(SerializedComponent.ACTION_RETIRE)
+            component.apply_action(SerializedComponent.Action.RETIRE)
 
     def test_cannot_skip_states(self):
         component = SerializedComponentFactory()
         # install requires in_stock first
         with pytest.raises(ValidationError):
-            component.apply_action(SerializedComponent.ACTION_INSTALL, asset=AssetFactory())
-        assert component.status == SerializedComponent.RECEIVED
+            component.apply_action(SerializedComponent.Action.INSTALL, asset=AssetFactory())
+        assert component.status == SerializedComponent.Status.RECEIVED
 
     def test_install_requires_asset(self):
         component = SerializedComponentFactory()
-        component.apply_action(SerializedComponent.ACTION_RECEIVE)
+        component.apply_action(SerializedComponent.Action.RECEIVE)
         with pytest.raises(ValidationError):
-            component.apply_action(SerializedComponent.ACTION_INSTALL)
+            component.apply_action(SerializedComponent.Action.INSTALL)
 
     def test_dispose_requires_reason(self):
         component = SerializedComponentFactory()
-        component.apply_action(SerializedComponent.ACTION_RECEIVE)
-        component.apply_action(SerializedComponent.ACTION_INSTALL, asset=AssetFactory())
-        component.apply_action(SerializedComponent.ACTION_CONSUME)
+        component.apply_action(SerializedComponent.Action.RECEIVE)
+        component.apply_action(SerializedComponent.Action.INSTALL, asset=AssetFactory())
+        component.apply_action(SerializedComponent.Action.CONSUME)
         with pytest.raises(ValidationError):
-            component.apply_action(SerializedComponent.ACTION_DISPOSE)
-        assert component.status == SerializedComponent.CONSUMED
+            component.apply_action(SerializedComponent.Action.DISPOSE)
+        assert component.status == SerializedComponent.Status.CONSUMED
 
     def test_dispose_clears_stale_current_asset_link_but_logs_it(self):
         asset = AssetFactory()
         component = SerializedComponentFactory(
-            status=SerializedComponent.CONSUMED,
+            status=SerializedComponent.Status.CONSUMED,
             installed_in_asset=asset,
         )
 
         event = component.apply_action(
-            SerializedComponent.ACTION_DISPOSE,
+            SerializedComponent.Action.DISPOSE,
             disposal_reason="already spent",
         )
 
-        assert component.status == SerializedComponent.DISPOSED
+        assert component.status == SerializedComponent.Status.DISPOSED
         assert component.installed_in_asset is None
         assert event.asset_id == asset.id
 
@@ -155,68 +155,68 @@ class TestConsumableLifecycle:
 class TestReusableLifecycle:
     def test_install_remove_is_repeatable(self):
         component = SerializedComponentFactory(
-            item__serial_tracking_mode=InventoryItem.SERIAL_TRACKING_REUSABLE
+            item__serial_tracking_mode=InventoryItem.SerialTrackingMode.REUSABLE
         )
         asset_a = AssetFactory()
         asset_b = AssetFactory()
 
-        component.apply_action(SerializedComponent.ACTION_RECEIVE)
-        component.apply_action(SerializedComponent.ACTION_INSTALL, asset=asset_a)
+        component.apply_action(SerializedComponent.Action.RECEIVE)
+        component.apply_action(SerializedComponent.Action.INSTALL, asset=asset_a)
         assert component.installed_in_asset_id == asset_a.id
 
-        component.apply_action(SerializedComponent.ACTION_REMOVE)
-        assert component.status == SerializedComponent.REMOVED
+        component.apply_action(SerializedComponent.Action.REMOVE)
+        assert component.status == SerializedComponent.Status.REMOVED
         assert component.installed_in_asset is None
 
         # Re-install into a different asset (repeatable).
-        component.apply_action(SerializedComponent.ACTION_INSTALL, asset=asset_b)
-        assert component.status == SerializedComponent.INSTALLED
+        component.apply_action(SerializedComponent.Action.INSTALL, asset=asset_b)
+        assert component.status == SerializedComponent.Status.INSTALLED
         assert component.installed_in_asset_id == asset_b.id
 
-        component.apply_action(SerializedComponent.ACTION_REMOVE)
-        component.apply_action(SerializedComponent.ACTION_RETIRE)
-        assert component.status == SerializedComponent.RETIRED
+        component.apply_action(SerializedComponent.Action.REMOVE)
+        component.apply_action(SerializedComponent.Action.RETIRE)
+        assert component.status == SerializedComponent.Status.RETIRED
 
-        component.apply_action(SerializedComponent.ACTION_DISPOSE, disposal_reason="end of life")
-        assert component.status == SerializedComponent.DISPOSED
+        component.apply_action(SerializedComponent.Action.DISPOSE, disposal_reason="end of life")
+        assert component.status == SerializedComponent.Status.DISPOSED
 
         # The remove event records the asset it was pulled from.
         remove_events = component.usage_events.filter(
-            action=SerializedComponent.ACTION_REMOVE
+            action=SerializedComponent.Action.REMOVE
         ).order_by("at")
         assert remove_events.count() == 2
         assert remove_events.first().asset_id == asset_a.id
 
     def test_retire_directly_from_in_stock(self):
         component = SerializedComponentFactory(
-            item__serial_tracking_mode=InventoryItem.SERIAL_TRACKING_REUSABLE
+            item__serial_tracking_mode=InventoryItem.SerialTrackingMode.REUSABLE
         )
-        component.apply_action(SerializedComponent.ACTION_RECEIVE)
-        component.apply_action(SerializedComponent.ACTION_RETIRE)
-        assert component.status == SerializedComponent.RETIRED
+        component.apply_action(SerializedComponent.Action.RECEIVE)
+        component.apply_action(SerializedComponent.Action.RETIRE)
+        assert component.status == SerializedComponent.Status.RETIRED
 
     def test_retire_from_installed_clears_asset_but_logs_it(self):
         asset = AssetFactory()
         component = SerializedComponentFactory(
-            item__serial_tracking_mode=InventoryItem.SERIAL_TRACKING_REUSABLE
+            item__serial_tracking_mode=InventoryItem.SerialTrackingMode.REUSABLE
         )
-        component.apply_action(SerializedComponent.ACTION_RECEIVE)
-        component.apply_action(SerializedComponent.ACTION_INSTALL, asset=asset)
+        component.apply_action(SerializedComponent.Action.RECEIVE)
+        component.apply_action(SerializedComponent.Action.INSTALL, asset=asset)
 
-        event = component.apply_action(SerializedComponent.ACTION_RETIRE)
+        event = component.apply_action(SerializedComponent.Action.RETIRE)
 
-        assert component.status == SerializedComponent.RETIRED
+        assert component.status == SerializedComponent.Status.RETIRED
         assert component.installed_in_asset is None
         assert event.asset_id == asset.id
 
     def test_cannot_consume_reusable(self):
         component = SerializedComponentFactory(
-            item__serial_tracking_mode=InventoryItem.SERIAL_TRACKING_REUSABLE
+            item__serial_tracking_mode=InventoryItem.SerialTrackingMode.REUSABLE
         )
-        component.apply_action(SerializedComponent.ACTION_RECEIVE)
-        component.apply_action(SerializedComponent.ACTION_INSTALL, asset=AssetFactory())
+        component.apply_action(SerializedComponent.Action.RECEIVE)
+        component.apply_action(SerializedComponent.Action.INSTALL, asset=AssetFactory())
         with pytest.raises(ValidationError):
-            component.apply_action(SerializedComponent.ACTION_CONSUME)
+            component.apply_action(SerializedComponent.Action.CONSUME)
 
 
 @pytest.mark.unit
@@ -225,16 +225,16 @@ class TestUsageEventLogging:
         user = django_user_model.objects.create_user(username="tech", password="x")
         component = SerializedComponentFactory()
         event = component.apply_action(
-            SerializedComponent.ACTION_RECEIVE, actor=user, notes="unboxed"
+            SerializedComponent.Action.RECEIVE, actor=user, notes="unboxed"
         )
         assert isinstance(event, ComponentUsageEvent)
         assert event.actor_id == user.id
         assert event.notes == "unboxed"
-        assert event.action == SerializedComponent.ACTION_RECEIVE
+        assert event.action == SerializedComponent.Action.RECEIVE
 
     def test_event_str_includes_serial_and_action(self):
         component = SerializedComponentFactory(serial_number="SN-STR")
-        event = component.apply_action(SerializedComponent.ACTION_RECEIVE)
+        event = component.apply_action(SerializedComponent.Action.RECEIVE)
         text = str(event)
         assert "SN-STR" in text
         assert "Receive" in text
@@ -242,5 +242,5 @@ class TestUsageEventLogging:
     def test_failed_transition_writes_no_event(self):
         component = SerializedComponentFactory()
         with pytest.raises(ValidationError):
-            component.apply_action(SerializedComponent.ACTION_CONSUME)
+            component.apply_action(SerializedComponent.Action.CONSUME)
         assert ComponentUsageEvent.objects.filter(component=component).count() == 0

--- a/backend/inventory/tests/test_supplier_api.py
+++ b/backend/inventory/tests/test_supplier_api.py
@@ -50,15 +50,17 @@ class TestSupplierAPI:
 
     def test_filter_suppliers_by_type(self, api_client):
         """Test filtering suppliers by type."""
-        SupplierFactory(supplier_type=Supplier.LOCAL)
-        SupplierFactory(supplier_type=Supplier.ONLINE)
-        SupplierFactory(supplier_type=Supplier.NATIONAL)
+        SupplierFactory(supplier_type=Supplier.SupplierType.LOCAL)
+        SupplierFactory(supplier_type=Supplier.SupplierType.ONLINE)
+        SupplierFactory(supplier_type=Supplier.SupplierType.NATIONAL)
 
         url = reverse("supplier-list")
-        response = api_client.get(url, {"supplier_type": Supplier.ONLINE})
+        response = api_client.get(url, {"supplier_type": Supplier.SupplierType.ONLINE})
 
         assert response.status_code == status.HTTP_200_OK
-        assert all(s["supplier_type"] == Supplier.ONLINE for s in response.data["results"])
+        assert all(
+            s["supplier_type"] == Supplier.SupplierType.ONLINE for s in response.data["results"]
+        )
 
     def test_search_suppliers(self, api_client):
         """Test searching suppliers by name."""
@@ -75,7 +77,7 @@ class TestSupplierAPI:
     def test_create_supplier_requires_auth(self, api_client):
         """Test creating supplier requires authentication."""
         url = reverse("supplier-list")
-        data = {"name": "New Supplier", "supplier_type": Supplier.ONLINE}
+        data = {"name": "New Supplier", "supplier_type": Supplier.SupplierType.ONLINE}
         response = api_client.post(url, data)
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
@@ -86,7 +88,7 @@ class TestSupplierAPI:
         url = reverse("supplier-list")
         data = {
             "name": "New Supplier",
-            "supplier_type": Supplier.ONLINE,
+            "supplier_type": Supplier.SupplierType.ONLINE,
             "website": "https://example.com",
             "account_number": "ACC-123",
             "tax_free_paperwork_filed": True,
@@ -96,7 +98,7 @@ class TestSupplierAPI:
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.data["name"] == "New Supplier"
-        assert response.data["supplier_type"] == Supplier.ONLINE
+        assert response.data["supplier_type"] == Supplier.SupplierType.ONLINE
         assert response.data["website"] == "https://example.com"
         assert response.data["account_number"] == "ACC-123"
         assert response.data["tax_free_paperwork_filed"] is True
@@ -192,7 +194,7 @@ class TestSupplierAPI:
             # Create a purchase order
             po = PurchaseOrder.objects.create(
                 supplier=supplier,
-                status=PurchaseOrder.RECEIVED,
+                status=PurchaseOrder.Status.RECEIVED,
                 created_by=user,
                 actual_total=Decimal("100.00"),
             )

--- a/backend/inventory/tests/test_supplies_used.py
+++ b/backend/inventory/tests/test_supplies_used.py
@@ -68,7 +68,7 @@ def _completed_pm_with_material(
     )
     wo = WorkOrder.objects.create(
         maintenance_item=mi,
-        status=WorkOrder.STATUS_COMPLETED,
+        status=WorkOrder.Status.COMPLETED,
         completed_at=completed_at,
     )
     material = MaintenanceMaterial.objects.create(
@@ -109,7 +109,7 @@ class TestSuppliesUsedSerialized:
         now = timezone.now()
         _event(
             asset,
-            action=SerializedComponent.ACTION_INSTALL,
+            action=SerializedComponent.Action.INSTALL,
             at=now - timedelta(days=3),
             item_name="Spindle bearing",
             serial="SN-INST",
@@ -117,7 +117,7 @@ class TestSuppliesUsedSerialized:
         )
         _event(
             asset,
-            action=SerializedComponent.ACTION_CONSUME,
+            action=SerializedComponent.Action.CONSUME,
             at=now - timedelta(days=4),
             item_name="Cutting fluid pod",
             serial="SN-CONS",
@@ -134,13 +134,13 @@ class TestSuppliesUsedSerialized:
         assert install["source"] == "serialized"
         assert install["asset_name"] == "Mill"
         assert install["item_name"] == "Spindle bearing"
-        assert install["action"] == "install"
+        assert install["action"] == SerializedComponent.Action.INSTALL
         assert install["action_display"] == "Install"
         assert install["actor"] == user.username
         assert "used_at" in install
 
         consume = by_serial["SN-CONS"]
-        assert consume["action"] == "consume"
+        assert consume["action"] == SerializedComponent.Action.CONSUME
         assert consume["action_display"] == "Consume"
         # No actor recorded on this event.
         assert consume["actor"] is None
@@ -152,7 +152,7 @@ class TestSuppliesUsedSerialized:
         # 45 days ago — outside the default 30-day window.
         _event(
             asset,
-            action=SerializedComponent.ACTION_INSTALL,
+            action=SerializedComponent.Action.INSTALL,
             at=now - timedelta(days=45),
             serial="SN-OLD",
         )
@@ -164,10 +164,10 @@ class TestSuppliesUsedSerialized:
     @pytest.mark.parametrize(
         "excluded_action",
         [
-            SerializedComponent.ACTION_RECEIVE,
-            SerializedComponent.ACTION_REMOVE,
-            SerializedComponent.ACTION_RETIRE,
-            SerializedComponent.ACTION_DISPOSE,
+            SerializedComponent.Action.RECEIVE,
+            SerializedComponent.Action.REMOVE,
+            SerializedComponent.Action.RETIRE,
+            SerializedComponent.Action.DISPOSE,
         ],
     )
     def test_excludes_non_install_consume_actions(self, authenticated_client, excluded_action):
@@ -192,7 +192,7 @@ class TestSuppliesUsedSerialized:
         ComponentUsageEvent.objects.create(
             component=component,
             asset=None,
-            action=SerializedComponent.ACTION_CONSUME,
+            action=SerializedComponent.Action.CONSUME,
             at=now - timedelta(days=1),
         )
 
@@ -269,7 +269,7 @@ class TestSuppliesUsedConsumable:
         )
         wo = WorkOrder.objects.create(
             maintenance_item=mi,
-            status=WorkOrder.STATUS_OPEN,
+            status=WorkOrder.Status.OPEN,
             completed_at=None,
         )
         material = MaintenanceMaterial.objects.create(
@@ -301,7 +301,7 @@ class TestSuppliesUsedConsumable:
         )
         wo = WorkOrder.objects.create(
             maintenance_item=mi,
-            status=WorkOrder.STATUS_COMPLETED,
+            status=WorkOrder.Status.COMPLETED,
             completed_at=timezone.now() - timedelta(days=2),
         )
         WorkOrderMaterialUsage.objects.create(
@@ -330,13 +330,13 @@ class TestSuppliesUsedFilteringAndSorting:
         now = timezone.now()
         _event(
             asset,
-            action=SerializedComponent.ACTION_INSTALL,
+            action=SerializedComponent.Action.INSTALL,
             at=now - timedelta(days=2),
             serial="SN-RECENT",
         )
         _event(
             asset,
-            action=SerializedComponent.ACTION_INSTALL,
+            action=SerializedComponent.Action.INSTALL,
             at=now - timedelta(days=20),
             serial="SN-EARLIER",
         )
@@ -359,19 +359,19 @@ class TestSuppliesUsedFilteringAndSorting:
         # Alpha: a later event and an earlier event (should come out ascending).
         _event(
             alpha,
-            action=SerializedComponent.ACTION_INSTALL,
+            action=SerializedComponent.Action.INSTALL,
             at=now - timedelta(days=2),
             serial="SN-ALPHA-NEW",
         )
         _event(
             alpha,
-            action=SerializedComponent.ACTION_CONSUME,
+            action=SerializedComponent.Action.CONSUME,
             at=now - timedelta(days=8),
             serial="SN-ALPHA-OLD",
         )
         _event(
             beta,
-            action=SerializedComponent.ACTION_INSTALL,
+            action=SerializedComponent.Action.INSTALL,
             at=now - timedelta(days=1),
             serial="SN-BETA",
         )
@@ -395,7 +395,7 @@ class TestSuppliesUsedExport:
         now = timezone.now()
         _event(
             asset,
-            action=SerializedComponent.ACTION_INSTALL,
+            action=SerializedComponent.Action.INSTALL,
             at=now - timedelta(days=3),
             item_name="Bearing",
             serial="SN-EXP",
@@ -437,7 +437,7 @@ class TestSuppliesUsedExport:
 
         serialized = by_source["serialized"]
         assert serialized["serial_number"] == "SN-EXP"
-        assert serialized["action"] == "install"
+        assert serialized["action"] == SerializedComponent.Action.INSTALL
         assert serialized["actor"] == user.username
         # Consumable-only columns are blank on a serialized row.
         assert serialized["quantity"] == ""

--- a/backend/inventory/tests/test_tasks.py
+++ b/backend/inventory/tests/test_tasks.py
@@ -8,6 +8,7 @@ import pytest
 
 from inventory.tasks import generate_index_card, generate_qr_code, update_average_lead_times
 from inventory.tests.factories import InventoryItemFactory
+from reorder_queue.models import ReorderRequest
 from reorder_queue.tests.factories import ReorderRequestFactory
 
 pytestmark = pytest.mark.django_db
@@ -82,7 +83,7 @@ class TestInventoryTasks:
 
         ReorderRequestFactory(
             item=item,
-            status="received",
+            status=ReorderRequest.Status.RECEIVED,
             ordered_at=ordered_date,
             actual_delivery=delivery_date,
         )
@@ -93,7 +94,7 @@ class TestInventoryTasks:
 
         ReorderRequestFactory(
             item=item,
-            status="received",
+            status=ReorderRequest.Status.RECEIVED,
             ordered_at=ordered_date2,
             actual_delivery=delivery_date2,
         )
@@ -119,10 +120,10 @@ class TestInventoryTasks:
         item = InventoryItemFactory(average_lead_time=7)
 
         # Pending request should be ignored
-        ReorderRequestFactory(item=item, status="pending")
+        ReorderRequestFactory(item=item, status=ReorderRequest.Status.PENDING)
 
         # Approved request should be ignored
-        ReorderRequestFactory(item=item, status="approved")
+        ReorderRequestFactory(item=item, status=ReorderRequest.Status.APPROVED)
 
         update_average_lead_times()
 

--- a/backend/inventory/tests/test_tco.py
+++ b/backend/inventory/tests/test_tco.py
@@ -25,7 +25,7 @@ URL = "/api/inventory/reports/assets/tco/"
 def _create_completed_wo(maintenance_item, completed_at, *, created_at=None):
     wo = WorkOrder.objects.create(
         maintenance_item=maintenance_item,
-        status=WorkOrder.STATUS_COMPLETED,
+        status=WorkOrder.Status.COMPLETED,
         completed_at=completed_at,
     )
     if created_at is not None:
@@ -151,7 +151,7 @@ class TestAssetTcoReport:
         )
 
         # Currently in MAINTENANCE — adds today.
-        asset.status = Asset.MAINTENANCE
+        asset.status = Asset.Status.MAINTENANCE
         asset.save(update_fields=["status"])
 
         response = client.get(URL)

--- a/backend/inventory/tests/test_third_party_wo_ingest.py
+++ b/backend/inventory/tests/test_third_party_wo_ingest.py
@@ -278,12 +278,12 @@ class TestDetectSubmissionKind:
         c.save()
 
         kind = detect_submission_kind(plain_pdf.getvalue(), subject="[3PWO] Vendor invoice")
-        assert kind == WorkOrderSubmission.KIND_THIRD_PARTY_WO
+        assert kind == WorkOrderSubmission.Kind.THIRD_PARTY_WO
 
     def test_acroform_marker_routes_to_third_party(self, tpwo):
         pdf_bytes = _make_3pwo_form_pdf(str(tpwo.id), include_header=False)
         kind = detect_submission_kind(pdf_bytes, subject="Completed work")
-        assert kind == WorkOrderSubmission.KIND_THIRD_PARTY_WO
+        assert kind == WorkOrderSubmission.Kind.THIRD_PARTY_WO
 
     def test_header_text_routes_to_third_party(self):
         buf = io.BytesIO()
@@ -292,7 +292,7 @@ class TestDetectSubmissionKind:
         c.showPage()
         c.save()
         kind = detect_submission_kind(buf.getvalue(), subject="WO from vendor")
-        assert kind == WorkOrderSubmission.KIND_THIRD_PARTY_WO
+        assert kind == WorkOrderSubmission.Kind.THIRD_PARTY_WO
 
     def test_default_to_pm_completion(self):
         buf = io.BytesIO()
@@ -301,7 +301,7 @@ class TestDetectSubmissionKind:
         c.showPage()
         c.save()
         kind = detect_submission_kind(buf.getvalue(), subject="Completed monthly check")
-        assert kind == WorkOrderSubmission.KIND_PM_COMPLETION
+        assert kind == WorkOrderSubmission.Kind.PM_COMPLETION
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -326,7 +326,7 @@ class TestApplyThirdPartySubmission:
         )
 
         submission = WorkOrderSubmission(
-            kind=WorkOrderSubmission.KIND_THIRD_PARTY_WO,
+            kind=WorkOrderSubmission.Kind.THIRD_PARTY_WO,
             submitted_by=staff_user,
         )
         submission.attachment.save("3pwo.pdf", ContentFile(filled), save=False)
@@ -336,7 +336,7 @@ class TestApplyThirdPartySubmission:
 
         submission.refresh_from_db()
         tpwo.refresh_from_db()
-        assert submission.status == WorkOrderSubmission.STATUS_APPLIED
+        assert submission.status == WorkOrderSubmission.Status.APPLIED
         assert submission.third_party_work_order_id == tpwo.id
         assert submission.work_order_id is None
         assert tpwo.status == ThirdPartyWorkOrder.STATUS_VALIDATED
@@ -368,7 +368,7 @@ class TestApplyThirdPartySubmission:
         pdf_bytes = _make_3pwo_form_pdf(bogus)
 
         submission = WorkOrderSubmission(
-            kind=WorkOrderSubmission.KIND_THIRD_PARTY_WO,
+            kind=WorkOrderSubmission.Kind.THIRD_PARTY_WO,
             submitted_by=staff_user,
         )
         submission.attachment.save("3pwo.pdf", ContentFile(pdf_bytes), save=False)
@@ -377,7 +377,7 @@ class TestApplyThirdPartySubmission:
         apply_submission(submission)
         submission.refresh_from_db()
 
-        assert submission.status == WorkOrderSubmission.STATUS_FAILED
+        assert submission.status == WorkOrderSubmission.Status.FAILED
         assert bogus in submission.parse_error
         assert submission.third_party_work_order_id is None
 
@@ -389,7 +389,7 @@ class TestApplyThirdPartySubmission:
         filled = _fill_text_fields(pdf_bytes, {"keyfob_id": "FOB-9999"})
 
         submission = WorkOrderSubmission(
-            kind=WorkOrderSubmission.KIND_THIRD_PARTY_WO,
+            kind=WorkOrderSubmission.Kind.THIRD_PARTY_WO,
             submitted_by=staff_user,
         )
         submission.attachment.save("3pwo.pdf", ContentFile(filled), save=False)
@@ -407,7 +407,7 @@ class TestApplyThirdPartySubmission:
         with_photo = _attach_image_to_pdf(pdf_bytes, _png_bytes())
 
         submission = WorkOrderSubmission(
-            kind=WorkOrderSubmission.KIND_THIRD_PARTY_WO,
+            kind=WorkOrderSubmission.Kind.THIRD_PARTY_WO,
             submitted_by=staff_user,
         )
         submission.attachment.save("3pwo.pdf", ContentFile(with_photo), save=False)
@@ -470,8 +470,8 @@ class TestPostmarkInbound3PWO:
         assert resp.status_code == status.HTTP_200_OK
 
         body = resp.json()
-        assert body["kind"] == WorkOrderSubmission.KIND_THIRD_PARTY_WO
-        assert body["status"] == WorkOrderSubmission.STATUS_APPLIED
+        assert body["kind"] == WorkOrderSubmission.Kind.THIRD_PARTY_WO
+        assert body["status"] == WorkOrderSubmission.Status.APPLIED
         assert body["third_party_work_order_id"] == str(tpwo.id)
         assert body["work_order_id"] is None
 

--- a/backend/inventory/tests/test_work_order_completes_pm.py
+++ b/backend/inventory/tests/test_work_order_completes_pm.py
@@ -59,7 +59,7 @@ def _validate(api, wo):
     )
 
 
-def _create_wo(api, item, *, status="open"):
+def _create_wo(api, item, *, status=WorkOrder.Status.OPEN):
     payload = {
         "maintenance_item": str(item.id),
         "due_date": (date.today() + timedelta(days=7)).isoformat(),
@@ -81,7 +81,7 @@ class TestWorkOrderClosesPM:
 
         resp = staff_client.patch(
             f"/api/inventory/work-orders/{wo.id}/",
-            {"status": "completed"},
+            {"status": WorkOrder.Status.COMPLETED},
             format="json",
         )
         assert resp.status_code == 200, resp.content
@@ -104,19 +104,19 @@ class TestWorkOrderClosesPM:
         _validate(staff_client, wo)
         staff_client.patch(
             f"/api/inventory/work-orders/{wo.id}/",
-            {"status": "completed"},
+            {"status": WorkOrder.Status.COMPLETED},
             format="json",
         )
         # Reopen.
         staff_client.patch(
             f"/api/inventory/work-orders/{wo.id}/",
-            {"status": "open"},
+            {"status": WorkOrder.Status.OPEN},
             format="json",
         )
         # Re-complete.
         staff_client.patch(
             f"/api/inventory/work-orders/{wo.id}/",
-            {"status": "completed"},
+            {"status": WorkOrder.Status.COMPLETED},
             format="json",
         )
 
@@ -131,7 +131,7 @@ class TestWorkOrderClosesPM:
         _validate(staff_client, wo)
         staff_client.patch(
             f"/api/inventory/work-orders/{wo.id}/",
-            {"status": "completed"},
+            {"status": WorkOrder.Status.COMPLETED},
             format="json",
         )
         pm_item.refresh_from_db()
@@ -142,7 +142,7 @@ class TestWorkOrderClosesPM:
         # completion is the last time the work was *actually* done).
         staff_client.patch(
             f"/api/inventory/work-orders/{wo.id}/",
-            {"status": "open"},
+            {"status": WorkOrder.Status.OPEN},
             format="json",
         )
         pm_item.refresh_from_db()
@@ -154,14 +154,14 @@ class TestWorkOrderClosesPM:
         # this unreachable. Build an in-memory WO with no FK set.
         from inventory.views import WorkOrderViewSet
 
-        wo = WorkOrder(status=WorkOrder.STATUS_COMPLETED, maintenance_item=None)
+        wo = WorkOrder(status=WorkOrder.Status.COMPLETED, maintenance_item=None)
         WorkOrderViewSet._sync_maintenance_item_completion(wo, actor=None)
         # Nothing was written.
         assert MaintenanceLog.objects.count() == 0
 
     def test_open_wo_no_log(self, staff_client, pm_item):
         # An open WO doesn't write a log even though the FK is set.
-        wo = _create_wo(staff_client, pm_item, status="open")
+        wo = _create_wo(staff_client, pm_item, status=WorkOrder.Status.OPEN)
         assert MaintenanceLog.objects.filter(work_order=wo).count() == 0
         pm_item.refresh_from_db()
         assert pm_item.last_completed_at is None

--- a/backend/inventory/tests/test_work_order_id_extraction.py
+++ b/backend/inventory/tests/test_work_order_id_extraction.py
@@ -341,7 +341,7 @@ class TestApplySubmissionFailureReporting:
         apply_submission(submission)
         submission.refresh_from_db()
 
-        assert submission.status == WorkOrderSubmission.STATUS_FAILED
+        assert submission.status == WorkOrderSubmission.Status.FAILED
         # Backwards-compatible prefix preserved so existing tests / dashboards
         # still match against "Work Order ID":
         assert "Work Order ID" in submission.parse_error
@@ -412,5 +412,5 @@ class TestImageOnlyPdfIngest:
         apply_submission(submission)
         submission.refresh_from_db()
 
-        assert submission.status == WorkOrderSubmission.STATUS_APPLIED
+        assert submission.status == WorkOrderSubmission.Status.APPLIED
         assert submission.work_order_id == wo.id

--- a/backend/inventory/tests/test_work_order_ingest.py
+++ b/backend/inventory/tests/test_work_order_ingest.py
@@ -179,9 +179,9 @@ class TestApplySubmission:
 
         submission.refresh_from_db()
         wo.refresh_from_db()
-        assert submission.status == WorkOrderSubmission.STATUS_APPLIED
+        assert submission.status == WorkOrderSubmission.Status.APPLIED
         assert submission.work_order_id == wo.id
-        assert wo.status == WorkOrder.STATUS_IN_PROGRESS
+        assert wo.status == WorkOrder.Status.IN_PROGRESS
         assert wo.completed_at is None
         tcs[0].refresh_from_db()
         tcs[1].refresh_from_db()
@@ -205,7 +205,7 @@ class TestApplySubmission:
         apply_submission(submission)
         wo.refresh_from_db()
 
-        assert wo.status == WorkOrder.STATUS_COMPLETED
+        assert wo.status == WorkOrder.Status.COMPLETED
         assert wo.completed_at is not None
         # MaintenanceItem.last_completed_at is stamped.
         wo.maintenance_item.refresh_from_db()
@@ -325,7 +325,7 @@ class TestApplySubmission:
         apply_submission(submission)
         submission.refresh_from_db()
 
-        assert submission.status == WorkOrderSubmission.STATUS_FAILED
+        assert submission.status == WorkOrderSubmission.Status.FAILED
         assert str(wo_id) in submission.parse_error
         assert submission.work_order is None
 
@@ -379,11 +379,11 @@ class TestPostmarkInboundView:
         )
         assert resp.status_code == status.HTTP_200_OK
         body = resp.json()
-        assert body["status"] == WorkOrderSubmission.STATUS_APPLIED
+        assert body["status"] == WorkOrderSubmission.Status.APPLIED
         assert body["work_order_id"] == str(wo.id)
 
         wo.refresh_from_db()
-        assert wo.status == WorkOrder.STATUS_COMPLETED
+        assert wo.status == WorkOrder.Status.COMPLETED
 
     def test_duplicate_message_id_is_idempotent(self, api_client, settings):
         settings.POSTMARK_INBOUND_TOKEN = "correct"

--- a/backend/inventory/tests/test_work_order_omr_reader.py
+++ b/backend/inventory/tests/test_work_order_omr_reader.py
@@ -149,11 +149,11 @@ def _task_target_ids(template):
     return [r["target_id"] for r in template.regions_json if r["target_id"].startswith("task_")]
 
 
-def _submission_for(wo, scan_bytes, *, source=WorkOrderSubmission.SOURCE_SCAN):
+def _submission_for(wo, scan_bytes, *, source=WorkOrderSubmission.Source.SCAN):
     sub = WorkOrderSubmission(
-        kind=WorkOrderSubmission.KIND_PM_COMPLETION,
+        kind=WorkOrderSubmission.Kind.PM_COMPLETION,
         source=source,
-        status=WorkOrderSubmission.STATUS_RECEIVED,
+        status=WorkOrderSubmission.Status.RECEIVED,
     )
     sub.attachment.save("scan.png", ContentFile(scan_bytes), save=False)
     sub.save()
@@ -244,7 +244,7 @@ class TestScanIngestion:
         apply_submission(sub)
         sub.refresh_from_db()
 
-        assert sub.status == WorkOrderSubmission.STATUS_PENDING_REVIEW
+        assert sub.status == WorkOrderSubmission.Status.PENDING_REVIEW
         assert sub.work_order_id == wo.id
         # the solid mark pre-checked its task box
         tc0 = WorkOrderTaskCompletion.objects.get(id=tasks[0][len("task_") :])
@@ -268,10 +268,10 @@ class TestScanIngestion:
         wo.refresh_from_db()
         sub.refresh_from_db()
 
-        assert wo.status != WorkOrder.STATUS_COMPLETED
+        assert wo.status != WorkOrder.Status.COMPLETED
         assert wo.completed_at is None
         assert not MaintenanceLog.objects.filter(maintenance_item=wo.maintenance_item).exists()
-        assert sub.status == WorkOrderSubmission.STATUS_PENDING_REVIEW
+        assert sub.status == WorkOrderSubmission.Status.PENDING_REVIEW
         # tasks are pre-checked though (visible on the WO for the reviewer)
         assert all(tc.is_completed for tc in wo.task_completions.all())
 
@@ -293,7 +293,7 @@ class TestScanIngestion:
         assert resp.data["work_order_completed"] is True
 
         wo.refresh_from_db()
-        assert wo.status == WorkOrder.STATUS_COMPLETED
+        assert wo.status == WorkOrder.Status.COMPLETED
         assert wo.completed_at is not None
         wo.maintenance_item.refresh_from_db()
         assert wo.maintenance_item.last_completed_at is not None
@@ -331,7 +331,7 @@ class TestScanIngestion:
         apply_submission(sub)
         sub.refresh_from_db()
 
-        assert sub.status == WorkOrderSubmission.STATUS_PENDING_REVIEW
+        assert sub.status == WorkOrderSubmission.Status.PENDING_REVIEW
         assert "reprint" in sub.parse_error.lower()
         assert sub.pending_changes == []
         assert not wo.task_completions.filter(
@@ -346,7 +346,7 @@ class TestScanIngestion:
         sub = _submission_for(wo, scan)
         apply_submission(sub)
         sub.refresh_from_db()
-        assert sub.status == WorkOrderSubmission.STATUS_PENDING_REVIEW
+        assert sub.status == WorkOrderSubmission.Status.PENDING_REVIEW
         assert "template" in sub.parse_error.lower()
 
     def test_unresolvable_wo_id_fails(self):
@@ -358,7 +358,7 @@ class TestScanIngestion:
         sub = _submission_for(wo, scan)
         apply_submission(sub)
         sub.refresh_from_db()
-        assert sub.status == WorkOrderSubmission.STATUS_FAILED
+        assert sub.status == WorkOrderSubmission.Status.FAILED
 
     def test_registration_failure_holds_for_review(self):
         wo = _make_work_order(num_tasks=2)
@@ -367,7 +367,7 @@ class TestScanIngestion:
         sub = _submission_for(wo, scan)
         apply_submission(sub)
         sub.refresh_from_db()
-        assert sub.status == WorkOrderSubmission.STATUS_PENDING_REVIEW
+        assert sub.status == WorkOrderSubmission.Status.PENDING_REVIEW
         assert "align" in sub.parse_error.lower()
 
 
@@ -434,5 +434,5 @@ class TestReviewFlow:
         )
         sub.refresh_from_db()
         # one row applied, one still queued → stays in review
-        assert sub.status == WorkOrderSubmission.STATUS_PENDING_REVIEW
+        assert sub.status == WorkOrderSubmission.Status.PENDING_REVIEW
         assert len(sub.pending_changes) == 1

--- a/backend/inventory/tests/test_work_order_parity.py
+++ b/backend/inventory/tests/test_work_order_parity.py
@@ -124,7 +124,7 @@ def test_electrical_context_pulls_asset_charfield_stubs():
         electrical_box="Panel A enclosure",
         breaker_location="Panel A / 12",
         suite="North bay",
-        wiring_type=Asset.WIRING_240V_PLUG,
+        wiring_type=Asset.WiringType.PLUG_240V,
         has_network_drop=True,
         network_drop_location="Wallplate 3A",
         power_draw_watts=1500,
@@ -173,7 +173,7 @@ def test_electrical_context_joins_electrical_circuits_via_location():
 
 
 def test_loto_context_empty_when_no_lockout_required():
-    asset = AssetFactory(lockout_type=Asset.LOCKOUT_NONE)
+    asset = AssetFactory(lockout_type=Asset.LockoutType.NONE)
     ctx = build_loto_context(asset)
     assert ctx["is_required"] is False
     assert ctx["is_empty"] is True
@@ -181,7 +181,7 @@ def test_loto_context_empty_when_no_lockout_required():
 
 def test_loto_context_populated_when_lockout_required():
     asset = AssetFactory(
-        lockout_type=Asset.LOCKOUT_LOTO,
+        lockout_type=Asset.LockoutType.LOTO,
         lockout_instructions="Open Panel A breaker 12. Lock with tag.",
         lockout_responsible="Ops lead",
     )
@@ -199,7 +199,7 @@ def test_loto_context_populated_when_lockout_required():
 
 def test_serializer_includes_electrical_and_loto_blocks(api):
     asset = AssetFactory(
-        lockout_type=Asset.LOCKOUT_LOTO,
+        lockout_type=Asset.LockoutType.LOTO,
         lockout_instructions="Lock breaker A12.",
         electrical_box="Panel A",
     )
@@ -223,13 +223,13 @@ def test_completion_blocked_without_validation(api):
     wo = _build_wo()
     res = api.patch(
         f"/api/inventory/work-orders/{wo.id}/",
-        {"status": WorkOrder.STATUS_COMPLETED},
+        {"status": WorkOrder.Status.COMPLETED},
         format="json",
     )
     assert res.status_code == status.HTTP_412_PRECONDITION_FAILED
     assert res.json()["code"] == "validation_required"
     wo.refresh_from_db()
-    assert wo.status != WorkOrder.STATUS_COMPLETED
+    assert wo.status != WorkOrder.Status.COMPLETED
 
 
 def test_pdf_generation_blocked_without_validation(api):
@@ -273,12 +273,12 @@ def test_completion_allowed_after_full_validation(api, staff_user):
 
     res = api.patch(
         f"/api/inventory/work-orders/{wo.id}/",
-        {"status": WorkOrder.STATUS_COMPLETED},
+        {"status": WorkOrder.Status.COMPLETED},
         format="json",
     )
     assert res.status_code == status.HTTP_200_OK
     wo.refresh_from_db()
-    assert wo.status == WorkOrder.STATUS_COMPLETED
+    assert wo.status == WorkOrder.Status.COMPLETED
 
 
 def test_completion_stamps_completed_at(api):
@@ -301,13 +301,13 @@ def test_completion_stamps_completed_at(api):
     )
     res = api.patch(
         f"/api/inventory/work-orders/{wo.id}/",
-        {"status": WorkOrder.STATUS_COMPLETED},
+        {"status": WorkOrder.Status.COMPLETED},
         format="json",
     )
 
     assert res.status_code == status.HTTP_200_OK
     wo.refresh_from_db()
-    assert wo.status == WorkOrder.STATUS_COMPLETED
+    assert wo.status == WorkOrder.Status.COMPLETED
     assert wo.completed_at is not None
 
 
@@ -325,7 +325,7 @@ def test_reopening_clears_completed_at(api):
     )
     api.patch(
         f"/api/inventory/work-orders/{wo.id}/",
-        {"status": WorkOrder.STATUS_COMPLETED},
+        {"status": WorkOrder.Status.COMPLETED},
         format="json",
     )
     wo.refresh_from_db()
@@ -333,13 +333,13 @@ def test_reopening_clears_completed_at(api):
 
     res = api.patch(
         f"/api/inventory/work-orders/{wo.id}/",
-        {"status": WorkOrder.STATUS_IN_PROGRESS},
+        {"status": WorkOrder.Status.IN_PROGRESS},
         format="json",
     )
 
     assert res.status_code == status.HTTP_200_OK
     wo.refresh_from_db()
-    assert wo.status == WorkOrder.STATUS_IN_PROGRESS
+    assert wo.status == WorkOrder.Status.IN_PROGRESS
     assert wo.completed_at is None
 
 
@@ -353,7 +353,7 @@ def test_backfill_migration_populates_completed_at():
     wo = _build_wo()
     # Simulate a legacy digital completion: completed status, no timestamp.
     # .update() bypasses auto_now, so updated_at stays at creation time.
-    WorkOrder.objects.filter(pk=wo.pk).update(status=WorkOrder.STATUS_COMPLETED, completed_at=None)
+    WorkOrder.objects.filter(pk=wo.pk).update(status=WorkOrder.Status.COMPLETED, completed_at=None)
 
     migration = importlib.import_module("inventory.migrations.0062_backfill_workorder_completed_at")
     migration.backfill_completed_at(global_apps, None)
@@ -403,9 +403,9 @@ def test_auto_apply_or_queue_splits_by_confidence(settings):
 def test_apply_pending_changes_endpoint(api):
     wo = _build_wo()
     sub = WorkOrderSubmission.objects.create(
-        kind=WorkOrderSubmission.KIND_PM_COMPLETION,
+        kind=WorkOrderSubmission.Kind.PM_COMPLETION,
         work_order=wo,
-        status=WorkOrderSubmission.STATUS_PENDING_REVIEW,
+        status=WorkOrderSubmission.Status.PENDING_REVIEW,
         pending_changes=[
             {
                 "kind": "signature",
@@ -428,7 +428,7 @@ def test_apply_pending_changes_endpoint(api):
     assert res.status_code == status.HTTP_200_OK
     assert res.json()["applied_count"] == 2
     sub.refresh_from_db()
-    assert sub.status == WorkOrderSubmission.STATUS_APPLIED
+    assert sub.status == WorkOrderSubmission.Status.APPLIED
     assert sub.pending_changes == []
     wo.refresh_from_db()
     assert "Replaced V-belt" in wo.notes
@@ -438,9 +438,9 @@ def test_apply_pending_changes_endpoint(api):
 def test_discard_pending_changes_endpoint(api):
     wo = _build_wo()
     sub = WorkOrderSubmission.objects.create(
-        kind=WorkOrderSubmission.KIND_PM_COMPLETION,
+        kind=WorkOrderSubmission.Kind.PM_COMPLETION,
         work_order=wo,
-        status=WorkOrderSubmission.STATUS_PENDING_REVIEW,
+        status=WorkOrderSubmission.Status.PENDING_REVIEW,
         pending_changes=[
             {
                 "kind": "handwritten",
@@ -456,7 +456,7 @@ def test_discard_pending_changes_endpoint(api):
     assert res.status_code == status.HTTP_200_OK
     assert res.json()["dropped_count"] == 1
     sub.refresh_from_db()
-    assert sub.status == WorkOrderSubmission.STATUS_APPLIED
+    assert sub.status == WorkOrderSubmission.Status.APPLIED
     assert sub.pending_changes == []
     wo.refresh_from_db()
     assert "illegible" not in wo.notes
@@ -474,10 +474,10 @@ def test_pdf_and_serializer_share_the_same_context_builder():
     LOTO data so any field that one surface drops will trip the test.
     """
     asset = AssetFactory(
-        wiring_type=Asset.WIRING_240V_PLUG,
+        wiring_type=Asset.WiringType.PLUG_240V,
         electrical_box="Panel A",
         breaker_location="Panel A / 12",
-        lockout_type=Asset.LOCKOUT_LOTO,
+        lockout_type=Asset.LockoutType.LOTO,
         lockout_instructions="Lock breaker A12.",
         lockout_responsible="Ops lead",
         has_network_drop=True,

--- a/backend/inventory/tests/test_work_order_permissions.py
+++ b/backend/inventory/tests/test_work_order_permissions.py
@@ -34,7 +34,7 @@ User = get_user_model()
 pytestmark = pytest.mark.django_db
 
 
-def _wo_payload(*, status="open"):
+def _wo_payload(*, status=WorkOrder.Status.OPEN):
     asset = AssetFactory()
     item = MaintenanceItem.objects.create(
         asset=asset,
@@ -100,7 +100,7 @@ class TestWorkOrderViewSetPermissions:
         )
         resp = self._client(_user("volunteer")).patch(
             f"/api/inventory/work-orders/{wo.id}/",
-            data={"status": "in_progress"},
+            data={"status": WorkOrder.Status.IN_PROGRESS},
             format="json",
         )
         assert resp.status_code == 403

--- a/backend/inventory/tests/test_work_order_upload.py
+++ b/backend/inventory/tests/test_work_order_upload.py
@@ -81,7 +81,7 @@ class TestUploadPdfEndpoint:
 
         assert resp.status_code == status.HTTP_200_OK, resp.content
         body = resp.json()
-        assert body["status"] == WorkOrderSubmission.STATUS_APPLIED
+        assert body["status"] == WorkOrderSubmission.Status.APPLIED
         assert body["work_order_id"] == str(wo.id)
         assert body["errors"] == []
 
@@ -89,11 +89,11 @@ class TestUploadPdfEndpoint:
         assert completed_titles == {tc.task_title for tc in tcs}
 
         submission = WorkOrderSubmission.objects.get(id=body["submission_id"])
-        assert submission.source == WorkOrderSubmission.SOURCE_MANUAL
+        assert submission.source == WorkOrderSubmission.Source.MANUAL
         assert submission.submitted_by_id == user.id
 
         wo.refresh_from_db()
-        assert wo.status == WorkOrder.STATUS_COMPLETED
+        assert wo.status == WorkOrder.Status.COMPLETED
 
     def test_upload_without_pdf_returns_400(self):
         client, _ = _staff_client()
@@ -127,14 +127,14 @@ class TestUploadPdfEndpoint:
         resp = _upload(client, buf.getvalue())
         assert resp.status_code == status.HTTP_200_OK, resp.content
         body = resp.json()
-        assert body["status"] == WorkOrderSubmission.STATUS_FAILED
+        assert body["status"] == WorkOrderSubmission.Status.FAILED
         assert body["work_order_id"] is None
         assert body["completed_items"] == []
         assert body["errors"]
         assert "Work Order ID" in body["errors"][0]
 
         submission = WorkOrderSubmission.objects.get(id=body["submission_id"])
-        assert submission.source == WorkOrderSubmission.SOURCE_MANUAL
+        assert submission.source == WorkOrderSubmission.Source.MANUAL
 
     def test_source_set_to_manual(self):
         """Manual uploads must record source='manual' on the submission."""
@@ -146,7 +146,7 @@ class TestUploadPdfEndpoint:
         assert resp.status_code == status.HTTP_200_OK
 
         submission = WorkOrderSubmission.objects.get(id=resp.json()["submission_id"])
-        assert submission.source == WorkOrderSubmission.SOURCE_MANUAL
+        assert submission.source == WorkOrderSubmission.Source.MANUAL
         assert submission.submitted_by_id == user.id
 
 
@@ -175,6 +175,6 @@ class TestWorkOrderSerializerExposesSubmissions:
         sub = body["submissions"][0]
         assert sub["pdf_url"], "pdf_url must be a non-empty URL"
         assert sub["pdf_url"].endswith(".pdf")
-        assert sub["source"] == WorkOrderSubmission.SOURCE_MANUAL
-        assert sub["status"] == WorkOrderSubmission.STATUS_APPLIED
+        assert sub["source"] == WorkOrderSubmission.Source.MANUAL
+        assert sub["status"] == WorkOrderSubmission.Status.APPLIED
         assert sub["received_at"]

--- a/backend/inventory/utils/brother_esc_p.py
+++ b/backend/inventory/utils/brother_esc_p.py
@@ -143,7 +143,7 @@ class BrotherESCPGenerator:
         # Status
         status_y = tag_y + 60 if asset.asset_tag else text_y + 80
         status_text = asset.get_status_display()
-        status_color = "green" if asset.status == Asset.ACTIVE else "orange"
+        status_color = "green" if asset.status == Asset.Status.ACTIVE else "orange"
         if font_medium:
             draw.text((text_x, status_y), status_text, fill=status_color, font=font_medium)
         else:

--- a/backend/inventory/utils/label_generator.py
+++ b/backend/inventory/utils/label_generator.py
@@ -176,7 +176,7 @@ class BrotherLabelRenderer:
         )
         font_size_status = 9  # Increased from 7
         pdf_canvas.setFont("Helvetica", font_size_status)
-        status_color = colors.green if asset.status == Asset.ACTIVE else colors.orange
+        status_color = colors.green if asset.status == Asset.Status.ACTIVE else colors.orange
         pdf_canvas.setFillColor(status_color)
         pdf_canvas.drawString(text_x, status_y, asset.get_status_display())
 

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -46,6 +46,7 @@ from .models import (
     ItemSupplier,
     Location,
     LocationProblem,
+    MaintenanceAuditEvent,
     MaintenanceItem,
     MaintenanceLog,
     MaintenanceMaterial,
@@ -211,10 +212,12 @@ class SupplierViewSet(viewsets.ModelViewSet):
             purchase_orders = PurchaseOrder.objects.filter(supplier=supplier)
             order_stats = {
                 "total_orders": purchase_orders.count(),
-                "received_orders": purchase_orders.filter(status=PurchaseOrder.RECEIVED).count(),
+                "received_orders": purchase_orders.filter(
+                    status=PurchaseOrder.Status.RECEIVED
+                ).count(),
                 "total_spent": (
                     purchase_orders.filter(
-                        status=PurchaseOrder.RECEIVED, actual_total__isnull=False
+                        status=PurchaseOrder.Status.RECEIVED, actual_total__isnull=False
                     ).aggregate(total=Sum("actual_total"))["total"]
                     or Decimal("0.00")
                 ),
@@ -412,8 +415,8 @@ class LocationViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        severity = request.data.get("severity") or LocationProblem.SEVERITY_MEDIUM
-        valid_sev = {choice for choice, _ in LocationProblem.SEVERITY_CHOICES}
+        severity = request.data.get("severity") or LocationProblem.Severity.MEDIUM
+        valid_sev = {choice for choice, _ in LocationProblem.Severity.choices}
         if severity not in valid_sev:
             return Response(
                 {"error": f"severity must be one of {sorted(valid_sev)}"},
@@ -464,8 +467,8 @@ class LocationViewSet(viewsets.ModelViewSet):
             pass
 
         if problem.severity in (
-            LocationProblem.SEVERITY_HIGH,
-            LocationProblem.SEVERITY_URGENT,
+            LocationProblem.Severity.HIGH,
+            LocationProblem.Severity.URGENT,
         ):
             try:
                 from inventory.services.location_problem_alerts import email_logistics_alert
@@ -671,7 +674,7 @@ class InventoryItemViewSet(viewsets.ModelViewSet):
         ownership_type = request.data.get("ownership_type")
         owning_group_id = request.data.get("owning_group")
 
-        if ownership_type == "group" and owning_group_id:
+        if ownership_type == InventoryItem.OwnershipType.GROUP and owning_group_id:
             try:
                 group = Group.objects.get(pk=owning_group_id)
                 if not (
@@ -1057,7 +1060,7 @@ class InventoryItemViewSet(viewsets.ModelViewSet):
         days-since-last-count.
 
         Body: ``counted_qty`` (required int >= 0), ``reason`` (required, from
-        ``StockReconciliation.REASON_CHOICES``), ``skip_reorder`` (optional bool),
+        ``StockReconciliation.ReasonCode.choices``), ``skip_reorder`` (optional bool),
         ``notes`` (optional str).
         """
         item = self.get_object()
@@ -1082,7 +1085,7 @@ class InventoryItemViewSet(viewsets.ModelViewSet):
             )
 
         reason = request.data.get("reason")
-        valid_reasons = {v for v, _ in StockReconciliation.REASON_CHOICES}
+        valid_reasons = {v for v, _ in StockReconciliation.ReasonCode.choices}
         if reason not in valid_reasons:
             return Response(
                 {"detail": ("reason is required; choose from " f"{sorted(valid_reasons)}.")},
@@ -1370,7 +1373,7 @@ class PriceHistoryViewSet(viewsets.ReadOnlyModelViewSet):
         since_date = timezone.now() - timedelta(days=days)
         recent_changes = self.get_queryset().filter(
             recorded_at__gte=since_date,
-            change_type="updated",  # Only actual price updates, not initial records
+            change_type=PriceHistory.ChangeType.UPDATED,  # Only actual price updates, not initial records
         )[
             :50
         ]  # Limit to 50 most recent
@@ -1571,7 +1574,7 @@ class AssetViewSet(viewsets.ModelViewSet):
         ownership_type = request.data.get("ownership_type")
         owning_group_id = request.data.get("owning_group")
 
-        if ownership_type == "group" and owning_group_id:
+        if ownership_type == Asset.OwnershipType.GROUP and owning_group_id:
             # Check if user is admin of the specified group
             from django.contrib.auth.models import Group
 
@@ -1986,7 +1989,7 @@ class AssetViewSet(viewsets.ModelViewSet):
             )
 
         # Check if user can operate assets in Implementing/Testing status
-        if asset.status in [asset.IMPLEMENTING, asset.TESTING]:
+        if asset.status in [asset.Status.IMPLEMENTING, asset.Status.TESTING]:
             if not asset.can_user_operate(user):
                 return Response(
                     {
@@ -2026,7 +2029,7 @@ class AssetViewSet(viewsets.ModelViewSet):
             )
 
         # Check if user can operate assets in Implementing/Testing status
-        if asset.status in [asset.IMPLEMENTING, asset.TESTING]:
+        if asset.status in [asset.Status.IMPLEMENTING, asset.Status.TESTING]:
             if not asset.can_user_operate(user):
                 return Response(
                     {
@@ -2321,11 +2324,11 @@ class AssetViewSet(viewsets.ModelViewSet):
             )
 
         # Update problem status and resolution details
-        new_status = request.data.get("status", AssetProblem.RESOLVED)
-        if new_status not in [AssetProblem.RESOLVED, AssetProblem.CLOSED]:
+        new_status = request.data.get("status", AssetProblem.Status.RESOLVED)
+        if new_status not in [AssetProblem.Status.RESOLVED, AssetProblem.Status.CLOSED]:
             return Response(
                 {
-                    "error": f"Invalid status. Must be '{AssetProblem.RESOLVED}' or '{AssetProblem.CLOSED}'"
+                    "error": f"Invalid status. Must be '{AssetProblem.Status.RESOLVED}' or '{AssetProblem.Status.CLOSED}'"
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )
@@ -2336,7 +2339,10 @@ class AssetViewSet(viewsets.ModelViewSet):
         )
 
         # Set resolved_at and resolved_by if resolving for the first time
-        if new_status in [AssetProblem.RESOLVED, AssetProblem.CLOSED] and not problem.resolved_at:
+        if (
+            new_status in [AssetProblem.Status.RESOLVED, AssetProblem.Status.CLOSED]
+            and not problem.resolved_at
+        ):
             problem.resolved_at = timezone.now()
             # Set resolved_by using handle or username
             if request.user.is_authenticated:
@@ -2798,7 +2804,7 @@ class AssetMeterViewSet(viewsets.ModelViewSet):
 
         spec_kwargs = {"absolute": value} if is_absolute else {"delta": value}
         spec = ReadingSpec(
-            source=AssetMeterReading.SOURCE_MANUAL,
+            source=AssetMeterReading.Source.MANUAL,
             observed_at=observed_at,
             is_estimated=is_estimated,
             source_ref="manual entry",
@@ -2831,7 +2837,7 @@ class AssetMeterViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         spec = ReadingSpec(
-            source=AssetMeterReading.SOURCE_MANUAL_ADJUST,
+            source=AssetMeterReading.Source.MANUAL_ADJUST,
             observed_at=timezone.now(),
             absolute=target,
             is_estimated=False,
@@ -2934,7 +2940,7 @@ class LocationProblemViewSet(viewsets.ReadOnlyModelViewSet):
                 assigned_to=request.user if request.user.is_authenticated else None,
             )
             problem.work_order = wo
-            problem.status = LocationProblem.IN_PROGRESS
+            problem.status = LocationProblem.Status.IN_PROGRESS
             problem.save(update_fields=["work_order", "status", "updated_at"])
             self._copy_attachments_to_work_order(problem, wo)
 
@@ -3010,7 +3016,7 @@ class LocationProblemViewSet(viewsets.ReadOnlyModelViewSet):
                     user=request.user if request.user.is_authenticated else None,
                 )
             problem.third_party_work_order = tpwo
-            problem.status = LocationProblem.IN_PROGRESS
+            problem.status = LocationProblem.Status.IN_PROGRESS
             problem.save(update_fields=["third_party_work_order", "status", "updated_at"])
 
         serializer = LocationProblemSerializer(problem, context={"request": request})
@@ -3020,13 +3026,13 @@ class LocationProblemViewSet(viewsets.ReadOnlyModelViewSet):
     def resolve(self, request, pk=None):
         """Mark this location problem as resolved or closed."""
         problem = self.get_object()
-        new_status = request.data.get("status", LocationProblem.RESOLVED)
-        if new_status not in (LocationProblem.RESOLVED, LocationProblem.CLOSED):
+        new_status = request.data.get("status", LocationProblem.Status.RESOLVED)
+        if new_status not in (LocationProblem.Status.RESOLVED, LocationProblem.Status.CLOSED):
             return Response(
                 {
                     "error": (
-                        f"status must be '{LocationProblem.RESOLVED}' or "
-                        f"'{LocationProblem.CLOSED}'"
+                        f"status must be '{LocationProblem.Status.RESOLVED}' or "
+                        f"'{LocationProblem.Status.CLOSED}'"
                     )
                 },
                 status=status.HTTP_400_BAD_REQUEST,
@@ -3043,7 +3049,7 @@ class LocationProblemViewSet(viewsets.ReadOnlyModelViewSet):
         problem.save()
 
         record_maintenance_audit_event(
-            action="location_problem_resolve",
+            action=MaintenanceAuditEvent.Action.LOCATION_PROBLEM_RESOLVE,
             actor=request.user,
             location_problem=problem,
             notes=problem.resolution_notes or "",
@@ -3303,9 +3309,9 @@ class FixtureViewSet(viewsets.ModelViewSet):
         from django.utils import timezone
 
         updated_count = FixtureRefillRequest.objects.filter(
-            fixture=fixture, status="pending"
+            fixture=fixture, status=FixtureRefillRequest.Status.PENDING
         ).update(
-            status="completed",
+            status=FixtureRefillRequest.Status.COMPLETED,
             resolved_at=timezone.now(),
             resolved_by=resolved_by,
             # Only update notes if provided
@@ -3359,7 +3365,7 @@ class FixtureRefillRequestViewSet(viewsets.ModelViewSet):
         """Mark a single refill request as completed."""
         refill_request = self.get_object()
 
-        if refill_request.status == "completed":
+        if refill_request.status == FixtureRefillRequest.Status.COMPLETED:
             return Response(
                 {"error": "This request is already completed"},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -3367,7 +3373,7 @@ class FixtureRefillRequestViewSet(viewsets.ModelViewSet):
 
         from django.utils import timezone
 
-        refill_request.status = "completed"
+        refill_request.status = FixtureRefillRequest.Status.COMPLETED
         refill_request.resolved_at = timezone.now()
         refill_request.resolved_by = request.user.username if request.user.is_authenticated else ""
         refill_request.notes = request.data.get("notes", refill_request.notes)
@@ -3790,8 +3796,8 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
         instance = self.get_object()
         new_status = request.data.get("status")
         if (
-            new_status == WorkOrder.STATUS_COMPLETED
-            and instance.status != WorkOrder.STATUS_COMPLETED
+            new_status == WorkOrder.Status.COMPLETED
+            and instance.status != WorkOrder.Status.COMPLETED
             and not self._has_complete_validation(instance)
         ):
             return Response(
@@ -3817,7 +3823,7 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
         it if a completed work order is reopened. An already-set timestamp (e.g.
         from the paper-form ingest) is left untouched.
         """
-        if work_order.status == WorkOrder.STATUS_COMPLETED:
+        if work_order.status == WorkOrder.Status.COMPLETED:
             if work_order.completed_at is None:
                 work_order.completed_at = timezone.now()
                 work_order.save(update_fields=["completed_at"])
@@ -3846,7 +3852,7 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
         ``last_completed_at`` only advances forward — a reopen + recomplete
         with an earlier ``wo.completed_at`` doesn't roll the date back.
         """
-        if work_order.status != WorkOrder.STATUS_COMPLETED:
+        if work_order.status != WorkOrder.Status.COMPLETED:
             return
         if not work_order.completed_at:
             return
@@ -3985,7 +3991,7 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
         self._bundle_due_siblings(work_order)
         self._sync_maintenance_item_completion(work_order, actor=self.request.user)
         record_maintenance_audit_event(
-            action="wo_create",
+            action=MaintenanceAuditEvent.Action.WO_CREATE,
             actor=self.request.user,
             work_order=work_order,
             metadata={
@@ -3998,15 +4004,15 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
         old_status = serializer.instance.status
         work_order = serializer.save()
         self._sync_completion_timestamp(
-            work_order, was_completed=(old_status == WorkOrder.STATUS_COMPLETED)
+            work_order, was_completed=(old_status == WorkOrder.Status.COMPLETED)
         )
         self._sync_maintenance_item_completion(work_order, actor=self.request.user)
         if (
-            work_order.status == WorkOrder.STATUS_COMPLETED
-            and old_status != WorkOrder.STATUS_COMPLETED
+            work_order.status == WorkOrder.Status.COMPLETED
+            and old_status != WorkOrder.Status.COMPLETED
         ):
             record_maintenance_audit_event(
-                action="wo_complete",
+                action=MaintenanceAuditEvent.Action.WO_COMPLETE,
                 actor=self.request.user,
                 work_order=work_order,
                 metadata={
@@ -4176,8 +4182,8 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
         tc.save()
 
         # Update work order status to in_progress if any task is completed
-        if tc.is_completed and work_order.status == WorkOrder.STATUS_OPEN:
-            work_order.status = WorkOrder.STATUS_IN_PROGRESS
+        if tc.is_completed and work_order.status == WorkOrder.Status.OPEN:
+            work_order.status = WorkOrder.Status.IN_PROGRESS
             work_order.save(update_fields=["status", "updated_at"])
 
         return Response(WorkOrderTaskCompletionSerializer(tc).data)
@@ -4226,12 +4232,12 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
         submission = WorkOrderSubmission(
             kind=kind,
             source=(
-                WorkOrderSubmission.SOURCE_SCAN if is_scan else WorkOrderSubmission.SOURCE_MANUAL
+                WorkOrderSubmission.Source.SCAN if is_scan else WorkOrderSubmission.Source.MANUAL
             ),
             submitted_by=user,
             from_email=(user.email or "")[:254],
             subject=(upload_name)[:500],
-            status=WorkOrderSubmission.STATUS_RECEIVED,
+            status=WorkOrderSubmission.Status.RECEIVED,
         )
         submission.attachment.save(
             pdf_file.name or "work-order.pdf",
@@ -4363,9 +4369,9 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
 
         submission.pending_changes = remaining
         submission.status = (
-            WorkOrderSubmission.STATUS_APPLIED
+            WorkOrderSubmission.Status.APPLIED
             if not remaining
-            else WorkOrderSubmission.STATUS_PENDING_REVIEW
+            else WorkOrderSubmission.Status.PENDING_REVIEW
         )
         submission.save(update_fields=["pending_changes", "status"])
 
@@ -4420,8 +4426,8 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
             dropped += 1
 
         submission.pending_changes = remaining
-        if not remaining and submission.status == WorkOrderSubmission.STATUS_PENDING_REVIEW:
-            submission.status = WorkOrderSubmission.STATUS_APPLIED
+        if not remaining and submission.status == WorkOrderSubmission.Status.PENDING_REVIEW:
+            submission.status = WorkOrderSubmission.Status.APPLIED
         submission.save(update_fields=["pending_changes", "status"])
 
         return Response(
@@ -4725,7 +4731,7 @@ class MaintenanceItemViewSet(viewsets.ModelViewSet):
 
                 # Skip if there's already an open/in-progress WO for this item
                 existing = item.work_orders.filter(
-                    status__in=[WorkOrder.STATUS_OPEN, WorkOrder.STATUS_IN_PROGRESS]
+                    status__in=[WorkOrder.Status.OPEN, WorkOrder.Status.IN_PROGRESS]
                 ).exists()
                 if existing:
                     continue
@@ -4820,9 +4826,9 @@ class MaintenanceDashboardViewSet(viewsets.ViewSet):
         )
 
         open_statuses = [
-            WorkOrder.STATUS_OPEN,
-            WorkOrder.STATUS_IN_PROGRESS,
-            WorkOrder.STATUS_BLOCKED,
+            WorkOrder.Status.OPEN,
+            WorkOrder.Status.IN_PROGRESS,
+            WorkOrder.Status.BLOCKED,
         ]
         unscheduled_qs = (
             WorkOrder.objects.filter(
@@ -4847,7 +4853,7 @@ class MaintenanceDashboardViewSet(viewsets.ViewSet):
 
         completed_qs = (
             WorkOrder.objects.filter(
-                status=WorkOrder.STATUS_COMPLETED,
+                status=WorkOrder.Status.COMPLETED,
                 completed_at__isnull=False,
             )
             .select_related("maintenance_item")
@@ -4902,7 +4908,7 @@ class MaintenanceDashboardViewSet(viewsets.ViewSet):
                             days_set.add(d)
                             d += timedelta(days=1)
                     if (
-                        wo.status == WorkOrder.STATUS_COMPLETED
+                        wo.status == WorkOrder.Status.COMPLETED
                         and wo.completed_at is not None
                         and window_start_date <= wo.completed_at.date() <= today
                     ):
@@ -4915,7 +4921,7 @@ class MaintenanceDashboardViewSet(viewsets.ViewSet):
                                         usage.quantity_planned
                                         * usage.material.estimated_cost_per_unit
                                     )
-            if asset.status == Asset.MAINTENANCE:
+            if asset.status == Asset.Status.MAINTENANCE:
                 days_set.add(today)
             if not days_set and total_cost == 0:
                 continue
@@ -4953,17 +4959,17 @@ class MaintenanceDashboardViewSet(viewsets.ViewSet):
         a ``kind`` discriminator so the frontend can render appropriate CTAs.
         """
         open_wo_statuses = [
-            WorkOrder.STATUS_OPEN,
-            WorkOrder.STATUS_IN_PROGRESS,
-            WorkOrder.STATUS_BLOCKED,
+            WorkOrder.Status.OPEN,
+            WorkOrder.Status.IN_PROGRESS,
+            WorkOrder.Status.BLOCKED,
         ]
         open_problem_statuses = [
-            AssetProblem.REPORTED,
-            AssetProblem.IN_PROGRESS,
+            AssetProblem.Status.REPORTED,
+            AssetProblem.Status.IN_PROGRESS,
         ]
         open_location_problem_statuses = [
-            LocationProblem.REPORTED,
-            LocationProblem.IN_PROGRESS,
+            LocationProblem.Status.REPORTED,
+            LocationProblem.Status.IN_PROGRESS,
         ]
 
         rows = []
@@ -5059,7 +5065,7 @@ class AssetReportViewSet(viewsets.ViewSet):
         queryset = Asset.objects.values("status").annotate(count=Count("id")).order_by("status")
 
         data = []
-        status_choices = dict(Asset.STATUS_CHOICES)
+        status_choices = dict(Asset.Status.choices)
         for item in queryset:
             data.append(
                 {
@@ -5105,9 +5111,9 @@ class AssetReportViewSet(viewsets.ViewSet):
                 )
 
         # Also check assets that are in maintenance status
-        assets_in_maintenance = Asset.objects.filter(status=Asset.MAINTENANCE).select_related(
-            "category", "location"
-        )
+        assets_in_maintenance = Asset.objects.filter(
+            status=Asset.Status.MAINTENANCE
+        ).select_related("category", "location")
 
         for asset in assets_in_maintenance:
             maintenance_needed.append(
@@ -5265,7 +5271,7 @@ class AssetReportViewSet(viewsets.ViewSet):
                             d += timedelta(days=1)
 
                     if (
-                        wo.status == WorkOrder.STATUS_COMPLETED
+                        wo.status == WorkOrder.Status.COMPLETED
                         and wo.completed_at is not None
                         and window_start <= wo.completed_at.date() <= today
                     ):
@@ -5287,7 +5293,7 @@ class AssetReportViewSet(viewsets.ViewSet):
                     if wo_closed is not None:
                         days_set.add(wo_closed.date())
 
-            if asset.status == Asset.MAINTENANCE:
+            if asset.status == Asset.Status.MAINTENANCE:
                 days_set.add(today)
 
             repair = Decimal("0.00")
@@ -5377,8 +5383,8 @@ class AssetReportViewSet(viewsets.ViewSet):
         events = ComponentUsageEvent.objects.filter(
             asset__isnull=False,
             action__in=[
-                SerializedComponent.ACTION_INSTALL,
-                SerializedComponent.ACTION_CONSUME,
+                SerializedComponent.Action.INSTALL,
+                SerializedComponent.Action.CONSUME,
             ],
             at__date__gte=start_date,
             at__date__lte=end_date,
@@ -5410,7 +5416,7 @@ class AssetReportViewSet(viewsets.ViewSet):
         for asset in assets:
             for mi in asset.maintenance_items.all():
                 for wo in mi.work_orders.all():
-                    if wo.status != WorkOrder.STATUS_COMPLETED or wo.completed_at is None:
+                    if wo.status != WorkOrder.Status.COMPLETED or wo.completed_at is None:
                         continue
                     completed_date = wo.completed_at.date()
                     if not (start_date <= completed_date <= end_date):
@@ -5715,8 +5721,8 @@ def postmark_inbound_work_order(request):
         from_email=(payload.get("FromFull") or {}).get("Email") or payload.get("From") or "",
         subject=subject,
         postmark_message_id=message_id[:200],
-        status=WorkOrderSubmission.STATUS_RECEIVED,
-        source=(WorkOrderSubmission.SOURCE_SCAN if is_scan else WorkOrderSubmission.SOURCE_EMAIL),
+        status=WorkOrderSubmission.Status.RECEIVED,
+        source=(WorkOrderSubmission.Source.SCAN if is_scan else WorkOrderSubmission.Source.EMAIL),
     )
     submission.attachment.save(filename, ContentFile(pdf_bytes), save=False)
     submission.save()
@@ -5933,7 +5939,7 @@ class InventoryReconciliationViewSet(viewsets.ViewSet):
             "yes",
         )
 
-        valid_reasons = {v for v, _ in StockReconciliation.REASON_CHOICES}
+        valid_reasons = {v for v, _ in StockReconciliation.ReasonCode.choices}
 
         try:
             decoded = io.TextIOWrapper(file_obj, encoding="utf-8-sig", newline="")
@@ -6436,32 +6442,32 @@ class SerializedComponentViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=["post"])
     def receive(self, request, pk=None):
         """Accession a received unit into stock (``received`` -> ``in_stock``)."""
-        return self._run_lifecycle_action(request, SerializedComponent.ACTION_RECEIVE)
+        return self._run_lifecycle_action(request, SerializedComponent.Action.RECEIVE)
 
     @action(detail=True, methods=["post"])
     def install(self, request, pk=None):
         """Install the unit into an asset (requires ``asset``)."""
-        return self._run_lifecycle_action(request, SerializedComponent.ACTION_INSTALL)
+        return self._run_lifecycle_action(request, SerializedComponent.Action.INSTALL)
 
     @action(detail=True, methods=["post"])
     def remove(self, request, pk=None):
         """Remove a reusable unit from its asset (``installed`` -> ``removed``)."""
-        return self._run_lifecycle_action(request, SerializedComponent.ACTION_REMOVE)
+        return self._run_lifecycle_action(request, SerializedComponent.Action.REMOVE)
 
     @action(detail=True, methods=["post"])
     def consume(self, request, pk=None):
         """Mark a consumable unit as used up (``installed`` -> ``consumed``)."""
-        return self._run_lifecycle_action(request, SerializedComponent.ACTION_CONSUME)
+        return self._run_lifecycle_action(request, SerializedComponent.Action.CONSUME)
 
     @action(detail=True, methods=["post"])
     def retire(self, request, pk=None):
         """Retire a reusable unit from service (-> ``retired``)."""
-        return self._run_lifecycle_action(request, SerializedComponent.ACTION_RETIRE)
+        return self._run_lifecycle_action(request, SerializedComponent.Action.RETIRE)
 
     @action(detail=True, methods=["post"])
     def dispose(self, request, pk=None):
         """Dispose the unit (requires ``disposal_reason``; -> ``disposed``)."""
-        return self._run_lifecycle_action(request, SerializedComponent.ACTION_DISPOSE)
+        return self._run_lifecycle_action(request, SerializedComponent.Action.DISPOSE)
 
     @action(detail=False, methods=["post"])
     def scan_receive(self, request):
@@ -6518,7 +6524,7 @@ class SerializedComponentViewSet(viewsets.ModelViewSet):
                 },
             )
             if created:
-                component.apply_action(SerializedComponent.ACTION_RECEIVE, actor=actor)
+                component.apply_action(SerializedComponent.Action.RECEIVE, actor=actor)
 
         component.refresh_from_db()
         data = self.get_serializer(component).data

--- a/backend/loto/tests/test_api.py
+++ b/backend/loto/tests/test_api.py
@@ -120,7 +120,7 @@ def test_loto_requirements_endpoint_empty_state(authenticated_client, asset):
 def test_loto_requirements_endpoint_populated(authenticated_client, asset):
     """AC-5: oms-2da serializer can join LOTO data via this endpoint."""
     client, _ = authenticated_client
-    asset.lockout_type = Asset.LOCKOUT_LOTO
+    asset.lockout_type = Asset.LockoutType.LOTO
     asset.lockout_instructions = "Lock breaker, tag valve, verify zero energy."
     asset.lockout_responsible = "Maintenance lead"
     asset.save()
@@ -138,7 +138,7 @@ def test_loto_requirements_endpoint_populated(authenticated_client, asset):
     body = client.get(url).json()
 
     assert body["is_required"] is True
-    assert body["lockout_type"] == Asset.LOCKOUT_LOTO
+    assert body["lockout_type"] == Asset.LockoutType.LOTO
     assert body["lockout_type_display"] == "LOTO (Lockout / Tagout)"
     assert body["lockout_instructions"].startswith("Lock breaker")
     assert body["lockout_responsible"] == "Maintenance lead"

--- a/backend/membership/tests/test_sig_api.py
+++ b/backend/membership/tests/test_sig_api.py
@@ -370,8 +370,8 @@ class TestReorderRequestSIGPermissions:
         sig_item = InventoryItemFactory(owning_group=sig_group)
         other_item = InventoryItemFactory(owning_group=None)
 
-        sig_request = ReorderRequestFactory(item=sig_item, status=ReorderRequest.PENDING)
-        other_request = ReorderRequestFactory(item=other_item, status=ReorderRequest.PENDING)
+        sig_request = ReorderRequestFactory(item=sig_item, status=ReorderRequest.Status.PENDING)
+        other_request = ReorderRequestFactory(item=other_item, status=ReorderRequest.Status.PENDING)
 
         url = reverse("reorderrequest-sig-pending")
         response = client.get(url)

--- a/backend/reorder_queue/admin.py
+++ b/backend/reorder_queue/admin.py
@@ -176,15 +176,15 @@ class ReorderRequestAdmin(admin.ModelAdmin):
     @admin.action(description="Approve selected requests")
     def approve_requests(self, request, queryset):
         """Bulk approve selected requests."""
-        updated = queryset.filter(status="pending").update(
-            status="approved", reviewed_by=request.user
+        updated = queryset.filter(status=ReorderRequest.Status.PENDING).update(
+            status=ReorderRequest.Status.APPROVED, reviewed_by=request.user
         )
         self.message_user(request, f"{updated} requests approved.")
 
     @admin.action(description="Cancel selected requests")
     def cancel_requests(self, request, queryset):
         """Bulk cancel selected requests."""
-        updated = queryset.update(status="cancelled", reviewed_by=request.user)
+        updated = queryset.update(status=ReorderRequest.Status.CANCELLED, reviewed_by=request.user)
         self.message_user(request, f"{updated} requests cancelled.")
 
 
@@ -291,7 +291,7 @@ class PurchaseOrderAdmin(admin.ModelAdmin):
         days = obj.days_since_ordered
         if days == 0:
             return "Today"
-        elif obj.status in [PurchaseOrder.SENT, PurchaseOrder.CONFIRMED]:
+        elif obj.status in [PurchaseOrder.Status.SENT, PurchaseOrder.Status.CONFIRMED]:
             if days > 30:
                 return format_html(
                     '<span style="color: red; font-weight: bold;">{} days</span>', days
@@ -308,15 +308,17 @@ class PurchaseOrderAdmin(admin.ModelAdmin):
     @admin.action(description="Mark selected orders as sent")
     def mark_as_sent(self, request, queryset):
         """Mark orders as sent to supplier."""
-        updated = queryset.filter(status=PurchaseOrder.DRAFT).update(
-            status=PurchaseOrder.SENT, sent_by=request.user
+        updated = queryset.filter(status=PurchaseOrder.Status.DRAFT).update(
+            status=PurchaseOrder.Status.SENT, sent_by=request.user
         )
         self.message_user(request, f"{updated} orders marked as sent.")
 
     @admin.action(description="Mark selected orders as confirmed")
     def mark_as_confirmed(self, request, queryset):
         """Mark orders as confirmed by supplier."""
-        updated = queryset.filter(status=PurchaseOrder.SENT).update(status=PurchaseOrder.CONFIRMED)
+        updated = queryset.filter(status=PurchaseOrder.Status.SENT).update(
+            status=PurchaseOrder.Status.CONFIRMED
+        )
         self.message_user(request, f"{updated} orders marked as confirmed.")
 
 

--- a/backend/reorder_queue/models.py
+++ b/backend/reorder_queue/models.py
@@ -33,40 +33,25 @@ class ReorderRequest(models.Model):
     - Cancelled: Request cancelled
     """
 
-    # Status choices
-    PENDING = "pending"
-    APPROVED = "approved"
-    ORDERED = "ordered"
-    RECEIVED = "received"
-    CANCELLED = "cancelled"
+    class Status(models.TextChoices):
+        PENDING = "pending", "Pending"
+        APPROVED = "approved", "Approved"
+        ORDERED = "ordered", "Ordered"
+        RECEIVED = "received", "Received"
+        CANCELLED = "cancelled", "Cancelled"
 
-    STATUS_CHOICES = [
-        (PENDING, "Pending"),
-        (APPROVED, "Approved"),
-        (ORDERED, "Ordered"),
-        (RECEIVED, "Received"),
-        (CANCELLED, "Cancelled"),
-    ]
-
-    # Priority choices
-    LOW = "low"
-    NORMAL = "normal"
-    HIGH = "high"
-    URGENT = "urgent"
-
-    PRIORITY_CHOICES = [
-        (LOW, "Low"),
-        (NORMAL, "Normal"),
-        (HIGH, "High"),
-        (URGENT, "Urgent"),
-    ]
+    class Priority(models.TextChoices):
+        LOW = "low", "Low"
+        NORMAL = "normal", "Normal"
+        HIGH = "high", "High"
+        URGENT = "urgent", "Urgent"
 
     item = models.ForeignKey(
         InventoryItem, on_delete=models.CASCADE, related_name="reorder_requests"
     )
     quantity = models.PositiveIntegerField(help_text="Quantity requested to reorder")
-    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="pending")
-    priority = models.CharField(max_length=20, choices=PRIORITY_CHOICES, default="normal")
+    status = models.CharField(max_length=20, choices=Status.choices, default=Status.PENDING)
+    priority = models.CharField(max_length=20, choices=Priority.choices, default=Priority.NORMAL)
 
     # Request information
     requested_by = models.CharField(
@@ -132,7 +117,7 @@ class ReorderRequest(models.Model):
     @property
     def days_pending(self) -> int:
         """Calculate how many days the request has been pending."""
-        if self.status == self.PENDING and self.requested_at:
+        if self.status == self.Status.PENDING and self.requested_at:
             return (timezone.now() - self.requested_at).days
         return 0
 
@@ -164,24 +149,14 @@ class PurchaseOrder(models.Model):
     Tracks the complete lifecycle from creation to delivery.
     """
 
-    # Status choices
-    DRAFT = "draft"
-    SENT = "sent"
-    CONFIRMED = "confirmed"
-    PARTIALLY_RECEIVED = "partially_received"
-    RECEIVED = "received"
-    CANCELLED = "cancelled"
-    VOIDED = "voided"
-
-    STATUS_CHOICES = [
-        (DRAFT, "Draft"),
-        (SENT, "Sent to Supplier"),
-        (CONFIRMED, "Confirmed by Supplier"),
-        (PARTIALLY_RECEIVED, "Partially Received"),
-        (RECEIVED, "Fully Received"),
-        (CANCELLED, "Cancelled"),
-        (VOIDED, "Voided"),
-    ]
+    class Status(models.TextChoices):
+        DRAFT = "draft", "Draft"
+        SENT = "sent", "Sent to Supplier"
+        CONFIRMED = "confirmed", "Confirmed by Supplier"
+        PARTIALLY_RECEIVED = "partially_received", "Partially Received"
+        RECEIVED = "received", "Fully Received"
+        CANCELLED = "cancelled", "Cancelled"
+        VOIDED = "voided", "Voided"
 
     # Core fields
     po_number = models.CharField(
@@ -192,7 +167,7 @@ class PurchaseOrder(models.Model):
         help_text="Purchase Order Number",
     )
     supplier = models.ForeignKey(Supplier, on_delete=models.CASCADE, related_name="purchase_orders")
-    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default=DRAFT)
+    status = models.CharField(max_length=20, choices=Status.choices, default=Status.DRAFT)
 
     # Order details
     order_date = models.DateTimeField(auto_now_add=True)
@@ -816,41 +791,26 @@ class WebHook(models.Model):
     such as reorder requests, low stock alerts, delivery notifications, etc.
     """
 
-    # Event type choices
-    REORDER_REQUEST_CREATED = "reorder_request_created"
-    REORDER_REQUEST_APPROVED = "reorder_request_approved"
-    REORDER_REQUEST_ORDERED = "reorder_request_ordered"
-    REORDER_REQUEST_RECEIVED = "reorder_request_received"
-    ITEM_LOW_STOCK = "item_low_stock"
-    PURCHASE_ORDER_CREATED = "purchase_order_created"
-    DELIVERY_RECEIVED = "delivery_received"
-    FIXTURE_REFILL_REQUESTED = "fixture_refill_requested"
-    LOCATION_CHECKIN = "location_checkin"
-    LOCATION_FEEDBACK = "location_feedback"
-    SECURITY_REPORT = "security_report"
-    LOCATION_PROBLEM_REPORTED = "location_problem_reported"
-
-    EVENT_TYPE_CHOICES = [
-        (REORDER_REQUEST_CREATED, "Reorder Request Created"),
-        (REORDER_REQUEST_APPROVED, "Reorder Request Approved"),
-        (REORDER_REQUEST_ORDERED, "Reorder Request Ordered"),
-        (REORDER_REQUEST_RECEIVED, "Reorder Request Received"),
-        (ITEM_LOW_STOCK, "Item Low Stock"),
-        (PURCHASE_ORDER_CREATED, "Purchase Order Created"),
-        (DELIVERY_RECEIVED, "Delivery Received"),
-        (FIXTURE_REFILL_REQUESTED, "Fixture Refill Requested"),
-        (LOCATION_CHECKIN, "Location Check-in"),
-        (LOCATION_FEEDBACK, "Location Feedback"),
-        (SECURITY_REPORT, "Security Report"),
-        (LOCATION_PROBLEM_REPORTED, "Location Problem Reported"),
-    ]
+    class EventType(models.TextChoices):
+        REORDER_REQUEST_CREATED = "reorder_request_created", "Reorder Request Created"
+        REORDER_REQUEST_APPROVED = "reorder_request_approved", "Reorder Request Approved"
+        REORDER_REQUEST_ORDERED = "reorder_request_ordered", "Reorder Request Ordered"
+        REORDER_REQUEST_RECEIVED = "reorder_request_received", "Reorder Request Received"
+        ITEM_LOW_STOCK = "item_low_stock", "Item Low Stock"
+        PURCHASE_ORDER_CREATED = "purchase_order_created", "Purchase Order Created"
+        DELIVERY_RECEIVED = "delivery_received", "Delivery Received"
+        FIXTURE_REFILL_REQUESTED = "fixture_refill_requested", "Fixture Refill Requested"
+        LOCATION_CHECKIN = "location_checkin", "Location Check-in"
+        LOCATION_FEEDBACK = "location_feedback", "Location Feedback"
+        SECURITY_REPORT = "security_report", "Security Report"
+        LOCATION_PROBLEM_REPORTED = "location_problem_reported", "Location Problem Reported"
 
     # Core fields
     name = models.CharField(max_length=200, help_text="Descriptive name for this webhook")
     url = models.URLField(help_text="Webhook endpoint URL to POST notifications to")
     event_type = models.CharField(
         max_length=50,
-        choices=EVENT_TYPE_CHOICES,
+        choices=EventType.choices,
         help_text="Type of event that triggers this webhook",
     )
 
@@ -946,25 +906,15 @@ class PurchaseOrderAuditEvent(models.Model):
     review surface (gh #359) can join across domains cleanly.
     """
 
-    ACTION_PO_CREATE = "po_create"
-    ACTION_PO_SEND = "po_send"
-    ACTION_PO_VOID = "po_void"
-    ACTION_PO_LINE_VOID = "po_line_void"
-    ACTION_PO_MARK_DELIVERED = "po_mark_delivered"
-    ACTION_PO_RECEIVE_ITEMS = "po_receive_items"
-    ACTION_ATTACHMENT_ADD = "attachment_add"
-    ACTION_ATTACHMENT_REMOVE = "attachment_remove"
-
-    ACTION_CHOICES = [
-        (ACTION_PO_CREATE, "Purchase order created"),
-        (ACTION_PO_SEND, "Purchase order sent to supplier"),
-        (ACTION_PO_VOID, "Purchase order voided"),
-        (ACTION_PO_LINE_VOID, "Purchase order line item voided"),
-        (ACTION_PO_MARK_DELIVERED, "Purchase order marked delivered"),
-        (ACTION_PO_RECEIVE_ITEMS, "Purchase order line items received"),
-        (ACTION_ATTACHMENT_ADD, "Attachment added"),
-        (ACTION_ATTACHMENT_REMOVE, "Attachment removed"),
-    ]
+    class Action(models.TextChoices):
+        PO_CREATE = "po_create", "Purchase order created"
+        PO_SEND = "po_send", "Purchase order sent to supplier"
+        PO_VOID = "po_void", "Purchase order voided"
+        PO_LINE_VOID = "po_line_void", "Purchase order line item voided"
+        PO_MARK_DELIVERED = "po_mark_delivered", "Purchase order marked delivered"
+        PO_RECEIVE_ITEMS = "po_receive_items", "Purchase order line items received"
+        ATTACHMENT_ADD = "attachment_add", "Attachment added"
+        ATTACHMENT_REMOVE = "attachment_remove", "Attachment removed"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     created_at = models.DateTimeField(auto_now_add=True)
@@ -976,7 +926,7 @@ class PurchaseOrderAuditEvent(models.Model):
         related_name="purchase_order_audit_actions",
         help_text="User who performed the action; null for system-initiated events.",
     )
-    action = models.CharField(max_length=32, choices=ACTION_CHOICES)
+    action = models.CharField(max_length=32, choices=Action.choices)
     # Optional FKs to the entities involved. At least one is set per row;
     # SET_NULL on delete so the audit trail survives entity teardown.
     purchase_order = models.ForeignKey(
@@ -1037,23 +987,16 @@ class WebhookAuditEvent(models.Model):
     becomes operationally necessary.
     """
 
-    ACTION_WEBHOOK_CREATE = "webhook_create"
-    ACTION_WEBHOOK_UPDATE = "webhook_update"
-    ACTION_WEBHOOK_DELETE = "webhook_delete"
-    ACTION_WEBHOOK_DISABLE = "webhook_disable"
-    ACTION_WEBHOOK_ENABLE = "webhook_enable"
-    ACTION_WEBHOOK_SECRET_ROTATE = (
-        "webhook_secret_rotate"  # nosec B105 — action name, not a credential
-    )
-
-    ACTION_CHOICES = [
-        (ACTION_WEBHOOK_CREATE, "Webhook created"),
-        (ACTION_WEBHOOK_UPDATE, "Webhook config updated"),
-        (ACTION_WEBHOOK_DELETE, "Webhook deleted"),
-        (ACTION_WEBHOOK_DISABLE, "Webhook disabled"),
-        (ACTION_WEBHOOK_ENABLE, "Webhook enabled"),
-        (ACTION_WEBHOOK_SECRET_ROTATE, "Webhook secret rotated"),
-    ]
+    class Action(models.TextChoices):
+        WEBHOOK_CREATE = "webhook_create", "Webhook created"
+        WEBHOOK_UPDATE = "webhook_update", "Webhook config updated"
+        WEBHOOK_DELETE = "webhook_delete", "Webhook deleted"
+        WEBHOOK_DISABLE = "webhook_disable", "Webhook disabled"
+        WEBHOOK_ENABLE = "webhook_enable", "Webhook enabled"
+        WEBHOOK_SECRET_ROTATE = (
+            "webhook_secret_rotate",  # nosec B105 — action name, not a credential
+            "Webhook secret rotated",
+        )
 
     # Non-secret config fields the audit hook tracks for diff capture.
     # ``secret`` is intentionally excluded — its value never appears in
@@ -1076,7 +1019,7 @@ class WebhookAuditEvent(models.Model):
         related_name="webhook_audit_actions",
         help_text="User who performed the action; null for system-initiated events.",
     )
-    action = models.CharField(max_length=32, choices=ACTION_CHOICES)
+    action = models.CharField(max_length=32, choices=Action.choices)
     webhook = models.ForeignKey(
         WebHook,
         on_delete=models.SET_NULL,

--- a/backend/reorder_queue/serializers.py
+++ b/backend/reorder_queue/serializers.py
@@ -627,9 +627,9 @@ class BarcodeReceiptSerializer(serializers.Serializer):
         try:
             po = PurchaseOrder.objects.get(id=value)
             if po.status not in [
-                PurchaseOrder.SENT,
-                PurchaseOrder.CONFIRMED,
-                PurchaseOrder.PARTIALLY_RECEIVED,
+                PurchaseOrder.Status.SENT,
+                PurchaseOrder.Status.CONFIRMED,
+                PurchaseOrder.Status.PARTIALLY_RECEIVED,
             ]:
                 raise serializers.ValidationError(
                     "Purchase order must be sent, confirmed, or partially received to accept deliveries"

--- a/backend/reorder_queue/tests/factories.py
+++ b/backend/reorder_queue/tests/factories.py
@@ -43,8 +43,15 @@ class ReorderRequestFactory(DjangoModelFactory):
 
     item = SubFactory(InventoryItemFactory)
     quantity = Faker("random_int", min=1, max=100)
-    status = "pending"
-    priority = factory.Iterator(["low", "normal", "high", "urgent"])
+    status = ReorderRequest.Status.PENDING
+    priority = factory.Iterator(
+        [
+            ReorderRequest.Priority.LOW,
+            ReorderRequest.Priority.NORMAL,
+            ReorderRequest.Priority.HIGH,
+            ReorderRequest.Priority.URGENT,
+        ]
+    )
     requested_by = Faker("name")
     request_notes = Faker("text", max_nb_chars=200)
     admin_notes = ""

--- a/backend/reorder_queue/tests/test_api.py
+++ b/backend/reorder_queue/tests/test_api.py
@@ -13,12 +13,14 @@ import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from inventory.models import Supplier
 from inventory.tests.factories import InventoryItemFactory, ItemSupplierFactory, SupplierFactory
 from reorder_queue.models import (
     LeadTimeLog,
     PurchaseOrder,
     PurchaseOrderAuditEvent,
     PurchaseOrderItem,
+    ReorderRequest,
 )
 from reorder_queue.tests.factories import ReorderRequestFactory
 
@@ -53,14 +55,14 @@ class TestReorderRequestAPI:
             "quantity": 25,
             "requested_by": "Jane Doe",
             "request_notes": "We are running low",
-            "priority": "high",
+            "priority": ReorderRequest.Priority.HIGH,
         }
         response = client.post(url, data, format="json")
 
         assert response.status_code == status.HTTP_201_CREATED
         assert str(response.data["item"]) == str(item.id)
         assert response.data["quantity"] == 25
-        assert response.data["status"] == "pending"
+        assert response.data["status"] == ReorderRequest.Status.PENDING
 
     def test_create_reorder_request_minimal(self, authenticated_client):
         """Test creating request with minimal required fields."""
@@ -141,7 +143,7 @@ class TestReorderRequestAPI:
 
     def test_pending_reorder_requests_anonymous_denied(self, api_client):
         """Anonymous users cannot view the pending queue (gh #327)."""
-        ReorderRequestFactory(status="pending")
+        ReorderRequestFactory(status=ReorderRequest.Status.PENDING)
 
         url = reverse("reorderrequest-pending")
         response = api_client.get(url)
@@ -163,7 +165,7 @@ class TestReorderRequestAPI:
     def test_admin_actions_anonymous_denied(self, api_client, action_name, method, detail):
         """All admin reorder actions reject anonymous callers (gh #327)."""
         if detail:
-            request_obj = ReorderRequestFactory(status="pending")
+            request_obj = ReorderRequestFactory(status=ReorderRequest.Status.PENDING)
             url = reverse(f"reorderrequest-{action_name}", kwargs={"pk": request_obj.pk})
         else:
             url = reverse(f"reorderrequest-{action_name}")
@@ -189,7 +191,7 @@ class TestReorderRequestAPI:
         request_obj = ReorderRequestFactory()
 
         url = reverse("reorderrequest-detail", kwargs={"pk": request_obj.pk})
-        data = {"status": "approved"}
+        data = {"status": ReorderRequest.Status.APPROVED}
         response = api_client.patch(url, data, format="json")
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
@@ -199,10 +201,10 @@ class TestReorderRequestAPI:
         client, user = authenticated_client
 
         # Create requests with different statuses
-        ReorderRequestFactory(status="pending")
-        ReorderRequestFactory(status="pending")
-        ReorderRequestFactory(status="approved")
-        ReorderRequestFactory(status="cancelled")
+        ReorderRequestFactory(status=ReorderRequest.Status.PENDING)
+        ReorderRequestFactory(status=ReorderRequest.Status.PENDING)
+        ReorderRequestFactory(status=ReorderRequest.Status.APPROVED)
+        ReorderRequestFactory(status=ReorderRequest.Status.CANCELLED)
 
         url = reverse("reorderrequest-pending")
         response = client.get(url)
@@ -211,22 +213,22 @@ class TestReorderRequestAPI:
         # Endpoint returns list directly, not paginated
         assert len(response.data) == 2
         for req in response.data:
-            assert req["status"] == "pending"
+            assert req["status"] == ReorderRequest.Status.PENDING
 
     def test_by_supplier_endpoint(self, authenticated_client):
         """Test grouping requests by supplier."""
         client, user = authenticated_client
 
-        supplier1 = SupplierFactory(supplier_type="online")
-        supplier2 = SupplierFactory(supplier_type="national")
+        supplier1 = SupplierFactory(supplier_type=Supplier.SupplierType.ONLINE)
+        supplier2 = SupplierFactory(supplier_type=Supplier.SupplierType.NATIONAL)
 
         item1 = InventoryItemFactory(supplier=supplier1)
         item2 = InventoryItemFactory(supplier=supplier1)
         item3 = InventoryItemFactory(supplier=supplier2)
 
-        ReorderRequestFactory(item=item1, status="pending")
-        ReorderRequestFactory(item=item2, status="pending")
-        ReorderRequestFactory(item=item3, status="pending")
+        ReorderRequestFactory(item=item1, status=ReorderRequest.Status.PENDING)
+        ReorderRequestFactory(item=item2, status=ReorderRequest.Status.PENDING)
+        ReorderRequestFactory(item=item3, status=ReorderRequest.Status.PENDING)
 
         url = reverse("reorderrequest-by-supplier")
         response = client.get(url)
@@ -242,27 +244,27 @@ class TestReorderRequestAPI:
     def test_approve_request(self, authenticated_client):
         """Test approving a reorder request."""
         client, user = authenticated_client
-        request_obj = ReorderRequestFactory(status="pending")
+        request_obj = ReorderRequestFactory(status=ReorderRequest.Status.PENDING)
 
         url = reverse("reorderrequest-approve", kwargs={"pk": request_obj.pk})
         data = {"admin_notes": "Approved for ordering"}
         response = client.post(url, data, format="json")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["status"] == "approved"
+        assert response.data["status"] == ReorderRequest.Status.APPROVED
         assert response.data["reviewed_by"] == user.id
         assert response.data["admin_notes"] == "Approved for ordering"
 
         # Verify in database
         request_obj.refresh_from_db()
-        assert request_obj.status == "approved"
+        assert request_obj.status == ReorderRequest.Status.APPROVED
         assert request_obj.reviewed_by == user
         assert request_obj.reviewed_at is not None
 
     def test_mark_ordered(self, authenticated_client):
         """Test marking a request as ordered."""
         client, user = authenticated_client
-        request_obj = ReorderRequestFactory(status="approved")
+        request_obj = ReorderRequestFactory(status=ReorderRequest.Status.APPROVED)
 
         url = reverse("reorderrequest-mark-ordered", kwargs={"pk": request_obj.pk})
         data = {
@@ -273,12 +275,12 @@ class TestReorderRequestAPI:
         response = client.post(url, data, format="json")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["status"] == "ordered"
+        assert response.data["status"] == ReorderRequest.Status.ORDERED
         assert response.data["order_number"] == "ORD-12345"
 
         # Verify in database
         request_obj.refresh_from_db()
-        assert request_obj.status == "ordered"
+        assert request_obj.status == ReorderRequest.Status.ORDERED
         assert request_obj.ordered_at is not None
         assert request_obj.order_number == "ORD-12345"
 
@@ -289,16 +291,16 @@ class TestReorderRequestAPI:
         operator is not forced to type one at mark-ordered time.
         """
         client, user = authenticated_client
-        request_obj = ReorderRequestFactory(status="approved")
+        request_obj = ReorderRequestFactory(status=ReorderRequest.Status.APPROVED)
 
         url = reverse("reorderrequest-mark-ordered", kwargs={"pk": request_obj.pk})
         response = client.post(url, {}, format="json")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["status"] == "ordered"
+        assert response.data["status"] == ReorderRequest.Status.ORDERED
 
         request_obj.refresh_from_db()
-        assert request_obj.status == "ordered"
+        assert request_obj.status == ReorderRequest.Status.ORDERED
         assert request_obj.ordered_at is not None
         # No number was typed; it stays blank for the PO to carry later.
         assert request_obj.order_number == ""
@@ -308,7 +310,7 @@ class TestReorderRequestAPI:
         client, user = authenticated_client
         existing_delivery = (timezone.now() + timedelta(days=5)).date()
         request_obj = ReorderRequestFactory(
-            status="approved",
+            status=ReorderRequest.Status.APPROVED,
             order_number="PO-2026-0007",
             estimated_delivery=existing_delivery,
         )
@@ -319,7 +321,7 @@ class TestReorderRequestAPI:
         assert response.status_code == status.HTTP_200_OK
 
         request_obj.refresh_from_db()
-        assert request_obj.status == "ordered"
+        assert request_obj.status == ReorderRequest.Status.ORDERED
         # Omitted fields are left untouched, not blanked.
         assert request_obj.order_number == "PO-2026-0007"
         assert request_obj.estimated_delivery == existing_delivery
@@ -329,7 +331,7 @@ class TestReorderRequestAPI:
         ordered_time = timezone.now()
         delivery_date = ordered_time.date()
         request_obj = ReorderRequestFactory(
-            status="received",
+            status=ReorderRequest.Status.RECEIVED,
             ordered_at=ordered_time,
             actual_delivery=delivery_date,
             actual_cost="150.25",
@@ -361,9 +363,14 @@ class TestReorderRequestAPI:
     def test_logistics_dashboard_public_endpoint(self, api_client):
         """The logistics dashboard data should be accessible without authentication."""
         urgent_request = ReorderRequestFactory(
-            status="pending", priority="urgent", quantity=7, request_notes="Needs ASAP"
+            status=ReorderRequest.Status.PENDING,
+            priority=ReorderRequest.Priority.URGENT,
+            quantity=7,
+            request_notes="Needs ASAP",
         )
-        approved_request = ReorderRequestFactory(status="approved", quantity=3)  # noqa: F841
+        approved_request = ReorderRequestFactory(  # noqa: F841
+            status=ReorderRequest.Status.APPROVED, quantity=3
+        )
 
         user = User.objects.create_user(username="logistics-user", password="pass12345")
         item_supplier = urgent_request.item.primary_item_supplier
@@ -371,7 +378,7 @@ class TestReorderRequestAPI:
         purchase_order = PurchaseOrder.objects.create(
             po_number="PO-LOG-001",
             supplier=item_supplier.supplier,
-            status=PurchaseOrder.SENT,
+            status=PurchaseOrder.Status.SENT,
             created_by=user,
             sent_at=timezone.now(),
             expected_delivery_date=timezone.now().date() + timedelta(days=5),
@@ -419,13 +426,15 @@ class TestReorderRequestAPI:
         """Test marking a request as received and updating inventory."""
         client, user = authenticated_client
         item = InventoryItemFactory(current_stock=10)
-        request_obj = ReorderRequestFactory(item=item, quantity=50, status="ordered")
+        request_obj = ReorderRequestFactory(
+            item=item, quantity=50, status=ReorderRequest.Status.ORDERED
+        )
 
         url = reverse("reorderrequest-mark-received", kwargs={"pk": request_obj.pk})
         response = client.post(url, format="json")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["status"] == "received"
+        assert response.data["status"] == ReorderRequest.Status.RECEIVED
 
         # Verify inventory was updated
         item.refresh_from_db()
@@ -433,24 +442,24 @@ class TestReorderRequestAPI:
 
         # Verify in database
         request_obj.refresh_from_db()
-        assert request_obj.status == "received"
+        assert request_obj.status == ReorderRequest.Status.RECEIVED
         assert request_obj.actual_delivery is not None
 
     def test_cancel_request(self, authenticated_client):
         """Test cancelling a reorder request."""
         client, user = authenticated_client
-        request_obj = ReorderRequestFactory(status="pending")
+        request_obj = ReorderRequestFactory(status=ReorderRequest.Status.PENDING)
 
         url = reverse("reorderrequest-cancel", kwargs={"pk": request_obj.pk})
         data = {"admin_notes": "Duplicate request"}
         response = client.post(url, data, format="json")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["status"] == "cancelled"
+        assert response.data["status"] == ReorderRequest.Status.CANCELLED
 
         # Verify in database
         request_obj.refresh_from_db()
-        assert request_obj.status == "cancelled"
+        assert request_obj.status == ReorderRequest.Status.CANCELLED
         assert request_obj.reviewed_by == user
         assert request_obj.admin_notes == "Duplicate request"
 
@@ -471,8 +480,8 @@ class TestReorderRequestAPI:
         item2 = InventoryItemFactory(supplier=globex, supplier_sku="GLBX-456")
 
         # An approved and a pending request both count as "live".
-        ReorderRequestFactory(item=item1, status="approved", quantity=3)
-        ReorderRequestFactory(item=item2, status="pending", quantity=5)
+        ReorderRequestFactory(item=item1, status=ReorderRequest.Status.APPROVED, quantity=3)
+        ReorderRequestFactory(item=item2, status=ReorderRequest.Status.PENDING, quantity=5)
 
         url = reverse("reorderrequest-generate-cart-links")
         response = client.get(url)
@@ -500,10 +509,10 @@ class TestReorderRequestAPI:
         live_item = InventoryItemFactory(supplier=supplier, supplier_sku="LIVE-1")
         done_item = InventoryItemFactory(supplier=supplier, supplier_sku="DONE-1")
 
-        ReorderRequestFactory(item=live_item, status="approved", quantity=2)
-        ReorderRequestFactory(item=done_item, status="ordered", quantity=9)
-        ReorderRequestFactory(item=done_item, status="received", quantity=9)
-        ReorderRequestFactory(item=done_item, status="cancelled", quantity=9)
+        ReorderRequestFactory(item=live_item, status=ReorderRequest.Status.APPROVED, quantity=2)
+        ReorderRequestFactory(item=done_item, status=ReorderRequest.Status.ORDERED, quantity=9)
+        ReorderRequestFactory(item=done_item, status=ReorderRequest.Status.RECEIVED, quantity=9)
+        ReorderRequestFactory(item=done_item, status=ReorderRequest.Status.CANCELLED, quantity=9)
 
         url = reverse("reorderrequest-generate-cart-links")
         response = client.get(url)
@@ -530,7 +539,7 @@ class TestPurchaseOrderExportOrder:
         purchase_order = PurchaseOrder.objects.create(
             po_number=po_number,
             supplier=supplier,
-            status=PurchaseOrder.DRAFT,
+            status=PurchaseOrder.Status.DRAFT,
             created_by=user,
         )
         return purchase_order, supplier
@@ -1097,7 +1106,7 @@ class TestPurchaseOrderMarkDelivered:
         purchase_order = PurchaseOrder.objects.create(
             po_number=f"PO-MD-{item_supplier.id}",
             supplier=supplier,
-            status=PurchaseOrder.SENT,
+            status=PurchaseOrder.Status.SENT,
             created_by=user,
             sent_by=user,
             sent_at=sent_at or (timezone.now() - timedelta(days=7)),
@@ -1134,7 +1143,7 @@ class TestPurchaseOrderMarkDelivered:
 
         purchase_order.refresh_from_db()
         po_item.refresh_from_db()
-        assert purchase_order.status == PurchaseOrder.RECEIVED
+        assert purchase_order.status == PurchaseOrder.Status.RECEIVED
         assert po_item.quantity_received == po_item.quantity_ordered
         assert purchase_order.deliveries.count() == 1
 
@@ -1202,7 +1211,7 @@ class TestPurchaseOrderMarkDelivered:
         purchase_order = PurchaseOrder.objects.create(
             po_number="PO-MD-AUTH",
             supplier=supplier,
-            status=PurchaseOrder.SENT,
+            status=PurchaseOrder.Status.SENT,
             created_by=user,
             sent_at=timezone.now(),
         )
@@ -1219,7 +1228,7 @@ class TestPurchaseOrderMarkDelivered:
         """Draft/cancelled/received orders cannot be re-delivered."""
         client, user = authenticated_client
         purchase_order, _, _ = self._create_sent_po(user)
-        purchase_order.status = PurchaseOrder.DRAFT
+        purchase_order.status = PurchaseOrder.Status.DRAFT
         purchase_order.save()
 
         url = reverse("purchaseorder-mark-delivered", kwargs={"pk": purchase_order.pk})
@@ -1235,7 +1244,7 @@ class TestPurchaseOrderMarkDelivered:
 class TestPurchaseOrderReceive:
     """Tests for the per-line-item PO receive endpoint (POST .../receive/)."""
 
-    def _create_po(self, user, *, lines=None, status_=PurchaseOrder.SENT):
+    def _create_po(self, user, *, lines=None, status_=PurchaseOrder.Status.SENT):
         """Create a PO in ``status_`` with one item_supplier line per spec.
 
         ``lines`` is a list of dicts with optional ``quantity_ordered`` (default
@@ -1295,7 +1304,7 @@ class TestPurchaseOrderReceive:
         po_item.refresh_from_db()
         po_item.item.refresh_from_db()
 
-        assert purchase_order.status == PurchaseOrder.PARTIALLY_RECEIVED
+        assert purchase_order.status == PurchaseOrder.Status.PARTIALLY_RECEIVED
         assert po_item.quantity_received == 2
         assert po_item.item.current_stock == 12  # 10 + 2
 
@@ -1326,7 +1335,7 @@ class TestPurchaseOrderReceive:
         po_item.refresh_from_db()
         po_item.item.refresh_from_db()
 
-        assert purchase_order.status == PurchaseOrder.RECEIVED
+        assert purchase_order.status == PurchaseOrder.Status.RECEIVED
         assert po_item.quantity_received == 5
         assert po_item.item.current_stock == 15  # 10 + 5
 
@@ -1365,7 +1374,7 @@ class TestPurchaseOrderReceive:
         line_b.item.refresh_from_db()
 
         # line_a partial (3/5), line_b full (4/4) -> PO is partially received.
-        assert purchase_order.status == PurchaseOrder.PARTIALLY_RECEIVED
+        assert purchase_order.status == PurchaseOrder.Status.PARTIALLY_RECEIVED
         assert line_a.quantity_received == 3
         assert line_b.quantity_received == 4
         assert line_a.item.current_stock == 4  # 1 + 3
@@ -1379,7 +1388,7 @@ class TestPurchaseOrderReceive:
         client, user = authenticated_client
         purchase_order, (po_item,) = self._create_po(
             user,
-            status_=PurchaseOrder.PARTIALLY_RECEIVED,
+            status_=PurchaseOrder.Status.PARTIALLY_RECEIVED,
             lines=[{"quantity_ordered": 5, "quantity_received": 2, "current_stock": 7}],
         )
 
@@ -1394,7 +1403,7 @@ class TestPurchaseOrderReceive:
         po_item.refresh_from_db()
         po_item.item.refresh_from_db()
 
-        assert purchase_order.status == PurchaseOrder.RECEIVED
+        assert purchase_order.status == PurchaseOrder.Status.RECEIVED
         assert po_item.quantity_received == 5
         assert po_item.item.current_stock == 10  # 7 + 3
 
@@ -1450,7 +1459,7 @@ class TestPurchaseOrderReceive:
         assert response.status_code == status.HTTP_200_OK, response.data
         event = PurchaseOrderAuditEvent.objects.filter(
             purchase_order=purchase_order,
-            action=PurchaseOrderAuditEvent.ACTION_PO_RECEIVE_ITEMS,
+            action=PurchaseOrderAuditEvent.Action.PO_RECEIVE_ITEMS,
         ).first()
         assert event is not None
         assert event.actor == user
@@ -1542,7 +1551,7 @@ class TestPurchaseOrderReceive:
     def test_receive_rejects_non_receivable_status(self, authenticated_client):
         """Draft/received/cancelled orders cannot receive items."""
         client, user = authenticated_client
-        purchase_order, (po_item,) = self._create_po(user, status_=PurchaseOrder.DRAFT)
+        purchase_order, (po_item,) = self._create_po(user, status_=PurchaseOrder.Status.DRAFT)
 
         response = client.post(
             self._url(purchase_order),
@@ -1611,7 +1620,7 @@ class TestPurchaseOrderReceive:
 class TestPurchaseOrderVoid:
     """Tests for PurchaseOrder void action (oms-rrx)."""
 
-    def _make_po_with_items(self, user, *, status_=PurchaseOrder.SENT, item_count=2):
+    def _make_po_with_items(self, user, *, status_=PurchaseOrder.Status.SENT, item_count=2):
         supplier = SupplierFactory()
         purchase_order = PurchaseOrder.objects.create(
             supplier=supplier,
@@ -1653,7 +1662,7 @@ class TestPurchaseOrderVoid:
 
         assert response.status_code == status.HTTP_200_OK
         purchase_order.refresh_from_db()
-        assert purchase_order.status == PurchaseOrder.VOIDED
+        assert purchase_order.status == PurchaseOrder.Status.VOIDED
         assert purchase_order.voided_at is not None
         assert purchase_order.voided_by == user
         assert purchase_order.void_reason == "supplier rejected all lines"
@@ -1688,14 +1697,14 @@ class TestPurchaseOrderVoid:
     def test_cannot_void_received_po(self):
         """AC-3: voiding a received PO returns 400."""
         client, user = self._staff_client()
-        purchase_order, _ = self._make_po_with_items(user, status_=PurchaseOrder.RECEIVED)
+        purchase_order, _ = self._make_po_with_items(user, status_=PurchaseOrder.Status.RECEIVED)
 
         url = reverse("purchaseorder-void", kwargs={"pk": purchase_order.pk})
         response = client.post(url, {"reason": "oops"}, format="json")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         purchase_order.refresh_from_db()
-        assert purchase_order.status == PurchaseOrder.RECEIVED
+        assert purchase_order.status == PurchaseOrder.Status.RECEIVED
 
     def test_cannot_double_void(self):
         """AC-2: voiding an already-voided PO returns 400."""
@@ -1719,7 +1728,7 @@ class TestPurchaseOrderVoid:
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         purchase_order.refresh_from_db()
-        assert purchase_order.status != PurchaseOrder.VOIDED
+        assert purchase_order.status != PurchaseOrder.Status.VOIDED
 
     def test_coo_group_member_can_void(self):
         """COO group members may void POs without is_staff."""
@@ -1741,7 +1750,7 @@ class TestPurchaseOrderVoid:
 
         assert response.status_code == status.HTTP_200_OK
         purchase_order.refresh_from_db()
-        assert purchase_order.status == PurchaseOrder.VOIDED
+        assert purchase_order.status == PurchaseOrder.Status.VOIDED
 
 
 @pytest.mark.integration
@@ -1752,7 +1761,7 @@ class TestPurchaseOrderMetadataAndAttachments:
         supplier = SupplierFactory()
         purchase_order = PurchaseOrder.objects.create(
             supplier=supplier,
-            status=PurchaseOrder.SENT,
+            status=PurchaseOrder.Status.SENT,
             created_by=user,
         )
         return purchase_order
@@ -1897,7 +1906,7 @@ class TestPurchaseOrderListVoidHandling:
         supplier = SupplierFactory()
         purchase_order = PurchaseOrder.objects.create(
             supplier=supplier,
-            status=PurchaseOrder.SENT,
+            status=PurchaseOrder.Status.SENT,
             created_by=user,
         )
         items = []
@@ -1995,7 +2004,7 @@ class TestPurchaseOrderAutoTransitionToSent:
     def _draft_po(self, user, **kwargs):
         return PurchaseOrder.objects.create(
             supplier=SupplierFactory(),
-            status=PurchaseOrder.DRAFT,
+            status=PurchaseOrder.Status.DRAFT,
             created_by=user,
             **kwargs,
         )
@@ -2004,7 +2013,7 @@ class TestPurchaseOrderAutoTransitionToSent:
         return reverse("purchaseorder-detail", kwargs={"pk": po.pk})
 
     def _po_send_events(self, po=None):
-        qs = PurchaseOrderAuditEvent.objects.filter(action=PurchaseOrderAuditEvent.ACTION_PO_SEND)
+        qs = PurchaseOrderAuditEvent.objects.filter(action=PurchaseOrderAuditEvent.Action.PO_SEND)
         return qs.filter(purchase_order=po) if po is not None else qs
 
     def test_attach_sales_order_number_to_draft_transitions_to_sent(self, authenticated_client):
@@ -2018,7 +2027,7 @@ class TestPurchaseOrderAutoTransitionToSent:
 
         assert response.status_code == status.HTTP_200_OK, response.data
         po.refresh_from_db()
-        assert po.status == PurchaseOrder.SENT
+        assert po.status == PurchaseOrder.Status.SENT
         assert po.sales_order_number == "SO-123"
         assert po.sent_at is not None
         assert po.sent_by == user
@@ -2042,7 +2051,7 @@ class TestPurchaseOrderAutoTransitionToSent:
         original_sent_at = timezone.now() - timedelta(days=3)
         po = PurchaseOrder.objects.create(
             supplier=SupplierFactory(),
-            status=PurchaseOrder.SENT,
+            status=PurchaseOrder.Status.SENT,
             created_by=user,
             sent_by=sender,
             sent_at=original_sent_at,
@@ -2055,7 +2064,7 @@ class TestPurchaseOrderAutoTransitionToSent:
 
         assert response.status_code == status.HTTP_200_OK, response.data
         po.refresh_from_db()
-        assert po.status == PurchaseOrder.SENT
+        assert po.status == PurchaseOrder.Status.SENT
         assert po.sales_order_number == "SO-NEW"
         # sent_by / sent_at untouched, and no new po_send event recorded.
         assert po.sent_by == sender
@@ -2076,7 +2085,7 @@ class TestPurchaseOrderAutoTransitionToSent:
 
         assert response.status_code == status.HTTP_200_OK, response.data
         po.refresh_from_db()
-        assert po.status == PurchaseOrder.DRAFT
+        assert po.status == PurchaseOrder.Status.DRAFT
         assert po.sent_at is None
         assert not self._po_send_events(po).exists()
 
@@ -2089,7 +2098,7 @@ class TestPurchaseOrderAutoTransitionToSent:
 
         assert response.status_code == status.HTTP_200_OK, response.data
         po.refresh_from_db()
-        assert po.status == PurchaseOrder.DRAFT
+        assert po.status == PurchaseOrder.Status.DRAFT
         assert po.notes == "rush order"
         assert po.sent_at is None
         assert not self._po_send_events(po).exists()
@@ -2099,7 +2108,7 @@ class TestPurchaseOrderAutoTransitionToSent:
         client, user = authenticated_client
         po = PurchaseOrder.objects.create(
             supplier=SupplierFactory(),
-            status=PurchaseOrder.SENT,
+            status=PurchaseOrder.Status.SENT,
             created_by=user,
             sent_by=user,
             sent_at=timezone.now(),
@@ -2110,7 +2119,7 @@ class TestPurchaseOrderAutoTransitionToSent:
 
         assert response.status_code == status.HTTP_200_OK, response.data
         po.refresh_from_db()
-        assert po.status == PurchaseOrder.SENT
+        assert po.status == PurchaseOrder.Status.SENT
         assert po.sales_order_number == ""
 
     def test_create_with_sales_order_number_transitions_to_sent(self, authenticated_client):
@@ -2132,11 +2141,11 @@ class TestPurchaseOrderAutoTransitionToSent:
         )
 
         assert response.status_code == status.HTTP_201_CREATED, response.data
-        assert response.data["status"] == PurchaseOrder.SENT
+        assert response.data["status"] == PurchaseOrder.Status.SENT
         assert response.data["sales_order_number"] == "SO-555"
 
         po = PurchaseOrder.objects.get(id=response.data["id"])
-        assert po.status == PurchaseOrder.SENT
+        assert po.status == PurchaseOrder.Status.SENT
         assert po.sent_at is not None
         assert po.sent_by == user
         # Both the create and the auto-send are audited.
@@ -2160,7 +2169,7 @@ class TestPurchaseOrderAutoTransitionToSent:
         )
 
         assert response.status_code == status.HTTP_201_CREATED, response.data
-        assert response.data["status"] == PurchaseOrder.DRAFT
+        assert response.data["status"] == PurchaseOrder.Status.DRAFT
         po = PurchaseOrder.objects.get(id=response.data["id"])
         assert po.sent_at is None
         assert not self._po_send_events(po).exists()
@@ -2176,7 +2185,7 @@ class TestPurchaseOrderAutoTransitionToSent:
 
         assert response.status_code == status.HTTP_200_OK, response.data
         po.refresh_from_db()
-        assert po.status == PurchaseOrder.SENT
+        assert po.status == PurchaseOrder.Status.SENT
         assert po.sent_by == user
         assert po.sent_at is not None
         event = self._po_send_events(po).get()
@@ -2241,11 +2250,11 @@ class TestReorderDataExcludesRetired:
 
         # Active low-stock item with a pending request -> should appear.
         active = InventoryItemFactory(current_stock=1, minimum_stock=10)
-        ReorderRequestFactory(item=active, status="pending", quantity=5)
+        ReorderRequestFactory(item=active, status=ReorderRequest.Status.PENDING, quantity=5)
 
         # Retired item that still carries a pending request -> must NOT appear.
         retired = InventoryItemFactory(current_stock=1, minimum_stock=10, is_retired=True)
-        ReorderRequestFactory(item=retired, status="pending", quantity=5)
+        ReorderRequestFactory(item=retired, status=ReorderRequest.Status.PENDING, quantity=5)
 
         response = client.get(self.URL)
 

--- a/backend/reorder_queue/tests/test_audit_events.py
+++ b/backend/reorder_queue/tests/test_audit_events.py
@@ -27,7 +27,7 @@ class TestPurchaseOrderAuditEvents:
         client.force_authenticate(user=user)
         return client
 
-    def _make_po(self, user, *, supplier=None, status=PurchaseOrder.DRAFT):
+    def _make_po(self, user, *, supplier=None, status=PurchaseOrder.Status.DRAFT):
         if supplier is None:
             supplier = SupplierFactory()
         return PurchaseOrder.objects.create(
@@ -76,7 +76,7 @@ class TestPurchaseOrderAuditEvents:
         assert response.status_code == status.HTTP_201_CREATED, response.data
 
         event = PurchaseOrderAuditEvent.objects.get()
-        assert event.action == PurchaseOrderAuditEvent.ACTION_PO_CREATE
+        assert event.action == PurchaseOrderAuditEvent.Action.PO_CREATE
         assert event.actor == user
         assert event.purchase_order_id == response.data["id"]
         assert event.metadata["po_number"]
@@ -95,10 +95,10 @@ class TestPurchaseOrderAuditEvents:
         assert response.status_code == status.HTTP_200_OK
 
         po.refresh_from_db()
-        assert po.status == PurchaseOrder.VOIDED
+        assert po.status == PurchaseOrder.Status.VOIDED
 
         event = PurchaseOrderAuditEvent.objects.get()
-        assert event.action == PurchaseOrderAuditEvent.ACTION_PO_VOID
+        assert event.action == PurchaseOrderAuditEvent.Action.PO_VOID
         assert event.actor == user
         assert event.purchase_order == po
         assert event.notes == "wrong supplier"
@@ -106,7 +106,7 @@ class TestPurchaseOrderAuditEvents:
     def test_po_void_already_voided_no_audit(self):
         user = UserFactory(is_staff=True)
         client = self._client_for(user)
-        po = self._make_po(user, status=PurchaseOrder.VOIDED)
+        po = self._make_po(user, status=PurchaseOrder.Status.VOIDED)
 
         response = client.post(
             reverse("purchaseorder-void", kwargs={"pk": po.pk}),
@@ -147,7 +147,7 @@ class TestPurchaseOrderAuditEvents:
         assert response.status_code == status.HTTP_200_OK
 
         event = PurchaseOrderAuditEvent.objects.get()
-        assert event.action == PurchaseOrderAuditEvent.ACTION_PO_LINE_VOID
+        assert event.action == PurchaseOrderAuditEvent.Action.PO_LINE_VOID
         assert event.actor == user
         assert event.line_item == item
         assert event.purchase_order == po
@@ -156,7 +156,7 @@ class TestPurchaseOrderAuditEvents:
     def test_po_mark_delivered_records_audit_event(self):
         user = UserFactory()
         client = self._client_for(user)
-        po = self._make_po(user, status=PurchaseOrder.SENT)
+        po = self._make_po(user, status=PurchaseOrder.Status.SENT)
         self._make_line_item(po, quantity=4, quantity_received=0)
         delivery_date = timezone.now().date().isoformat()
 
@@ -175,7 +175,7 @@ class TestPurchaseOrderAuditEvents:
 
         po.refresh_from_db()
         event = PurchaseOrderAuditEvent.objects.get()
-        assert event.action == PurchaseOrderAuditEvent.ACTION_PO_MARK_DELIVERED
+        assert event.action == PurchaseOrderAuditEvent.Action.PO_MARK_DELIVERED
         assert event.actor == user
         assert event.purchase_order == po
         assert event.notes == "left at dock"
@@ -204,7 +204,7 @@ class TestPurchaseOrderAuditEvents:
         assert response.status_code == status.HTTP_201_CREATED, response.data
 
         event = PurchaseOrderAuditEvent.objects.get()
-        assert event.action == PurchaseOrderAuditEvent.ACTION_ATTACHMENT_ADD
+        assert event.action == PurchaseOrderAuditEvent.Action.ATTACHMENT_ADD
         assert event.actor == user
         assert event.purchase_order == po
         assert event.attachment is not None
@@ -227,7 +227,7 @@ class TestPurchaseOrderAuditEvents:
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
         event = PurchaseOrderAuditEvent.objects.get()
-        assert event.action == PurchaseOrderAuditEvent.ACTION_ATTACHMENT_REMOVE
+        assert event.action == PurchaseOrderAuditEvent.Action.ATTACHMENT_REMOVE
         assert event.actor == user
         assert event.purchase_order == po
         assert event.attachment is None
@@ -238,7 +238,7 @@ class TestPurchaseOrderAuditEvents:
         po = self._make_po(user)
 
         event = record_event(
-            action=PurchaseOrderAuditEvent.ACTION_PO_CREATE,
+            action=PurchaseOrderAuditEvent.Action.PO_CREATE,
             actor=None,
             purchase_order=po,
         )
@@ -252,7 +252,7 @@ class TestPurchaseOrderAuditEvents:
         item = self._make_line_item(po)
 
         event = record_event(
-            action=PurchaseOrderAuditEvent.ACTION_PO_LINE_VOID,
+            action=PurchaseOrderAuditEvent.Action.PO_LINE_VOID,
             actor=user,
             line_item=item,
         )
@@ -266,7 +266,7 @@ class TestPurchaseOrderAuditEvents:
         attachment = self._make_attachment(po, user)
 
         event = record_event(
-            action=PurchaseOrderAuditEvent.ACTION_ATTACHMENT_ADD,
+            action=PurchaseOrderAuditEvent.Action.ATTACHMENT_ADD,
             actor=user,
             attachment=attachment,
         )

--- a/backend/reorder_queue/tests/test_models.py
+++ b/backend/reorder_queue/tests/test_models.py
@@ -29,7 +29,7 @@ class TestReorderRequestModel:
         assert request.item == item
         assert request.quantity == 25
         assert request.requested_by == "John Doe"
-        assert request.status == "pending"
+        assert request.status == ReorderRequest.Status.PENDING
         assert str(request).startswith(item.name)
 
     def test_estimated_cost_calculation(self):
@@ -51,13 +51,13 @@ class TestReorderRequestModel:
         """Test days_pending property calculates correctly."""
         # Create request 5 days ago
         with freeze_time("2024-01-10 12:00:00"):
-            request = ReorderRequestFactory(status="pending")
+            request = ReorderRequestFactory(status=ReorderRequest.Status.PENDING)
 
         assert request.days_pending == 5
 
     def test_days_pending_for_non_pending_status(self):
         """Test days_pending returns 0 for non-pending requests."""
-        request = ReorderRequestFactory(status="approved")
+        request = ReorderRequestFactory(status=ReorderRequest.Status.APPROVED)
         assert request.days_pending == 0
 
     def test_request_ordering(self):
@@ -71,7 +71,13 @@ class TestReorderRequestModel:
 
     def test_status_choices(self):
         """Test all status choices are valid."""
-        statuses = ["pending", "approved", "ordered", "received", "cancelled"]
+        statuses = [
+            ReorderRequest.Status.PENDING,
+            ReorderRequest.Status.APPROVED,
+            ReorderRequest.Status.ORDERED,
+            ReorderRequest.Status.RECEIVED,
+            ReorderRequest.Status.CANCELLED,
+        ]
 
         for status_choice in statuses:
             request = ReorderRequestFactory(status=status_choice)
@@ -79,7 +85,12 @@ class TestReorderRequestModel:
 
     def test_priority_choices(self):
         """Test all priority choices are valid."""
-        priorities = ["low", "normal", "high", "urgent"]
+        priorities = [
+            ReorderRequest.Priority.LOW,
+            ReorderRequest.Priority.NORMAL,
+            ReorderRequest.Priority.HIGH,
+            ReorderRequest.Priority.URGENT,
+        ]
 
         for priority in priorities:
             request = ReorderRequestFactory(priority=priority)
@@ -89,7 +100,7 @@ class TestReorderRequestModel:
         """Test reviewed_by relationship with User."""
         user = UserFactory(username="admin")
         request = ReorderRequestFactory(
-            status="approved", reviewed_by=user, reviewed_at=timezone.now()
+            status=ReorderRequest.Status.APPROVED, reviewed_by=user, reviewed_at=timezone.now()
         )
 
         assert request.reviewed_by == user
@@ -98,7 +109,7 @@ class TestReorderRequestModel:
     def test_order_tracking_fields(self):
         """Test order tracking fields."""
         request = ReorderRequestFactory(
-            status="ordered",
+            status=ReorderRequest.Status.ORDERED,
             ordered_at=timezone.now(),
             order_number="ORD-12345",
             actual_cost=Decimal("125.50"),
@@ -114,7 +125,9 @@ class TestReorderRequestModel:
         actual = timezone.now().date() + timedelta(days=5)
 
         request = ReorderRequestFactory(
-            status="received", estimated_delivery=estimated, actual_delivery=actual
+            status=ReorderRequest.Status.RECEIVED,
+            estimated_delivery=estimated,
+            actual_delivery=actual,
         )
 
         assert request.estimated_delivery == estimated

--- a/backend/reorder_queue/tests/test_notifications.py
+++ b/backend/reorder_queue/tests/test_notifications.py
@@ -174,7 +174,7 @@ class TestSignalIntegration:
         ReorderRequest.objects.create(
             item=sig_item,
             quantity=2,
-            status=ReorderRequest.APPROVED,
+            status=ReorderRequest.Status.APPROVED,
             requested_by="Automation",
         )
 

--- a/backend/reorder_queue/tests/test_ordering_adapters.py
+++ b/backend/reorder_queue/tests/test_ordering_adapters.py
@@ -185,7 +185,7 @@ class TestExportOrderAdapterRouting:
         purchase_order = PurchaseOrder.objects.create(
             po_number="PO-2026-0100",
             supplier=supplier,
-            status=PurchaseOrder.DRAFT,
+            status=PurchaseOrder.Status.DRAFT,
             created_by=user,
         )
         item = InventoryItemFactory(name=name, supplier=supplier, supplier_sku=sku)
@@ -200,14 +200,14 @@ class TestExportOrderAdapterRouting:
     def test_amazon_adapter_returns_cart_urls_not_a_file(self, authenticated_client):
         client, user = authenticated_client
         purchase_order = self._po_with_line(
-            user, adapter=Supplier.ADAPTER_AMAZON, sku="B07X1234YZ", qty=2
+            user, adapter=Supplier.OrderingAdapter.AMAZON, sku="B07X1234YZ", qty=2
         )
 
         url = reverse("purchaseorder-export-order", kwargs={"pk": purchase_order.pk})
         response = client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["adapter"] == "amazon"
+        assert response.data["adapter"] == Supplier.OrderingAdapter.AMAZON
         assert response.data["supplier"] == "Adapter Co"
         assert len(response.data["cart_urls"]) == 1
         assert "ASIN.1=B07X1234YZ" in response.data["cart_urls"][0]
@@ -222,7 +222,7 @@ class TestExportOrderAdapterRouting:
         client, user = authenticated_client
         purchase_order = self._po_with_line(
             user,
-            adapter=Supplier.ADAPTER_AMAZON,
+            adapter=Supplier.OrderingAdapter.AMAZON,
             sku="NOT-AN-ASIN",
             name="Bad ASIN Line",
         )
@@ -231,7 +231,7 @@ class TestExportOrderAdapterRouting:
         response = client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["adapter"] == "amazon"
+        assert response.data["adapter"] == Supplier.OrderingAdapter.AMAZON
         # A mis-typed ASIN is surfaced by line name and kept out of any cart.
         assert response.data["invalid_sku"] == ["Bad ASIN Line"]
         assert response.data["cart_urls"] == []
@@ -240,14 +240,14 @@ class TestExportOrderAdapterRouting:
     def test_hdsupply_adapter_returns_part_number_csv(self, authenticated_client):
         client, user = authenticated_client
         purchase_order = self._po_with_line(
-            user, adapter=Supplier.ADAPTER_HDSUPPLY, sku="12345", qty=3
+            user, adapter=Supplier.OrderingAdapter.HDSUPPLY, sku="12345", qty=3
         )
 
         url = reverse("purchaseorder-export-order", kwargs={"pk": purchase_order.pk})
         response = client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["adapter"] == "hdsupply"
+        assert response.data["adapter"] == Supplier.OrderingAdapter.HDSUPPLY
         csv_lines = response.data["csv"].splitlines()
         assert csv_lines[0] == "Part Number,Quantity"
         assert "12345,3" in csv_lines
@@ -261,7 +261,7 @@ class TestExportOrderAdapterRouting:
         client, user = authenticated_client
         purchase_order = self._po_with_line(
             user,
-            adapter=Supplier.ADAPTER_HDSUPPLY,
+            adapter=Supplier.OrderingAdapter.HDSUPPLY,
             sku="ABC-9",
             name="Non-numeric Part",
         )
@@ -270,21 +270,21 @@ class TestExportOrderAdapterRouting:
         response = client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["adapter"] == "hdsupply"
+        assert response.data["adapter"] == Supplier.OrderingAdapter.HDSUPPLY
         assert response.data["invalid_sku"] == ["Non-numeric Part"]
         assert response.data["line_count"] == 0
 
     def test_generic_adapter_returns_part_qty_csv(self, authenticated_client):
         client, user = authenticated_client
         purchase_order = self._po_with_line(
-            user, adapter=Supplier.ADAPTER_NONE, sku="ANY-SKU", qty=4
+            user, adapter=Supplier.OrderingAdapter.NONE, sku="ANY-SKU", qty=4
         )
 
         url = reverse("purchaseorder-export-order", kwargs={"pk": purchase_order.pk})
         response = client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["adapter"] == "none"
+        assert response.data["adapter"] == Supplier.OrderingAdapter.NONE
         csv_lines = response.data["csv"].splitlines()
         assert csv_lines[0] == "part#,qty"
         assert "ANY-SKU,4" in csv_lines
@@ -302,33 +302,33 @@ class TestSupplierOrderingAdapterField:
     def test_defaults_to_none(self):
         supplier = SupplierFactory()
 
-        assert supplier.ordering_adapter == Supplier.ADAPTER_NONE
+        assert supplier.ordering_adapter == Supplier.OrderingAdapter.NONE
 
     def test_choices_cover_the_four_adapters(self):
         field = Supplier._meta.get_field("ordering_adapter")
         choice_values = {value for value, _label in field.choices}
 
         assert choice_values == {
-            Supplier.ADAPTER_NONE,
-            Supplier.ADAPTER_GENERIC_CSV,
-            Supplier.ADAPTER_AMAZON,
-            Supplier.ADAPTER_HDSUPPLY,
+            Supplier.OrderingAdapter.NONE,
+            Supplier.OrderingAdapter.GENERIC_CSV,
+            Supplier.OrderingAdapter.AMAZON,
+            Supplier.OrderingAdapter.HDSUPPLY,
         }
-        assert field.default == Supplier.ADAPTER_NONE
+        assert field.default == Supplier.OrderingAdapter.NONE
 
     def test_serializer_exposes_supplier_ordering_adapter(self, authenticated_client):
         from reorder_queue.serializers import PurchaseOrderSerializer
 
         client, user = authenticated_client
-        supplier = SupplierFactory(ordering_adapter=Supplier.ADAPTER_AMAZON)
+        supplier = SupplierFactory(ordering_adapter=Supplier.OrderingAdapter.AMAZON)
         purchase_order = PurchaseOrder.objects.create(
             po_number="PO-2026-0200",
             supplier=supplier,
-            status=PurchaseOrder.DRAFT,
+            status=PurchaseOrder.Status.DRAFT,
             created_by=user,
         )
 
         data = PurchaseOrderSerializer(purchase_order).data
 
         # The web reads the adapter off the PO without a second request.
-        assert data["supplier_ordering_adapter"] == "amazon"
+        assert data["supplier_ordering_adapter"] == Supplier.OrderingAdapter.AMAZON

--- a/backend/reorder_queue/tests/test_webhook_audit_events.py
+++ b/backend/reorder_queue/tests/test_webhook_audit_events.py
@@ -13,7 +13,7 @@ def _webhook_payload(**overrides):
     payload = {
         "name": "Inventory Alerts",
         "url": "https://example.com/webhooks/inventory",
-        "event_type": WebHook.REORDER_REQUEST_CREATED,
+        "event_type": WebHook.EventType.REORDER_REQUEST_CREATED,
     }
     payload.update(overrides)
     return payload
@@ -23,7 +23,7 @@ def _create_webhook(**overrides):
     defaults = {
         "name": "Inventory Alerts",
         "url": "https://example.com/webhooks/inventory",
-        "event_type": WebHook.REORDER_REQUEST_CREATED,
+        "event_type": WebHook.EventType.REORDER_REQUEST_CREATED,
         "is_active": True,
         "secret": "initial-secret",
     }
@@ -42,7 +42,7 @@ def test_webhook_create_records_audit_event(authenticated_client):
     # serializer's id-key shape (which may be `id` / `uuid` / etc).
     webhook = WebHook.objects.get()
     event = WebhookAuditEvent.objects.get()
-    assert event.action == WebhookAuditEvent.ACTION_WEBHOOK_CREATE
+    assert event.action == WebhookAuditEvent.Action.WEBHOOK_CREATE
     assert event.actor == user
     assert event.webhook == webhook
     assert event.metadata == {
@@ -67,7 +67,7 @@ def test_webhook_update_records_diff(authenticated_client):
 
     assert response.status_code == status.HTTP_200_OK
     event = WebhookAuditEvent.objects.get()
-    assert event.action == WebhookAuditEvent.ACTION_WEBHOOK_UPDATE
+    assert event.action == WebhookAuditEvent.Action.WEBHOOK_UPDATE
     assert event.actor == user
     assert event.webhook == webhook
     assert event.metadata["changes"] == {
@@ -95,12 +95,12 @@ def test_webhook_secret_rotate_emits_distinct_event(authenticated_client):
 
     assert response.status_code == status.HTTP_200_OK
     event = WebhookAuditEvent.objects.get()
-    assert event.action == WebhookAuditEvent.ACTION_WEBHOOK_SECRET_ROTATE
+    assert event.action == WebhookAuditEvent.Action.WEBHOOK_SECRET_ROTATE
     assert "secret" not in event.metadata
     assert "new-secret" not in str(event.metadata)
     assert "new-secret" not in event.notes
     assert not WebhookAuditEvent.objects.filter(
-        action=WebhookAuditEvent.ACTION_WEBHOOK_UPDATE
+        action=WebhookAuditEvent.Action.WEBHOOK_UPDATE
     ).exists()
 
 
@@ -116,7 +116,7 @@ def test_webhook_disable_records_audit(authenticated_client):
 
     assert response.status_code == status.HTTP_200_OK
     event = WebhookAuditEvent.objects.get()
-    assert event.action == WebhookAuditEvent.ACTION_WEBHOOK_DISABLE
+    assert event.action == WebhookAuditEvent.Action.WEBHOOK_DISABLE
     assert event.actor == user
     assert event.webhook == webhook
 
@@ -133,7 +133,7 @@ def test_webhook_enable_records_audit(authenticated_client):
 
     assert response.status_code == status.HTTP_200_OK
     event = WebhookAuditEvent.objects.get()
-    assert event.action == WebhookAuditEvent.ACTION_WEBHOOK_ENABLE
+    assert event.action == WebhookAuditEvent.Action.WEBHOOK_ENABLE
     assert event.actor == user
     assert event.webhook == webhook
 
@@ -154,8 +154,8 @@ def test_webhook_update_does_not_include_is_active_in_diff(authenticated_client)
     assert response.status_code == status.HTTP_200_OK
     assert WebhookAuditEvent.objects.count() == 2
 
-    update_event = WebhookAuditEvent.objects.get(action=WebhookAuditEvent.ACTION_WEBHOOK_UPDATE)
-    disable_event = WebhookAuditEvent.objects.get(action=WebhookAuditEvent.ACTION_WEBHOOK_DISABLE)
+    update_event = WebhookAuditEvent.objects.get(action=WebhookAuditEvent.Action.WEBHOOK_UPDATE)
+    disable_event = WebhookAuditEvent.objects.get(action=WebhookAuditEvent.Action.WEBHOOK_DISABLE)
 
     assert update_event.actor == user
     assert update_event.webhook == webhook
@@ -178,12 +178,12 @@ def test_webhook_delete_records_audit_before_delete(authenticated_client):
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
     event = WebhookAuditEvent.objects.get()
-    assert event.action == WebhookAuditEvent.ACTION_WEBHOOK_DELETE
+    assert event.action == WebhookAuditEvent.Action.WEBHOOK_DELETE
     assert event.actor == user
     assert event.metadata == {
         "name": "Inventory Alerts",
         "url": "https://example.com/webhooks/inventory",
-        "event_type": WebHook.REORDER_REQUEST_CREATED,
+        "event_type": WebHook.EventType.REORDER_REQUEST_CREATED,
     }
     event.refresh_from_db()
     assert event.webhook is None
@@ -193,14 +193,14 @@ def test_diff_audited_fields_excludes_secret():
     before = WebHook(
         name="Inventory Alerts",
         url="https://example.com/webhooks/inventory",
-        event_type=WebHook.REORDER_REQUEST_CREATED,
+        event_type=WebHook.EventType.REORDER_REQUEST_CREATED,
         is_active=True,
         secret="old-secret",
     )
     after = WebHook(
         name="Inventory Alerts",
         url="https://example.com/webhooks/inventory",
-        event_type=WebHook.REORDER_REQUEST_CREATED,
+        event_type=WebHook.EventType.REORDER_REQUEST_CREATED,
         is_active=True,
         secret="new-secret",
     )
@@ -212,11 +212,11 @@ def test_record_event_with_anonymous_actor_creates_row_with_null_actor():
     webhook = _create_webhook()
 
     event = record_event(
-        action=WebhookAuditEvent.ACTION_WEBHOOK_CREATE,
+        action=WebhookAuditEvent.Action.WEBHOOK_CREATE,
         webhook=webhook,
         actor=None,
     )
 
     assert event.actor is None
     assert event.webhook == webhook
-    assert event.action == WebhookAuditEvent.ACTION_WEBHOOK_CREATE
+    assert event.action == WebhookAuditEvent.Action.WEBHOOK_CREATE

--- a/backend/reorder_queue/tests/test_webhooks.py
+++ b/backend/reorder_queue/tests/test_webhooks.py
@@ -30,7 +30,7 @@ class TestWebHookModel(TestCase):
             name="Test Webhook",
             description="Test webhook description",
             url="https://example.com/webhook",
-            event_type=WebHook.REORDER_REQUEST_CREATED,
+            event_type=WebHook.EventType.REORDER_REQUEST_CREATED,
             is_active=True,
             secret="test-secret-key",
         )
@@ -39,7 +39,7 @@ class TestWebHookModel(TestCase):
         """Test webhook can be created."""
         self.assertEqual(self.webhook.name, "Test Webhook")
         self.assertEqual(self.webhook.url, "https://example.com/webhook")
-        self.assertEqual(self.webhook.event_type, WebHook.REORDER_REQUEST_CREATED)
+        self.assertEqual(self.webhook.event_type, WebHook.EventType.REORDER_REQUEST_CREATED)
         self.assertTrue(self.webhook.is_active)
         self.assertEqual(self.webhook.success_count, 0)
         self.assertEqual(self.webhook.failure_count, 0)
@@ -101,7 +101,7 @@ class TestWebHookModel(TestCase):
         webhook = WebHook.objects.create(
             name="Webhook with headers",
             url="https://api.example.com/hook",
-            event_type=WebHook.ITEM_LOW_STOCK,
+            event_type=WebHook.EventType.ITEM_LOW_STOCK,
             headers=headers,
         )
 
@@ -118,7 +118,7 @@ class TestWebHookTasks(TestCase):
         self.webhook = WebHook.objects.create(
             name="Test Webhook",
             url="https://example.com/webhook",
-            event_type=WebHook.REORDER_REQUEST_CREATED,
+            event_type=WebHook.EventType.REORDER_REQUEST_CREATED,
             is_active=True,
             secret="test-secret-key",
         )
@@ -150,10 +150,10 @@ class TestWebHookTasks(TestCase):
         payload = {"event": "test_event", "data": {"id": 1}}
         # Use .run() to call the task function directly without Celery
         result = send_webhook_notification.run(
-            event_type=WebHook.REORDER_REQUEST_CREATED, payload=payload
+            event_type=WebHook.EventType.REORDER_REQUEST_CREATED, payload=payload
         )
 
-        self.assertEqual(result["event_type"], WebHook.REORDER_REQUEST_CREATED)
+        self.assertEqual(result["event_type"], WebHook.EventType.REORDER_REQUEST_CREATED)
         self.assertEqual(result["webhooks_triggered"], 1)
         self.assertEqual(len(result["successful"]), 1)
         self.assertEqual(len(result["failed"]), 0)
@@ -171,10 +171,10 @@ class TestWebHookTasks(TestCase):
 
         payload = {"event": "test_event", "data": {"id": 1}}
         result = send_webhook_notification.run(
-            event_type=WebHook.REORDER_REQUEST_CREATED, payload=payload
+            event_type=WebHook.EventType.REORDER_REQUEST_CREATED, payload=payload
         )
 
-        self.assertEqual(result["event_type"], WebHook.REORDER_REQUEST_CREATED)
+        self.assertEqual(result["event_type"], WebHook.EventType.REORDER_REQUEST_CREATED)
         self.assertEqual(result["webhooks_triggered"], 1)
         self.assertEqual(len(result["successful"]), 0)
         self.assertEqual(len(result["failed"]), 1)
@@ -193,7 +193,9 @@ class TestWebHookTasks(TestCase):
         mock_post.return_value = mock_response
 
         payload = {"event": "test_event"}
-        send_webhook_notification.run(event_type=WebHook.REORDER_REQUEST_CREATED, payload=payload)
+        send_webhook_notification.run(
+            event_type=WebHook.EventType.REORDER_REQUEST_CREATED, payload=payload
+        )
 
         # Verify HMAC signature header was added
         call_args = mock_post.call_args
@@ -208,10 +210,10 @@ class TestWebHookTasks(TestCase):
 
         payload = {"event": "test_event"}
         result = send_webhook_notification.run(
-            event_type=WebHook.REORDER_REQUEST_CREATED, payload=payload
+            event_type=WebHook.EventType.REORDER_REQUEST_CREATED, payload=payload
         )
 
-        self.assertEqual(result["event_type"], WebHook.REORDER_REQUEST_CREATED)
+        self.assertEqual(result["event_type"], WebHook.EventType.REORDER_REQUEST_CREATED)
         self.assertEqual(result["webhooks_triggered"], 0)
         mock_post.assert_not_called()
 
@@ -221,7 +223,7 @@ class TestWebHookTasks(TestCase):
         """Test triggering webhook for reorder request."""
         # Mock the return value of send_webhook_notification.run()
         mock_send_webhook.run.return_value = {
-            "event_type": WebHook.REORDER_REQUEST_CREATED,
+            "event_type": WebHook.EventType.REORDER_REQUEST_CREATED,
             "webhooks_triggered": 1,
             "successful": [],
             "failed": [],
@@ -229,7 +231,10 @@ class TestWebHookTasks(TestCase):
 
         # Create reorder request (signal mocked so won't trigger webhook)
         reorder_request = ReorderRequest.objects.create(
-            item=self.item, quantity=20, requested_by="testuser", status="pending"
+            item=self.item,
+            quantity=20,
+            requested_by="testuser",
+            status=ReorderRequest.Status.PENDING,
         )
 
         # Call the task function directly
@@ -240,7 +245,7 @@ class TestWebHookTasks(TestCase):
         call_args = mock_send_webhook.run.call_args
 
         # Verify event type
-        self.assertEqual(call_args[0][0], "reorder_request_created")
+        self.assertEqual(call_args[0][0], WebHook.EventType.REORDER_REQUEST_CREATED)
 
         # Verify payload structure
         payload = call_args[0][1]
@@ -274,7 +279,7 @@ class TestWebHookSignals(TestCase):
         WebHook.objects.create(
             name="Reorder Request Webhook",
             url="https://example.com/webhook",
-            event_type=WebHook.REORDER_REQUEST_CREATED,
+            event_type=WebHook.EventType.REORDER_REQUEST_CREATED,
             is_active=True,
         )
 
@@ -295,7 +300,10 @@ class TestWebHookSignals(TestCase):
     def test_reorder_request_created_triggers_webhook(self, mock_trigger):
         """Test that creating a reorder request triggers webhook."""
         reorder_request = ReorderRequest.objects.create(
-            item=self.item, quantity=20, requested_by="testuser", status="pending"
+            item=self.item,
+            quantity=20,
+            requested_by="testuser",
+            status=ReorderRequest.Status.PENDING,
         )
 
         # Verify webhook task was queued
@@ -305,14 +313,17 @@ class TestWebHookSignals(TestCase):
     def test_reorder_request_update_does_not_trigger_webhook(self, mock_trigger):
         """Test that updating a reorder request does not trigger webhook."""
         reorder_request = ReorderRequest.objects.create(
-            item=self.item, quantity=20, requested_by="testuser", status="pending"
+            item=self.item,
+            quantity=20,
+            requested_by="testuser",
+            status=ReorderRequest.Status.PENDING,
         )
 
         # Reset mock to ignore the creation call
         mock_trigger.reset_mock()
 
         # Update the request
-        reorder_request.status = "approved"
+        reorder_request.status = ReorderRequest.Status.APPROVED
         reorder_request.save()
 
         # Verify webhook was not triggered on update

--- a/backend/reorder_queue/views.py
+++ b/backend/reorder_queue/views.py
@@ -309,9 +309,9 @@ def _apply_po_receipt(
             _create_lead_time_log(po_item, delivery.delivery_date)
 
     if purchase_order.is_fully_received:
-        purchase_order.status = PurchaseOrder.RECEIVED
+        purchase_order.status = PurchaseOrder.Status.RECEIVED
     else:
-        purchase_order.status = PurchaseOrder.PARTIALLY_RECEIVED
+        purchase_order.status = PurchaseOrder.Status.PARTIALLY_RECEIVED
     purchase_order.save()
 
     delivery.is_complete = purchase_order.is_fully_received
@@ -432,7 +432,9 @@ class ReorderRequestViewSet(viewsets.ModelViewSet):
         try:
             # Return all pending requests without pagination for admin dashboard
             # Use the base queryset to ensure all prefetching is maintained
-            pending = self.queryset.filter(status="pending").order_by("-priority", "requested_at")
+            pending = self.queryset.filter(status=ReorderRequest.Status.PENDING).order_by(
+                "-priority", "requested_at"
+            )
 
             # Filter by SIG ownership for SIG admins
             user = request.user
@@ -485,9 +487,9 @@ class ReorderRequestViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        pending = self.queryset.filter(status="pending", item__owning_group__in=user_sigs).order_by(
-            "-priority", "requested_at"
-        )
+        pending = self.queryset.filter(
+            status=ReorderRequest.Status.PENDING, item__owning_group__in=user_sigs
+        ).order_by("-priority", "requested_at")
         serializer = self.get_serializer(pending, many=True)
         return Response(serializer.data)
 
@@ -495,7 +497,7 @@ class ReorderRequestViewSet(viewsets.ModelViewSet):
     def by_supplier(self, request):
         """Group pending requests by supplier for easier bulk ordering."""
         pending = (
-            ReorderRequest.objects.filter(status="pending")
+            ReorderRequest.objects.filter(status=ReorderRequest.Status.PENDING)
             .select_related("item")
             .prefetch_related("item__item_suppliers__supplier")
         )
@@ -526,7 +528,7 @@ class ReorderRequestViewSet(viewsets.ModelViewSet):
     def approve(self, request, pk=None):
         """Approve a reorder request."""
         reorder = self.get_object()
-        reorder.status = "approved"
+        reorder.status = ReorderRequest.Status.APPROVED
         reorder.reviewed_by = request.user
         reorder.reviewed_at = timezone.now()
         reorder.admin_notes = request.data.get("admin_notes", reorder.admin_notes)
@@ -547,7 +549,7 @@ class ReorderRequestViewSet(viewsets.ModelViewSet):
         bare mark-ordered never wipes values a PO already populated.
         """
         reorder = self.get_object()
-        reorder.status = "ordered"
+        reorder.status = ReorderRequest.Status.ORDERED
         reorder.ordered_at = timezone.now()
 
         if "order_number" in request.data:
@@ -570,7 +572,7 @@ class ReorderRequestViewSet(viewsets.ModelViewSet):
     def mark_received(self, request, pk=None):
         """Mark a request as received and update inventory."""
         reorder = self.get_object()
-        reorder.status = "received"
+        reorder.status = ReorderRequest.Status.RECEIVED
         reorder.actual_delivery = request.data.get("actual_delivery", timezone.now().date())
         reorder.save()
 
@@ -586,7 +588,7 @@ class ReorderRequestViewSet(viewsets.ModelViewSet):
     def cancel(self, request, pk=None):
         """Cancel a reorder request."""
         reorder = self.get_object()
-        reorder.status = "cancelled"
+        reorder.status = ReorderRequest.Status.CANCELLED
         reorder.reviewed_by = request.user
         reorder.reviewed_at = timezone.now()
         reorder.admin_notes = request.data.get("admin_notes", reorder.admin_notes)
@@ -613,7 +615,7 @@ class ReorderRequestViewSet(viewsets.ModelViewSet):
         """
         open_requests = (
             ReorderRequest.objects.filter(
-                status__in=[ReorderRequest.PENDING, ReorderRequest.APPROVED]
+                status__in=[ReorderRequest.Status.PENDING, ReorderRequest.Status.APPROVED]
             )
             .select_related("item")
             .prefetch_related("item__item_suppliers__supplier")
@@ -677,10 +679,10 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         if not self.request.user.is_authenticated:
             queryset = queryset.filter(
                 status__in=[
-                    PurchaseOrder.SENT,
-                    PurchaseOrder.CONFIRMED,
-                    PurchaseOrder.PARTIALLY_RECEIVED,
-                    PurchaseOrder.RECEIVED,
+                    PurchaseOrder.Status.SENT,
+                    PurchaseOrder.Status.CONFIRMED,
+                    PurchaseOrder.Status.PARTIALLY_RECEIVED,
+                    PurchaseOrder.Status.RECEIVED,
                 ]
             )
 
@@ -717,7 +719,7 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         purchase_order = serializer.save()
         record_audit_event(
-            action=PurchaseOrderAuditEvent.ACTION_PO_CREATE,
+            action=PurchaseOrderAuditEvent.Action.PO_CREATE,
             actor=self.request.user,
             purchase_order=purchase_order,
             metadata={
@@ -757,7 +759,7 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         downgrades it. Wrapped defensively so a failure in the transition never
         breaks the create/update that triggered it (oms-qdxss).
         """
-        if purchase_order.status != PurchaseOrder.DRAFT:
+        if purchase_order.status != PurchaseOrder.Status.DRAFT:
             return
         try:
             self._mark_sent(purchase_order, self.request.user)
@@ -776,12 +778,12 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         ``sent_by``/``sent_at`` stamped, a ``po_send`` audit event recorded, and
         the linked reorder requests synced. Callers own the DRAFT precondition.
         """
-        purchase_order.status = PurchaseOrder.SENT
+        purchase_order.status = PurchaseOrder.Status.SENT
         purchase_order.sent_by = user
         purchase_order.sent_at = timezone.now()
         purchase_order.save()
         record_audit_event(
-            action=PurchaseOrderAuditEvent.ACTION_PO_SEND,
+            action=PurchaseOrderAuditEvent.Action.PO_SEND,
             actor=user,
             purchase_order=purchase_order,
             metadata={"po_number": purchase_order.po_number},
@@ -888,7 +890,10 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         # even if a request lingered from before they were retired.
         items_with_requests = (
             InventoryItem.objects.filter(
-                reorder_requests__status__in=[ReorderRequest.PENDING, ReorderRequest.APPROVED],
+                reorder_requests__status__in=[
+                    ReorderRequest.Status.PENDING,
+                    ReorderRequest.Status.APPROVED,
+                ],
                 is_active=True,
                 is_retired=False,
             )
@@ -996,7 +1001,12 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
             assets = Asset.objects.filter(
                 manufacturer_id=supplier_id,
                 is_active=True,
-                status__in=[Asset.ACTIVE, Asset.MAINTENANCE, Asset.IMPLEMENTING, Asset.TESTING],
+                status__in=[
+                    Asset.Status.ACTIVE,
+                    Asset.Status.MAINTENANCE,
+                    Asset.Status.IMPLEMENTING,
+                    Asset.Status.TESTING,
+                ],
             ).values("id", "name", "asset_tag", "serial_number", "product_url")
 
             data["assets"] = [
@@ -1022,10 +1032,10 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
             Supplier.objects.filter(
                 manufactured_assets__is_active=True,
                 manufactured_assets__status__in=[
-                    Asset.ACTIVE,
-                    Asset.MAINTENANCE,
-                    Asset.IMPLEMENTING,
-                    Asset.TESTING,
+                    Asset.Status.ACTIVE,
+                    Asset.Status.MAINTENANCE,
+                    Asset.Status.IMPLEMENTING,
+                    Asset.Status.TESTING,
                 ],
             )
             .exclude(id__in=supplier_data.keys())
@@ -1036,7 +1046,12 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
             assets = Asset.objects.filter(
                 manufacturer=supplier,
                 is_active=True,
-                status__in=[Asset.ACTIVE, Asset.MAINTENANCE, Asset.IMPLEMENTING, Asset.TESTING],
+                status__in=[
+                    Asset.Status.ACTIVE,
+                    Asset.Status.MAINTENANCE,
+                    Asset.Status.IMPLEMENTING,
+                    Asset.Status.TESTING,
+                ],
             ).values("id", "name", "asset_tag", "serial_number", "product_url")
 
             supplier_data[supplier.id] = {
@@ -1167,7 +1182,7 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
             # Find active reorder requests for this item (pending or approved)
             active_requests = ReorderRequest.objects.filter(
                 item=item,
-                status__in=[ReorderRequest.PENDING, ReorderRequest.APPROVED],
+                status__in=[ReorderRequest.Status.PENDING, ReorderRequest.Status.APPROVED],
             )
 
             # Calculate estimated delivery date
@@ -1186,7 +1201,7 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
 
             # Update each active request
             for reorder_request in active_requests:
-                reorder_request.status = ReorderRequest.ORDERED
+                reorder_request.status = ReorderRequest.Status.ORDERED
                 reorder_request.order_number = purchase_order.po_number
                 reorder_request.ordered_at = purchase_order.sent_at or timezone.now()
                 reorder_request.estimated_delivery = estimated_delivery
@@ -1224,7 +1239,7 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         """Mark purchase order as sent to supplier."""
         purchase_order = self.get_object()
 
-        if purchase_order.status != PurchaseOrder.DRAFT:
+        if purchase_order.status != PurchaseOrder.Status.DRAFT:
             return Response(
                 {"error": "Only draft orders can be sent to suppliers"},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -1240,13 +1255,13 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         """Mark purchase order as confirmed by supplier."""
         purchase_order = self.get_object()
 
-        if purchase_order.status != PurchaseOrder.SENT:
+        if purchase_order.status != PurchaseOrder.Status.SENT:
             return Response(
                 {"error": "Only sent orders can be confirmed"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        purchase_order.status = PurchaseOrder.CONFIRMED
+        purchase_order.status = PurchaseOrder.Status.CONFIRMED
         purchase_order.expected_delivery_date = request.data.get("expected_delivery_date")
         purchase_order.save()
 
@@ -1293,11 +1308,11 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         ]
 
         supplier = purchase_order.supplier if purchase_order.supplier_id else None
-        adapter = supplier.ordering_adapter if supplier else Supplier.ADAPTER_NONE
+        adapter = supplier.ordering_adapter if supplier else Supplier.OrderingAdapter.NONE
 
-        if adapter == Supplier.ADAPTER_AMAZON:
+        if adapter == Supplier.OrderingAdapter.AMAZON:
             payload = build_amazon_cart(lines)
-        elif adapter == Supplier.ADAPTER_HDSUPPLY:
+        elif adapter == Supplier.OrderingAdapter.HDSUPPLY:
             payload = build_order_pad(
                 lines,
                 header=("Part Number", "Quantity"),
@@ -1334,9 +1349,9 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         purchase_order = self.get_object()
 
         if purchase_order.status not in [
-            PurchaseOrder.SENT,
-            PurchaseOrder.CONFIRMED,
-            PurchaseOrder.PARTIALLY_RECEIVED,
+            PurchaseOrder.Status.SENT,
+            PurchaseOrder.Status.CONFIRMED,
+            PurchaseOrder.Status.PARTIALLY_RECEIVED,
         ]:
             return Response(
                 {
@@ -1375,7 +1390,7 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
             )
 
         record_audit_event(
-            action="po_mark_delivered",
+            action=PurchaseOrderAuditEvent.Action.PO_MARK_DELIVERED,
             actor=request.user,
             purchase_order=purchase_order,
             notes=data.get("receipt_notes", ""),
@@ -1383,7 +1398,7 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
                 "delivery_date": delivery_datetime.isoformat(),
                 "tracking_number": data.get("tracking_number", ""),
                 "carrier": data.get("carrier", ""),
-                "fully_received": purchase_order.status == PurchaseOrder.RECEIVED,
+                "fully_received": purchase_order.status == PurchaseOrder.Status.RECEIVED,
             },
         )
 
@@ -1406,9 +1421,9 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         purchase_order = self.get_object()
 
         if purchase_order.status not in [
-            PurchaseOrder.SENT,
-            PurchaseOrder.CONFIRMED,
-            PurchaseOrder.PARTIALLY_RECEIVED,
+            PurchaseOrder.Status.SENT,
+            PurchaseOrder.Status.CONFIRMED,
+            PurchaseOrder.Status.PARTIALLY_RECEIVED,
         ]:
             return Response(
                 {
@@ -1480,7 +1495,7 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
             )
 
         record_audit_event(
-            action="po_receive_items",
+            action=PurchaseOrderAuditEvent.Action.PO_RECEIVE_ITEMS,
             actor=request.user,
             purchase_order=purchase_order,
             notes=data.get("receipt_notes", ""),
@@ -1488,7 +1503,7 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
                 "delivery_date": delivery_datetime.isoformat(),
                 "tracking_number": data.get("tracking_number", ""),
                 "carrier": data.get("carrier", ""),
-                "fully_received": purchase_order.status == PurchaseOrder.RECEIVED,
+                "fully_received": purchase_order.status == PurchaseOrder.Status.RECEIVED,
                 "received_items": [
                     {"purchase_order_item": po_item.id, "quantity_received": quantity}
                     for po_item, quantity in resolved_lines
@@ -1645,7 +1660,7 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         line_item.save()
 
         record_audit_event(
-            action="po_line_void",
+            action=PurchaseOrderAuditEvent.Action.PO_LINE_VOID,
             actor=request.user,
             line_item=line_item,
             notes=line_item.void_reason or "",
@@ -1680,13 +1695,13 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
 
         purchase_order = self.get_object()
 
-        if purchase_order.status == PurchaseOrder.VOIDED:
+        if purchase_order.status == PurchaseOrder.Status.VOIDED:
             return Response(
                 {"detail": "Purchase order is already voided."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        if purchase_order.status == PurchaseOrder.RECEIVED:
+        if purchase_order.status == PurchaseOrder.Status.RECEIVED:
             return Response(
                 {"detail": "Cannot void a received PO; create a return instead."},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -1696,7 +1711,7 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         reason = request.data.get("reason", "")
 
         with transaction.atomic():
-            purchase_order.status = PurchaseOrder.VOIDED
+            purchase_order.status = PurchaseOrder.Status.VOIDED
             purchase_order.voided_at = now
             purchase_order.voided_by = user
             purchase_order.void_reason = reason
@@ -1710,7 +1725,7 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
             )
 
         record_audit_event(
-            action="po_void",
+            action=PurchaseOrderAuditEvent.Action.PO_VOID,
             actor=user,
             purchase_order=purchase_order,
             notes=reason,
@@ -1742,7 +1757,7 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
 
         attachment = serializer.save(purchase_order=purchase_order, uploaded_by=request.user)
         record_audit_event(
-            action="attachment_add",
+            action=PurchaseOrderAuditEvent.Action.ATTACHMENT_ADD,
             actor=request.user,
             purchase_order=purchase_order,
             attachment=attachment,
@@ -1777,7 +1792,7 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         # survives, but we want the filename in metadata while we still have
         # the field on hand.
         record_audit_event(
-            action="attachment_remove",
+            action=PurchaseOrderAuditEvent.Action.ATTACHMENT_REMOVE,
             actor=user,
             purchase_order=purchase_order,
             attachment=attachment,
@@ -1792,24 +1807,26 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         # Order status counts
         status_counts = PurchaseOrder.objects.aggregate(
             total=Count("id"),
-            draft=Count("id", filter=Q(status=PurchaseOrder.DRAFT)),
-            sent=Count("id", filter=Q(status=PurchaseOrder.SENT)),
-            confirmed=Count("id", filter=Q(status=PurchaseOrder.CONFIRMED)),
-            partially_received=Count("id", filter=Q(status=PurchaseOrder.PARTIALLY_RECEIVED)),
-            received=Count("id", filter=Q(status=PurchaseOrder.RECEIVED)),
+            draft=Count("id", filter=Q(status=PurchaseOrder.Status.DRAFT)),
+            sent=Count("id", filter=Q(status=PurchaseOrder.Status.SENT)),
+            confirmed=Count("id", filter=Q(status=PurchaseOrder.Status.CONFIRMED)),
+            partially_received=Count(
+                "id", filter=Q(status=PurchaseOrder.Status.PARTIALLY_RECEIVED)
+            ),
+            received=Count("id", filter=Q(status=PurchaseOrder.Status.RECEIVED)),
         )
 
         # Financial metrics
         financial_metrics = PurchaseOrder.objects.aggregate(
             total_value=Sum("estimated_total"),
-            received_value=Sum("actual_total", filter=Q(status=PurchaseOrder.RECEIVED)),
+            received_value=Sum("actual_total", filter=Q(status=PurchaseOrder.Status.RECEIVED)),
         )
 
         # Recent activity (this week)
         week_ago = timezone.now() - timedelta(days=7)
         recent_activity = PurchaseOrder.objects.filter(order_date__gte=week_ago).aggregate(
             orders_created=Count("id"),
-            orders_received=Count("id", filter=Q(status=PurchaseOrder.RECEIVED)),
+            orders_received=Count("id", filter=Q(status=PurchaseOrder.Status.RECEIVED)),
         )
 
         # Items metrics
@@ -1976,9 +1993,9 @@ class OrderReceiptViewSet(viewsets.ModelViewSet):
 
             # Update purchase order status
             if purchase_order.is_fully_received:
-                purchase_order.status = PurchaseOrder.RECEIVED
+                purchase_order.status = PurchaseOrder.Status.RECEIVED
             else:
-                purchase_order.status = PurchaseOrder.PARTIALLY_RECEIVED
+                purchase_order.status = PurchaseOrder.Status.PARTIALLY_RECEIVED
             purchase_order.save()
 
             # Create lead time log if order is complete
@@ -2008,9 +2025,9 @@ class OrderReceiptViewSet(viewsets.ModelViewSet):
         pending_orders = (
             PurchaseOrder.objects.filter(
                 status__in=[
-                    PurchaseOrder.SENT,
-                    PurchaseOrder.CONFIRMED,
-                    PurchaseOrder.PARTIALLY_RECEIVED,
+                    PurchaseOrder.Status.SENT,
+                    PurchaseOrder.Status.CONFIRMED,
+                    PurchaseOrder.Status.PARTIALLY_RECEIVED,
                 ]
             )
             .select_related("supplier")
@@ -2063,9 +2080,9 @@ class AnalyticsViewSet(viewsets.ViewSet):
             # Order metrics
             orders = supplier.purchase_orders.all()
             total_orders = orders.count()
-            completed_orders = orders.filter(status=PurchaseOrder.RECEIVED).count()
+            completed_orders = orders.filter(status=PurchaseOrder.Status.RECEIVED).count()
             active_orders = orders.exclude(
-                status__in=[PurchaseOrder.RECEIVED, PurchaseOrder.CANCELLED]
+                status__in=[PurchaseOrder.Status.RECEIVED, PurchaseOrder.Status.CANCELLED]
             ).count()
 
             # Lead time metrics
@@ -2277,10 +2294,10 @@ class AnalyticsViewSet(viewsets.ViewSet):
             purchase_orders = (
                 PurchaseOrder.objects.filter(
                     status__in=[
-                        PurchaseOrder.SENT,
-                        PurchaseOrder.CONFIRMED,
-                        PurchaseOrder.PARTIALLY_RECEIVED,
-                        PurchaseOrder.RECEIVED,
+                        PurchaseOrder.Status.SENT,
+                        PurchaseOrder.Status.CONFIRMED,
+                        PurchaseOrder.Status.PARTIALLY_RECEIVED,
+                        PurchaseOrder.Status.RECEIVED,
                     ]
                 )
                 .select_related("supplier")
@@ -2393,7 +2410,7 @@ class AnalyticsViewSet(viewsets.ViewSet):
         # Locations with open LocationProblem reports (oms-0yz). Anything still
         # in REPORTED/IN_PROGRESS counts toward the dashboard's problem total.
         open_location_problems_qs = LocationProblem.objects.filter(
-            status__in=[LocationProblem.REPORTED, LocationProblem.IN_PROGRESS]
+            status__in=[LocationProblem.Status.REPORTED, LocationProblem.Status.IN_PROGRESS]
         )
         locations_with_lp = open_location_problems_qs.values_list(
             "location_id", flat=True
@@ -2411,8 +2428,8 @@ class AnalyticsViewSet(viewsets.ViewSet):
         # Urgent / high severity open problems trigger the dashboard alert mode.
         urgent_location_problems = open_location_problems_qs.filter(
             severity__in=[
-                LocationProblem.SEVERITY_HIGH,
-                LocationProblem.SEVERITY_URGENT,
+                LocationProblem.Severity.HIGH,
+                LocationProblem.Severity.URGENT,
             ]
         ).count()
         alert_active = urgent_location_problems > 0
@@ -2552,7 +2569,7 @@ class WebHookViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         webhook = serializer.save()
         record_webhook_audit_event(
-            action=WebhookAuditEvent.ACTION_WEBHOOK_CREATE,
+            action=WebhookAuditEvent.Action.WEBHOOK_CREATE,
             actor=self.request.user,
             webhook=webhook,
             metadata={
@@ -2576,7 +2593,7 @@ class WebHookViewSet(viewsets.ModelViewSet):
 
         if webhook.secret != before_secret:
             record_webhook_audit_event(
-                action=WebhookAuditEvent.ACTION_WEBHOOK_SECRET_ROTATE,
+                action=WebhookAuditEvent.Action.WEBHOOK_SECRET_ROTATE,
                 actor=self.request.user,
                 webhook=webhook,
             )
@@ -2593,7 +2610,7 @@ class WebHookViewSet(viewsets.ModelViewSet):
             changes.pop("is_active")
         if changes:
             record_webhook_audit_event(
-                action=WebhookAuditEvent.ACTION_WEBHOOK_UPDATE,
+                action=WebhookAuditEvent.Action.WEBHOOK_UPDATE,
                 actor=self.request.user,
                 webhook=webhook,
                 metadata={"changes": changes},
@@ -2601,9 +2618,9 @@ class WebHookViewSet(viewsets.ModelViewSet):
         if before_active != webhook.is_active:
             record_webhook_audit_event(
                 action=(
-                    WebhookAuditEvent.ACTION_WEBHOOK_ENABLE
+                    WebhookAuditEvent.Action.WEBHOOK_ENABLE
                     if webhook.is_active
-                    else WebhookAuditEvent.ACTION_WEBHOOK_DISABLE
+                    else WebhookAuditEvent.Action.WEBHOOK_DISABLE
                 ),
                 actor=self.request.user,
                 webhook=webhook,
@@ -2614,7 +2631,7 @@ class WebHookViewSet(viewsets.ModelViewSet):
         # fields while we still have the row. The webhook FK on the audit
         # row is SET_NULL on cascade, so the audit row survives the delete.
         record_webhook_audit_event(
-            action=WebhookAuditEvent.ACTION_WEBHOOK_DELETE,
+            action=WebhookAuditEvent.Action.WEBHOOK_DELETE,
             actor=self.request.user,
             webhook=instance,
             metadata={
@@ -2783,7 +2800,7 @@ class PurchasingReportViewSet(viewsets.ViewSet):
     def spend_by_supplier(self, request):
         """Get total spend per supplier from purchase orders."""
         queryset = (
-            PurchaseOrder.objects.filter(status=PurchaseOrder.RECEIVED)
+            PurchaseOrder.objects.filter(status=PurchaseOrder.Status.RECEIVED)
             .select_related("supplier")
             .values("supplier__id", "supplier__name")
             .annotate(
@@ -2813,7 +2830,7 @@ class PurchasingReportViewSet(viewsets.ViewSet):
         """Get total spend grouped by item category."""
         queryset = (
             PurchaseOrderItem.objects.filter(
-                purchase_order__status=PurchaseOrder.RECEIVED,
+                purchase_order__status=PurchaseOrder.Status.RECEIVED,
                 item_supplier__isnull=False,
             )
             .select_related("item_supplier__item__category", "purchase_order")

--- a/backend/search/tests/test_views.py
+++ b/backend/search/tests/test_views.py
@@ -95,7 +95,7 @@ class TestGlobalSearchView:
     def test_global_search_supplier(self, authenticated_client, db):
         """Test searching for suppliers."""
         client, _ = authenticated_client
-        SupplierFactory(name="Test Supplier", supplier_type=Supplier.ONLINE)
+        SupplierFactory(name="Test Supplier", supplier_type=Supplier.SupplierType.ONLINE)
 
         url = reverse("global-search")
         response = client.get(url, {"q": "Test Supplier"})

--- a/backend/storage_vision/tests/test_review.py
+++ b/backend/storage_vision/tests/test_review.py
@@ -216,7 +216,7 @@ class TestApprove:
         # AC-21: reconciliation with reason=vision_supply_check, item set to 0.
         recon = StockReconciliation.objects.get(item=item)
         assert recon.actual_count == 0
-        assert recon.reason == StockReconciliation.REASON_VISION_SUPPLY_CHECK
+        assert recon.reason == StockReconciliation.ReasonCode.VISION_SUPPLY_CHECK
         assert f"VisionObservation #{obs.id}" in recon.notes
         assert recon.reconciled_by == staff_user
 

--- a/backend/storage_vision/views.py
+++ b/backend/storage_vision/views.py
@@ -583,7 +583,7 @@ def _approve_one(obs, reviewer, reason_text: str):
             user=reviewer,
             item=item,
             actual_count=0,
-            reason=StockReconciliation.REASON_VISION_SUPPLY_CHECK,
+            reason=StockReconciliation.ReasonCode.VISION_SUPPLY_CHECK,
             notes=notes,
         )
 


### PR DESCRIPTION
## Summary

Converts all **32** ad-hoc `*_CHOICES` constant blocks in `inventory/models/` (26) and `reorder_queue/models.py` (6) into idiomatic **nested `models.TextChoices`** classes (style-matched to ForgeKey's `LockoutLevel`), and migrates every reference to the `Model.Nested.MEMBER` form. Flagship TextChoices pattern for the codebase; the remaining 6 apps (donations, location_checkins, checklists, membership, notifications, search) are a documented follow-up. **Zero migration, no stored-value change.** Closes #889.

### What changed
- **32 nested `TextChoices` classes** — asset (10), core (8), maintenance (5), location_problem (2), fixtures (1); reorder_queue (6). Two same-file models each get their own nested class (no collision).
- **835 qualified `Model.OLD` references** rewritten to `Model.Nested.MEMBER` across the two apps and their importers (analytics, forgekey, loto, dashboard, storage_vision, config, membership, search); raw string-literal choice values in production code and tests replaced with enum members.
- Old bare constants and `*_CHOICES` lists **fully removed — no back-compat aliases, 0 dangling references** (whole-backend scan).
- Deliberately left as raw strings (not model-choice values): docstrings, DRF `source=` / argparse `action=`, custom filter-param keys, and report-row / union discriminators.

### Why zero migration
Django tracks `choices` + `default` in migration state. Each member preserves the exact stored value, human label, and order, and `default=` now points at a `TextChoices` member (a `str` subclass equal to its value) → the autodetector sees no field change. `makemigrations --check --dry-run` → *"No changes detected"*.

### Acceptance criteria
- **AC-1** — zero migration: `makemigrations --check --dry-run` → "No changes detected". ✅
- **AC-2** — all 32 blocks → nested TextChoices. ✅
- **AC-3** — idiomatic `Model.Nested.MEMBER` references; 0 dangling; genuine non-choice strings untouched. ✅
- **AC-4** — no behavior/DB change; full `pytest`: **3225 passed / 4 skipped / 0 failed**; `manage.py check` clean. ✅
- **AC-5** — black / isort / flake8 clean. ✅

### Independent verification (reviewer)
- `makemigrations --check --dry-run` (all apps) → "No changes detected"; `manage.py check` → no issues.
- 26 + 6 = 32 nested TextChoices; zero `*_CHOICES` lists remain in the two apps.
- black / isort clean; flake8 introduces **zero new findings** vs `main` (the few bugbear `B0xx` warnings are pre-existing and CI-tolerated — Backend Lint was green on #886 with them present).
- Conversions + a sample of the reference rewrites spot-checked faithful (value/label/order preserved; `WorkOrder.STATUS_COMPLETED`→`WorkOrder.Status.COMPLETED`, `self.PENDING`→`self.Status.PENDING`, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
