### PR TITLE
feat(purchasing): hide PO number spinners + case-cost edit-either entry (op-7j8v)

### DIFF
--- a/frontend/src/__tests__/pages/PurchaseOrderFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/PurchaseOrderFormPage.test.tsx
@@ -51,6 +51,31 @@ describe('PurchaseOrderFormPage', () => {
     localStorage.setItem('token', 'test-token');
   });
 
+  // Render the form, load a single-item supplier, and select it so the line
+  // item (and its cost fields) are on screen.
+  const renderWithItem = async (item: api.ReorderDataItem) => {
+    (api.purchaseOrderAPI.getReorderData as jest.Mock).mockResolvedValue({
+      data: { suppliers: [{ ...mockSupplier, items: [item] }] },
+    });
+    (api.purchaseOrderAPI.createOrder as jest.Mock).mockResolvedValue({
+      data: { id: 42, po_number: 'PO-2024-0042', supplier: 1, status: 'draft' },
+    });
+
+    render(
+      <MemoryRouter>
+        <PurchaseOrderFormPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Supplier')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('Test Supplier').closest('button')!);
+    await waitFor(() => {
+      expect(screen.getByText('Test Item')).toBeInTheDocument();
+    });
+  };
+
   test('displays loading state initially', async () => {
     (api.purchaseOrderAPI.getReorderData as jest.Mock).mockReturnValue(
       new Promise(() => {})
@@ -220,6 +245,118 @@ describe('PurchaseOrderFormPage', () => {
     expect(call.items[0].item_supplier_id).toBe(1);
     expect(call.items[0].quantity).toBe(144);
     expect(call.items[0].order_in_packages).toBe(6);
+  });
+
+  describe('case-cost entry (show both, edit either)', () => {
+    // QPP=12, unit $2.50, case $30.00 — clean division for exact assertions.
+    const caseCostItem: api.ReorderDataItem = {
+      ...mockItem,
+      quantity_per_package: 12,
+      suggested_quantity: 12,
+      unit_cost: '2.50',
+      package_cost: '30.00',
+    };
+
+    test('case-packed item shows both cost fields, prefilled from supplier unit/package cost', async () => {
+      await renderWithItem(caseCostItem);
+
+      const unitInput = screen.getByLabelText(/cost per unit for test item/i) as HTMLInputElement;
+      const caseInput = screen.getByLabelText(/cost per case for test item/i) as HTMLInputElement;
+
+      // Both prefilled (as placeholders) from the supplier's saved costs.
+      expect(unitInput).toHaveAttribute('placeholder', '2.50');
+      expect(caseInput).toHaveAttribute('placeholder', '30.00');
+      // No user override yet.
+      expect(unitInput.value).toBe('');
+      expect(caseInput.value).toBe('');
+    });
+
+    test('editing case cost live-derives unit cost (case / qpp)', async () => {
+      await renderWithItem(caseCostItem);
+
+      const unitInput = screen.getByLabelText(/cost per unit for test item/i) as HTMLInputElement;
+      const caseInput = screen.getByLabelText(/cost per case for test item/i) as HTMLInputElement;
+
+      fireEvent.change(caseInput, { target: { value: '36' } });
+
+      expect(caseInput.value).toBe('36');
+      expect(unitInput.value).toBe('3'); // 36 / 12
+    });
+
+    test('editing unit cost live-derives case cost (unit × qpp)', async () => {
+      await renderWithItem(caseCostItem);
+
+      const unitInput = screen.getByLabelText(/cost per unit for test item/i) as HTMLInputElement;
+      const caseInput = screen.getByLabelText(/cost per case for test item/i) as HTMLInputElement;
+
+      fireEvent.change(unitInput, { target: { value: '3' } });
+
+      expect(unitInput.value).toBe('3');
+      expect(caseInput.value).toBe('36'); // 3 × 12
+    });
+
+    test('submit sends the derived per-unit unit_cost after editing the case cost', async () => {
+      await renderWithItem(caseCostItem);
+
+      const caseInput = screen.getByLabelText(/cost per case for test item/i) as HTMLInputElement;
+      fireEvent.change(caseInput, { target: { value: '36' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /create purchase order/i }));
+
+      await waitFor(() => {
+        expect(api.purchaseOrderAPI.createOrder).toHaveBeenCalled();
+      });
+      const call = (api.purchaseOrderAPI.createOrder as jest.Mock).mock.calls[0][0];
+      // Backend contract is unchanged: per-unit cost only.
+      expect(call.items[0].unit_cost).toBe(3); // 36 / 12
+      expect(call.items[0]).not.toHaveProperty('case_cost');
+      expect(call.items[0]).not.toHaveProperty('package_cost');
+    });
+
+    test('non-clean division keeps full per-unit precision (no cent drift)', async () => {
+      const oddItem: api.ReorderDataItem = {
+        ...mockItem,
+        quantity_per_package: 3,
+        suggested_quantity: 3,
+        unit_cost: '3.00',
+        package_cost: '9.00',
+      };
+      await renderWithItem(oddItem);
+
+      const unitInput = screen.getByLabelText(/cost per unit for test item/i) as HTMLInputElement;
+      const caseInput = screen.getByLabelText(/cost per case for test item/i) as HTMLInputElement;
+
+      // $10 / 3 units = 3.333333 (not rounded to 3.33, which would drift to $9.99).
+      fireEvent.change(caseInput, { target: { value: '10' } });
+      expect(unitInput.value).toBe('3.333333');
+      // The derived per-unit value is not a whole cent; the field must not be
+      // step-invalid, or a real browser would block form submission on click.
+      expect(unitInput.checkValidity()).toBe(true);
+
+      fireEvent.click(screen.getByRole('button', { name: /create purchase order/i }));
+      await waitFor(() => {
+        expect(api.purchaseOrderAPI.createOrder).toHaveBeenCalled();
+      });
+      const call = (api.purchaseOrderAPI.createOrder as jest.Mock).mock.calls[0][0];
+      expect(call.items[0].unit_cost).toBe(3.333333);
+    });
+
+    test('non-case item (qpp=1) shows a single unit-cost field', async () => {
+      const singleUnitItem: api.ReorderDataItem = {
+        ...mockItem,
+        quantity_per_package: 1,
+        suggested_quantity: 5,
+        unit_cost: '4.00',
+        package_cost: null,
+      };
+      await renderWithItem(singleUnitItem);
+
+      // Single unit-cost field, no paired case cost.
+      expect(screen.getByLabelText(/unit cost for test item/i)).toBeInTheDocument();
+      expect(screen.queryByLabelText(/cost per case for test item/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/cost \/ case/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/cost \/ unit/i)).not.toBeInTheDocument();
+    });
   });
 
   test('handles API error gracefully', async () => {

--- a/frontend/src/pages/PurchaseOrderFormPage.tsx
+++ b/frontend/src/pages/PurchaseOrderFormPage.tsx
@@ -23,6 +23,9 @@ interface SelectedItem extends ReorderDataItem {
   quantity: number;
   cases: number;
   unit_cost_override?: string;
+  // Per-case cost, kept in sync with unit_cost_override (case = unit × qpp).
+  // Display/edit convenience only — submit always uses the per-unit value.
+  case_cost_override?: string;
   expected_shipment_date?: string;
 }
 
@@ -38,6 +41,15 @@ interface FreeformItem {
   quantity: number;
   unit_cost: string;
 }
+
+// Normalize a derived cost to a clean string, stripping IEEE-754 float noise
+// (e.g. 39.959999999999994 -> "39.96") without cent-level rounding. Six
+// decimals is well beyond cents, so paired unit/case costs stay consistent
+// even when the case size doesn't divide evenly (avoids cent drift on submit).
+const formatCostValue = (value: number): string => {
+  if (!Number.isFinite(value)) return '';
+  return String(parseFloat(value.toFixed(6)));
+};
 
 const PurchaseOrderFormPage: React.FC = () => {
   const navigate = useNavigate();
@@ -181,13 +193,50 @@ const PurchaseOrderFormPage: React.FC = () => {
     );
   };
 
-  // Update item price override
-  const updateItemPrice = (itemSupplierId: number, unitCostOverride: string) => {
+  // Update the per-unit cost override. For case-packed items, keep the paired
+  // case-cost field in sync (case = unit × qpp). The per-unit value the user
+  // typed is stored verbatim (full precision) and remains the source of truth
+  // for submit.
+  const updateItemUnitCost = (itemSupplierId: number, unitCostOverride: string) => {
     setSelectedItems((prev) =>
-      prev.map((item) =>
-        item.item_supplier_id === itemSupplierId ? { ...item, unit_cost_override: unitCostOverride } : item
-      )
+      prev.map((item) => {
+        if (item.item_supplier_id !== itemSupplierId) return item;
+        const qpp = item.quantity_per_package || 1;
+        const parsed = parseFloat(unitCostOverride);
+        const caseCost =
+          unitCostOverride.trim() === '' || Number.isNaN(parsed)
+            ? ''
+            : formatCostValue(parsed * qpp);
+        return { ...item, unit_cost_override: unitCostOverride, case_cost_override: caseCost };
+      })
     );
+  };
+
+  // Update the per-case cost. Derives the per-unit cost (unit = case / qpp) at
+  // full precision — the per-unit value is what submit sends, so no cent drift
+  // is introduced by rounding the case cost to display precision.
+  const updateItemCaseCost = (itemSupplierId: number, caseCostOverride: string) => {
+    setSelectedItems((prev) =>
+      prev.map((item) => {
+        if (item.item_supplier_id !== itemSupplierId) return item;
+        const qpp = item.quantity_per_package || 1;
+        const parsed = parseFloat(caseCostOverride);
+        const unitCost =
+          caseCostOverride.trim() === '' || Number.isNaN(parsed)
+            ? ''
+            : formatCostValue(parsed / qpp);
+        return { ...item, case_cost_override: caseCostOverride, unit_cost_override: unitCost };
+      })
+    );
+  };
+
+  // Per-case cost placeholder: the supplier's saved package cost when present,
+  // otherwise derived from the saved unit cost (unit × qpp).
+  const caseCostPlaceholderFor = (item: SelectedItem): string => {
+    if (item.package_cost != null && item.package_cost !== '') return item.package_cost;
+    const qpp = item.quantity_per_package || 1;
+    const unit = parseFloat(item.unit_cost || '0');
+    return Number.isNaN(unit) ? '' : formatCostValue(unit * qpp);
   };
 
   // Update item expected shipment date
@@ -704,17 +753,63 @@ const PurchaseOrderFormPage: React.FC = () => {
                             )}
                           </td>
                           <td className="col-cost">
-                            <input
-                              type="number"
-                              min="0"
-                              step="0.01"
-                              placeholder={item.unit_cost}
-                              value={item.unit_cost_override || ''}
-                              onChange={(e) => updateItemPrice(item.item_supplier_id, e.target.value)}
-                              disabled={!item.selected}
-                              className="input-cost"
-                              title="Cost per individual unit (we use this for inventory valuation; total = unit cost × units ordered)."
-                            />
+                            {item.quantity_per_package > 1 ? (
+                              <div className="case-cost-group">
+                                {/*
+                                  step="any" (not 0.01) on both inputs: a case cost that
+                                  doesn't divide evenly by qpp derives a sub-cent per-unit
+                                  value (kept at full precision on purpose). step="0.01"
+                                  would mark that field :invalid and block form submission.
+                                */}
+                                <label className="case-cost-field">
+                                  <span className="case-cost-label">Cost / unit</span>
+                                  <input
+                                    type="number"
+                                    min="0"
+                                    step="any"
+                                    placeholder={item.unit_cost}
+                                    value={item.unit_cost_override || ''}
+                                    onChange={(e) =>
+                                      updateItemUnitCost(item.item_supplier_id, e.target.value)
+                                    }
+                                    disabled={!item.selected}
+                                    className="input-cost"
+                                    aria-label={`Cost per unit for ${item.item_name}`}
+                                    title="Cost per individual unit (used for inventory valuation; line total = unit cost × units ordered). Editing this updates cost per case."
+                                  />
+                                </label>
+                                <label className="case-cost-field">
+                                  <span className="case-cost-label">Cost / case</span>
+                                  <input
+                                    type="number"
+                                    min="0"
+                                    step="any"
+                                    placeholder={caseCostPlaceholderFor(item)}
+                                    value={item.case_cost_override || ''}
+                                    onChange={(e) =>
+                                      updateItemCaseCost(item.item_supplier_id, e.target.value)
+                                    }
+                                    disabled={!item.selected}
+                                    className="input-cost"
+                                    aria-label={`Cost per case for ${item.item_name}`}
+                                    title="Cost per case (= unit cost × units per case). Editing this updates cost per unit."
+                                  />
+                                </label>
+                              </div>
+                            ) : (
+                              <input
+                                type="number"
+                                min="0"
+                                step="0.01"
+                                placeholder={item.unit_cost}
+                                value={item.unit_cost_override || ''}
+                                onChange={(e) => updateItemUnitCost(item.item_supplier_id, e.target.value)}
+                                disabled={!item.selected}
+                                className="input-cost"
+                                aria-label={`Unit cost for ${item.item_name}`}
+                                title="Cost per individual unit (we use this for inventory valuation; total = unit cost × units ordered)."
+                              />
+                            )}
                           </td>
                           <td className="col-lead">{item.lead_time_days} days</td>
                           <td className="col-shipment">

--- a/frontend/src/styles/PurchaseOrderFormPage.css
+++ b/frontend/src/styles/PurchaseOrderFormPage.css
@@ -332,6 +332,20 @@
   border-color: #dc2626 !important;
 }
 
+/* Hide native number-input spin buttons (cases / units / cost) for cleaner
+   numeric entry. Scoped to the PO form's table inputs so it does not affect
+   number inputs elsewhere in the app. */
+.items-table input[type="number"] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+.items-table input[type="number"]::-webkit-inner-spin-button,
+.items-table input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 /* Subtotals */
 .subtotal-label {
   text-align: right !important;
@@ -561,6 +575,25 @@
   margin-top: 2px;
 }
 
+/* Paired unit / case cost entry for case-packed items. Editing either field
+   live-derives the other; the per-unit value stays the source of truth. */
+.case-cost-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.case-cost-group .case-cost-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.case-cost-label {
+  font-size: 11px;
+  color: #475569;
+}
+
 /* Dark mode support */
 @media (prefers-color-scheme: dark) {
   .case-help-text {
@@ -570,7 +603,8 @@
   }
 
   .case-qty-label,
-  .case-qty-summary {
+  .case-qty-summary,
+  .case-cost-label {
     color: #cbd5e1;
   }
 


### PR DESCRIPTION
## Summary

Two web PO-form UX improvements (`frontend/src/pages/PurchaseOrderFormPage.tsx` + its CSS). **Frontend-only** — no backend/API change (submit still sends per-unit `unit_cost` / `unit_cost_override` + `order_in_packages`).

### 1. Hide number-input spinner arrows
The native spin buttons on the PO-form table number inputs (cases / units / cost) are hidden via a **page-scoped** `.items-table input[type=number]` rule (`appearance: textfield` + webkit spin-button `none`) — scoped to the PO form, not broadened app-wide.

### 2. Case-cost entry — "show both, edit either"
Case-packed line items (`quantity_per_package` > 1) render paired **Cost / unit** + **Cost / case** fields side by side; editing either **live-derives** the other (`case = unit × qpp`, `unit = case / qpp`), both prefilled (placeholders) from the supplier's saved `unit_cost` / `package_cost`. Non-case items (qpp = 1) keep the single unit-cost field, unchanged.
- Per-unit cost stays the **single source of truth** for submit; full precision kept in state (6dp float-noise cleanup, no cent rounding), so odd case sizes don't drift.
- `step="any"` on the paired fields so a sub-cent derived per-unit value doesn't mark the input `:invalid` and block browser form submission.

### Tests
`PurchaseOrderFormPage.test.tsx` extended — edit-either in both directions, supplier prefill, submit sends the correct per-unit cost, non-clean division handling.

### Verification (reviewer)
- node24 (v24.18.0): `PurchaseOrderFormPage.test.tsx` vitest + `tsc --noEmit` — PO-form vitest **11/11 passed**; `PurchaseOrderFormPage.tsx` typechecks clean. (A bare `tsc --noEmit` surfaces pre-existing type errors in unrelated files not in this 3-file diff.).
- Diff is 3 frontend files (tsx / css / test); no backend touched, no `package.json` / deps change. (CI runs the full Frontend Lint + Frontend Tests as the authoritative gate.)

### Companion (ScanTTY parity)
`uid0/scantty#101` — TUI PO-create case-cost entry (same derivation, backend payload unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
