### PR TITLE
refactor(inventory,dashboard,donations): prefetch remaining list-view N+1s (#890)

### DIFF
--- a/backend/dashboard/views.py
+++ b/backend/dashboard/views.py
@@ -254,8 +254,15 @@ def get_inventory_summary(request):
             .count()
         )
 
-        # Total inventory value
-        total_value = sum(item.total_value for item in items_query)
+        # Total inventory value. total_value -> lowest_unit_cost reads
+        # item_suppliers.all(), so prefetch it for THIS unpaginated sum only
+        # (a fresh clone; the count-only reuses of items_query stay untouched)
+        # to avoid a per-item supplier query — the N+1 the property fix in #882
+        # made cacheable. Value-identical; not a Sum annotate (null-cost /
+        # Decimal("0") / rounding would differ). Issue #890.
+        total_value = sum(
+            item.total_value for item in items_query.prefetch_related("item_suppliers")
+        )
 
         # Recently added items (last 30 days)
         thirty_days_ago = timezone.now() - timedelta(days=30)

--- a/backend/donations/admin.py
+++ b/backend/donations/admin.py
@@ -103,6 +103,12 @@ class DonationAdmin(admin.ModelAdmin):
         ),
     )
 
+    def get_queryset(self, request):
+        # total_items (items.count()) and total_quantity (items.all()) render on
+        # the changelist; prefetch items so both read from the reverse-FK cache
+        # instead of firing 2 queries per row (issue #890). Byte-identical.
+        return super().get_queryset(request).prefetch_related("items")
+
     @admin.action(description="Generate donation items from estimated count")
     def generate_items_from_estimate(self, request, queryset):
         """Generate DonationItem instances based on estimated_number_of_items."""
@@ -571,6 +577,12 @@ class DonationItemAdmin(admin.ModelAdmin):
             },
         ),
     )
+
+    def get_queryset(self, request):
+        # remaining_quantity (list_display) sums dispositions.all() per row;
+        # prefetch them so the changelist reads from cache instead of firing one
+        # query per row (issue #890). Byte-identical.
+        return super().get_queryset(request).prefetch_related("dispositions")
 
 
 @admin.register(Disposition)

--- a/backend/donations/models.py
+++ b/backend/donations/models.py
@@ -190,7 +190,15 @@ class Donation(models.Model):
 
     @property
     def items_processed(self) -> int:
-        """Number of items that have been fully processed (have dispositions)."""
+        """Number of items that have been fully processed (have dispositions).
+
+        NOT prefetch-safe: iterates ``self.items.all()`` and, per item, calls
+        ``dispositions.exists()`` plus ``is_fully_disposed`` (another
+        ``dispositions.all()`` sum) — an N+1 landmine. Left as-is (issue #890)
+        because it is currently rendered nowhere (no serializer / admin /
+        dashboard / report references it). If it is ever surfaced on a list,
+        prefetch ``items__dispositions`` on that queryset first.
+        """
         return sum(
             1 for item in self.items.all() if item.dispositions.exists() and item.is_fully_disposed
         )

--- a/backend/donations/views.py
+++ b/backend/donations/views.py
@@ -51,7 +51,17 @@ class DonationViewSet(viewsets.ModelViewSet):
         status_filter = self.request.query_params.get("status")
         if status_filter:
             queryset = queryset.filter(status=status_filter)
-        return queryset.select_related("received_by", "reviewed_by").prefetch_related("items")
+        queryset = queryset.select_related("received_by", "reviewed_by")
+        if self.action == "list":
+            # DonationListSerializer reads items only for total_items /
+            # total_quantity; the existing "items" prefetch covers that.
+            queryset = queryset.prefetch_related("items")
+        else:
+            # DonationSerializer (detail) nests items -> DonationItemSerializer,
+            # whose remaining_quantity sums each item's dispositions.all();
+            # prefetch them too so the nested render stays flat (issue #890).
+            queryset = queryset.prefetch_related("items", "items__dispositions")
+        return queryset
 
     def perform_create(self, serializer):
         donation = serializer.save()
