### PR TITLE
refactor(reorder_queue): extract PO + receiving workflow into services (#883)

### DIFF
--- a/backend/reorder_queue/admin.py
+++ b/backend/reorder_queue/admin.py
@@ -242,6 +242,12 @@ class PurchaseOrderAdmin(admin.ModelAdmin):
     ]
     date_hierarchy = "order_date"
 
+    def get_queryset(self, request):
+        # Prefetch line items so the changelist's total_items column (and any
+        # other line-item aggregate) reads from cache instead of one query per
+        # row (#883).
+        return super().get_queryset(request).prefetch_related("items")
+
     inlines = [PurchaseOrderItemInline]
 
     fieldsets = (
@@ -414,6 +420,11 @@ class OrderDeliveryAdmin(admin.ModelAdmin):
         "updated_at",
     ]
     date_hierarchy = "delivery_date"
+
+    def get_queryset(self, request):
+        # Prefetch delivery items so the changelist's total_quantity_received
+        # column reads from cache instead of one query per row (#883).
+        return super().get_queryset(request).prefetch_related("items")
 
     inlines = [DeliveryItemInline]
 

--- a/backend/reorder_queue/models.py
+++ b/backend/reorder_queue/models.py
@@ -13,6 +13,7 @@ from django.contrib.auth import get_user_model
 from django.core.validators import MinValueValidator
 from django.db import IntegrityError, models, transaction
 from django.utils import timezone
+from django.utils.functional import cached_property
 
 from config.observability_redaction import redact
 from inventory.models import InventoryItem, ItemSupplier, Supplier
@@ -245,19 +246,55 @@ class PurchaseOrder(models.Model):
     def __str__(self) -> str:
         return f"PO #{self.po_number} - {self.supplier.name} ({self.status})"
 
+    @cached_property
+    def _line_item_totals(self) -> dict:
+        """Compute all PO-level line-item aggregates in a single pass (#883).
+
+        The list serializer, ``pending_orders``, and the admin changelist read
+        several of the calculated fields below; deriving them together here (and
+        caching per instance) collapses what were 5-6 separate loops over the
+        prefetched line items into one. Values are identical to the standalone
+        properties they back, including the voided-line exclusion.
+
+        Cached per instance: the receive/void workflows read these aggregates
+        only AFTER their line-item mutations (never before), so a stale
+        pre-mutation read cannot occur — matching prior behaviour.
+        """
+        active_count = 0
+        total_quantity = 0
+        total_received_quantity = 0
+        voided_estimated_total = Decimal("0.00")
+        all_fully_received = True
+        for item in self.items.all():
+            # total_received_quantity counts every line, voided or not.
+            if item.quantity_received is not None:
+                total_received_quantity += item.quantity_received
+            # is_fully_received is all() over every line, voided or not.
+            if not item.is_fully_received:
+                all_fully_received = False
+            if item.is_voided:
+                voided_estimated_total += item.estimated_cost
+            else:
+                active_count += 1
+                if item.quantity_ordered is not None:
+                    total_quantity += item.quantity_ordered
+        return {
+            "total_items": active_count,
+            "total_quantity": total_quantity,
+            "total_received_quantity": total_received_quantity,
+            "voided_estimated_total": voided_estimated_total,
+            "is_fully_received": all_fully_received,
+        }
+
     @property
     def total_items(self) -> int:
         """Total number of distinct non-voided items in this order."""
-        return sum(1 for item in self.items.all() if not item.is_voided)
+        return self._line_item_totals["total_items"]
 
     @property
     def total_quantity(self) -> int:
         """Total quantity of non-voided items ordered."""
-        return sum(
-            item.quantity_ordered
-            for item in self.items.all()
-            if not item.is_voided and item.quantity_ordered is not None
-        )
+        return self._line_item_totals["total_quantity"]
 
     @property
     def effective_estimated_total(self) -> Decimal:
@@ -266,12 +303,8 @@ class PurchaseOrder(models.Model):
         Voided lines are subtracted from the stored ``estimated_total`` so the
         displayed cost reflects only items the supplier is actually fulfilling.
         """
-        voided_total = sum(
-            (item.estimated_cost for item in self.items.all() if item.is_voided),
-            start=Decimal("0.00"),
-        )
         base = self.estimated_total or Decimal("0.00")
-        adjusted = base - voided_total
+        adjusted = base - self._line_item_totals["voided_estimated_total"]
         if adjusted < Decimal("0.00"):
             return Decimal("0.00")
         return adjusted
@@ -279,21 +312,17 @@ class PurchaseOrder(models.Model):
     @property
     def has_active_items(self) -> bool:
         """Whether any line item on this PO is not voided."""
-        return any(not item.is_voided for item in self.items.all())
+        return self._line_item_totals["total_items"] > 0
 
     @property
     def total_received_quantity(self) -> int:
         """Total quantity of all items received."""
-        return sum(
-            item.quantity_received
-            for item in self.items.all()
-            if item.quantity_received is not None
-        )
+        return self._line_item_totals["total_received_quantity"]
 
     @property
     def is_fully_received(self) -> bool:
         """Check if all ordered items have been fully received."""
-        return all(item.is_fully_received for item in self.items.all())
+        return self._line_item_totals["is_fully_received"]
 
     @property
     def days_since_ordered(self) -> int:

--- a/backend/reorder_queue/serializers.py
+++ b/backend/reorder_queue/serializers.py
@@ -2,14 +2,8 @@
 Serializers for reorder queue API.
 """
 
-from decimal import Decimal, InvalidOperation
-
-from django.core.exceptions import ValidationError as DjangoValidationError
-from django.db import transaction
-
 from rest_framework import serializers
 
-from inventory.models import ItemSupplier
 from inventory.serializers import InventoryItemSerializer, ItemSupplierSerializer
 
 from .models import (
@@ -22,6 +16,7 @@ from .models import (
     ReorderRequest,
     WebHook,
 )
+from .services import create_purchase_order
 
 
 class ReorderRequestSerializer(serializers.ModelSerializer):
@@ -345,9 +340,14 @@ class PurchaseOrderCreateSerializer(serializers.ModelSerializer):
         """Return full purchase order details after creation."""
         return PurchaseOrderSerializer(instance, context=self.context).data
 
-    @transaction.atomic
     def create(self, validated_data):
-        """Create purchase order with line items (inventory items, assets, or freeform)."""
+        """Create purchase order with line items (inventory items, assets, or freeform).
+
+        The PO/line-item creation workflow lives in
+        :func:`reorder_queue.services.create_purchase_order` (#883); this
+        serializer stays the request/response boundary and owns input
+        validation.
+        """
         items_data = validated_data.pop("items")
 
         # Validate items list is not empty
@@ -366,180 +366,7 @@ class PurchaseOrderCreateSerializer(serializers.ModelSerializer):
                 "User must be authenticated to create a purchase order."
             )
 
