### PR TITLE
refactor(inventory): route primary-supplier compat fields through a service, kill N+1 (#882)

### DIFF
--- a/backend/index_cards/views.py
+++ b/backend/index_cards/views.py
@@ -46,7 +46,14 @@ class IndexCardBatchGenerateView(APIView):
 
         validated_ids = serializer.validated_data["item_ids"]
         item_ids: List[str] = [str(value) for value in validated_ids]
-        items = list(InventoryItem.objects.filter(id__in=validated_ids))
+        # Prefetch each item's suppliers so the renderer's per-card lead-time
+        # reads (``item.average_lead_time`` and ``_get_longest_lead_time``) hit
+        # the cache instead of firing a query per card (issue #882).
+        items = list(
+            InventoryItem.objects.filter(id__in=validated_ids).prefetch_related(
+                "item_suppliers__supplier"
+            )
+        )
 
         if len(items) != len(validated_ids):
             missing = set(item_ids) - {str(item.id) for item in items}

--- a/backend/inventory/models/core.py
+++ b/backend/inventory/models/core.py
@@ -12,6 +12,7 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models, transaction
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.text import slugify
 
 from imagekit.models import ImageSpecField
@@ -475,10 +476,19 @@ class InventoryItem(models.Model):
 
     @property
     def lowest_unit_cost(self) -> Optional[Decimal]:
-        """Get the lowest unit cost from all suppliers."""
+        """Get the lowest unit cost from all suppliers.
+
+        Reads from ``item_suppliers.all()`` and filters the nulls out in Python
+        so a caller that prefetched ``item_suppliers`` (e.g. the list endpoint,
+        which serialises ``total_value``) hits the prefetch cache instead of
+        firing a per-row ``filter(unit_cost__isnull=False)`` query — the same
+        N+1 fix applied to :meth:`primary_item_supplier` (issue #882). The value
+        is unchanged: the minimum non-null unit cost across all suppliers.
+        """
         costs = [
             item_supplier.unit_cost
-            for item_supplier in self.item_suppliers.filter(unit_cost__isnull=False)
+            for item_supplier in self.item_suppliers.all()
+            if item_supplier.unit_cost is not None
         ]
         return min(costs) if costs else None
 
@@ -512,16 +522,27 @@ class InventoryItem(models.Model):
         link = self.primary_item_supplier
         return link.supplier if link else None
 
-    @property
+    @cached_property
     def primary_item_supplier(self) -> Optional["ItemSupplier"]:
-        """Return the preferred ItemSupplier relationship if available."""
+        """Preferred supplier relationship for this item — prefetch-friendly.
 
-        item_supplier = (
-            self.item_suppliers.select_related("supplier").filter(is_primary=True).first()
-        )
-        if item_supplier:
-            return item_supplier
-        return self.item_suppliers.select_related("supplier").first()
+        Delegates to the named :mod:`inventory.services.supplier_selection`
+        service (issue #882) so the selection lives in one place rather than a
+        hidden model query. The chosen row is byte-for-byte the one the previous
+        ``filter(is_primary=True).first() or first()`` returned — the supplier
+        flagged primary with the lowest unit cost, or the cheapest supplier when
+        none is primary — because the service resolves it from
+        ``item_suppliers``' ``Meta.ordering`` (``["-is_primary", "unit_cost"]``).
+
+        The result rides an ``item_suppliers`` prefetch when the caller set one
+        up (the list/detail/reorder read paths all do), so serialising the seven
+        flat compat fields across a page costs ZERO extra queries instead of an
+        N+1. It is memoised per instance via ``cached_property`` so reading all
+        seven flats touches the database at most once.
+        """
+        from inventory.services.supplier_selection import primary_item_supplier
+
+        return primary_item_supplier(self)
 
     @property
     def supplier(self) -> Optional[Supplier]:

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -420,7 +420,16 @@ class SupplierDetailSerializer(SupplierSerializer):
 
 
 class InventoryItemSerializer(serializers.ModelSerializer):
-    # Primary supplier fields (for backward compatibility)
+    # Primary-supplier compat fields (issue #882). ``supplier_name`` here and the
+    # flat ``supplier_sku`` / ``supplier_url`` / ``unit_cost`` / ``package_cost``
+    # / ``quantity_per_package`` / ``average_lead_time`` keys listed in
+    # ``Meta.fields`` are READ-ONLY legacy accessors for the item's primary
+    # supplier, superseded by the ``suppliers[]`` array (below) and the
+    # ``/metrics/`` (``?with_metrics=1``) endpoint. They are retained because
+    # ScanTTY's detail screen reads all of them and the web reads four; a future
+    # hard-removal needs coordinated ScanTTY + web changes. They resolve through
+    # the prefetch-friendly ``InventoryItem.primary_item_supplier`` so serialising
+    # a page no longer costs a query per row.
     supplier_name = serializers.SerializerMethodField()
     category_name = serializers.CharField(source="category.name", read_only=True)
 

--- a/backend/inventory/services/supplier_selection.py
+++ b/backend/inventory/services/supplier_selection.py
@@ -1,0 +1,72 @@
+"""Named primary-supplier selection for inventory items (issue #882).
+
+Historically ``InventoryItem`` exposed its "primary supplier" through a cluster
+of model properties (``supplier``, ``supplier_sku``, ``unit_cost``,
+``average_lead_time`` …) that each ran a hidden
+``item_suppliers.filter(is_primary=True).first()`` query. Reading them across a
+page of items was therefore an N+1, and the selection logic was buried in the
+model rather than named anywhere.
+
+This module is the single, named home for that selection — for one item or a
+whole page — built to ride the ``item_suppliers`` prefetch cache when the caller
+set one up. ``InventoryItem.primary_item_supplier`` is now a thin, cached shim
+that delegates here.
+
+Selection is defined by ``ItemSupplier.Meta.ordering`` (``["-is_primary",
+"unit_cost"]``): the supplier flagged primary with the lowest unit cost, or —
+when none is flagged primary — the cheapest supplier overall. Both helpers
+return byte-for-byte the row the legacy ``filter(is_primary=True).first() or
+first()`` chose, because that pair of queries and this resolution both defer to
+the same database ordering.
+"""
+
+from typing import Dict, Iterable, Optional
+
+from inventory.models import ItemSupplier
+
+
+def primary_item_supplier(item) -> Optional[ItemSupplier]:
+    """Return the preferred :class:`ItemSupplier` for ``item`` (or ``None``).
+
+    When ``item`` was loaded with ``prefetch_related("item_suppliers")`` this
+    reads the prefetch cache and costs ZERO queries; otherwise it runs a single
+    query, pulling ``supplier`` in the same round-trip so a downstream
+    ``.supplier`` access does not add another. The first row under
+    ``item_suppliers``' ``Meta.ordering`` is the primary — identical to the
+    legacy ``filter(is_primary=True).first() or first()``.
+    """
+    prefetched = getattr(item, "_prefetched_objects_cache", None) or {}
+    if "item_suppliers" in prefetched:
+        item_suppliers = item.item_suppliers.all()
+    else:
+        item_suppliers = item.item_suppliers.select_related("supplier").all()
+    return next(iter(item_suppliers), None)
+
+
+def primary_suppliers_for(items: Iterable) -> Dict:
+    """Return ``{item_id: primary ItemSupplier | None}`` for ``items`` in ONE query.
+
+    ``items`` is an iterable of :class:`~inventory.models.InventoryItem`
+    instances (typically a single paginated page). Every item id is present in
+    the result — ``None`` where the item has no supplier — so callers can index
+    the map directly. The batch pulls every candidate ``ItemSupplier`` for the
+    page in a single ``select_related("supplier")`` query ordered by ``item``
+    then the primary-selection ordering, keeping the first row seen per item.
+    That first row is exactly what :func:`primary_item_supplier` would return for
+    each item, but resolved once for the whole page rather than per row — the
+    same shape as ``inventory.services.item_metrics.compute_item_metrics_batch``.
+    """
+    items = list(items)
+    result: Dict = {item.id: None for item in items}
+    if not items:
+        return result
+
+    for link in (
+        ItemSupplier.objects.filter(item_id__in=list(result))
+        .select_related("supplier")
+        .order_by("item", "-is_primary", "unit_cost")
+    ):
+        # Rows arrive primary-first within each item; keep the first one seen.
+        if result[link.item_id] is None:
+            result[link.item_id] = link
+    return result

--- a/backend/inventory/tests/test_inventory_list_metrics.py
+++ b/backend/inventory/tests/test_inventory_list_metrics.py
@@ -267,3 +267,42 @@ class TestListMetricsQueryBudget:
             api_client.get(_list_url(with_metrics=True))
         assert len(ctx.captured_queries) > base_6  # opt-in strictly adds queries
         assert base_2 <= base_6  # sanity: default path still serves the list
+
+
+def _supplier_query_count(api_client, url):
+    """Number of captured queries that read the ItemSupplier table."""
+    with CaptureQueriesContext(connection) as ctx:
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+    return sum(1 for q in ctx.captured_queries if "inventory_itemsupplier" in q["sql"])
+
+
+class TestDefaultListSupplierQueryBudget:
+    """Regression guard for the primary-supplier compat-field N+1 (issue #882)."""
+
+    def test_supplier_compat_fields_do_not_add_a_query_per_row(self, api_client):
+        """The seven flat primary-supplier compat fields are served from the list
+        viewset's ``item_suppliers`` prefetch, not a per-row query.
+
+        Before the prefetch-friendly ``primary_item_supplier`` (and the matching
+        ``lowest_unit_cost`` fix behind ``total_value``), serialising the flat
+        compat fields fired several ItemSupplier queries PER item, so a page of 6
+        cost far more supplier queries than a page of 2. Now a single prefetch
+        serves the whole page: the ItemSupplier query count is constant — and
+        equal to one — regardless of page size.
+        """
+        for i in range(2):
+            InventoryItemFactory(image=None, name=f"supbudget-a-{i}")
+        # Warm one-time caches (content types, etc.) so the counts are stable.
+        _supplier_query_count(api_client, _list_url())
+        sup_2 = _supplier_query_count(api_client, _list_url())
+
+        for i in range(4):  # grow the page from 2 to 6 items
+            InventoryItemFactory(image=None, name=f"supbudget-b-{i}")
+        sup_6 = _supplier_query_count(api_client, _list_url())
+
+        # The heart of the regression: the supplier-table query count does NOT
+        # grow with the number of rows — an N+1 would make sup_6 > sup_2 ...
+        assert sup_2 == sup_6, (sup_2, sup_6)
+        # ... and it is a single prefetch query, not a per-row handful.
+        assert sup_6 == 1, sup_6

--- a/backend/inventory/tests/test_supplier_selection.py
+++ b/backend/inventory/tests/test_supplier_selection.py
@@ -1,0 +1,190 @@
+"""Tests for the named primary-supplier selection service (issue #882).
+
+The service (``inventory.services.supplier_selection``) and the thin
+``InventoryItem.primary_item_supplier`` shim that delegates to it must:
+
+* select the IDENTICAL row the legacy ``filter(is_primary=True).first() or
+  first()`` chose (primary-first, then cheapest);
+* cost ZERO extra queries when ``item_suppliers`` is prefetched (killing the
+  per-row N+1 behind the seven flat compat fields), and one query otherwise;
+* resolve a whole page in a single query via the batch helper.
+"""
+
+from decimal import Decimal
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+import pytest
+
+from inventory.models import InventoryItem, ItemSupplier, Supplier
+from inventory.services.supplier_selection import primary_item_supplier, primary_suppliers_for
+
+pytestmark = pytest.mark.django_db
+
+
+def _item(name="Widget"):
+    return InventoryItem.objects.create(
+        name=name,
+        description="x",
+        reorder_quantity=1,
+        current_stock=10,
+        minimum_stock=1,
+    )
+
+
+def _supplier(name):
+    return Supplier.objects.create(name=name, supplier_type=Supplier.SupplierType.LOCAL)
+
+
+def _link(item, name, *, is_primary, unit_cost, quantity_per_package=1):
+    return ItemSupplier.objects.create(
+        item=item,
+        supplier=_supplier(name),
+        supplier_sku=f"{name}-sku",
+        unit_cost=None if unit_cost is None else Decimal(unit_cost),
+        quantity_per_package=quantity_per_package,
+        is_primary=is_primary,
+    )
+
+
+def _legacy_primary(item):
+    """The exact selection the property used before #882."""
+    link = item.item_suppliers.select_related("supplier").filter(is_primary=True).first()
+    if link:
+        return link
+    return item.item_suppliers.select_related("supplier").first()
+
+
+# ── Selection identical to the legacy behaviour ──────────────────────────────
+
+
+def test_returns_none_when_item_has_no_suppliers():
+    assert primary_item_supplier(_item()) is None
+
+
+def test_prefers_the_flagged_primary_over_a_cheaper_non_primary():
+    item = _item()
+    primary = _link(item, "A", is_primary=True, unit_cost="5.00")
+    _link(item, "B", is_primary=False, unit_cost="1.00")
+    assert primary_item_supplier(item).pk == primary.pk
+
+
+def test_falls_back_to_cheapest_when_none_is_primary():
+    item = _item()
+    _link(item, "A", is_primary=False, unit_cost="5.00")
+    cheapest = _link(item, "B", is_primary=False, unit_cost="1.00")
+    assert primary_item_supplier(item).pk == cheapest.pk
+
+
+def test_among_multiple_primaries_picks_the_cheapest():
+    item = _item()
+    _link(item, "A", is_primary=True, unit_cost="5.00")
+    cheaper_primary = _link(item, "B", is_primary=True, unit_cost="1.00")
+    assert primary_item_supplier(item).pk == cheaper_primary.pk
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [("A", True, "3.00")],
+        [("A", False, "3.00")],
+        [("A", True, "5.00"), ("B", False, "1.00")],
+        [("A", False, "5.00"), ("B", False, "1.00")],
+        [("A", True, "5.00"), ("B", True, "1.00")],
+        [("A", False, None), ("B", False, "1.00")],
+        [("A", True, None), ("B", False, "1.00")],
+    ],
+)
+def test_selection_matches_legacy_query(rows):
+    """For every supplier arrangement, the service picks the legacy row."""
+    item = _item()
+    for name, is_primary, cost in rows:
+        _link(item, name, is_primary=is_primary, unit_cost=cost)
+
+    # Re-fetch so neither path is warmed by a prefetch/cache.
+    fresh = InventoryItem.objects.get(pk=item.pk)
+    expected = _legacy_primary(fresh)
+    assert primary_item_supplier(InventoryItem.objects.get(pk=item.pk)).pk == expected.pk
+
+
+# ── Query budget ─────────────────────────────────────────────────────────────
+
+
+def test_single_lookup_costs_one_query_without_prefetch():
+    item = _item()
+    _link(item, "A", is_primary=True, unit_cost="1.00")
+    fresh = InventoryItem.objects.get(pk=item.pk)
+    with CaptureQueriesContext(connection) as ctx:
+        link = primary_item_supplier(fresh)
+        _ = link.supplier.name  # must NOT trigger a second query
+    assert len(ctx.captured_queries) == 1
+
+
+def test_single_lookup_costs_zero_queries_when_prefetched():
+    item = _item()
+    _link(item, "A", is_primary=True, unit_cost="1.00")
+    prefetched = InventoryItem.objects.prefetch_related("item_suppliers__supplier").get(pk=item.pk)
+    with CaptureQueriesContext(connection) as ctx:
+        link = primary_item_supplier(prefetched)
+        _ = link.supplier.name
+    assert len(ctx.captured_queries) == 0
+
+
+def test_reading_all_flat_fields_is_one_query_unprefetched_and_cached():
+    item = _item()
+    _link(item, "A", is_primary=True, unit_cost="2.50", quantity_per_package=6)
+    fresh = InventoryItem.objects.get(pk=item.pk)
+    with CaptureQueriesContext(connection) as ctx:
+        # All seven flat compat reads + the derived ones share one cached load.
+        _ = (
+            fresh.supplier,
+            fresh.primary_supplier,
+            fresh.supplier_sku,
+            fresh.supplier_url,
+            fresh.unit_cost,
+            fresh.package_cost,
+            fresh.quantity_per_package,
+            fresh.average_lead_time,
+        )
+    assert len(ctx.captured_queries) == 1
+
+
+def test_property_delegates_to_service_and_is_cached():
+    item = _item()
+    link = _link(item, "A", is_primary=True, unit_cost="1.00")
+    prefetched = InventoryItem.objects.prefetch_related("item_suppliers__supplier").get(pk=item.pk)
+    assert prefetched.primary_item_supplier.pk == link.pk
+    with CaptureQueriesContext(connection) as ctx:
+        # Second access is memoised — no query even without a prefetch cache hit.
+        _ = prefetched.primary_item_supplier
+    assert len(ctx.captured_queries) == 0
+
+
+# ── Batch helper ─────────────────────────────────────────────────────────────
+
+
+def test_batch_resolves_a_page_in_one_query_and_matches_per_item():
+    items = []
+    for i in range(4):
+        it = _item(f"Item-{i}")
+        _link(it, f"P{i}", is_primary=True, unit_cost=str(5 + i))
+        _link(it, f"C{i}", is_primary=False, unit_cost="0.50")
+        items.append(it)
+    supplierless = _item("Bare")
+    items.append(supplierless)
+
+    with CaptureQueriesContext(connection) as ctx:
+        batch = primary_suppliers_for(items)
+    assert len(ctx.captured_queries) == 1
+
+    assert batch[supplierless.id] is None
+    for it in items[:4]:
+        expected = primary_item_supplier(InventoryItem.objects.get(pk=it.pk))
+        assert batch[it.id].pk == expected.pk
+
+
+def test_batch_empty_input_returns_empty_map_without_querying():
+    with CaptureQueriesContext(connection) as ctx:
+        assert primary_suppliers_for([]) == {}
+    assert len(ctx.captured_queries) == 0