@@ -278,7 +288,12 @@ class DonationItemViewSet(viewsets.ModelViewSet):
         donation_id = self.request.query_params.get("donation")
         if donation_id:
             queryset = queryset.filter(donation_id=donation_id)
-        return queryset.select_related("donation", "asset", "inventory_item")
+        # DonationItemSerializer.remaining_quantity (and is_fully_disposed) sum
+        # dispositions.all(); prefetch them so the list stays flat instead of
+        # one query per row (issue #890). Byte-identical — reads from cache.
+        return queryset.select_related("donation", "asset", "inventory_item").prefetch_related(
+            "dispositions"
+        )
 
     @action(detail=True, methods=["post"])
     def generate_qr_code(self, request, pk=None):

--- a/backend/inventory/models/core.py
+++ b/backend/inventory/models/core.py
@@ -403,7 +403,13 @@ class InventoryItem(OwnableModel):
 
     @property
     def needs_reorder(self) -> bool:
-        """Check if item stock is below minimum and needs reordering."""
+        """Check if item stock is below minimum and needs reordering.
+
+        Pure stock math — despite the name it never touches ``reorder_requests``,
+        so it is prefetch-safe and is intentionally NOT part of the
+        ``reorder_requests`` N+1 fix (issue #890). Do not add a reorder-request
+        query here.
+        """
         # Retired items are phased out: never flagged for reorder, regardless of
         # stock level. This is the central chokepoint for every property-based
         # low-stock surface (reorder_status, low_stock action, serializer
@@ -419,7 +425,18 @@ class InventoryItem(OwnableModel):
             return self.current_stock <= self.minimum_stock
 
     def get_active_reorder_request(self):
-        """Get the most recent active (pending/approved/ordered) reorder request for this item."""
+        """Get the most recent active (pending/approved/ordered) reorder request for this item.
+
+        When the list view has prefetched ``_active_reorder_requests`` (a
+        ``Prefetch(to_attr=...)`` mirroring this exact filter + ``-requested_at``
+        order — see ``InventoryItemViewSet.get_queryset``), read the first
+        element of that cached list to avoid a per-row query (the
+        ``reorder_requests`` N+1, issue #890). Falls back to the live ORM query
+        when not prefetched (detail retrieve, admin, tasks) so the returned row
+        is identical either way.
+        """
+        if hasattr(self, "_active_reorder_requests"):
+            return self._active_reorder_requests[0] if self._active_reorder_requests else None
         return (
             self.reorder_requests.filter(status__in=["pending", "approved", "ordered"])
             .order_by("-requested_at")
@@ -427,14 +444,34 @@ class InventoryItem(OwnableModel):
         )
 
     def has_pending_reorder(self) -> bool:
-        """Check if item has any pending, approved, or ordered reorder requests."""
+        """Check if item has any pending, approved, or ordered reorder requests.
+
+        Reads the prefetched ``_active_reorder_requests`` list when present (see
+        :meth:`get_active_reorder_request`) to avoid the ``reorder_requests``
+        N+1; otherwise falls back to a live ``.exists()`` query.
+        """
+        if hasattr(self, "_active_reorder_requests"):
+            return bool(self._active_reorder_requests)
         return self.reorder_requests.filter(status__in=["pending", "approved", "ordered"]).exists()
 
     def get_expected_delivery_date(self):
-        """Calculate expected delivery date for ordered items."""
-        ordered_request = (
-            self.reorder_requests.filter(status="ordered").order_by("-ordered_at").first()
-        )
+        """Calculate expected delivery date for ordered items.
+
+        ⚠️ Orders by ``-ordered_at`` (NOT the ``-requested_at`` used by the
+        active-request accessors), so the list view prefetches a SEPARATE
+        ``_ordered_reorder_requests`` list with that exact filter + order. Read
+        it when present, else fall back to the live query. Sharing a single
+        prefetch with :meth:`get_active_reorder_request` would silently return
+        the wrong row (issue #890 ordering trap).
+        """
+        if hasattr(self, "_ordered_reorder_requests"):
+            ordered_request = (
+                self._ordered_reorder_requests[0] if self._ordered_reorder_requests else None
+            )
+        else:
+            ordered_request = (
+                self.reorder_requests.filter(status="ordered").order_by("-ordered_at").first()
+            )
         if ordered_request and ordered_request.ordered_at and self.average_lead_time:
             from datetime import timedelta
 
