### PR TITLE
refactor(models): extract save() side-effects into explicit services (#887)

### DIFF
--- a/backend/customization/models.py
+++ b/backend/customization/models.py
@@ -9,12 +9,30 @@ from django.core.exceptions import ValidationError
 from django.db import models
 
 
+class SiteSettingsManager(models.Manager):
+    """Manager exposing the explicit singleton accessor for :class:`SiteSettings`."""
+
+    def get_singleton(self) -> "SiteSettings":
+        """Return the single settings row, creating it with defaults on first access.
+
+        This is the explicit creation path for the singleton (gh #887). It
+        replaces the old ``save()`` field-copy redirect: creating the row is no
+        longer a surprising side effect of saving a second instance — callers
+        ask for the singleton and always get exactly one row back.
+        """
+        obj = self.first()
+        if obj is None:
+            obj = self.create()
+        return obj
+
+
 class SiteSettings(models.Model):
     """
     Site-wide customization settings.
 
     This is a singleton model - only one instance should exist.
-    Use SiteSettings.get() to get or create the single instance.
+    Use ``SiteSettings.objects.get_singleton()`` (or the ``SiteSettings.get()``
+    compatibility wrapper) to get or create the single instance.
     """
 
     # Basic branding
@@ -137,6 +155,8 @@ class SiteSettings(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    objects = SiteSettingsManager()
+
     class Meta:
         verbose_name = "Site Settings"
         verbose_name_plural = "Site Settings"
@@ -155,26 +175,26 @@ class SiteSettings(models.Model):
                 )
 
     def save(self, *args, **kwargs):
-        """Override save to ensure singleton pattern."""
+        """Validate (which enforces the singleton via ``clean()``) then persist.
+
+        The old override redirected a second-instance save onto the existing
+        row by copying fields — a surprising side effect. Singleton *creation*
+        now lives in :meth:`SiteSettingsManager.get_singleton`; ``save()`` just
+        validates and writes. ``clean()`` still raises on a second instance, so
+        the one-row guarantee is preserved (gh #887, AC-3).
+        """
         self.full_clean()
-        # If this is the first instance, allow it
-        if not SiteSettings.objects.exists() or self.pk:
-            super().save(*args, **kwargs)
-        else:
-            # If another instance exists, update it instead
-            existing = SiteSettings.objects.first()
-            for field in self._meta.fields:
-                if field.name not in ["id", "created_at", "updated_at"]:
-                    setattr(existing, field.name, getattr(self, field.name))
-            existing.save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     @classmethod
     def get(cls):
-        """Get or create the single SiteSettings instance."""
-        obj = cls.objects.first()
-        if not obj:
-            obj = cls.objects.create()
-        return obj
+        """Get or create the single SiteSettings instance.
+
+        Thin compatibility wrapper over
+        :meth:`SiteSettingsManager.get_singleton` so existing callers keep
+        working unchanged.
+        """
+        return cls.objects.get_singleton()
 
 
 class SiteSettingsAuditEvent(models.Model):

--- a/backend/customization/tests.py
+++ b/backend/customization/tests.py
@@ -19,20 +19,45 @@ User = get_user_model()
 class TestSiteSettingsModel:
     """Test SiteSettings model."""
 
-    def test_singleton_get_or_create(self, db):
-        """Test that get() returns the same instance."""
-        settings1 = SiteSettings.get()
-        settings2 = SiteSettings.get()
+    def test_singleton_get_singleton_creates_and_reuses(self, db):
+        """get_singleton() creates the row once and returns it on subsequent calls."""
+        settings1 = SiteSettings.objects.get_singleton()
+        settings2 = SiteSettings.objects.get_singleton()
         assert settings1.pk == settings2.pk
         assert SiteSettings.objects.count() == 1
 
+    def test_get_delegates_to_get_singleton(self, db):
+        """The .get() compatibility wrapper returns the same singleton row."""
+        via_get = SiteSettings.get()
+        via_manager = SiteSettings.objects.get_singleton()
+        assert via_get.pk == via_manager.pk
+        assert SiteSettings.objects.count() == 1
+
     def test_singleton_prevent_multiple_instances(self, db):
-        """Test that only one instance can exist."""
-        SiteSettings.get()  # Create first instance
+        """Only one instance may exist — a second fails validation."""
+        SiteSettings.objects.get_singleton()  # Create first instance
 
         # Try to create another instance directly
         with pytest.raises(ValidationError):
             SiteSettings().full_clean()
+
+    def test_saving_second_new_instance_raises_instead_of_redirecting(self, db):
+        """Saving a *new* second instance raises rather than silently redirecting.
+
+        The old save() copied fields onto the existing row when a second
+        instance was saved; that surprising redirect was removed (gh #887,
+        AC-3). The existing row must be left untouched.
+        """
+        first = SiteSettings.objects.get_singleton()
+        first.site_name = "Original"
+        first.save()
+
+        with pytest.raises(ValidationError):
+            SiteSettings(site_name="Second").save()
+
+        assert SiteSettings.objects.count() == 1
+        first.refresh_from_db()
+        assert first.site_name == "Original"
 
     def test_default_values(self, db):
         """Test default values for SiteSettings."""
@@ -50,15 +75,16 @@ class TestSiteSettingsModel:
         assert str(settings) == "Site Settings for Test Makerspace"
 
     def test_update_existing_instance(self, db):
-        """Test that updating an existing instance works."""
-        settings = SiteSettings.get()
+        """Fetch → mutate → save keeps the same row (no new instance)."""
+        settings = SiteSettings.objects.get_singleton()
         settings.site_name = "Updated Name"
         settings.save()
 
         # Get again and verify update
-        updated = SiteSettings.get()
+        updated = SiteSettings.objects.get_singleton()
         assert updated.site_name == "Updated Name"
         assert updated.pk == settings.pk
+        assert SiteSettings.objects.count() == 1
 
 
 @pytest.mark.integration

--- a/backend/donations/models.py
+++ b/backend/donations/models.py
@@ -165,24 +165,17 @@ class Donation(models.Model):
         return f"Donation from {self.donor_name} ({self.date_received})"
 
     def save(self, *args, **kwargs):
-        """Auto-generate donation number if not provided."""
+        """Auto-generate donation number if not provided.
+
+        The ``DON-YYYY-NNN`` composition is delegated to
+        :func:`donations.services.numbering.next_donation_number` (gh #887); the
+        received-year selection stays here since it reads ``self.date_received``.
+        """
         if not self.donation_number:
-            # Generate a donation number like DON-2024-001
+            from .services.numbering import next_donation_number
+
             year = self.date_received.year if self.date_received else timezone.now().year
-            last_donation = (
-                Donation.objects.filter(donation_number__startswith=f"DON-{year}-")
-                .order_by("-donation_number")
-                .first()
-            )
-            if last_donation and last_donation.donation_number:
-                try:
-                    last_num = int(last_donation.donation_number.split("-")[-1])
-                    next_num = last_num + 1
-                except (ValueError, IndexError):
-                    next_num = 1
-            else:
-                next_num = 1
-            self.donation_number = f"DON-{year}-{next_num:03d}"
+            self.donation_number = next_donation_number(year)
         super().save(*args, **kwargs)
 
     @property

--- a/backend/donations/services/numbering.py
+++ b/backend/donations/services/numbering.py
@@ -1,0 +1,34 @@
+"""Donation number composition (gh #887).
+
+``Donation.save()`` delegates the ``DON-YYYY-NNN`` composition here so the
+override stays a thin delegator. The single production caller and the audit
+path both read ``donation_number`` immediately after save, so numbering stays
+synchronous on the create path.
+"""
+
+from __future__ import annotations
+
+
+def next_donation_number(year: int) -> str:
+    """Return the next ``DON-YYYY-NNN`` number for ``year``.
+
+    Reads the highest existing number for the year and increments its trailing
+    counter, falling back to ``001`` when none exist or the counter can't be
+    parsed.
+    """
+    from donations.models import Donation
+
+    last_donation = (
+        Donation.objects.filter(donation_number__startswith=f"DON-{year}-")
+        .order_by("-donation_number")
+        .first()
+    )
+    if last_donation and last_donation.donation_number:
+        try:
+            next_num = int(last_donation.donation_number.split("-")[-1]) + 1
+        except (ValueError, IndexError):
+            next_num = 1
+    else:
+        next_num = 1
+
+    return f"DON-{year}-{next_num:03d}"

--- a/backend/donations/tests/test_services_numbering.py
+++ b/backend/donations/tests/test_services_numbering.py
@@ -1,0 +1,41 @@
+"""Tests for :func:`donations.services.numbering.next_donation_number` — the
+``DON-YYYY-NNN`` composition extracted from ``Donation.save()`` (gh #887).
+"""
+
+from datetime import date
+
+import pytest
+
+from donations.services.numbering import next_donation_number
+from donations.tests.factories import DonationFactory
+
+pytestmark = pytest.mark.django_db
+
+
+class TestNextDonationNumber:
+    def test_first_number_for_year(self):
+        assert next_donation_number(2099) == "DON-2099-001"
+
+    def test_increments_from_latest(self):
+        DonationFactory(donation_number="DON-2099-005", date_received=date(2099, 1, 1))
+        assert next_donation_number(2099) == "DON-2099-006"
+
+    def test_unparseable_counter_falls_back_to_one(self):
+        DonationFactory(donation_number="DON-2099-BAD", date_received=date(2099, 1, 1))
+        assert next_donation_number(2099) == "DON-2099-001"
+
+    def test_scoped_to_year(self):
+        DonationFactory(donation_number="DON-2098-050", date_received=date(2098, 1, 1))
+        assert next_donation_number(2099) == "DON-2099-001"
+
+
+class TestDonationSaveNumbering:
+    """Donation.save() delegates to the helper when no number is supplied."""
+
+    def test_save_generates_number_when_blank(self):
+        donation = DonationFactory(date_received=date(2099, 3, 1))
+        assert donation.donation_number == "DON-2099-001"
+
+    def test_save_preserves_explicit_number(self):
+        donation = DonationFactory(donation_number="DON-2099-042", date_received=date(2099, 3, 1))
+        assert donation.donation_number == "DON-2099-042"

--- a/backend/inventory/models/asset.py
+++ b/backend/inventory/models/asset.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import MinValueValidator, RegexValidator
-from django.db import IntegrityError, models, transaction
+from django.db import models, transaction
 from django.utils import timezone
 
 from imagekit.models import ImageSpecField
@@ -503,18 +503,15 @@ class Asset(OwnableModel):
         received) and falls back to the current year when unset. The per-year
         counter guarantees uniqueness, but we still retry on the off chance a
         backfilled tag collides with the freshly allocated one.