-        # Create the purchase order; PurchaseOrder.save() auto-generates the
-        # po_number and retries on uniqueness collisions (concurrent-create race).
-        purchase_order = PurchaseOrder.objects.create(
-            created_by=user,
-            **validated_data,
-        )
-
-        # Create line items
-        total_cost = Decimal("0.00")
-        for idx, item_data in enumerate(items_data):
-            quantity = item_data.get("quantity", 1)
-            notes = item_data.get("notes", "")
-
-            # Validate quantity
-            if not isinstance(quantity, (int, float)) or quantity <= 0:
-                raise serializers.ValidationError(
-                    f"Item at index {idx}: quantity must be a positive number, got {quantity}"
-                )
-
-            # Handle inventory items
-            if "item_supplier_id" in item_data:
-                item_supplier_id = item_data["item_supplier_id"]
-                try:
-                    item_supplier = ItemSupplier.objects.get(id=item_supplier_id)
-
-                    # Ensure the supplier matches the PO supplier
-                    if item_supplier.supplier != purchase_order.supplier:
-                        raise serializers.ValidationError(
-                            f"Item supplier {item_supplier_id} does not belong to selected supplier"
-                        )
-
-                    # Calculate order_in_packages: prefer explicit caller value
-                    # (frontend sends this when user enters whole cases), otherwise
-                    # ceil-divide the unit quantity by the supplier's case size.
-                    quantity_per_package = item_supplier.quantity_per_package or 1
-                    explicit_packages = item_data.get("order_in_packages")
-                    if explicit_packages is not None:
-                        try:
-                            order_in_packages = int(explicit_packages)
-                        except (TypeError, ValueError):
-                            raise serializers.ValidationError(
-                                f"Item at index {idx}: order_in_packages must be "
-                                f"an integer, got {explicit_packages!r}"
-                            )
-                        if order_in_packages < 0:
-                            raise serializers.ValidationError(
-                                f"Item at index {idx}: order_in_packages must be "
-                                f"non-negative, got {order_in_packages}"
-                            )
-                    else:
-                        order_in_packages = (
-                            (int(quantity) + quantity_per_package - 1) // quantity_per_package
-                            if quantity_per_package > 0
-                            else 0
-                        )
-
-                    # Get unit_cost override if provided, otherwise use item_supplier.unit_cost
-                    unit_cost_override = item_data.get("unit_cost")
-                    if unit_cost_override is not None:
-                        try:
-                            unit_cost_ordered = Decimal(str(unit_cost_override))
-                        except (InvalidOperation, ValueError):
-                            raise serializers.ValidationError(
-                                f"Item at index {idx}: unit_cost must be numeric, "
-                                f"got {unit_cost_override!r}"
-                            )
-                    else:
-                        unit_cost_ordered = item_supplier.unit_cost or Decimal("0.00")
-
-                    # Get expected_shipment_date if provided
-                    expected_shipment_date = item_data.get("expected_shipment_date")
-
-                    # Create the line item
-                    line_item = PurchaseOrderItem.objects.create(
-                        purchase_order=purchase_order,
-                        item_supplier=item_supplier,
-                        quantity_ordered=quantity,
-                        unit_cost_ordered=unit_cost_ordered,
-                        order_in_packages=order_in_packages,
-                        notes=notes,
-                        expected_shipment_date=expected_shipment_date,
-                    )
-
-                    total_cost += line_item.estimated_cost
-
-                except (ItemSupplier.DoesNotExist, ValueError, TypeError):
-                    raise serializers.ValidationError(
-                        f"ItemSupplier with id {item_supplier_id} does not exist"
-                    )
-
-            # Handle assets
-            elif "asset_id" in item_data:
-                asset_id = item_data["asset_id"]
-                unit_cost = item_data.get("unit_cost")
-                if unit_cost is None:
-                    raise serializers.ValidationError(
-                        f"unit_cost is required when purchasing asset {asset_id}"
-                    )
-                try:
-                    unit_cost = Decimal(str(unit_cost))
-                except (InvalidOperation, ValueError):
-                    raise serializers.ValidationError(
-                        f"Item at index {idx}: unit_cost must be numeric, " f"got {unit_cost!r}"
-                    )
-
-                try:
-                    from inventory.models import Asset
-
-                    asset = Asset.objects.get(id=asset_id)
-
-                    # Ensure the asset's manufacturer matches the PO supplier (if set)
-                    if asset.manufacturer and asset.manufacturer != purchase_order.supplier:
-                        raise serializers.ValidationError(
-                            f"Asset {asset_id} manufacturer does not match selected supplier"
-                        )
-
-                    # Create the line item (assets don't have package information)
-                    line_item = PurchaseOrderItem.objects.create(
-                        purchase_order=purchase_order,
-                        asset=asset,
-                        quantity_ordered=quantity,
-                        unit_cost_ordered=unit_cost,
-                        order_in_packages=0,  # Assets don't have package information
-                        notes=notes,
-                    )
-
-                    total_cost += line_item.estimated_cost
-
-                except (Asset.DoesNotExist, DjangoValidationError, ValueError):
-                    raise serializers.ValidationError(f"Invalid asset id: {asset_id}")
-
-            # Handle freeform line items
-            elif "description" in item_data:
-                description = item_data["description"]
-                unit_cost = item_data.get("unit_cost")
-
-                if not description:
-                    raise serializers.ValidationError(
-                        "Freeform items must have a non-empty description"
-                    )
-
-                if unit_cost is None:
-                    raise serializers.ValidationError(
-                        f"unit_cost is required for freeform item: {description}"
-                    )
-                try:
-                    unit_cost = Decimal(str(unit_cost))
-                except (InvalidOperation, ValueError):
-                    raise serializers.ValidationError(
-                        f"Item at index {idx}: unit_cost must be numeric, " f"got {unit_cost!r}"
-                    )
-
-                # Create the freeform line item (freeform items don't have package information)
-                line_item = PurchaseOrderItem.objects.create(
-                    purchase_order=purchase_order,
-                    description=description,
-                    quantity_ordered=quantity,
-                    unit_cost_ordered=unit_cost,
-                    order_in_packages=0,  # Freeform items don't have package information
-                    notes=notes,
-                )
-
-                total_cost += line_item.estimated_cost
-
-            else:
-                raise serializers.ValidationError(
-                    "Each item must have 'item_supplier_id', 'asset_id', or 'description'"
-                )
-
-        # Update estimated total
-        purchase_order.estimated_total = total_cost
-        purchase_order.save()
-
-        return purchase_order
+        return create_purchase_order(validated_data, items_data, user)
 
 
 # Delivery and Receipt Serializers

--- a/backend/reorder_queue/services/__init__.py
+++ b/backend/reorder_queue/services/__init__.py
@@ -1,0 +1,29 @@
+"""Service layer for reorder-queue purchase-order + receiving workflow (#883).
+
+Views keep the serializers as the request/response boundary and keep their
+``record_audit_event`` calls; the workflow bodies live in these services.
+"""
+
+from .purchase_orders import (
+    add_business_days,
+    confirm_order,
+    create_purchase_order,
+    mark_sent,
+    update_reorder_requests_from_po,
+    void_line_item,
+    void_po,
+)
+from .receiving import create_lead_time_log, mark_delivered_receipt, receive_delivery
+
+__all__ = [
+    "add_business_days",
+    "confirm_order",
+    "create_purchase_order",
+    "mark_sent",
+    "update_reorder_requests_from_po",
+    "void_line_item",
+    "void_po",
+    "create_lead_time_log",
+    "mark_delivered_receipt",
+    "receive_delivery",
+]