@@ -1137,7 +1174,19 @@ class PriceHistory(models.Model):
 
     @property
     def price_change_percentage(self) -> Optional[Decimal]:
-        """Calculate percentage change from previous record."""
+        """Calculate percentage change from previous record.
+
+        Single-instance-preferred and NOT prefetch-safe: it runs a
+        self-referential ``recorded_at__lt`` prior-row lookup, so rendering it
+        across a list (``PriceHistorySerializer`` list / ``PriceHistoryAdmin``)
+        is one query per row. A ``Window(Lag("unit_cost"), partition_by=
+        item_supplier, order_by=recorded_at)`` annotation would move it DB-side,
+        but is intentionally NOT applied (issue #890): ``Lag`` ordered by
+        ``recorded_at`` treats an equal-``recorded_at`` neighbour as the prior
+        row, whereas the strict ``recorded_at__lt`` filter here excludes it — a
+        non-byte-identical tie edge. Prefer small/paginated result sets, or add
+        the annotation deliberately if a tie-behaviour change is acceptable.
+        """
         previous = PriceHistory.objects.filter(
             item_supplier=self.item_supplier, recorded_at__lt=self.recorded_at
         ).first()

--- a/backend/inventory/models/fixtures.py
+++ b/backend/inventory/models/fixtures.py
@@ -61,7 +61,17 @@ class Fixture(models.Model):
 
     @property
     def pending_requests_count(self) -> int:
-        """Count of pending refill requests for this fixture."""
+        """Count of pending refill requests for this fixture.
+
+        Reads the prefetched ``_pending_refill_requests`` list when the list
+        view supplied it (a ``Prefetch(to_attr=...)`` pre-filtered to PENDING —
+        see ``FixtureViewSet.get_queryset``) to avoid a per-row ``.count()``
+        query (the fixture-list N+1, issue #890); otherwise falls back to the
+        live count. ``to_attr`` is used rather than a same-named ``annotate``
+        because this property would shadow the annotation.
+        """
+        if hasattr(self, "_pending_refill_requests"):
+            return len(self._pending_refill_requests)
         return self.refill_requests.filter(status=FixtureRefillRequest.Status.PENDING).count()
 
 