-        """
-        if not self.asset_tag:
-            from ..services.asset_tag_id import generate_asset_tag
 
-            year = self.date_received.year if self.date_received else timezone.now().year
-            for _ in range(10):
-                candidate = generate_asset_tag(year)
-                if not Asset.objects.filter(asset_tag=candidate).exists():
-                    self.asset_tag = candidate
-                    break
-            else:  # pragma: no cover - only if 10 consecutive allocations collide
-                raise IntegrityError("Could not allocate a unique asset tag")
+        The empty-guard + retry/allocate logic lives in
+        :func:`inventory.services.asset_tag_id.assign_asset_tag` (gh #887); this
+        override stays a thin delegator so bare ``Asset(...).save()`` callers
+        keep getting a tag on first save.
+        """
+        from ..services.asset_tag_id import assign_asset_tag
+
+        assign_asset_tag(self)
 
         super().save(*args, **kwargs)
 

--- a/backend/inventory/models/core.py
+++ b/backend/inventory/models/core.py
@@ -346,13 +346,21 @@ class InventoryItem(OwnableModel):
         return self.name
 
     def save(self, *args: Any, **kwargs: Any) -> None:
-        """Auto-generate SKU and trigger async image download if needed."""
-        # Auto-generate SKU if not provided
-        if not self.sku:
-            self.sku = generate_sku()
+        """Persist the item, delegating SKU + image-download side effects to services.
 
-        # Track if we need to download image (before save)
-        should_download_image = self.image_url and not self.image
+        The workflow lives in :mod:`inventory.services.items` so this override
+        stays a thin delegator (gh #887): :func:`assign_sku` keeps the
+        synchronous SKU invariant (the SKU is in the create response), and
+        :func:`schedule_image_download` enqueues the async fetch on
+        ``transaction.on_commit`` — fixing a race where the task could run
+        before the row committed (or for a rolled-back row).
+        """
+        from ..services.items import assign_sku, schedule_image_download, should_download_image
+
+        assign_sku(self)
+
+        # Decide before saving; neither field changes during super().save().
+        needs_image_download = should_download_image(self)
 
         # Save first to get an ID
         super().save(*args, **kwargs)