--- a/backend/reorder_queue/models.py
+++ b/backend/reorder_queue/models.py
@@ -110,8 +110,12 @@ class ReorderRequest(models.Model):
     @property
     def estimated_cost(self) -> Optional[Decimal]:
         """Calculate estimated cost based on item unit cost."""
-        if self.item.unit_cost:
-            return self.quantity * self.item.unit_cost
+        # Read the item's primary unit cost once: ``item.unit_cost`` resolves the
+        # primary supplier, so reading it twice used to double the (now cached,
+        # prefetch-friendly) lookup on every row of a reorder list (issue #882).
+        unit_cost = self.item.unit_cost
+        if unit_cost:
+            return self.quantity * unit_cost
         return None
 
     @property


### PR DESCRIPTION
## Summary

Retires the *hidden-query anti-pattern* behind `InventoryItem`'s legacy primary-supplier compat fields — **without changing the API**. Supplier writes already route through `ItemSupplier`, and both clients (web + ScanTTY) read the flat fields, so this is a read-contract + N+1 fix: **backend-only, zero schema change**. Closes #882.

### The fix
- `primary_item_supplier` was `item_suppliers.filter(is_primary=True).first()` — a per-access query that **bypassed `prefetch_related`**. It is now a `@cached_property` delegating to a new named service `inventory/services/supplier_selection.py` (`primary_item_supplier(item)` + batched `primary_suppliers_for(items)`) that resolves from the prefetched `item_suppliers` (0 queries when prefetched, 1 otherwise, with `select_related("supplier")`). The selected row is **byte-for-byte identical** — both the old `filter(is_primary=True).first() or first()` and the new resolution defer to `ItemSupplier.Meta.ordering = ["-is_primary", "unit_cost"]`. `lowest_unit_cost` got the same prefetch-friendly rewrite.
- All 7 flat compat fields (`supplier_sku`, `supplier_url`, `unit_cost`, `package_cost`, `quantity_per_package`, `average_lead_time`) + `supplier_name` + the computed fields stay in the API with **identical values** — none removed (ScanTTY reads all 7; the web reads 4).