--- a/backend/inventory/tests/test_inventory_list_metrics.py
+++ b/backend/inventory/tests/test_inventory_list_metrics.py
@@ -6,18 +6,21 @@ number of queries — never an N+1 — and only when explicitly requested. The
 default response is unchanged.
 """
 
+from datetime import timedelta
 from decimal import Decimal
 
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
+from django.utils import timezone
 
 import pytest
 from rest_framework import status
 
-from inventory.models import MaintenanceItem, MaintenanceMaterial, WorkOrder
-from inventory.tests.factories import AssetFactory, InventoryItemFactory
-from reorder_queue.models import PurchaseOrder, PurchaseOrderItem
+from donations.tests.factories import DispositionFactory, DonationFactory, DonationItemFactory
+from inventory.models import FixtureRefillRequest, MaintenanceItem, MaintenanceMaterial, WorkOrder
+from inventory.tests.factories import AssetFactory, FixtureFactory, InventoryItemFactory
+from reorder_queue.models import PurchaseOrder, PurchaseOrderItem, ReorderRequest
 from reorder_queue.tests.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
@@ -306,3 +309,222 @@ class TestDefaultListSupplierQueryBudget:
         assert sup_2 == sup_6, (sup_2, sup_6)
         # ... and it is a single prefetch query, not a per-row handful.
         assert sup_6 == 1, sup_6
+
+
+def _table_query_count(client, url, table):
+    """Number of captured queries whose SQL reads ``table``.
+
+    An N+1 grows this with the row count; a prefetch/annotate keeps it flat.
+    Table names are the Django defaults (``<app>_<model>``).
+    """
+    with CaptureQueriesContext(connection) as ctx:
+        response = client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+    return sum(1 for q in ctx.captured_queries if table in q["sql"])
+
+
+def _make_item_with_reorders(name):
+    """An item carrying reorder requests in the states the default-list
+    accessors read — one PENDING (active set) and one ORDERED (the separate
+    ``-ordered_at`` set) — so both order-preserving prefetches and all four
+    accessors (has_pending_reorder / reorder_status / active_reorder_request /
+    expected_delivery_date) have rows to resolve.
+    """
+    item = InventoryItemFactory(image=None, name=name)
+    ReorderRequest.objects.create(item=item, quantity=1, status=ReorderRequest.Status.PENDING)
+    ReorderRequest.objects.create(
+        item=item,
+        quantity=1,
+        status=ReorderRequest.Status.ORDERED,
+        ordered_at=timezone.now(),
+    )
+    return item
+
+
+class TestDefaultListReorderQueryBudget:
+    """PRIMARY regression guard for the default-list reorder_requests N+1 (issue #890).
+
+    ``InventoryItemSerializer`` renders four fields that each fired a per-row
+    ``reorder_requests`` query — ``has_pending_reorder``, ``reorder_status``,
+    ``active_reorder_request`` and ``expected_delivery_date`` — while the list
+    queryset prefetched only suppliers. Two order-preserving
+    ``Prefetch(to_attr=...)`` (``-requested_at`` for the active set,
+    ``-ordered_at`` for the ordered set — the ordering trap) now serve all four
+    from cache, so the ReorderRequest-table query count is a constant two,
+    independent of page size.
+    """
+
+    _TABLE = "reorder_queue_reorderrequest"
+
+    def test_reorder_fields_do_not_add_a_query_per_row(self, api_client):
+        for i in range(2):
+            _make_item_with_reorders(f"reorderbudget-a-{i}")
+        # Warm one-time caches (content types, etc.) so the counts are stable.
+        _table_query_count(api_client, _list_url(), self._TABLE)
+        reorder_2 = _table_query_count(api_client, _list_url(), self._TABLE)
+
+        for i in range(4):  # grow the page from 2 to 6 items
+            _make_item_with_reorders(f"reorderbudget-b-{i}")
+        reorder_6 = _table_query_count(api_client, _list_url(), self._TABLE)
+
+        # The heart of the regression: the ReorderRequest-table query count does
+        # NOT grow with the number of rows. Before the fix each row fired
+        # several of these queries (has_pending_reorder + expected_delivery_date
+        # + active_reorder_request, unconditionally), so reorder_6 > reorder_2.
+        assert reorder_2 == reorder_6, (reorder_2, reorder_6)
+        # ... and it is exactly the two order-preserving Prefetches.
+        assert reorder_6 == 2, reorder_6
+
+
+class TestDefaultListReorderValueParity:
+    """Byte-identical guard: the prefetched default-list values equal the live
+    (fallback) accessor values, including the ``-ordered_at`` ORDERING TRAP.
+
+    Builds an item whose most-recent reorder request by ``requested_at`` is a
+    DIFFERENT row than the most-recent ORDERED request by ``ordered_at``. A
+    naive single ``-requested_at`` prefetch shared by
+    ``get_expected_delivery_date`` would then read the wrong ``ordered_at``; the
+    two separate ``Prefetch(to_attr=...)`` keep every rendered value identical
+    to the per-instance live query.
+    """
+
+    def test_list_values_match_live_query_including_ordering_trap(self, api_client):
+        now = timezone.now()
+        item = InventoryItemFactory(image=None, current_stock=0, minimum_stock=5)
+        # A lead time on the primary supplier so expected_delivery_date resolves.
+        item.item_suppliers.update(average_lead_time=7)
+
+        newest_ordered = ReorderRequest.objects.create(
+            item=item, quantity=1, status=ReorderRequest.Status.ORDERED
+        )
+        latest_requested = ReorderRequest.objects.create(
+            item=item, quantity=1, status=ReorderRequest.Status.ORDERED
+        )
+        # requested_at is auto_now_add; .update() bypasses it to set explicit
+        # times. The two ORDERED rows are ranked in REVERSE by the two orders:
+        #   -requested_at head -> latest_requested ; -ordered_at head -> newest_ordered
+        ReorderRequest.objects.filter(pk=newest_ordered.pk).update(
+            requested_at=now - timedelta(days=10), ordered_at=now - timedelta(days=1)
+        )
+        ReorderRequest.objects.filter(pk=latest_requested.pk).update(
+            requested_at=now - timedelta(days=2), ordered_at=now - timedelta(days=8)
+        )
+
+        row = _row_for(_results(api_client.get(_list_url())), item)
+        fresh = type(item).objects.get(pk=item.pk)  # no prefetch -> live path
+
+        # Prefetch path == live path (byte-identical) ...
+        assert fresh.has_pending_reorder() is True
+        assert row["has_pending_reorder"] is True
+        assert fresh.reorder_status == "ordered"
+        assert row["reorder_status"] == "ordered"
+        assert row["active_reorder_request"]["id"] == fresh.get_active_reorder_request().id
+        # ... active request is the latest by -requested_at ...
+        assert fresh.get_active_reorder_request().id == latest_requested.id
+        # ... and expected delivery derives from the latest by -ordered_at (the
+        # trap): newest_ordered.ordered_at.date() + 7-day lead time.
+        expected = fresh.get_expected_delivery_date()
+        assert expected == (now - timedelta(days=1)).date() + timedelta(days=7)
+        assert row["expected_delivery_date"] == expected.isoformat()
+
+
+class TestDashboardOverviewSupplierQueryBudget:
+    """Regression guard for the dashboard overview total_value N+1 (issue #890).
+
+    ``get_inventory_summary`` sums ``total_value`` over every active item;
+    ``total_value`` -> ``lowest_unit_cost`` reads ``item_suppliers.all()``, so
+    without a prefetch the ItemSupplier table was read once per active item. The
+    sum now iterates ``prefetch_related("item_suppliers")``, so that table is
+    read exactly once regardless of how many active items exist.
+    """
+
+    _TABLE = "inventory_itemsupplier"
+
+    def test_total_value_sum_does_not_add_a_query_per_item(self, api_client):
+        url = reverse("inventory_summary")
+        for i in range(2):
+            InventoryItemFactory(image=None, name=f"dashbudget-a-{i}")
+        _table_query_count(api_client, url, self._TABLE)  # warm caches
+        sup_2 = _table_query_count(api_client, url, self._TABLE)
+
+        for i in range(4):  # grow from 2 to 6 active items
+            InventoryItemFactory(image=None, name=f"dashbudget-b-{i}")
+        sup_6 = _table_query_count(api_client, url, self._TABLE)
+
+        assert sup_2 == sup_6, (sup_2, sup_6)
+        assert sup_6 == 1, sup_6  # the single supplier prefetch for the value sum
+
+
+class TestFixtureListRefillQueryBudget:
+    """Regression guard for the fixture-list pending_requests_count N+1 (issue #890).
+
+    ``FixtureSerializer.pending_requests_count`` filtered ``refill_requests`` to
+    PENDING and counted them per row. A ``Prefetch(to_attr=...)`` pre-filtered
+    to PENDING now serves the count via ``len()``, so the FixtureRefillRequest
+    table is read once regardless of page size.
+    """
+
+    _TABLE = "inventory_fixturerefillrequest"
+
+    def _make_fixture_with_pending(self):
+        fixture = FixtureFactory()
+        # Status defaults to PENDING.
+        FixtureRefillRequest.objects.create(fixture=fixture)
+        return fixture
+
+    def test_pending_count_does_not_add_a_query_per_row(self, api_client):
+        url = reverse("fixture-list")
+        for _ in range(2):
+            self._make_fixture_with_pending()
+        _table_query_count(api_client, url, self._TABLE)  # warm caches
+        refill_2 = _table_query_count(api_client, url, self._TABLE)
+
+        for _ in range(4):  # grow the page from 2 to 6 fixtures
+            self._make_fixture_with_pending()
+        refill_6 = _table_query_count(api_client, url, self._TABLE)
+
+        assert refill_2 == refill_6, (refill_2, refill_6)
+        assert refill_6 == 1, refill_6  # the single PENDING prefetch
+
+
+class TestDonationListQueryBudget:
+    """Regression guards for the donations list N+1s (issue #890)."""
+
+    def test_donation_item_list_dispositions_stay_flat(self, authenticated_client):
+        """``DonationItemSerializer.remaining_quantity`` sums ``dispositions.all()``
+        per row; the viewset now prefetches ``dispositions`` so the disposition
+        table is read once regardless of row count."""
+        client, _user = authenticated_client
+        url = reverse("donation-item-list")
+        donation = DonationFactory()
+        for _ in range(2):
+            DispositionFactory(donation_item=DonationItemFactory(donation=donation))
+        _table_query_count(client, url, "donations_disposition")  # warm caches
+        disp_2 = _table_query_count(client, url, "donations_disposition")
+
+        for _ in range(4):  # grow the list from 2 to 6 items
+            DispositionFactory(donation_item=DonationItemFactory(donation=donation))
+        disp_6 = _table_query_count(client, url, "donations_disposition")
+
+        assert disp_2 == disp_6, (disp_2, disp_6)
+        assert disp_6 == 1, disp_6  # the single dispositions prefetch
+
+    def test_donation_list_items_stay_flat(self, authenticated_client):
+        """Lock-in: the Donation list serves ``total_items`` (items.count()) and
+        ``total_quantity`` (items.all()) from the list ``items`` prefetch. The
+        #890 refactor split get_queryset into list/detail branches — the list
+        branch must keep prefetching items, so the DonationItem-table read stays
+        flat as donations grow."""
+        client, _user = authenticated_client
+        url = reverse("donation-list")
+        for _ in range(2):
+            DonationItemFactory(donation=DonationFactory())
+        _table_query_count(client, url, "donations_donationitem")  # warm caches
+        items_2 = _table_query_count(client, url, "donations_donationitem")
+
+        for _ in range(4):  # grow the list from 2 to 6 donations
+            DonationItemFactory(donation=DonationFactory())
+        items_6 = _table_query_count(client, url, "donations_donationitem")
+
+        assert items_2 == items_6, (items_2, items_6)
+        assert items_6 == 1, items_6  # the single items prefetch

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -525,9 +525,41 @@ class InventoryItemViewSet(viewsets.ModelViewSet):
         return InventoryItemSerializer
 
     def get_queryset(self):
+        # Two order-preserving Prefetches kill the default-list reorder_requests
+        # N+1 (issue #890). Each mirrors its accessor's exact filter + order so
+        # the cached [0]/bool() reads in inventory/models/core.py are
+        # byte-identical to the live queries they replace:
+        #   * _active_reorder_requests -> get_active_reorder_request /
+        #     has_pending_reorder / reorder_status  (status in pending/approved/
+        #     ordered, ordered by -requested_at)
+        #   * _ordered_reorder_requests -> get_expected_delivery_date, which
+        #     orders by -ordered_at (the ORDERING TRAP: sharing one prefetch
+        #     would silently return the wrong row).
+        # Each Prefetch is a single query regardless of page size (2 total).
+        # ReorderRequest is imported locally to avoid a circular import.
+        from django.db.models import Prefetch
+
+        from reorder_queue.models import ReorderRequest
+
         queryset = (
             InventoryItem.objects.select_related("category", "location", "safety_profile")
-            .prefetch_related("item_suppliers__supplier")
+            .prefetch_related(
+                "item_suppliers__supplier",
+                Prefetch(
+                    "reorder_requests",
+                    queryset=ReorderRequest.objects.filter(
+                        status__in=["pending", "approved", "ordered"]
+                    ).order_by("-requested_at"),
+                    to_attr="_active_reorder_requests",
+                ),
+                Prefetch(
+                    "reorder_requests",
+                    queryset=ReorderRequest.objects.filter(status="ordered").order_by(
+                        "-ordered_at"
+                    ),
+                    to_attr="_ordered_reorder_requests",
+                ),
+            )
             .all()
         )
 
@@ -3180,6 +3212,23 @@ class FixtureViewSet(viewsets.ModelViewSet):
             queryset = queryset.prefetch_related(
                 "refill_requests__requested_user",
                 "refill_requests__resolved_user",
+            )
+        elif self.action == "list":
+            # FixtureSerializer.pending_requests_count would otherwise fire a
+            # per-row PENDING .count() (the fixture-list N+1, issue #890).
+            # Prefetch the PENDING subset into a to_attr the property reads via
+            # len(); a same-named annotate would be shadowed by the property.
+            # One query regardless of page size.
+            from django.db.models import Prefetch
+
+            queryset = queryset.prefetch_related(
+                Prefetch(
+                    "refill_requests",
+                    queryset=FixtureRefillRequest.objects.filter(
+                        status=FixtureRefillRequest.Status.PENDING
+                    ),
+                    to_attr="_pending_refill_requests",
+                )
             )
 
         # Filter by location if specified


### PR DESCRIPTION
## Summary

Fixes the remaining hidden-query model-property N+1s flagged in #890 — the **last of the #881–890 cleanup series**. Backend-only, behavior-preserving (values **byte-identical**), **zero migration** (prefetch / `to_attr` / single-pass only). Closes #890.

Builds on #882 (supplier N+1) and #883 (PO aggregates), which already fixed their parts.

### Fixes
- **P0 — default inventory list `reorder_requests` N+1** (~5 queries/row on the busiest endpoint): two **order-preserving** `Prefetch(to_attr=…)` on `InventoryItemViewSet.get_queryset` — `_active_reorder_requests` (status ∈ pending/approved/ordered, `-requested_at`) and `_ordered_reorder_requests` (status=ordered, **`-ordered_at`** — the ordering trap). The four accessors (`has_pending_reorder` / `reorder_status` / `active_reorder_request` / `get_expected_delivery_date`) read the matching cached list when present, else fall back to the live ORM query (detail retrieve / admin / tasks stay correct). Each Prefetch mirrors its accessor's `filter().order_by()` exactly → **byte-identical** (a naïve single `prefetch_related` would have made `expected_delivery_date` silently wrong). `needs_reorder` unchanged (pure stock math).
- **P1** — dashboard `total_value` sum iterates `prefetch_related("item_suppliers")` (that sum only); fixture list `pending_requests_count` via `Prefetch(to_attr=_pending_refill_requests)` filtered to PENDING.
- **P2** — `DonationItem.remaining_quantity` prefetches `dispositions` (viewset + admin + `DonationViewSet` detail `items__dispositions`); `DonationAdmin.get_queryset` prefetches `items`.
- **P3** — `PriceHistory.price_change_percentage` intentionally kept as-is with a docstring: the `Window(Lag)` DB fix has a non-byte-identical `recorded_at`-tie edge, so it is deliberately not shipped. `Donation.items_processed` (rendered nowhere) + `needs_reorder` get docstring notes.

### Query-count regression tests
Extends `inventory/tests/test_inventory_list_metrics.py` (existing `_count_queries` / `CaptureQueriesContext` harness): primary **`TestDefaultListReorderQueryBudget`** (`reorder_queue_reorderrequest` count **== 2**, constant across a 2→6-row page) + dashboard (`inventory_itemsupplier`), fixture (`inventory_fixturerefillrequest`), and donations (`donations_disposition` + a `donations_donationitem` lock-in) guards, plus a value-parity test exercising the ordering trap. **Each N+1 guard fails without the source fix** (stash-verified).

### Acceptance criteria
- **AC-1** — P0 two order-preserving prefetches + accessor cache-or-live fallback; byte-identical. ✅
- **AC-2** — dashboard / fixture / donations prefetch fixes. ✅
- **AC-3** — query-count regression tests that fail without the fix. ✅
- **AC-4** — P3 documented-not-shipped (tie edge); `items_processed` / `needs_reorder` docstrings. ✅
- **AC-5** — `makemigrations --check` clean; full `pytest` **3408 passed / 4 skipped**; lint clean. ✅

### Independent verification (reviewer)
- `makemigrations --check --dry-run` → "No changes detected" (zero schema change); `manage.py check` clean; black/isort/flake8 clean.
- Confirmed the two order-preserving Prefetches + accessor cache-or-live fallback (reads `[0]` from the order-matching prefetch = identical to `.first()`).
- `test_inventory_list_metrics.py`: 15 passed (incl. TestDefaultListReorderQueryBudget + dashboard/fixture/donations guards + value-parity).
- `frontend/` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