@@ -362,12 +370,8 @@ class InventoryItem(OwnableModel):
         # the compat-setter kwargs through ``__init__`` before a PK exists).
         self._flush_pending_hazmat()
 
-        # Trigger async image download after save
-        if should_download_image:
-            # Import here to avoid circular imports
-            from ..tasks import download_image_from_url
-
-            download_image_from_url.delay(str(self.id), self.image_url)
+        if needs_image_download:
+            schedule_image_download(self)
 
     def clean(self) -> None:
         """Validate the attached/persisted safety profile as part of the item.
@@ -1039,13 +1043,20 @@ class ItemSupplier(models.Model):
         return None
 
     def save(self, *args: Any, **kwargs: Any) -> None:
-        """
-        Ensure only one primary supplier per item and auto-calculate unit cost.
+        """Derive cost fields, then delegate the primary-flag + price-history side effects.
+
+        Cost derivation (``unit_cost``/``package_cost``) is a pure local
+        invariant and stays here. The single-primary enforcement and
+        :class:`PriceHistory` write are grouped into one ``transaction.atomic``
+        block and delegated to :mod:`inventory.services.suppliers` (gh #887,
+        AC-2) so a failure can't leave a demoted sibling without the save, or a
+        saved row without its history entry. Order is preserved exactly:
+        demote siblings, snapshot the pre-save pricing, save, then record.
 
         If package_cost is provided, calculate unit_cost automatically.
         If only unit_cost is provided (backward compatibility), calculate package_cost.
         """
-        # Auto-calculate unit cost from package cost
+        # Auto-calculate unit cost from package cost (local invariant)
         if self.package_cost is not None and self.quantity_per_package > 0:
             self.unit_cost = self.package_cost / self.quantity_per_package
         # Backward compatibility: if only unit_cost is provided, calculate package_cost
@@ -1056,36 +1067,18 @@ class ItemSupplier(models.Model):
         ):
             self.package_cost = self.unit_cost * self.quantity_per_package
 
-        if self.is_primary:
-            # Remove primary flag from other suppliers for this item
-            ItemSupplier.objects.filter(item=self.item, is_primary=True).exclude(pk=self.pk).update(
-                is_primary=False
-            )
-        # Check if this is a new record or if pricing has changed
+        from ..services.suppliers import (
+            enforce_single_primary,
+            pricing_changed,
+            record_price_history,
+        )
+
         is_new = self.pk is None
-        price_changed = False
-
-        if not is_new:
-            # Get the old values from the database
-            old_instance = ItemSupplier.objects.get(pk=self.pk)
-            price_changed = (
-                old_instance.unit_cost != self.unit_cost
-                or old_instance.package_cost != self.package_cost
-                or old_instance.quantity_per_package != self.quantity_per_package
-            )
-
-        super().save(*args, **kwargs)
-
-        # Create price history record if this is new or if pricing changed
-        if is_new or price_changed:
-            change_type = "created" if is_new else "updated"
-            PriceHistory.objects.create(
-                item_supplier=self,
-                unit_cost=self.unit_cost,
-                package_cost=self.package_cost,
-                quantity_per_package=self.quantity_per_package,
-                change_type=change_type,
-            )
+        with transaction.atomic():
+            enforce_single_primary(self)
+            price_changed = pricing_changed(self)
+            super().save(*args, **kwargs)
+            record_price_history(self, is_new=is_new, price_changed=price_changed)
 
 
 class PriceHistory(models.Model):

--- a/backend/inventory/services/asset_tag_id.py
+++ b/backend/inventory/services/asset_tag_id.py
@@ -23,6 +23,13 @@ safe to call from anywhere (serializers, admin, scanners).
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
+
+from django.db import IntegrityError
+from django.utils import timezone
+
+if TYPE_CHECKING:
+    from inventory.models.asset import Asset
 
 # Prefix that every asset tag carries.
 TAG_PREFIX = "DMS-"
@@ -104,6 +111,39 @@ def generate_asset_tag(year: int) -> str:
     return compose_asset_tag(core)
 
 