--- a/backend/reorder_queue/services/purchase_orders.py
+++ b/backend/reorder_queue/services/purchase_orders.py
@@ -1,0 +1,353 @@
+"""Purchase-order creation and status-transition workflow.
+
+Extracted from ``reorder_queue.serializers`` and ``reorder_queue.views`` (#883).
+The views keep the serializers as the request/response boundary and keep their
+``record_audit_event`` calls; the workflow body lives here.
+
+Note: PO number generation stays in ``PurchaseOrder.save()`` (owned by #887) —
+``create_purchase_order`` relies on ``save()`` to number and retry on
+uniqueness collisions.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal, InvalidOperation
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
+from django.utils import timezone
+
+from rest_framework import serializers
+
+from inventory.models import ItemSupplier
+
+from ..models import PurchaseOrder, PurchaseOrderItem, ReorderRequest
+
+
+@transaction.atomic
+def create_purchase_order(validated_data, items_data, user):
+    """Create a purchase order with line items (inventory items, assets, freeform).
+
+    ``validated_data`` is the create serializer's validated data with ``items``
+    already popped; ``items_data`` is that popped list. The caller (the create
+    serializer) owns the non-empty / request-context / authenticated-user
+    checks. Raises :class:`rest_framework.serializers.ValidationError` on any
+    per-item validation failure, exactly as the serializer did.
+    """
+    # Create the purchase order; PurchaseOrder.save() auto-generates the
+    # po_number and retries on uniqueness collisions (concurrent-create race).
+    purchase_order = PurchaseOrder.objects.create(
+        created_by=user,
+        **validated_data,
+    )
+
+    # Create line items
+    total_cost = Decimal("0.00")
+    for idx, item_data in enumerate(items_data):
+        quantity = item_data.get("quantity", 1)
+        notes = item_data.get("notes", "")
+
+        # Validate quantity
+        if not isinstance(quantity, (int, float)) or quantity <= 0:
+            raise serializers.ValidationError(
+                f"Item at index {idx}: quantity must be a positive number, got {quantity}"
+            )
+
+        # Handle inventory items
+        if "item_supplier_id" in item_data:
+            item_supplier_id = item_data["item_supplier_id"]
+            try:
+                item_supplier = ItemSupplier.objects.get(id=item_supplier_id)
+
+                # Ensure the supplier matches the PO supplier
+                if item_supplier.supplier != purchase_order.supplier:
+                    raise serializers.ValidationError(
+                        f"Item supplier {item_supplier_id} does not belong to selected supplier"
+                    )
+
+                # Calculate order_in_packages: prefer explicit caller value
+                # (frontend sends this when user enters whole cases), otherwise
+                # ceil-divide the unit quantity by the supplier's case size.
+                quantity_per_package = item_supplier.quantity_per_package or 1
+                explicit_packages = item_data.get("order_in_packages")
+                if explicit_packages is not None:
+                    try:
+                        order_in_packages = int(explicit_packages)
+                    except (TypeError, ValueError):
+                        raise serializers.ValidationError(
+                            f"Item at index {idx}: order_in_packages must be "
+                            f"an integer, got {explicit_packages!r}"
+                        )
+                    if order_in_packages < 0:
+                        raise serializers.ValidationError(
+                            f"Item at index {idx}: order_in_packages must be "
+                            f"non-negative, got {order_in_packages}"
+                        )
+                else:
+                    order_in_packages = (
+                        (int(quantity) + quantity_per_package - 1) // quantity_per_package
+                        if quantity_per_package > 0
+                        else 0
+                    )
+
+                # Get unit_cost override if provided, otherwise use item_supplier.unit_cost
+                unit_cost_override = item_data.get("unit_cost")
+                if unit_cost_override is not None:
+                    try:
+                        unit_cost_ordered = Decimal(str(unit_cost_override))
+                    except (InvalidOperation, ValueError):
+                        raise serializers.ValidationError(
+                            f"Item at index {idx}: unit_cost must be numeric, "
+                            f"got {unit_cost_override!r}"
+                        )
+                else:
+                    unit_cost_ordered = item_supplier.unit_cost or Decimal("0.00")
+
+                # Get expected_shipment_date if provided
+                expected_shipment_date = item_data.get("expected_shipment_date")
+
+                # Create the line item
+                line_item = PurchaseOrderItem.objects.create(
+                    purchase_order=purchase_order,
+                    item_supplier=item_supplier,
+                    quantity_ordered=quantity,
+                    unit_cost_ordered=unit_cost_ordered,
+                    order_in_packages=order_in_packages,
+                    notes=notes,
+                    expected_shipment_date=expected_shipment_date,
+                )
+
+                total_cost += line_item.estimated_cost
+
+            except (ItemSupplier.DoesNotExist, ValueError, TypeError):
+                raise serializers.ValidationError(
+                    f"ItemSupplier with id {item_supplier_id} does not exist"
+                )
+
+        # Handle assets
+        elif "asset_id" in item_data:
+            asset_id = item_data["asset_id"]
+            unit_cost = item_data.get("unit_cost")
+            if unit_cost is None:
+                raise serializers.ValidationError(
+                    f"unit_cost is required when purchasing asset {asset_id}"
+                )
+            try:
+                unit_cost = Decimal(str(unit_cost))
+            except (InvalidOperation, ValueError):
+                raise serializers.ValidationError(
+                    f"Item at index {idx}: unit_cost must be numeric, " f"got {unit_cost!r}"
+                )
+
+            try:
+                from inventory.models import Asset
+
+                asset = Asset.objects.get(id=asset_id)
+
+                # Ensure the asset's manufacturer matches the PO supplier (if set)
+                if asset.manufacturer and asset.manufacturer != purchase_order.supplier:
+                    raise serializers.ValidationError(
+                        f"Asset {asset_id} manufacturer does not match selected supplier"
+                    )
+
+                # Create the line item (assets don't have package information)
+                line_item = PurchaseOrderItem.objects.create(
+                    purchase_order=purchase_order,
+                    asset=asset,
+                    quantity_ordered=quantity,
+                    unit_cost_ordered=unit_cost,
+                    order_in_packages=0,  # Assets don't have package information
+                    notes=notes,
+                )
+
+                total_cost += line_item.estimated_cost
+
+            except (Asset.DoesNotExist, DjangoValidationError, ValueError):
+                raise serializers.ValidationError(f"Invalid asset id: {asset_id}")
+
+        # Handle freeform line items
+        elif "description" in item_data:
+            description = item_data["description"]
+            unit_cost = item_data.get("unit_cost")
+
+            if not description:
+                raise serializers.ValidationError(
+                    "Freeform items must have a non-empty description"
+                )
+
+            if unit_cost is None:
+                raise serializers.ValidationError(
+                    f"unit_cost is required for freeform item: {description}"
+                )
+            try:
+                unit_cost = Decimal(str(unit_cost))
+            except (InvalidOperation, ValueError):
+                raise serializers.ValidationError(
+                    f"Item at index {idx}: unit_cost must be numeric, " f"got {unit_cost!r}"
+                )
+
+            # Create the freeform line item (freeform items don't have package information)
+            line_item = PurchaseOrderItem.objects.create(
+                purchase_order=purchase_order,
+                description=description,
+                quantity_ordered=quantity,
+                unit_cost_ordered=unit_cost,
+                order_in_packages=0,  # Freeform items don't have package information
+                notes=notes,
+            )
+
+            total_cost += line_item.estimated_cost
+
+        else:
+            raise serializers.ValidationError(
+                "Each item must have 'item_supplier_id', 'asset_id', or 'description'"
+            )
+
+    # Update estimated total
+    purchase_order.estimated_total = total_cost
+    purchase_order.save()
+
+    return purchase_order
+
+
+def add_business_days(start_date, business_days):
+    """Add business days to a date (excluding weekends)."""
+    if isinstance(start_date, timezone.datetime):
+        start_date = start_date.date()
+
+    current_date = start_date
+    days_added = 0
+
+    while days_added < business_days:
+        current_date += timedelta(days=1)
+        # Monday = 0, Sunday = 6
+        if current_date.weekday() < 5:  # Monday to Friday
+            days_added += 1
+
+    return current_date
+
+
+def update_reorder_requests_from_po(purchase_order):
+    """Update associated ReorderRequest objects when a PurchaseOrder is finalized.
+
+    Updates requests with:
+    - order_number (PO number)
+    - actual_cost (from PO line items)
+    - estimated_delivery (calculated from expected_delivery_date or lead time)
+    - ordered_at (when PO was sent)
+    - status = "ordered"
+    """
+    # Find all inventory items in this PO
+    po_items = purchase_order.items.filter(item_supplier__isnull=False).select_related(
+        "item_supplier__item"
+    )
+
+    for po_item in po_items:
+        item = po_item.item_supplier.item
+
+        # Find active reorder requests for this item (pending or approved)
+        active_requests = ReorderRequest.objects.filter(
+            item=item,
+            status__in=[ReorderRequest.Status.PENDING, ReorderRequest.Status.APPROVED],
+        )
+
+        # Calculate estimated delivery date
+        estimated_delivery = None
+        if purchase_order.expected_delivery_date:
+            estimated_delivery = purchase_order.expected_delivery_date
+        elif po_item.item_supplier.average_lead_time:
+            # Calculate from lead time in business days
+            order_date = (
+                purchase_order.sent_at.date() if purchase_order.sent_at else timezone.now().date()
+            )
+            lead_time_days = po_item.item_supplier.average_lead_time
+            estimated_delivery = add_business_days(order_date, lead_time_days)
+
+        # Update each active request
+        for reorder_request in active_requests:
+            reorder_request.status = ReorderRequest.Status.ORDERED
+            reorder_request.order_number = purchase_order.po_number
+            reorder_request.ordered_at = purchase_order.sent_at or timezone.now()
+            reorder_request.estimated_delivery = estimated_delivery
+
+            # Set actual cost if not already set
+            if not reorder_request.actual_cost:
+                # Calculate cost per unit from PO
+                if po_item.quantity_ordered > 0 and po_item.unit_cost_ordered:
+                    cost_per_unit = po_item.unit_cost_ordered
+                    reorder_request.actual_cost = cost_per_unit * reorder_request.quantity
+                else:
+                    # Fallback to estimated cost from line item
+                    reorder_request.actual_cost = po_item.estimated_cost
+
+            reorder_request.save()
+
+
+def mark_sent(purchase_order, user):
+    """Stamp a purchase order as SENT and sync its linked reorder requests.
+
+    Status -> SENT, ``sent_by``/``sent_at`` stamped, and the linked reorder
+    requests synced. The caller owns the DRAFT precondition and records the
+    ``po_send`` audit event.
+    """
+    purchase_order.status = PurchaseOrder.Status.SENT
+    purchase_order.sent_by = user
+    purchase_order.sent_at = timezone.now()
+    purchase_order.save()
+    # Keep linked reorder requests in step with the PO going out.
+    update_reorder_requests_from_po(purchase_order)
+
+
+def confirm_order(purchase_order, expected_delivery_date):
+    """Mark a purchase order as confirmed by the supplier.
+
+    The caller owns the SENT precondition.
+    """
+    purchase_order.status = PurchaseOrder.Status.CONFIRMED
+    purchase_order.expected_delivery_date = expected_delivery_date
+    purchase_order.save()
+
+
+def void_po(purchase_order, user, reason=""):
+    """Void an entire purchase order and cascade to its non-voided line items.
+
+    The caller owns the permission/status guards and records the ``po_void``
+    audit event.
+    """
+    now = timezone.now()
+
+    with transaction.atomic():
+        purchase_order.status = PurchaseOrder.Status.VOIDED
+        purchase_order.voided_at = now
+        purchase_order.voided_by = user
+        purchase_order.void_reason = reason
+        purchase_order.save()
+
+        purchase_order.items.filter(is_voided=False).update(
+            is_voided=True,
+            voided_at=now,
+            voided_by=user,
+            void_reason="PO voided",
+        )
+
+
+def void_line_item(line_item, user, reason):
+    """Void a single purchase-order line item.
+
+    Marks the linked ``item_supplier`` discontinued/inactive when present. The
+    caller owns the not-found / already-voided / already-received guards and
+    records the ``po_line_void`` audit event.
+    """
+    line_item.is_voided = True
+    line_item.voided_at = timezone.now()
+    line_item.voided_by = user
+    line_item.void_reason = reason
+
+    # If this is an item_supplier relationship, mark it as discontinued
+    if line_item.item_supplier:
+        line_item.item_supplier.is_discontinued = True
+        line_item.item_supplier.is_active = False
+        line_item.item_supplier.save()
+
+    line_item.save()

--- a/backend/reorder_queue/services/receiving.py
+++ b/backend/reorder_queue/services/receiving.py
@@ -1,0 +1,140 @@
+"""Receiving/delivery workflow for purchase orders.
+
+Extracted from ``reorder_queue.views`` (#883). Keeps the receipt side effects
+(delivery + delivery items, per-line received quantity, inventory stock,
+PO status advance, lead-time logging) in one transactional service so the
+``receive`` and ``mark-delivered`` actions stay behaviour-identical.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.db import transaction
+
+from ..models import DeliveryItem, LeadTimeLog, OrderDelivery, PurchaseOrder
+
+
+def create_lead_time_log(po_item, delivery_date):
+    """Create a LeadTimeLog entry when a PO item is fully received.
+
+    No-op if the PO was never sent or if the item has no item_supplier
+    (e.g. asset-only lines).
+    """
+    purchase_order = po_item.purchase_order
+
+    if not purchase_order.sent_at or not po_item.item_supplier:
+        return
+
+    order_date = purchase_order.sent_at
+    actual_delivery_date = delivery_date.date() if hasattr(delivery_date, "date") else delivery_date
+
+    estimated_lead_time = po_item.item_supplier.average_lead_time or 14
+    actual_lead_time = LeadTimeLog.calculate_business_days(order_date, actual_delivery_date)
+
+    LeadTimeLog.objects.create(
+        item_supplier=po_item.item_supplier,
+        purchase_order=purchase_order,
+        order_date=order_date,
+        expected_delivery_date=purchase_order.expected_delivery_date
+        or (order_date.date() + timedelta(days=estimated_lead_time)),
+        actual_delivery_date=actual_delivery_date,
+        estimated_lead_time_days=estimated_lead_time,
+        actual_lead_time_days=actual_lead_time,
+        quantity_ordered=po_item.quantity_ordered,
+        quantity_received=po_item.quantity_received,
+    )
+
+
+def receive_delivery(
+    purchase_order,
+    line_quantities,
+    *,
+    received_by,
+    delivery_datetime,
+    tracking_number="",
+    carrier="",
+    receipt_notes="",
+):
+    """Record a receipt of specific quantities against PO line items.
+
+    Creates a single :class:`OrderDelivery` plus one :class:`DeliveryItem` per
+    ``(po_item, quantity)`` pair, increments each line's received quantity and
+    the linked inventory stock, advances the PO status, and writes a
+    :class:`LeadTimeLog` for any line that becomes fully received.
+
+    Shared by ``mark_delivered`` (which passes every pending quantity) and the
+    per-item ``receive`` action so receipt side effects stay consistent (DRY).
+    The delivery is flagged ``is_complete`` when this receipt leaves the whole
+    PO fully received — for ``mark_delivered`` that is always the case, matching
+    its previous behaviour.
+
+    Callers are responsible for validating ``line_quantities``; the transaction
+    is owned here. Returns the created :class:`OrderDelivery`.
+    """
+    with transaction.atomic():
+        delivery = OrderDelivery.objects.create(
+            purchase_order=purchase_order,
+            delivery_date=delivery_datetime,
+            tracking_number=tracking_number,
+            carrier=carrier,
+            received_by=received_by,
+            receipt_notes=receipt_notes,
+        )
+
+        for po_item, quantity in line_quantities:
+            DeliveryItem.objects.create(
+                delivery=delivery,
+                purchase_order_item=po_item,
+                quantity_received=quantity,
+            )
+
+            po_item.quantity_received += quantity
+            po_item.save()
+
+            inventory_item = po_item.item
+            if inventory_item is not None:
+                inventory_item.current_stock += quantity
+                inventory_item.save()
+
+            if po_item.is_fully_received:
+                create_lead_time_log(po_item, delivery.delivery_date)
+
+        if purchase_order.is_fully_received:
+            purchase_order.status = PurchaseOrder.Status.RECEIVED
+        else:
+            purchase_order.status = PurchaseOrder.Status.PARTIALLY_RECEIVED
+        purchase_order.save()
+
+        delivery.is_complete = purchase_order.is_fully_received
+        delivery.save(update_fields=["is_complete"])
+
+    return delivery
+
+
+def mark_delivered_receipt(
+    purchase_order,
+    *,
+    received_by,
+    delivery_datetime,
+    tracking_number="",
+    carrier="",
+    receipt_notes="",
+):
+    """Receive every still-pending quantity on the PO as a single delivery.
+
+    Thin wrapper over :func:`receive_delivery` used by the ``mark-delivered``
+    action: every line that is not yet fully received is receipted for its
+    outstanding quantity. Callers own the "already fully received" guard.
+    """
+    pending_items = [item for item in purchase_order.items.all() if not item.is_fully_received]
+    line_quantities = [(po_item, po_item.quantity_pending) for po_item in pending_items]
+    return receive_delivery(
+        purchase_order,
+        line_quantities,
+        received_by=received_by,
+        delivery_datetime=delivery_datetime,
+        tracking_number=tracking_number,
+        carrier=carrier,
+        receipt_notes=receipt_notes,
+    )

--- a/backend/reorder_queue/tests/test_services.py
+++ b/backend/reorder_queue/tests/test_services.py
@@ -1,0 +1,392 @@
+"""Focused tests for the reorder_queue service layer (#883).
+
+These exercise the extracted workflow functions directly (create, receive,
+status transitions) so the service contract is covered independently of the
+API/serializer boundary. The API-level behaviour contract lives in test_api.py.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.utils import timezone
+
+import pytest
+from rest_framework import serializers as drf_serializers
+
+from inventory.tests.factories import AssetFactory, ItemSupplierFactory, SupplierFactory
+from reorder_queue import services
+from reorder_queue.models import (
+    LeadTimeLog,
+    OrderDelivery,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    ReorderRequest,
+)
+from reorder_queue.tests.factories import ReorderRequestFactory, UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+class TestCreatePurchaseOrder:
+    """create_purchase_order — the three line-item routes + validation."""
+
+    def test_inventory_line_ceildiv_packages_and_total(self):
+        user = UserFactory()
+        supplier = SupplierFactory()
+        # package_cost=None so ItemSupplier.save() keeps our explicit unit_cost
+        # instead of deriving it from package_cost / quantity_per_package.
+        item_supplier = ItemSupplierFactory(
+            supplier=supplier,
+            unit_cost=Decimal("10.00"),
+            package_cost=None,
+            quantity_per_package=6,
+        )
+
+        po = services.create_purchase_order(
+            {"supplier": supplier},
+            [{"item_supplier_id": item_supplier.id, "quantity": 10}],
+            user,
+        )
+
+        assert po.pk is not None
+        # PO numbering stays in PurchaseOrder.save() (#887).
+        assert po.po_number
+        assert po.created_by == user
+        assert po.items.count() == 1
+        line = po.items.first()
+        assert line.quantity_ordered == 10
+        assert line.unit_cost_ordered == Decimal("10.00")
+        assert line.order_in_packages == 2  # ceil(10 / 6)
+        assert po.estimated_total == Decimal("100.00")
+
+    def test_explicit_packages_and_unit_cost_override(self):
+        user = UserFactory()
+        supplier = SupplierFactory()
+        item_supplier = ItemSupplierFactory(
+            supplier=supplier, unit_cost=Decimal("10.00"), quantity_per_package=6
+        )
+
+        po = services.create_purchase_order(
+            {"supplier": supplier},
+            [
+                {
+                    "item_supplier_id": item_supplier.id,
+                    "quantity": 10,
+                    "unit_cost": "3.50",
+                    "order_in_packages": 4,
+                }
+            ],
+            user,
+        )
+
+        line = po.items.first()
+        assert line.order_in_packages == 4
+        assert line.unit_cost_ordered == Decimal("3.50")
+        assert po.estimated_total == Decimal("35.00")
+
+    def test_asset_line(self):
+        user = UserFactory()
+        supplier = SupplierFactory()
+        asset = AssetFactory(manufacturer=supplier)
+
+        po = services.create_purchase_order(
+            {"supplier": supplier},
+            [{"asset_id": str(asset.id), "quantity": 2, "unit_cost": "100.00"}],
+            user,
+        )
+
+        line = po.items.first()
+        assert line.asset_id == asset.id
+        assert line.order_in_packages == 0
+        assert po.estimated_total == Decimal("200.00")
+
+    def test_freeform_line(self):
+        user = UserFactory()
+        supplier = SupplierFactory()
+
+        po = services.create_purchase_order(
+            {"supplier": supplier},
+            [{"description": "Custom bracket", "quantity": 3, "unit_cost": "5.00"}],
+            user,
+        )
+
+        line = po.items.first()
+        assert line.description == "Custom bracket"
+        assert line.item_supplier is None
+        assert line.asset is None
+        assert po.estimated_total == Decimal("15.00")
+
+    def test_supplier_mismatch_raises_and_rolls_back(self):
+        user = UserFactory()
+        supplier = SupplierFactory()
+        other = SupplierFactory()
+        item_supplier = ItemSupplierFactory(supplier=other, unit_cost=Decimal("1.00"))
+
+        with pytest.raises(drf_serializers.ValidationError):
+            services.create_purchase_order(
+                {"supplier": supplier},
+                [{"item_supplier_id": item_supplier.id, "quantity": 1}],
+                user,
+            )
+
+        # @transaction.atomic rolls the half-built PO back.
+        assert PurchaseOrder.objects.count() == 0
+
+    def test_invalid_quantity_raises(self):
+        user = UserFactory()
+        supplier = SupplierFactory()
+        item_supplier = ItemSupplierFactory(supplier=supplier)
+
+        with pytest.raises(drf_serializers.ValidationError):
+            services.create_purchase_order(
+                {"supplier": supplier},
+                [{"item_supplier_id": item_supplier.id, "quantity": 0}],
+                user,
+            )
+
+
+class TestReceiveDelivery:
+    """receive_delivery / mark_delivered_receipt — receipt side effects."""
+
+    def _sent_po(self, user, *, qty=10, unit_cost=None, stock=0):
+        if unit_cost is None:
+            unit_cost = Decimal("2.00")
+        supplier = SupplierFactory()
+        po = PurchaseOrder.objects.create(
+            supplier=supplier,
+            status=PurchaseOrder.Status.SENT,
+            created_by=user,
+            sent_at=timezone.now(),
+        )
+        item_supplier = ItemSupplierFactory(
+            supplier=supplier, unit_cost=unit_cost, average_lead_time=5
+        )
+        item = item_supplier.item
+        item.current_stock = stock
+        item.save()
+        line = PurchaseOrderItem.objects.create(
+            purchase_order=po,
+            item_supplier=item_supplier,
+            quantity_ordered=qty,
+            unit_cost_ordered=unit_cost,
+        )
+        return po, line, item
+
+    def test_partial_receipt(self):
+        user = UserFactory()
+        po, line, item = self._sent_po(user, qty=10, stock=0)
+
+        delivery = services.receive_delivery(
+            po, [(line, 4)], received_by=user, delivery_datetime=timezone.now()
+        )
+
+        line.refresh_from_db()
+        po.refresh_from_db()
+        item.refresh_from_db()
+        assert line.quantity_received == 4
+        assert po.status == PurchaseOrder.Status.PARTIALLY_RECEIVED
+        assert delivery.is_complete is False
+        assert item.current_stock == 4
+        # Not fully received — no lead-time log yet.
+        assert LeadTimeLog.objects.filter(purchase_order=po).count() == 0
+
+    def test_full_receipt_logs_lead_time(self):
+        user = UserFactory()
+        po, line, item = self._sent_po(user, qty=10, stock=1)
+
+        delivery = services.receive_delivery(
+            po, [(line, 10)], received_by=user, delivery_datetime=timezone.now()
+        )
+
+        line.refresh_from_db()
+        po.refresh_from_db()
+        item.refresh_from_db()
+        assert line.quantity_received == 10
+        assert po.status == PurchaseOrder.Status.RECEIVED
+        assert delivery.is_complete is True
+        assert item.current_stock == 11
+        assert LeadTimeLog.objects.filter(purchase_order=po).count() == 1
+
+    def test_mark_delivered_receipt_receives_all_pending(self):
+        user = UserFactory()
+        po, line, _item = self._sent_po(user, qty=10, stock=0)
+
+        delivery = services.mark_delivered_receipt(
+            po, received_by=user, delivery_datetime=timezone.now()
+        )
+
+        line.refresh_from_db()
+        po.refresh_from_db()
+        assert line.quantity_received == 10
+        assert po.status == PurchaseOrder.Status.RECEIVED
+        assert delivery.is_complete is True
+        assert OrderDelivery.objects.filter(purchase_order=po).count() == 1
+
+
+class TestStatusTransitions:
+    """mark_sent / confirm_order / void_po / void_line_item + helpers."""
+
+    def test_mark_sent_stamps_and_syncs_requests(self):
+        user = UserFactory()
+        supplier = SupplierFactory()
+        po = PurchaseOrder.objects.create(
+            supplier=supplier, status=PurchaseOrder.Status.DRAFT, created_by=user
+        )
+        item_supplier = ItemSupplierFactory(supplier=supplier, average_lead_time=3)
+        PurchaseOrderItem.objects.create(
+            purchase_order=po,
+            item_supplier=item_supplier,
+            quantity_ordered=5,
+            unit_cost_ordered=Decimal("2.00"),
+        )
+        req = ReorderRequestFactory(
+            item=item_supplier.item, status=ReorderRequest.Status.PENDING, quantity=5
+        )
+
+        services.mark_sent(po, user)
+
+        po.refresh_from_db()
+        req.refresh_from_db()
+        assert po.status == PurchaseOrder.Status.SENT
+        assert po.sent_by == user
+        assert po.sent_at is not None
+        assert req.status == ReorderRequest.Status.ORDERED
+        assert req.order_number == po.po_number
+        assert req.actual_cost == Decimal("10.00")  # 2.00 * 5
+
+    def test_confirm_order(self):
+        user = UserFactory()
+        supplier = SupplierFactory()
+        po = PurchaseOrder.objects.create(
+            supplier=supplier, status=PurchaseOrder.Status.SENT, created_by=user
+        )
+
+        services.confirm_order(po, date(2026, 1, 15))
+
+        po.refresh_from_db()
+        assert po.status == PurchaseOrder.Status.CONFIRMED
+        assert po.expected_delivery_date == date(2026, 1, 15)
+
+    def test_void_po_cascades_to_items(self):
+        user = UserFactory()
+        supplier = SupplierFactory()
+        po = PurchaseOrder.objects.create(
+            supplier=supplier, status=PurchaseOrder.Status.DRAFT, created_by=user
+        )
+        item_supplier = ItemSupplierFactory(supplier=supplier)
+        line = PurchaseOrderItem.objects.create(
+            purchase_order=po,
+            item_supplier=item_supplier,
+            quantity_ordered=5,
+            unit_cost_ordered=Decimal("2.00"),
+        )
+
+        services.void_po(po, user, "orphaned")
+
+        po.refresh_from_db()
+        line.refresh_from_db()
+        assert po.status == PurchaseOrder.Status.VOIDED
+        assert po.voided_by == user
+        assert po.void_reason == "orphaned"
+        assert line.is_voided is True
+        assert line.void_reason == "PO voided"
+
+    def test_void_line_item_marks_supplier_discontinued(self):
+        user = UserFactory()
+        supplier = SupplierFactory()
+        po = PurchaseOrder.objects.create(
+            supplier=supplier, status=PurchaseOrder.Status.SENT, created_by=user
+        )
+        item_supplier = ItemSupplierFactory(supplier=supplier, is_active=True)
+        line = PurchaseOrderItem.objects.create(
+            purchase_order=po,
+            item_supplier=item_supplier,
+            quantity_ordered=5,
+            unit_cost_ordered=Decimal("2.00"),
+        )
+
+        services.void_line_item(line, user, "discontinued")
+
+        line.refresh_from_db()
+        item_supplier.refresh_from_db()
+        assert line.is_voided is True
+        assert line.void_reason == "discontinued"
+        assert item_supplier.is_discontinued is True
+        assert item_supplier.is_active is False
+
+    def test_add_business_days_skips_weekend(self):
+        # 2026-01-15 is a Thursday; +3 business days -> Tuesday 2026-01-20.
+        assert services.add_business_days(date(2026, 1, 15), 3) == date(2026, 1, 20)
+
+
+class TestPurchaseOrderAggregates:
+    """Single-pass PO aggregates preserve the voided-exclusion semantics (#883)."""
+
+    def test_aggregates_exclude_voided_lines(self):
+        user = UserFactory()
+        supplier = SupplierFactory()
+        po = PurchaseOrder.objects.create(
+            supplier=supplier,
+            status=PurchaseOrder.Status.SENT,
+            created_by=user,
+            estimated_total=Decimal("100.00"),
+        )
+        PurchaseOrderItem.objects.create(
+            purchase_order=po,
+            item_supplier=ItemSupplierFactory(supplier=supplier),
+            quantity_ordered=5,
+            unit_cost_ordered=Decimal("10.00"),
+        )
+        PurchaseOrderItem.objects.create(
+            purchase_order=po,
+            item_supplier=ItemSupplierFactory(supplier=supplier),
+            quantity_ordered=5,
+            unit_cost_ordered=Decimal("10.00"),
+            is_voided=True,
+        )
+
+        po = PurchaseOrder.objects.get(pk=po.pk)  # fresh instance, no cache
+        assert po.total_items == 1
+        assert po.total_quantity == 5
+        assert po.has_active_items is True
+        assert po.effective_estimated_total == Decimal("50.00")  # 100 - 50 voided
+        assert po.total_received_quantity == 0
+        # Voided line has 0 received of 5 ordered, so the PO is not fully received.
+        assert po.is_fully_received is False
+
+    def test_is_fully_received_true_when_all_received(self):
+        user = UserFactory()
+        supplier = SupplierFactory()
+        po = PurchaseOrder.objects.create(
+            supplier=supplier, status=PurchaseOrder.Status.SENT, created_by=user
+        )
+        PurchaseOrderItem.objects.create(
+            purchase_order=po,
+            item_supplier=ItemSupplierFactory(supplier=supplier),
+            quantity_ordered=5,
+            unit_cost_ordered=Decimal("1.00"),
+            quantity_received=5,
+        )
+
+        po = PurchaseOrder.objects.get(pk=po.pk)
+        assert po.is_fully_received is True
+        assert po.total_received_quantity == 5
+        assert po.total_items == 1
+
+    def test_all_voided_po_has_no_active_items(self):
+        user = UserFactory()
+        supplier = SupplierFactory()
+        po = PurchaseOrder.objects.create(
+            supplier=supplier, status=PurchaseOrder.Status.SENT, created_by=user
+        )
+        PurchaseOrderItem.objects.create(
+            purchase_order=po,
+            item_supplier=ItemSupplierFactory(supplier=supplier),
+            quantity_ordered=5,
+            unit_cost_ordered=Decimal("1.00"),
+            is_voided=True,
+        )
+
+        po = PurchaseOrder.objects.get(pk=po.pk)
+        assert po.has_active_items is False
+        assert po.total_items == 0

--- a/backend/reorder_queue/views.py
+++ b/backend/reorder_queue/views.py
@@ -21,6 +21,7 @@ from rest_framework_simplejwt.authentication import JWTAuthentication
 
 from inventory.models import InventoryItem, Supplier
 
+from . import services
 from .audit import record_event as record_audit_event
 from .models import (
     DeliveryItem,
@@ -222,102 +223,6 @@ def build_amazon_cart(lines):
         "missing_sku": missing_sku,
         "invalid_sku": invalid_sku,
     }
-
-
-def _create_lead_time_log(po_item, delivery_date):
-    """Create a LeadTimeLog entry when a PO item is fully received.
-
-    No-op if the PO was never sent or if the item has no item_supplier
-    (e.g. asset-only lines).
-    """
-    purchase_order = po_item.purchase_order
-
-    if not purchase_order.sent_at or not po_item.item_supplier:
-        return
-
-    order_date = purchase_order.sent_at
-    actual_delivery_date = delivery_date.date() if hasattr(delivery_date, "date") else delivery_date
-
-    estimated_lead_time = po_item.item_supplier.average_lead_time or 14
-    actual_lead_time = LeadTimeLog.calculate_business_days(order_date, actual_delivery_date)
-
-    LeadTimeLog.objects.create(
-        item_supplier=po_item.item_supplier,
-        purchase_order=purchase_order,
-        order_date=order_date,
-        expected_delivery_date=purchase_order.expected_delivery_date
-        or (order_date.date() + timedelta(days=estimated_lead_time)),
-        actual_delivery_date=actual_delivery_date,
-        estimated_lead_time_days=estimated_lead_time,
-        actual_lead_time_days=actual_lead_time,
-        quantity_ordered=po_item.quantity_ordered,
-        quantity_received=po_item.quantity_received,
-    )
-
-
-def _apply_po_receipt(
-    purchase_order,
-    line_quantities,
-    *,
-    received_by,
-    delivery_datetime,
-    tracking_number="",
-    carrier="",
-    receipt_notes="",
-):
-    """Record a receipt of specific quantities against PO line items.
-
-    Creates a single :class:`OrderDelivery` plus one :class:`DeliveryItem` per
-    ``(po_item, quantity)`` pair, increments each line's received quantity and
-    the linked inventory stock, advances the PO status, and writes a
-    :class:`LeadTimeLog` for any line that becomes fully received.
-
-    Shared by ``mark_delivered`` (which passes every pending quantity) and the
-    per-item ``receive`` action so receipt side effects stay consistent (DRY).
-    The delivery is flagged ``is_complete`` when this receipt leaves the whole
-    PO fully received — for ``mark_delivered`` that is always the case, matching
-    its previous behaviour.
-
-    Callers are responsible for validating ``line_quantities`` and for wrapping
-    the call in a transaction. Returns the created :class:`OrderDelivery`.
-    """
-    delivery = OrderDelivery.objects.create(
-        purchase_order=purchase_order,
-        delivery_date=delivery_datetime,
-        tracking_number=tracking_number,
-        carrier=carrier,
-        received_by=received_by,
-        receipt_notes=receipt_notes,
-    )
-
-    for po_item, quantity in line_quantities:
-        DeliveryItem.objects.create(
-            delivery=delivery,
-            purchase_order_item=po_item,
-            quantity_received=quantity,
-        )
-
-        po_item.quantity_received += quantity
-        po_item.save()
-
-        inventory_item = po_item.item
-        if inventory_item is not None:
-            inventory_item.current_stock += quantity
-            inventory_item.save()
-
-        if po_item.is_fully_received:
-            _create_lead_time_log(po_item, delivery.delivery_date)
-
-    if purchase_order.is_fully_received:
-        purchase_order.status = PurchaseOrder.Status.RECEIVED
-    else:
-        purchase_order.status = PurchaseOrder.Status.PARTIALLY_RECEIVED
-    purchase_order.save()
-
-    delivery.is_complete = purchase_order.is_fully_received
-    delivery.save(update_fields=["is_complete"])
-
-    return delivery
 
 
 class ReorderRequestViewSet(viewsets.ModelViewSet):
@@ -775,21 +680,17 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
 
         Shared by the manual ``send_to_supplier`` action and the automatic
         sales-order-number trigger so both paths stay consistent: status -> SENT,
-        ``sent_by``/``sent_at`` stamped, a ``po_send`` audit event recorded, and
-        the linked reorder requests synced. Callers own the DRAFT precondition.
+        ``sent_by``/``sent_at`` stamped, the linked reorder requests synced (both
+        via :func:`services.mark_sent`), and a ``po_send`` audit event recorded.
+        Callers own the DRAFT precondition.
         """
-        purchase_order.status = PurchaseOrder.Status.SENT
-        purchase_order.sent_by = user
-        purchase_order.sent_at = timezone.now()
-        purchase_order.save()
+        services.mark_sent(purchase_order, user)
         record_audit_event(
             action=PurchaseOrderAuditEvent.Action.PO_SEND,
             actor=user,
             purchase_order=purchase_order,
             metadata={"po_number": purchase_order.po_number},
         )
-        # Keep linked reorder requests in step with the PO going out.
-        self._update_reorder_requests_from_po(purchase_order)
 
     @action(detail=False, methods=["post"])
     def create_optimized_order(self, request):
@@ -1160,80 +1061,6 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
 
         return base_quantity
 
-    def _update_reorder_requests_from_po(self, purchase_order):
-        """
-        Update associated ReorderRequest objects when a PurchaseOrder is finalized.
-
-        Updates requests with:
-        - order_number (PO number)
-        - actual_cost (from PO line items)
-        - estimated_delivery (calculated from expected_delivery_date or lead time)
-        - ordered_at (when PO was sent)
-        - status = "ordered"
-        """
-        # Find all inventory items in this PO
-        po_items = purchase_order.items.filter(item_supplier__isnull=False).select_related(
-            "item_supplier__item"
-        )
-
-        for po_item in po_items:
-            item = po_item.item_supplier.item
-
-            # Find active reorder requests for this item (pending or approved)
-            active_requests = ReorderRequest.objects.filter(
-                item=item,
-                status__in=[ReorderRequest.Status.PENDING, ReorderRequest.Status.APPROVED],
-            )
-
-            # Calculate estimated delivery date
-            estimated_delivery = None
-            if purchase_order.expected_delivery_date:
-                estimated_delivery = purchase_order.expected_delivery_date
-            elif po_item.item_supplier.average_lead_time:
-                # Calculate from lead time in business days
-                order_date = (
-                    purchase_order.sent_at.date()
-                    if purchase_order.sent_at
-                    else timezone.now().date()
-                )
-                lead_time_days = po_item.item_supplier.average_lead_time
-                estimated_delivery = self._add_business_days(order_date, lead_time_days)
-
-            # Update each active request
-            for reorder_request in active_requests:
-                reorder_request.status = ReorderRequest.Status.ORDERED
-                reorder_request.order_number = purchase_order.po_number
-                reorder_request.ordered_at = purchase_order.sent_at or timezone.now()
-                reorder_request.estimated_delivery = estimated_delivery
-
-                # Set actual cost if not already set
-                if not reorder_request.actual_cost:
-                    # Calculate cost per unit from PO
-                    if po_item.quantity_ordered > 0 and po_item.unit_cost_ordered:
-                        cost_per_unit = po_item.unit_cost_ordered
-                        reorder_request.actual_cost = cost_per_unit * reorder_request.quantity
-                    else:
-                        # Fallback to estimated cost from line item
-                        reorder_request.actual_cost = po_item.estimated_cost
-
-                reorder_request.save()
-
-    def _add_business_days(self, start_date, business_days):
-        """Add business days to a date (excluding weekends)."""
-        if isinstance(start_date, timezone.datetime):
-            start_date = start_date.date()
-
-        current_date = start_date
-        days_added = 0
-
-        while days_added < business_days:
-            current_date += timedelta(days=1)
-            # Monday = 0, Sunday = 6
-            if current_date.weekday() < 5:  # Monday to Friday
-                days_added += 1
-
-        return current_date
-
     @action(detail=True, methods=["post"])
     def send_to_supplier(self, request, pk=None):
         """Mark purchase order as sent to supplier."""
@@ -1261,9 +1088,7 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        purchase_order.status = PurchaseOrder.Status.CONFIRMED
-        purchase_order.expected_delivery_date = request.data.get("expected_delivery_date")
-        purchase_order.save()
+        services.confirm_order(purchase_order, request.data.get("expected_delivery_date"))
 
         serializer = self.get_serializer(purchase_order)
         return Response(serializer.data)
@@ -1378,16 +1203,14 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
             datetime.combine(data["delivery_date"], datetime.min.time())
         )
 
-        with transaction.atomic():
-            _apply_po_receipt(
-                purchase_order,
-                [(po_item, po_item.quantity_pending) for po_item in pending_items],
-                received_by=request.user,
-                delivery_datetime=delivery_datetime,
-                tracking_number=data.get("tracking_number", ""),
-                carrier=data.get("carrier", ""),
-                receipt_notes=data.get("receipt_notes", ""),
-            )
+        services.mark_delivered_receipt(
+            purchase_order,
+            received_by=request.user,
+            delivery_datetime=delivery_datetime,
+            tracking_number=data.get("tracking_number", ""),
+            carrier=data.get("carrier", ""),
+            receipt_notes=data.get("receipt_notes", ""),
+        )
 
         record_audit_event(
             action=PurchaseOrderAuditEvent.Action.PO_MARK_DELIVERED,
@@ -1483,16 +1306,15 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         else:
             delivery_datetime = timezone.now()
 
-        with transaction.atomic():
-            _apply_po_receipt(
-                purchase_order,
-                resolved_lines,
-                received_by=request.user,
-                delivery_datetime=delivery_datetime,
-                tracking_number=data.get("tracking_number", ""),
-                carrier=data.get("carrier", ""),
-                receipt_notes=data.get("receipt_notes", ""),
-            )
+        services.receive_delivery(
+            purchase_order,
+            resolved_lines,
+            received_by=request.user,
+            delivery_datetime=delivery_datetime,
+            tracking_number=data.get("tracking_number", ""),
+            carrier=data.get("carrier", ""),
+            receipt_notes=data.get("receipt_notes", ""),
+        )
 
         record_audit_event(
             action=PurchaseOrderAuditEvent.Action.PO_RECEIVE_ITEMS,
@@ -1645,19 +1467,9 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # Void the line item
-        line_item.is_voided = True
-        line_item.voided_at = timezone.now()
-        line_item.voided_by = request.user
-        line_item.void_reason = request.data.get("reason", "Item discontinued by supplier")
-
-        # If this is an item_supplier relationship, mark it as discontinued
-        if line_item.item_supplier:
-            line_item.item_supplier.is_discontinued = True
-            line_item.item_supplier.is_active = False
-            line_item.item_supplier.save()
-
-        line_item.save()
+        # Void the line item (marks the linked item_supplier discontinued too)
+        reason = request.data.get("reason", "Item discontinued by supplier")
+        services.void_line_item(line_item, request.user, reason)
 
         record_audit_event(
             action=PurchaseOrderAuditEvent.Action.PO_LINE_VOID,
@@ -1707,22 +1519,9 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        now = timezone.now()
         reason = request.data.get("reason", "")
 
-        with transaction.atomic():
-            purchase_order.status = PurchaseOrder.Status.VOIDED
-            purchase_order.voided_at = now
-            purchase_order.voided_by = user
-            purchase_order.void_reason = reason
-            purchase_order.save()
-
-            purchase_order.items.filter(is_voided=False).update(
-                is_voided=True,
-                voided_at=now,
-                voided_by=user,
-                void_reason="PO voided",
-            )
+        services.void_po(purchase_order, user, reason)
 
         record_audit_event(
             action=PurchaseOrderAuditEvent.Action.PO_VOID,
@@ -1897,7 +1696,18 @@ class OrderReceiptViewSet(viewsets.ModelViewSet):
 
     @action(detail=False, methods=["post"])
     def scan_barcode(self, request):
-        """Process barcode scan for order receipt."""
+        """Process barcode scan for order receipt.
+
+        NOTE (#883): this is a SEPARATE receive path from
+        :func:`services.receive_delivery` (used by ``receive``/``mark-delivered``)
+        and is intentionally left inline. Its behaviour diverges in ways that do
+        not parameterize cleanly: it upserts one delivery per day
+        (``get_or_create`` on ``delivery_date``) instead of always creating a new
+        delivery, it records scan-specific ``DeliveryItem`` fields
+        (``scanned_upc``/``scanned_at``/``scanned_by``/damage/expiry), it never
+        sets ``delivery.is_complete``, and it records NO audit event. Kept as-is
+        to preserve exact behaviour; flagged here as a future de-duplication.
+        """
         serializer = BarcodeReceiptSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
@@ -2017,7 +1827,7 @@ class OrderReceiptViewSet(viewsets.ModelViewSet):
 
     def _create_lead_time_log(self, po_item, delivery_date):
         """Create a lead time log entry when an item is fully received."""
-        _create_lead_time_log(po_item, delivery_date)
+        services.create_lead_time_log(po_item, delivery_date)
 
     @action(detail=False, methods=["get"])
     def pending_orders(self, request):


### PR DESCRIPTION
## Summary

Moves purchase-order **creation, receiving, and status-transition workflow** out of `reorder_queue` models/serializers/views into a new **`reorder_queue/services/`** package. Views keep the serializers as the request/response boundary and their `record_audit_event` calls; they delegate the workflow body to services. **Behavior- and API-preserving, backend-only.** Closes #883.

### New `reorder_queue/services/` package
- **`purchase_orders.py`** — `create_purchase_order` (inventory/asset/freeform line items; PO **numbering stays in `PurchaseOrder.save()`**, owned by #887), `mark_sent` + `update_reorder_requests_from_po` + `add_business_days`, `confirm_order`, `void_po`, `void_line_item`.
- **`receiving.py`** — `receive_delivery` (`@transaction.atomic` now **inside** the service), `mark_delivered_receipt`, `create_lead_time_log`.

### Notable decisions
- **`scan_barcode` left inline** with a flag comment: its divergent per-day delivery `get_or_create`, scan-specific `DeliveryItem` fields, absence of `is_complete`, and absence of an audit event don't parameterize cleanly, so unifying it would risk changing its behavior. Duplication flagged for a future cleanup. Behavior unchanged.
- **Aggregates de-looped**: `PurchaseOrder` totals now derive from a single `@cached_property` `_line_item_totals` pass instead of 5-6 separate loops over the prefetched line items. Values are identical, including the voided-line semantics (`total_items`/`total_quantity` exclude voided; `total_received_quantity` counts all lines; `effective_estimated_total` subtracts voided). Admin changelist prefetches items so its columns read from cache.
- PO number generation left in `save()` (→ **#887**); the broader N+1 audit left for **#890**.

### Acceptance criteria
- **AC-1** — `create_purchase_order` service (all three line-item shapes); numbering stays in `save()`. ✅
- **AC-2** — `receive_delivery` service with `@transaction.atomic` inside; `scan_barcode` behavior preserved. ✅
- **AC-3** — status transitions + reorder-request sync moved to services; each action's guards/audit/side-effects preserved. ✅
- **AC-4** — aggregate totals de-looped, values identical incl. voided-exclusion; API/serializer contract unchanged (actions still return the full `PurchaseOrderSerializer`). ✅
- **AC-5** — all existing `reorder_queue` tests pass unchanged + new `test_services.py`; `makemigrations --check` clean. ✅

### Independent verification (reviewer)
- `makemigrations --check --dry-run` → "No changes detected"; `manage.py check` clean; black/isort/flake8 clean (only the pre-existing `tasks.py` B023s).
- **reorder_queue suite: 211 passed / 0 failed** (create / receive / mark-delivered / void / list-void-handling / auto-transition / numbering — the behavior contract).
- Reviewed the aggregate rewrite (single cached pass, voided-exclusion preserved) and confirmed `scan_barcode` is left inline + flagged.
- No migrations added; `frontend/` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