### N+1s fixed
- `ReorderRequest.estimated_cost` no longer double-reads `item.unit_cost`.
- `index_cards` batch-card view prefetches `item_suppliers__supplier`.
- reorder `by_supplier` / `generate_cart_links` / analytics already prefetched — now actually hit the cache via the property.
- **New regression test**: the default inventory-list `ItemSupplier` query count is **constant (×1)** regardless of page size (was ~8/row; measured 19→55 for 2→6 items before).

### Acceptance criteria
- **AC-1** — prefetch-friendly selection via a named service; result identical to the legacy property. ✅
- **AC-2** — API contract unchanged (all 7 flat + `supplier_name` + computed, identical values). ✅
- **AC-3** — supplier N+1s fixed; default-list query count constant (regression test). ✅
- **AC-4** — backend-only (frontend/ + scantty/ untouched); factory shim preserved; deprecation path documented. ✅
- **AC-5** — `makemigrations --check` clean (no schema change); full `pytest` **3256 passed / 4 skipped / 0 failed**; black/isort/flake8 green. ✅

### Independent verification (reviewer)
- `makemigrations --check --dry-run` → "No changes detected"; `manage.py check` clean; black/isort clean; flake8 no new findings (only pre-existing `reorder_queue/tasks.py` B023s in an untouched file).
- Reviewed `supplier_selection.py`: selection provably identical to `filter(is_primary=True).first() or first()` (both defer to `Meta.ordering`), prefetch-cache-aware.
- No migrations added; `frontend/` untouched.

### Follow-up (flagged, out of scope)
The default inventory list also has a *separate, pre-existing* `reorder_requests` N+1 (`has_pending_reorder` / `reorder_status` / `expected_delivery_date` query per row). Left untouched here because `get_expected_delivery_date` orders by `-ordered_at` (not `Meta.ordering`), so a naive prefetch rewrite would change values — belongs in the **#890** N+1 audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