+def assign_asset_tag(asset: "Asset", *, max_retries: int = 10) -> str:
+    """Assign a unique asset tag to ``asset`` when it does not already have one.
+
+    Returns the tag. A no-op — and never a regeneration — when
+    ``asset.asset_tag`` is already set, so an existing tag survives repeated
+    saves. The received year drives the ``YY`` segment (see
+    :func:`generate_asset_tag`) and falls back to the current year when
+    ``date_received`` is unset.
+
+    The atomic per-year sequence already guarantees uniqueness, but we still
+    retry on the off chance a freshly allocated tag collides with a backfilled
+    one; after ``max_retries`` consecutive collisions we raise
+    :class:`~django.db.IntegrityError`.
+
+    Extracted from ``Asset.save()`` (gh #887) so bare ``Asset(...).save()``
+    callers (admin duplicate action, ``epaper_preview`` command) keep getting a
+    tag generated synchronously on first save.
+    """
+    if asset.asset_tag:
+        return asset.asset_tag
+
+    from inventory.models import Asset
+
+    year = asset.date_received.year if asset.date_received else timezone.now().year
+    for _ in range(max_retries):
+        candidate = generate_asset_tag(year)
+        if not Asset.objects.filter(asset_tag=candidate).exists():
+            asset.asset_tag = candidate
+            return asset.asset_tag
+    # pragma: no cover - only if max_retries consecutive allocations collide
+    raise IntegrityError("Could not allocate a unique asset tag")
+
+
 __all__ = [
     "TAG_PREFIX",
     "CHECKSUM_LEN",
@@ -111,4 +151,5 @@ __all__ = [
     "validate_asset_tag",
     "compose_asset_tag",
     "generate_asset_tag",
+    "assign_asset_tag",
 ]

--- a/backend/inventory/services/items.py
+++ b/backend/inventory/services/items.py
@@ -1,0 +1,55 @@
+"""Write-path services for :class:`inventory.models.InventoryItem`.
+
+These hold the workflow side effects that used to live inline in
+``InventoryItem.save()`` so the override stays a thin, documented delegator
+(gh #887). ``save()`` still calls them, so the many bare
+``InventoryItem.objects.create(...)`` callers keep generating a SKU and
+scheduling the image download exactly as before. The one deliberate change is
+that the async download now fires on ``transaction.on_commit`` instead of
+mid-transaction (see :func:`schedule_image_download`).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.db import transaction
+
+if TYPE_CHECKING:
+    from inventory.models.core import InventoryItem
+
+
+def assign_sku(item: "InventoryItem") -> None:
+    """Assign a generated SKU when the item does not already have one.
+
+    A tiny local invariant kept synchronous on the create path because the SKU
+    is returned in the create response; only the assignment is factored out of
+    ``save()`` so the behaviour has a named, testable home. No-op when a SKU is
+    already set, so it never regenerates an existing value.
+    """
+    if not item.sku:
+        from inventory.models.core import generate_sku
+
+        item.sku = generate_sku()
+
+
+def should_download_image(item: "InventoryItem") -> bool:
+    """Return ``True`` when the item names a source image URL but has no file yet."""
+    return bool(item.image_url and not item.image)
+
+
+def schedule_image_download(item: "InventoryItem") -> None:
+    """Enqueue the async image download once the current transaction commits.
+
+    The enqueue is wrapped in ``transaction.on_commit`` so the Celery worker
+    never races ahead of the row it reads. Previously ``save()`` called
+    ``.delay()`` inline, which could dispatch the task before the item row was
+    committed — or for a row a later rollback discarded — leaving the worker to
+    fetch against a missing/uncommitted item. Callers decide *whether* to
+    download via :func:`should_download_image`; this schedules the *how*.
+    """
+    from inventory.tasks import download_image_from_url
+
+    item_id = str(item.id)
+    image_url = item.image_url
+    transaction.on_commit(lambda: download_image_from_url.delay(item_id, image_url))

--- a/backend/inventory/services/suppliers.py
+++ b/backend/inventory/services/suppliers.py
@@ -1,0 +1,86 @@
+"""Write-path services for :class:`inventory.models.ItemSupplier`.
+
+Holds the two workflow side effects that used to live inline in
+``ItemSupplier.save()`` — single-primary enforcement and price-history
+recording — so the override becomes a thin, transactional delegator (gh #887,
+AC-2). ``save()`` still calls these, so the many bare
+``ItemSupplier.objects.create(is_primary=True, ...)`` callers keep demoting
+sibling primaries and writing a :class:`PriceHistory` row exactly as before.
+
+Cost derivation (``unit_cost``/``package_cost``) stays in ``save()`` — it is a
+pure local invariant, not a workflow side effect.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from inventory.models.core import ItemSupplier, PriceHistory
+
+
+def enforce_single_primary(item_supplier: "ItemSupplier") -> None:
+    """Ensure at most one primary supplier per item.
+
+    When ``item_supplier`` is primary, clear the flag on every *other* supplier
+    of the same item. A no-op when this row is not primary. On a new (unsaved)
+    row ``pk`` is ``None`` and ``.exclude(pk=None)`` excludes nothing, so all
+    existing primaries for the item are demoted — the intended behaviour.
+    """
+    if not item_supplier.is_primary:
+        return
+
+    from inventory.models.core import ItemSupplier
+
+    ItemSupplier.objects.filter(item=item_supplier.item, is_primary=True).exclude(
+        pk=item_supplier.pk
+    ).update(is_primary=False)
+
+
+def pricing_changed(item_supplier: "ItemSupplier") -> bool:
+    """Return ``True`` when a persisted supplier's cost/quantity differs from its DB row.
+
+    Always ``False`` for an unsaved (new) instance — a create is reported via
+    the ``is_new`` flag in :func:`record_price_history` instead. Reads the
+    pre-save row, so it must be called *before* ``super().save()``.
+    """
+    if item_supplier.pk is None:
+        return False
+
+    from inventory.models.core import ItemSupplier
+
+    try:
+        old = ItemSupplier.objects.get(pk=item_supplier.pk)
+    except ItemSupplier.DoesNotExist:
+        return False
+
+    return (
+        old.unit_cost != item_supplier.unit_cost
+        or old.package_cost != item_supplier.package_cost
+        or old.quantity_per_package != item_supplier.quantity_per_package
+    )
+
+
+def record_price_history(
+    item_supplier: "ItemSupplier", *, is_new: bool, price_changed: bool
+) -> Optional["PriceHistory"]:
+    """Write a :class:`PriceHistory` row when the supplier is new or its pricing changed.
+
+    Returns the created row, or ``None`` when nothing changed. Call *after*
+    ``super().save()`` so the ``item_supplier`` FK target exists. The stored
+    ``change_type`` is ``created`` on first save and ``updated`` on a price
+    change, matching the historical values.
+    """
+    if not (is_new or price_changed):
+        return None
+
+    from inventory.models.core import PriceHistory
+
+    change_type = PriceHistory.ChangeType.CREATED if is_new else PriceHistory.ChangeType.UPDATED
+    return PriceHistory.objects.create(
+        item_supplier=item_supplier,
+        unit_cost=item_supplier.unit_cost,
+        package_cost=item_supplier.package_cost,
+        quantity_per_package=item_supplier.quantity_per_package,
+        change_type=change_type,
+    )

--- a/backend/inventory/tests/test_assign_asset_tag.py
+++ b/backend/inventory/tests/test_assign_asset_tag.py
@@ -1,0 +1,73 @@
+"""Tests for :func:`inventory.services.asset_tag_id.assign_asset_tag` — the
+empty-guard + collision-retry allocation extracted from ``Asset.save()`` (gh #887).
+"""
+
+from datetime import date
+from unittest.mock import patch
+
+from django.db import IntegrityError
+
+import pytest
+
+from inventory.services.asset_tag_id import assign_asset_tag, validate_asset_tag
+from inventory.tests.factories import AssetFactory
+
+pytestmark = pytest.mark.django_db
+
+
+class TestAssignAssetTag:
+    def test_assigns_valid_tag_when_missing(self):
+        asset = AssetFactory.build(asset_tag="", date_received=date(2026, 6, 1))
+
+        tag = assign_asset_tag(asset)
+
+        assert tag == asset.asset_tag
+        assert validate_asset_tag(tag)
+        assert tag.startswith("DMS-26")
+
+    def test_preserves_existing_tag(self):
+        asset = AssetFactory.build(asset_tag="AST-ALREADY-SET")
+
+        result = assign_asset_tag(asset)
+
+        assert result == "AST-ALREADY-SET"
+        assert asset.asset_tag == "AST-ALREADY-SET"
+
+    def test_uses_current_year_when_no_date_received(self):
+        asset = AssetFactory.build(asset_tag="", date_received=None)
+
+        tag = assign_asset_tag(asset)
+
+        assert validate_asset_tag(tag)
+
+    def test_retries_then_succeeds_on_collision(self):
+        # A real asset already holds the first candidate tag, so the DB
+        # ``exists()`` check forces one retry before the second is accepted.
+        AssetFactory(asset_tag="DMS-26A00111")
+        asset = AssetFactory.build(asset_tag="", date_received=date(2026, 6, 1))
+
+        with patch(
+            "inventory.services.asset_tag_id.generate_asset_tag",
+            side_effect=["DMS-26A00111", "DMS-26A00222"],
+        ):
+            tag = assign_asset_tag(asset)
+
+        assert tag == "DMS-26A00222"
+
+    def test_raises_after_exhausting_retries(self):
+        # Every generated candidate collides with an existing tag.
+        AssetFactory(asset_tag="DMS-26A00111")
+        asset = AssetFactory.build(asset_tag="", date_received=date(2026, 6, 1))
+
+        with patch(
+            "inventory.services.asset_tag_id.generate_asset_tag",
+            return_value="DMS-26A00111",
+        ):
+            with pytest.raises(IntegrityError):
+                assign_asset_tag(asset, max_retries=3)
+
+    def test_save_generates_tag_on_create(self):
+        asset = AssetFactory(asset_tag="")
+
+        assert asset.asset_tag
+        assert validate_asset_tag(asset.asset_tag)

--- a/backend/inventory/tests/test_services_items.py
+++ b/backend/inventory/tests/test_services_items.py
@@ -1,0 +1,95 @@
+"""Tests for :mod:`inventory.services.items` — SKU assignment and image-download
+scheduling extracted from ``InventoryItem.save()`` (gh #887).
+
+The image download is the one behavioural change: it now fires on
+``transaction.on_commit`` instead of inline, so the Celery worker can never
+race ahead of the committed row.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from inventory.services.items import (
+    assign_sku,
+    schedule_image_download,
+    should_download_image,
+)
+from inventory.tests.factories import InventoryItemFactory
+
+
+class TestAssignSku:
+    """assign_sku — the tiny SKU invariant, now a named service function."""
+
+    def test_assigns_when_missing(self):
+        item = InventoryItemFactory.build(sku="")
+        assign_sku(item)
+        assert item.sku
+
+    def test_preserves_existing(self):
+        item = InventoryItemFactory.build(sku="KEEP-ME")
+        assign_sku(item)
+        assert item.sku == "KEEP-ME"
+
+    @pytest.mark.django_db
+    def test_save_generates_sku_when_blank(self):
+        item = InventoryItemFactory(sku="", image=None)
+        assert item.sku  # save() delegated to assign_sku and filled it in
+
+
+class TestShouldDownloadImage:
+    """should_download_image — the download decision, isolated and testable."""
+
+    def test_true_when_url_without_image(self):
+        item = InventoryItemFactory.build(image_url="https://example.com/x.jpg", image=None)
+        assert should_download_image(item) is True
+
+    def test_false_without_url(self):
+        item = InventoryItemFactory.build(image_url="", image=None)
+        assert should_download_image(item) is False
+
+    def test_false_when_image_already_present(self):
+        item = InventoryItemFactory.build(
+            image_url="https://example.com/x.jpg", image="existing.jpg"
+        )
+        assert should_download_image(item) is False
+
+
+@pytest.mark.django_db
+class TestScheduleImageDownloadOnCommit:
+    """The behavioural fix (AC-4): the download enqueues on commit, not before."""
+
+    def test_save_enqueues_on_commit_not_before(self, django_capture_on_commit_callbacks):
+        # Create with no pending image so the factory's own saves schedule nothing,
+        # then drive a single save() with an image to download — one clean enqueue.
+        item = InventoryItemFactory(image=None, image_url="")
+        item.image_url = "https://example.com/x.jpg"
+
+        with patch("inventory.tasks.download_image_from_url.delay") as mock_delay:
+            with django_capture_on_commit_callbacks(execute=True):
+                item.save()
+                # Still inside the transaction: the task must NOT have dispatched.
+                mock_delay.assert_not_called()
+            # The transaction committed: the on_commit callback fired.
+            mock_delay.assert_called_once_with(str(item.id), "https://example.com/x.jpg")
+
+    def test_no_enqueue_without_image_url(self, django_capture_on_commit_callbacks):
+        with patch("inventory.tasks.download_image_from_url.delay") as mock_delay:
+            with django_capture_on_commit_callbacks(execute=True):
+                InventoryItemFactory(image_url="", image=None)
+            mock_delay.assert_not_called()
+
+    def test_no_enqueue_when_image_already_present(self, django_capture_on_commit_callbacks):
+        with patch("inventory.tasks.download_image_from_url.delay") as mock_delay:
+            with django_capture_on_commit_callbacks(execute=True):
+                # Factory supplies a generated image, so there is nothing to fetch.
+                InventoryItemFactory(image_url="https://example.com/x.jpg")
+            mock_delay.assert_not_called()
+
+    def test_schedule_service_defers_until_commit(self, django_capture_on_commit_callbacks):
+        item = InventoryItemFactory(image_url="https://example.com/y.jpg", image=None)
+        with patch("inventory.tasks.download_image_from_url.delay") as mock_delay:
+            with django_capture_on_commit_callbacks(execute=True):
+                schedule_image_download(item)
+                mock_delay.assert_not_called()
+            mock_delay.assert_called_once_with(str(item.id), "https://example.com/y.jpg")

--- a/backend/inventory/tests/test_services_suppliers.py
+++ b/backend/inventory/tests/test_services_suppliers.py
@@ -1,0 +1,166 @@
+"""Tests for :mod:`inventory.services.suppliers` — single-primary enforcement and
+PriceHistory recording extracted from ``ItemSupplier.save()`` (gh #887, AC-2).
+
+PriceHistory had zero test coverage before this change; these tests exercise
+both the extracted service functions directly and their behaviour through
+``ItemSupplier.save()`` so the create/update history rows and the
+one-primary-per-item guarantee stay locked in.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from inventory.models import ItemSupplier, PriceHistory
+from inventory.services.suppliers import (
+    enforce_single_primary,
+    pricing_changed,
+    record_price_history,
+)
+from inventory.tests.factories import (
+    InventoryItemFactory,
+    ItemSupplierFactory,
+    SupplierFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+class TestEnforceSinglePrimaryViaSave:
+    """Saving a primary supplier demotes the item's other primaries — same item only."""
+
+    def test_creating_second_primary_demotes_first(self):
+        item = InventoryItemFactory(image=None)
+        first = ItemSupplierFactory(item=item, supplier=SupplierFactory(), is_primary=True)
+        second = ItemSupplierFactory(item=item, supplier=SupplierFactory(), is_primary=True)
+
+        first.refresh_from_db()
+        assert second.is_primary is True
+        assert first.is_primary is False
+
+    def test_non_primary_save_leaves_existing_primary(self):
+        item = InventoryItemFactory(image=None)
+        primary = ItemSupplierFactory(item=item, supplier=SupplierFactory(), is_primary=True)
+        ItemSupplierFactory(item=item, supplier=SupplierFactory(), is_primary=False)
+
+        primary.refresh_from_db()
+        assert primary.is_primary is True
+
+    def test_scoped_to_same_item(self):
+        item_a = InventoryItemFactory(image=None)
+        item_b = InventoryItemFactory(image=None)
+        primary_a = ItemSupplierFactory(item=item_a, supplier=SupplierFactory(), is_primary=True)
+        ItemSupplierFactory(item=item_b, supplier=SupplierFactory(), is_primary=True)
+
+        primary_a.refresh_from_db()
+        assert primary_a.is_primary is True
+
+
+class TestEnforceSinglePrimaryService:
+    """enforce_single_primary called directly."""
+
+    def test_demotes_sibling_primaries(self):
+        item = InventoryItemFactory(image=None)
+        sibling = ItemSupplierFactory(item=item, supplier=SupplierFactory(), is_primary=True)
+        # A second row that is primary in memory but not yet enforced.
+        newcomer = ItemSupplierFactory(item=item, supplier=SupplierFactory(), is_primary=False)
+        newcomer.is_primary = True
+
+        enforce_single_primary(newcomer)
+
+        sibling.refresh_from_db()
+        assert sibling.is_primary is False
+
+    def test_noop_when_not_primary(self):
+        item = InventoryItemFactory(image=None)
+        primary = ItemSupplierFactory(item=item, supplier=SupplierFactory(), is_primary=True)
+        other = ItemSupplierFactory(item=item, supplier=SupplierFactory(), is_primary=False)
+
+        enforce_single_primary(other)
+
+        primary.refresh_from_db()
+        assert primary.is_primary is True
+
+
+class TestPriceHistoryViaSave:
+    """PriceHistory is written on create and on a real pricing change — never otherwise."""
+
+    def test_create_writes_created_history(self):
+        link = ItemSupplierFactory(package_cost=Decimal("12.00"), quantity_per_package=1)
+
+        history = PriceHistory.objects.filter(item_supplier=link)
+        assert history.count() == 1
+        assert history.first().change_type == PriceHistory.ChangeType.CREATED
+
+    def test_price_change_writes_updated_history(self):
+        link = ItemSupplierFactory(package_cost=Decimal("12.00"), quantity_per_package=1)
+
+        link.package_cost = Decimal("24.00")
+        link.save()
+
+        history = PriceHistory.objects.filter(item_supplier=link).order_by("recorded_at")
+        assert history.count() == 2
+        assert history.last().change_type == PriceHistory.ChangeType.UPDATED
+        # unit_cost is derived from package_cost / quantity_per_package (24.00 / 1).
+        assert history.last().unit_cost == Decimal("24.00")
+
+    def test_quantity_change_writes_updated_history(self):
+        link = ItemSupplierFactory(package_cost=Decimal("12.00"), quantity_per_package=1)
+
+        link.quantity_per_package = 2
+        link.save()
+
+        history = PriceHistory.objects.filter(item_supplier=link)
+        assert history.count() == 2
+
+    def test_non_pricing_save_writes_no_new_history(self):
+        link = ItemSupplierFactory(package_cost=Decimal("12.00"), quantity_per_package=1)
+
+        link.notes = "just a note"
+        link.save()
+
+        assert PriceHistory.objects.filter(item_supplier=link).count() == 1
+
+
+class TestPriceHistoryService:
+    """pricing_changed / record_price_history called directly."""
+
+    def test_pricing_changed_false_for_unsaved(self):
+        item = InventoryItemFactory(image=None)
+        link = ItemSupplier(
+            item=item,
+            supplier=SupplierFactory(),
+            supplier_sku="X",
+            unit_cost=Decimal("1.00"),
+            package_cost=None,
+            quantity_per_package=1,
+        )
+        assert pricing_changed(link) is False
+
+    def test_pricing_changed_detects_change(self):
+        link = ItemSupplierFactory(package_cost=Decimal("10.00"), quantity_per_package=1)
+        link.package_cost = Decimal("20.00")
+        assert pricing_changed(link) is True
+
+    def test_pricing_changed_false_when_unchanged(self):
+        link = ItemSupplierFactory(package_cost=Decimal("10.00"), quantity_per_package=1)
+        assert pricing_changed(link) is False
+
+    def test_record_price_history_noop_when_unchanged(self):
+        link = ItemSupplierFactory(package_cost=Decimal("10.00"), quantity_per_package=1)
+        before = PriceHistory.objects.filter(item_supplier=link).count()
+
+        result = record_price_history(link, is_new=False, price_changed=False)
+
+        assert result is None
+        assert PriceHistory.objects.filter(item_supplier=link).count() == before
+
+    def test_record_price_history_writes_updated_row(self):
+        link = ItemSupplierFactory(package_cost=Decimal("10.00"), quantity_per_package=1)
+        before = PriceHistory.objects.filter(item_supplier=link).count()
+
+        row = record_price_history(link, is_new=False, price_changed=True)
+
+        assert row is not None
+        assert row.change_type == PriceHistory.ChangeType.UPDATED
+        assert PriceHistory.objects.filter(item_supplier=link).count() == before + 1

--- a/backend/reorder_queue/models.py
+++ b/backend/reorder_queue/models.py
@@ -338,26 +338,17 @@ class PurchaseOrder(models.Model):
         return total
 
     def auto_generate_po_number(self) -> str:
-        """Auto-generate a PO number if not set."""
+        """Auto-generate a PO number if not set.
+
+        Delegates the ``PO-YYYY-NNNN`` composition to
+        :func:`reorder_queue.services.numbering.next_po_number` (gh #887) but
+        stays an instance method: the concurrency test patches it, and
+        ``save()`` calls it once per retry attempt on uniqueness collisions.
+        """
         if not self.po_number:
-            # Format: PO-YYYY-NNNN
-            year = timezone.now().year
-            last_po = (
-                PurchaseOrder.objects.filter(po_number__startswith=f"PO-{year}-")
-                .order_by("-po_number")
-                .first()
-            )
+            from .services.numbering import next_po_number
 
-            if last_po:
-                try:
-                    last_num = int(last_po.po_number.split("-")[-1])
-                    next_num = last_num + 1
-                except (ValueError, IndexError):
-                    next_num = 1
-            else:
-                next_num = 1
-
-            self.po_number = f"PO-{year}-{next_num:04d}"
+            self.po_number = next_po_number(timezone.now().year)
         return self.po_number
 
     def save(self, *args, **kwargs) -> None:

--- a/backend/reorder_queue/services/__init__.py
+++ b/backend/reorder_queue/services/__init__.py
@@ -4,6 +4,7 @@ Views keep the serializers as the request/response boundary and keep their
 ``record_audit_event`` calls; the workflow bodies live in these services.
 """
 
+from .numbering import next_po_number
 from .purchase_orders import (
     add_business_days,
     confirm_order,
@@ -20,6 +21,7 @@ __all__ = [
     "confirm_order",
     "create_purchase_order",
     "mark_sent",
+    "next_po_number",
     "update_reorder_requests_from_po",
     "void_line_item",
     "void_po",

--- a/backend/reorder_queue/services/numbering.py
+++ b/backend/reorder_queue/services/numbering.py
@@ -1,0 +1,37 @@
+"""Purchase-order number composition (gh #887).
+
+``PurchaseOrder.auto_generate_po_number`` delegates the ``PO-YYYY-NNNN``
+composition here, but the method itself — and the ``save()`` retry loop that
+recovers from uniqueness collisions — stay on the model: the concurrency seam
+and its ``patch.object(PurchaseOrder, "auto_generate_po_number", ...)`` test
+rely on that method remaining patchable, and ~20 bare
+``PurchaseOrder.objects.create()`` callers rely on ``save()`` numbering them.
+"""
+
+from __future__ import annotations
+
+
+def next_po_number(year: int) -> str:
+    """Return the next ``PO-YYYY-NNNN`` number for ``year``.
+
+    Reads the highest existing number for the year and increments its trailing
+    counter, falling back to ``0001`` when none exist or the counter can't be
+    parsed. Not collision-proof under concurrency on its own —
+    ``PurchaseOrder.save()`` wraps the insert in a retry loop for that.
+    """
+    from reorder_queue.models import PurchaseOrder
+
+    last_po = (
+        PurchaseOrder.objects.filter(po_number__startswith=f"PO-{year}-")
+        .order_by("-po_number")
+        .first()
+    )
+    if last_po:
+        try:
+            next_num = int(last_po.po_number.split("-")[-1]) + 1
+        except (ValueError, IndexError):
+            next_num = 1
+    else:
+        next_num = 1
+
+    return f"PO-{year}-{next_num:04d}"

--- a/backend/reorder_queue/tests/test_services.py
+++ b/backend/reorder_queue/tests/test_services.py
@@ -390,3 +390,32 @@ class TestPurchaseOrderAggregates:
         po = PurchaseOrder.objects.get(pk=po.pk)
         assert po.has_active_items is False
         assert po.total_items == 0
+
+
+class TestNextPoNumber:
+    """next_po_number — the ``PO-YYYY-NNNN`` composition extracted from save() (#887).
+
+    ``PurchaseOrder.auto_generate_po_number`` delegates to this helper while the
+    method + save() retry loop stay on the model (the concurrency patch seam).
+    """
+
+    def test_first_number_for_year(self):
+        assert services.next_po_number(2099) == "PO-2099-0001"
+
+    def test_increments_from_latest(self):
+        PurchaseOrder.objects.create(
+            created_by=UserFactory(), supplier=SupplierFactory(), po_number="PO-2099-0007"
+        )
+        assert services.next_po_number(2099) == "PO-2099-0008"
+
+    def test_unparseable_counter_falls_back_to_one(self):
+        PurchaseOrder.objects.create(
+            created_by=UserFactory(), supplier=SupplierFactory(), po_number="PO-2099-BAD"
+        )
+        assert services.next_po_number(2099) == "PO-2099-0001"
+
+    def test_scoped_to_year(self):
+        PurchaseOrder.objects.create(
+            created_by=UserFactory(), supplier=SupplierFactory(), po_number="PO-2098-0042"
+        )
+        assert services.next_po_number(2099) == "PO-2099-0001"


### PR DESCRIPTION
## Summary

Moves workflow side-effects out of model `save()` overrides / singleton methods into named, testable services; each `save()` becomes a **thin, documented delegator** with **zero schema change** and identical API output. Closes #887.

### Per model
- **InventoryItem** — `assign_sku` + `schedule_image_download` (`inventory/services/items.py`); the async image download now fires on **`transaction.on_commit`**, fixing a pre-commit/rollback race where the Celery task could run before the row committed.
- **ItemSupplier** — `enforce_single_primary` + `record_price_history` extracted to `inventory/services/suppliers.py`, grouped in one `transaction.atomic`; adds the **first tests for `PriceHistory`** (created/updated) + single-primary enforcement.
- **Asset** — `assign_asset_tag` (empty-guard + collision retry) in `inventory/services/asset_tag_id.py`; `save()` delegates (bare admin-duplicate / mgmt-command callers preserved).
- **PurchaseOrder** — PO-number composition → `reorder_queue/services/numbering.py`; `auto_generate_po_number` **stays a patchable instance method** and the `save()` `IntegrityError` retry loop is unchanged — the concurrency-test mocking seam is preserved.
- **Donation** — numbering → `donations/services/numbering.py`.
- **SiteSettings** — `SiteSettingsManager.get_singleton()` replaces the surprising `save()` field-copy redirect; `.get()` kept as a compat delegator; `clean()` still enforces the one-row guarantee; customization tests updated.
- **Category / DashboardConfig / DashboardWidget** — left as-is (already clean tiny-invariant / explicit-classmethod patterns).

### Approach note
SKU/tag/number generators stay synchronous in the create path and remain reachable via `save()` because ~40 bare `Model.objects.create(...)` callers + test mocking seams rely on it. So this extracts the *logic* into named, transactional, testable services with `save()` as a thin documented delegator, rather than deleting the effects from `save()`. The one genuine behavioral change is the image download → `on_commit`.

### Acceptance criteria
- **AC-1** — named services for SKU/tag/PO/donation numbering + image-download scheduling; `save()` thin delegators. ✅
- **AC-2** — `ItemSupplier` primary enforcement + price-history transactional and newly tested. ✅
- **AC-3** — `SiteSettings` singleton via a manager; surprising `save()` redirect removed. ✅
- **AC-4** — image download on `transaction.on_commit`; PO numbering seam preserved. ✅
- **AC-5** — existing tests pass + service-level tests added; `makemigrations --check` clean. ✅

### Independent verification (reviewer)
- `makemigrations --check --dry-run` → "No changes detected"; `manage.py check` clean; black/isort/flake8 clean.
- PO seam confirmed: `auto_generate_po_number` is still a patchable instance method and `save()`'s retry loop is intact.
- `SiteSettings`: explicit manager + compat `get()`; observable singleton guarantees preserved.
- **Targeted seam + new-service suite: 224 passed / 0 failed** (numbering patch-seam, costing, asset-tag never-regenerate, suppliers price-history/primary, items `on_commit`, singleton, donations numbering, dashboard).
- No migrations added; `frontend/` untouched. (The full local run shows 2 reds that are the pre-existing `MEDIA_ROOT` `--reuse-db` attachment-audit flake — they pass on clean media, as CI runs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
