### PR TITLE
feat(omr): auto-apply confidently-filled work-order scan marks — two-axis gate (op-f034)

### DIFF
--- a/backend/inventory/services/work_order_cv.py
+++ b/backend/inventory/services/work_order_cv.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import io
 import logging
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import Iterable, Optional
 
 from django.conf import settings
@@ -58,6 +58,13 @@ class Detection:
     ``target_id`` is the AcroForm field name (e.g. ``"task_<uuid>"``) when
     the detection maps to a known checkbox; otherwise ``None`` for free-form
     detections like signatures.
+
+    ``fill_ratio`` / ``confident_checked`` are populated only on the OMR
+    (scan-to-complete) path by ``detections_from_result``: the mark's measured
+    fill fraction and whether that fill sits cleanly in the "checked" band.
+    They drive the two-axis OMR auto-apply decision in ``auto_apply_or_queue``
+    and stay at their inert defaults (``0.0`` / ``False``) on the born-digital
+    signature/OCR path, which splits purely on ``confidence``.
     """
 
     kind: str
@@ -65,9 +72,22 @@ class Detection:
     value: object
     confidence: float
     label: str = ""
+    fill_ratio: float = 0.0
+    confident_checked: bool = False
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        # Wire shape for the born-digital CV pending-review queue
+        # (``work_order_ingest`` serialises queued detections with this). The
+        # OMR-only ``fill_ratio`` / ``confident_checked`` scoring fields are
+        # deliberately excluded — they are an internal auto-apply signal, not
+        # part of this payload.
+        return {
+            "kind": self.kind,
+            "target_id": self.target_id,
+            "value": self.value,
+            "confidence": self.confidence,
+            "label": self.label,
+        }
 
 
 def detect_filled_checkbox(image_bytes: bytes) -> tuple[bool, float]:
@@ -198,16 +218,50 @@ def ocr_handwritten(image_bytes: bytes) -> tuple[str, float]:
 def auto_apply_or_queue(
     detections: Iterable[Detection],
     threshold: Optional[float] = None,
+    *,
+    registration_confidence: Optional[float] = None,
+    reg_min: Optional[float] = None,
 ) -> tuple[list[Detection], list[Detection]]:
-    """Split detections into (auto_apply, queue_for_review) by confidence.
+    """Split detections into ``(auto_apply, queue_for_review)``.
 
     Used by the ingest pipeline to decide which CV-derived changes commit
-    silently and which surface in the digital WO's pending-review panel.
+    silently and which surface in the digital WO's pending-review panel. Two
+    policies share this splitter; both keep the ``(auto, queue)`` shape.
+
+    **OMR two-axis** — selected when ``registration_confidence`` is supplied
+    (the scan-to-complete path). A mark auto-applies IFF the scan registered
+    well enough (``registration_confidence >= reg_min``) AND its fill is
+    confidently CHECKED (``det.confident_checked``). Fill-confidence and
+    registration quality are thus independent axes: a solidly-ticked box on an
+    ordinary (skewed, 4-corner) scan records automatically, while any ambiguous
+    fill — or *every* mark on an inadequately-registered scan (a 3-corner affine
+    read is hard-capped at 0.7, so ``reg_min > 0.7`` sends it wholesale to
+    review) — routes to ``pending_changes``. ``reg_min`` defaults to
+    ``OMR_REG_MIN``.
+
+    **Single-axis confidence** — the default (born-digital signature/OCR path).
+    A detection auto-applies when ``det.confidence >= threshold`` (defaults to
+    ``confidence_threshold()``), a standalone certainty rather than an OMR
+    fill × registration product.
     """
-    if threshold is None:
-        threshold = confidence_threshold()
     auto: list[Detection] = []
     queue: list[Detection] = []
+
+    if registration_confidence is not None:
+        if reg_min is None:
+            from inventory.services.work_order_omr import OMR_REG_MIN
+
+            reg_min = OMR_REG_MIN
+        registration_adequate = registration_confidence >= reg_min
+        for det in detections:
+            if registration_adequate and det.confident_checked:
+                auto.append(det)
+            else:
+                queue.append(det)
+        return auto, queue
+
+    if threshold is None:
+        threshold = confidence_threshold()
     for det in detections:
         if det.confidence >= threshold:
             auto.append(det)

--- a/backend/inventory/services/work_order_ingest.py
+++ b/backend/inventory/services/work_order_ingest.py
@@ -310,11 +310,12 @@ def apply_submission(submission: WorkOrderSubmission) -> WorkOrderSubmission:
     finally:
         submission.attachment.close()
 
-    # OMR scan path (bead-2): a flatbed scan of a printed PM work-order form.
-    # The interactive AcroForm layer is gone, so marks are recovered by
-    # computer vision and — per the 0.999 bar — almost everything routes to
-    # human review. Only PM-completion scans use OMR; 3PWO/LOCPROB keep their
-    # existing QR/text handlers.
+    # OMR scan path (bead-2): a scan of a printed PM work-order form. The
+    # interactive AcroForm layer is gone, so marks are recovered by computer
+    # vision and split by the two-axis auto-apply policy (registration adequacy
+    # × fill confidence): a confidently-filled mark on an adequately-registered
+    # scan applies, everything else routes to human review. Only PM-completion
+    # scans use OMR; 3PWO/LOCPROB keep their existing QR/text handlers.
     if (
         submission.source == WorkOrderSubmission.Source.SCAN
         and submission.kind == WorkOrderSubmission.Kind.PM_COMPLETION
@@ -478,7 +479,7 @@ OMR_FIXED_MARK_LABELS = {
 
 
 def looks_like_scan(raw_bytes: bytes, *, is_image: bool = False) -> bool:
-    """Decide whether an inbound attachment is a flatbed scan (vs born-digital).
+    """Decide whether an inbound attachment is a scan (vs born-digital).
 
     An image attachment is always a scan. A PDF is a scan when its interactive
     AcroForm layer is gone (no ``work_order_id`` field) but it still carries an
@@ -603,7 +604,7 @@ def omr_confirm_completion(
         maintenance_item=item,
         completed_by=user if (user and getattr(user, "is_authenticated", False)) else None,
         notes=(
-            f"Completed via reviewed flatbed scan "
+            f"Completed via reviewed scan "
             f"(submission {submission.id}, WO {work_order.short_id})."
         ),
     )
@@ -633,16 +634,19 @@ def _omr_review(
 
 @transaction.atomic
 def _apply_omr_submission(submission: WorkOrderSubmission, raw_bytes: bytes) -> WorkOrderSubmission:
-    """Read marks off a flatbed OMR scan and stage them for human review.
+    """Read marks off an OMR scan and stage them for human review.
 
-    Marks at confidence ≥ 0.999 pre-check their task/material box; everything
-    else queues to ``pending_changes``. The work order is NEVER auto-advanced
+    Auto-apply is two-axis (``auto_apply_or_queue``): a mark pre-checks its
+    task/material box only when the scan registered adequately
+    (``registration_confidence >= OMR_REG_MIN``) AND the box is confidently
+    filled; every ambiguous fill, and every mark on an inadequately-registered
+    scan, queues to ``pending_changes``. The work order is NEVER auto-advanced
     to COMPLETED here — that transition is gated behind an explicit human
     confirm on the review screen (design rule: never auto-close from a scan).
     """
     from inventory.services.work_order_cv import auto_apply_or_queue
     from inventory.services.work_order_omr import (
-        OMR_AUTO_APPLY_THRESHOLD,
+        OMR_REG_MIN,
         compute_template_version,
         detections_from_result,
         read_omr_scan,
@@ -696,10 +700,14 @@ def _apply_omr_submission(submission: WorkOrderSubmission, raw_bytes: bytes) -> 
         )
 
     detections = detections_from_result(result)
-    auto, queue = auto_apply_or_queue(detections, threshold=OMR_AUTO_APPLY_THRESHOLD)
+    auto, queue = auto_apply_or_queue(
+        detections,
+        registration_confidence=result.registration_confidence,
+        reg_min=OMR_REG_MIN,
+    )
 
     now = timezone.now()
-    note = "Pre-checked from flatbed scan (OMR, pending confirmation)."
+    note = "Pre-checked from scan (OMR, pending confirmation)."
     task_titles = {str(tc.id): tc.task_title for tc in work_order.task_completions.all()}
     material_names = {str(mu.id): mu.material_name for mu in work_order.material_usage.all()}
 

--- a/backend/inventory/services/work_order_omr.py
+++ b/backend/inventory/services/work_order_omr.py
@@ -111,22 +111,24 @@ def build_and_persist_omr_template(
 # bead-2: the scan reader
 # ---------------------------------------------------------------------------
 #
-# Given a flatbed scan of a printed OMR form and the WO's persisted
+# Given a scan of a printed OMR form and the WO's persisted
 # :class:`WorkOrderOmrTemplate` snapshot, recover the 4 corner fiducials, warp
 # the scan into template space, and threshold every ``regions_json`` region so
-# each mark becomes a ``(marked, confidence)`` read. Registration quality
-# multiplies down every region's confidence — a poorly-aligned scan drags the
-# whole page under the auto-apply bar and routes it to human review.
+# each mark becomes a ``(marked, confidence, fill_ratio)`` read. The scan-level
+# ``registration_confidence`` and each mark's fill are then weighed as two
+# independent axes at auto-apply time (``work_order_cv.auto_apply_or_queue``):
+# an inadequately-registered scan routes wholesale to review, while a
+# well-registered one auto-applies only its confidently-filled marks.
 
 # Canonical warp resolution (dpi). 200dpi keeps a 10pt checkbox ~28px wide —
 # comfortably above the threshold floor — without ballooning the warp buffer.
 CANON_DPI = 200
 
-# Only a near-perfect fiducial quad may auto-apply: with the 0.999 confidence
-# bar, registration and per-region confidence *multiply*, so registration must
-# round to 1.0 for a clean scan or nothing could ever clear the bar. A quad
-# this rectangular is geometrically aligned; subpixel marker-center jitter on a
-# genuinely-square scan should not, by itself, force review.
+# A near-perfect fiducial quad snaps its registration confidence to exactly 1.0.
+# A quad this rectangular is geometrically aligned; subpixel marker-center
+# jitter on a genuinely-square scan should not drag ``registration_confidence``
+# toward the ``OMR_REG_MIN`` auto-apply floor, nor pull the per-region displayed
+# confidence (which still scales by this score) off a clean 1.0.
 _REG_SNAP_TO_ONE = 0.997
 
 # Fraction of each region rect trimmed on every side before thresholding, so
@@ -220,9 +222,11 @@ def _rectangularity(centers: dict) -> float:
 
     1.0 for an axis-aligned rectangle (a flat, square-on scan); it falls off
     with shear (skew) and keystoning (perspective), and collapses toward 0 for
-    a grossly misdetected / non-convex quad. This is the key robustness lever:
-    the score multiplies every region's confidence, so a warped scan can never
-    clear the 0.999 bar and routes wholesale to review.
+    a grossly misdetected / non-convex quad. It is the scan's
+    ``registration_confidence`` — the registration axis of the auto-apply
+    decision: a read below ``OMR_REG_MIN`` (in particular any 3-corner affine
+    read, hard-capped at 0.7) routes wholesale to review, independent of how
+    confidently any individual box is filled.
     """
     try:
         p = {c: np.asarray(centers[c], dtype=np.float64) for c in ("tl", "tr", "br", "bl")}
@@ -392,8 +396,8 @@ def _register_and_warp(gray, fiducials: dict, page_w_pt: float, page_h_pt: float
         dpts = np.array([dst[c] for c in present], dtype=np.float32)
         matrix = cv2.getAffineTransform(src, dpts)
         warp = cv2.warpAffine(gray, matrix, (w_px, h_px), borderValue=255, flags=cv2.INTER_LINEAR)
-        # An affine model cannot correct keystoning; cap confidence hard so a
-        # 3-corner read can never clear the 0.999 bar (always routes to review).
+        # An affine model cannot correct keystoning; cap confidence at 0.7 so a
+        # 3-corner read stays below OMR_REG_MIN and always routes to review.
         return warp, 0.7, None
 
     return None, 0.0, "could not align form: fewer than 3 corner fiducials detected"
@@ -515,13 +519,18 @@ def detections_from_result(result: OmrReadResult) -> list:
     """Convert an :class:`OmrReadResult` into ``work_order_cv.Detection`` rows.
 
     Only *marked* regions and *uncertain* reads are emitted — a confidently
-    blank checkbox is a no-op and would only clutter the review queue. The
-    caller splits these on the 0.999 bar via ``auto_apply_or_queue``.
+    blank checkbox is a no-op and would only clutter the review queue. Each
+    detection carries its ``fill_ratio`` and a ``confident_checked`` flag (the
+    mark is present AND its fill sits cleanly in the "on" band); the caller
+    pairs that per-mark fill-confidence with the scan-level
+    ``registration_confidence`` in ``auto_apply_or_queue`` to decide auto-apply
+    vs review.
     """
     from inventory.services.work_order_cv import Detection
 
     detections: list = []
     for read in result.reads:
+        on = _INK_ON if read.kind == "ink" else _CHECK_ON
         off = _INK_OFF if read.kind == "ink" else _CHECK_OFF
         if not read.marked and read.fill_ratio <= off:
             continue  # clearly empty box — a no-op that would only clutter review
@@ -532,12 +541,19 @@ def detections_from_result(result: OmrReadResult) -> list:
                 value=bool(read.marked),
                 confidence=float(read.confidence),
                 label="",
+                fill_ratio=float(read.fill_ratio),
+                confident_checked=bool(read.marked and read.fill_ratio >= on),
             )
         )
     return detections
 
 
-# The scan auto-apply bar (Ian, 07-08): a mark commits silently ONLY at
-# confidence >= 0.999; everything below routes to human review. Deliberately
-# near-1.0 so, in practice, almost every scanned mark is confirmed by a person.
-OMR_AUTO_APPLY_THRESHOLD = 0.999
+# Scan auto-apply policy (Ian, 07-14 — revises the 07-08 flatbed-only 0.999
+# bar). Auto-apply is two-axis (see ``work_order_cv.auto_apply_or_queue``): a
+# mark commits silently only when the scan registered adequately AND its box is
+# confidently filled. ``OMR_REG_MIN`` is the registration floor for the
+# "adequate" half. It MUST stay above the 0.7 three-corner affine cap
+# (``_register_and_warp``) so any read with fewer than 4 recovered fiducials
+# always routes to human review; a clean or ordinarily-skewed 4-corner scan
+# clears it, and only then do its confidently-checked marks auto-apply.
+OMR_REG_MIN = 0.8

--- a/backend/inventory/tests/test_work_order_omr_reader.py
+++ b/backend/inventory/tests/test_work_order_omr_reader.py
@@ -1,8 +1,11 @@
-"""Tests for the OMR scan reader + scan-ingestion pipeline (op-6pc8, bead-2).
+"""Tests for the OMR scan reader + scan-ingestion pipeline (op-6pc8, bead-2;
+two-axis auto-apply revised in op-f034).
 
 bead-1 printed the form + fiducials and persisted a region map; this reader
-aligns a *scan*, thresholds each mark, and — per Ian's 0.999 confidence bar —
-routes almost everything to human review and NEVER auto-closes a work order.
+aligns a *scan*, thresholds each mark, and applies the two-axis auto-apply
+policy — a mark records automatically only when the scan registered adequately
+(``registration_confidence >= OMR_REG_MIN``) AND the box is confidently filled,
+otherwise it routes to human review — and NEVER auto-closes a work order.
 
 The synthetic harness renders fiducials + checkboxes + a QR directly into
 canonical template space (there is no PDF rasterizer in the venv), stamps known
@@ -29,14 +32,19 @@ from inventory.models import (
     MaintenanceLog,
     MaintenanceTask,
     WorkOrder,
+    WorkOrderMaterialUsage,
     WorkOrderSubmission,
     WorkOrderTaskCompletion,
 )
 from inventory.services import work_order_omr as omr
+from inventory.services.work_order_cv import Detection, auto_apply_or_queue
 from inventory.services.work_order_ingest import apply_submission
 from inventory.services.work_order_omr import (
-    OMR_AUTO_APPLY_THRESHOLD,
+    OMR_REG_MIN,
+    OmrReadResult,
+    OmrRegionRead,
     build_and_persist_omr_template,
+    detections_from_result,
     read_omr_scan,
 )
 from inventory.tests.test_work_order_omr import (
@@ -183,9 +191,10 @@ class TestReader:
         assert by_id[tasks[0]].marked is True
         assert by_id[tasks[1]].marked is True
         assert by_id[tasks[2]].marked is False
-        # the two clear marks clear the auto-apply bar; the blank does not read.
-        assert by_id[tasks[0]].confidence >= OMR_AUTO_APPLY_THRESHOLD
-        assert by_id[tasks[1]].confidence >= OMR_AUTO_APPLY_THRESHOLD
+        # the two clear marks are confidently CHECKED (fill in the on-band);
+        # the blank does not read at all.
+        assert by_id[tasks[0]].fill_ratio >= omr._CHECK_ON
+        assert by_id[tasks[1]].fill_ratio >= omr._CHECK_ON
 
     def test_marginal_mark_is_uncertain(self):
         wo = _make_work_order(num_tasks=2)
@@ -193,9 +202,16 @@ class TestReader:
         tasks = _task_target_ids(template)
         result = read_omr_scan(_synth_scan(template, marks={tasks[0]: "marginal"}), template)
         by_id = {r.target_id: r for r in result.reads}
-        assert by_id[tasks[0]].confidence < OMR_AUTO_APPLY_THRESHOLD
+        # a marginal mark lands in the ambiguous band — above "off" (so it still
+        # surfaces for review) but below the "on" bar, so it is NOT confidently
+        # CHECKED and will never auto-apply, regardless of registration.
+        assert omr._CHECK_OFF < by_id[tasks[0]].fill_ratio < omr._CHECK_ON
 
-    def test_skew_drags_all_reads_below_bar(self):
+    def test_ordinary_skewed_4corner_scan_is_adequate_for_auto_apply(self):
+        # The decisive op-f034 behaviour change: an ordinary hand-fed skewed scan
+        # is NOT flatbed-perfect (reg < 1.0) yet still registers adequately off
+        # its 4 corners (reg >= OMR_REG_MIN), so its solidly-filled boxes qualify
+        # for auto-apply — the retired 0.999 bar wrongly queued exactly these.
         wo = _make_work_order(num_tasks=3)
         template = _persisted(wo)
         tasks = _task_target_ids(template)
@@ -206,9 +222,25 @@ class TestReader:
             _synth_scan(template, marks={t: "full" for t in tasks}, warp_dst=warp_dst),
             template,
         )
-        assert result.ok  # still aligned (4 fiducials) — just not confidently
-        assert result.registration_confidence < OMR_AUTO_APPLY_THRESHOLD
-        assert all(r.confidence < OMR_AUTO_APPLY_THRESHOLD for r in result.reads)
+        assert result.ok  # aligned off 4 fiducials
+        # adequate for auto-apply, but demonstrably not a flatbed-perfect scan.
+        assert OMR_REG_MIN <= result.registration_confidence < 1.0
+        marks = [r for r in result.reads if r.target_id in tasks]
+        assert marks and all(r.fill_ratio >= omr._CHECK_ON for r in marks)
+
+    def test_three_corner_read_is_inadequate(self):
+        # Exactly one corner missing → affine fallback hard-capped at 0.7, which
+        # sits below OMR_REG_MIN so the whole page routes to review even though
+        # the box is solidly filled.
+        wo = _make_work_order(num_tasks=2)
+        template = _persisted(wo)
+        tasks = _task_target_ids(template)
+        result = read_omr_scan(
+            _synth_scan(template, marks={tasks[0]: "full"}, drop_fiducials=("tl",)), template
+        )
+        assert result.ok  # 3 corners still align (affine)
+        assert result.registration_confidence == pytest.approx(0.7)
+        assert result.registration_confidence < OMR_REG_MIN
 
     def test_brightness_gradient_still_reads_marks(self):
         wo = _make_work_order(num_tasks=2)
@@ -219,7 +251,7 @@ class TestReader:
         )
         by_id = {r.target_id: r for r in result.reads}
         assert by_id[tasks[0]].marked is True
-        assert by_id[tasks[0]].confidence >= OMR_AUTO_APPLY_THRESHOLD
+        assert by_id[tasks[0]].fill_ratio >= omr._CHECK_ON
 
     def test_missing_fiducials_fail_registration(self):
         wo = _make_work_order(num_tasks=2)
@@ -254,7 +286,10 @@ class TestScanIngestion:
         assert tasks[0] in by_id
         assert by_id[tasks[0]]["auto_applied"] is True
         assert by_id[tasks[0]]["crop_url"].endswith(f"/mark-crop/{tasks[0]}/")
-        assert by_id[tasks[0]]["confidence"] >= OMR_AUTO_APPLY_THRESHOLD
+        # auto-applied because registration was adequate AND the fill was
+        # confidently in the "on" band (a clean scan → high displayed confidence).
+        assert by_id[tasks[0]]["confidence"] >= 0.9
+        assert sub.parsed_fields["registration_confidence"] >= OMR_REG_MIN
 
     def test_scan_never_auto_closes_work_order(self):
         wo = _make_work_order(num_tasks=2, all_required=True)
@@ -313,7 +348,9 @@ class TestScanIngestion:
         by_id = {c["target_id"]: c for c in sub.pending_changes}
         assert tasks[0] in by_id
         assert by_id[tasks[0]]["auto_applied"] is False
-        assert by_id[tasks[0]]["confidence"] < OMR_AUTO_APPLY_THRESHOLD
+        # queued on the FILL axis: registration was adequate (a clean scan), but
+        # the ambiguous fill is not confidently CHECKED, so it never auto-applies.
+        assert sub.parsed_fields["registration_confidence"] >= OMR_REG_MIN
 
     def test_template_version_mismatch_routes_to_review(self):
         wo = _make_work_order(num_tasks=2)
@@ -369,6 +406,95 @@ class TestScanIngestion:
         sub.refresh_from_db()
         assert sub.status == WorkOrderSubmission.Status.PENDING_REVIEW
         assert "align" in sub.parse_error.lower()
+
+    def test_ordinary_skewed_scan_auto_applies_solid_marks(self):
+        # End-to-end headline regression (op-f034): a solidly-ticked box on an
+        # ordinary skewed (non-flatbed) 4-corner scan now records automatically,
+        # advancing OPEN → IN_PROGRESS — the retired 0.999 bar queued these.
+        wo = _make_work_order(num_tasks=3)
+        template = _persisted(wo)
+        tasks = _task_target_ids(template)
+        w = int(round(template.page_w_pt / 72.0 * DPI))
+        h = int(round(template.page_h_pt / 72.0 * DPI))
+        warp_dst = np.float32([[40, 30], [w - 20, 70], [w - 60, h - 40], [30, h - 25]])
+        scan = _synth_scan(template, wo_id=wo.id, marks={tasks[0]: "full"}, warp_dst=warp_dst)
+        sub = _submission_for(wo, scan)
+        apply_submission(sub)
+        sub.refresh_from_db()
+        wo.refresh_from_db()
+
+        assert sub.status == WorkOrderSubmission.Status.PENDING_REVIEW
+        assert OMR_REG_MIN <= sub.parsed_fields["registration_confidence"] < 1.0
+        tc0 = WorkOrderTaskCompletion.objects.get(id=tasks[0][len("task_") :])
+        assert tc0.is_completed is True  # auto-applied despite the skew
+        by_id = {c["target_id"]: c for c in sub.pending_changes}
+        assert by_id[tasks[0]]["auto_applied"] is True
+        assert wo.status == WorkOrder.Status.IN_PROGRESS  # progressed, never COMPLETED
+
+    def test_three_corner_scan_queues_all_marks(self):
+        # A 3-corner (affine, reg 0.7) scan is inadequate: even a solid mark
+        # routes to review, nothing is applied, and the WO stays OPEN.
+        wo = _make_work_order(num_tasks=2)
+        template = _persisted(wo)
+        tasks = _task_target_ids(template)
+        scan = _synth_scan(template, wo_id=wo.id, marks={tasks[0]: "full"}, drop_fiducials=("tl",))
+        sub = _submission_for(wo, scan)
+        apply_submission(sub)
+        sub.refresh_from_db()
+        wo.refresh_from_db()
+
+        assert sub.status == WorkOrderSubmission.Status.PENDING_REVIEW
+        assert sub.parsed_fields["registration_confidence"] < OMR_REG_MIN
+        tc0 = WorkOrderTaskCompletion.objects.get(id=tasks[0][len("task_") :])
+        assert tc0.is_completed is False  # inadequate registration → queued
+        by_id = {c["target_id"]: c for c in sub.pending_changes}
+        assert tasks[0] in by_id
+        assert by_id[tasks[0]]["auto_applied"] is False
+        assert wo.status == WorkOrder.Status.OPEN  # nothing applied
+
+    def test_two_axis_matrix_through_apply(self, monkeypatch):
+        # Craft reads (registration + fill controlled directly) to drive every
+        # branch through _apply_omr_submission in one pass: solid task + solid
+        # material auto-apply on an adequately-registered scan; an ambiguous-fill
+        # task queues. WO advances OPEN → IN_PROGRESS but is NEVER COMPLETED.
+        wo = _make_wo_with_materials(num_tasks=2, num_materials=1)
+        template = _persisted(wo)
+        tasks = _task_target_ids(template)
+        mu = wo.material_usage.first()
+        material_tid = f"material_{mu.id}"
+
+        crafted = OmrReadResult(
+            ok=True,
+            registration_confidence=0.9,  # adequate (>= OMR_REG_MIN)
+            recovered_work_order_id=str(wo.id),
+            reads=[
+                OmrRegionRead(tasks[0], "checkbox", True, 0.9, 1.0),  # solid → auto
+                OmrRegionRead(tasks[1], "checkbox", True, 0.6, 0.15),  # ambiguous → queue
+                OmrRegionRead(material_tid, "checkbox", True, 0.9, 1.0),  # solid → auto
+            ],
+            canonical_size=(100, 100),
+        )
+        monkeypatch.setattr(omr, "read_omr_scan", lambda *a, **k: crafted)
+
+        sub = _submission_for(wo, _synth_scan(template, wo_id=wo.id))
+        apply_submission(sub)
+        sub.refresh_from_db()
+        wo.refresh_from_db()
+
+        assert WorkOrderTaskCompletion.objects.get(id=tasks[0][len("task_") :]).is_completed is True
+        assert WorkOrderMaterialUsage.objects.get(id=mu.id).was_used is True
+        assert (
+            WorkOrderTaskCompletion.objects.get(id=tasks[1][len("task_") :]).is_completed is False
+        )
+
+        by_id = {c["target_id"]: c for c in sub.pending_changes}
+        assert by_id[tasks[0]]["auto_applied"] is True
+        assert by_id[material_tid]["auto_applied"] is True
+        assert by_id[tasks[1]]["auto_applied"] is False
+
+        assert wo.status == WorkOrder.Status.IN_PROGRESS
+        assert wo.completed_at is None
+        assert sub.status == WorkOrderSubmission.Status.PENDING_REVIEW
 
 
 # ---------------------------------------------------------------------------
@@ -436,3 +562,77 @@ class TestReviewFlow:
         # one row applied, one still queued → stays in review
         assert sub.status == WorkOrderSubmission.Status.PENDING_REVIEW
         assert len(sub.pending_changes) == 1
+
+
+# ---------------------------------------------------------------------------
+# two-axis auto-apply decision (op-f034) — pure unit, no CV/DB
+# ---------------------------------------------------------------------------
+class TestAutoApplyPolicy:
+    """The registration × fill-confidence split in ``auto_apply_or_queue`` and
+    the ``confident_checked`` flag ``detections_from_result`` derives."""
+
+    def _det(self, *, confident_checked, value=True, fill_ratio=1.0):
+        return Detection(
+            kind="checkbox",
+            target_id="task_x",
+            value=value,
+            confidence=0.5,  # irrelevant under the OMR two-axis policy
+            fill_ratio=fill_ratio,
+            confident_checked=confident_checked,
+        )
+
+    def test_reg_min_above_three_corner_cap(self):
+        # 3-corner affine reads are hard-capped at 0.7; the floor must exceed it
+        # so those reads always route to review.
+        assert OMR_REG_MIN > 0.7
+
+    def test_solid_fill_adequate_registration_auto_applies(self):
+        det = self._det(confident_checked=True)
+        auto, queue = auto_apply_or_queue([det], registration_confidence=0.85, reg_min=OMR_REG_MIN)
+        assert auto == [det]
+        assert queue == []
+
+    def test_solid_fill_three_corner_registration_queues(self):
+        det = self._det(confident_checked=True)
+        auto, queue = auto_apply_or_queue([det], registration_confidence=0.7, reg_min=OMR_REG_MIN)
+        assert auto == []
+        assert queue == [det]
+
+    def test_ambiguous_fill_adequate_registration_queues(self):
+        det = self._det(confident_checked=False, fill_ratio=0.15)
+        auto, queue = auto_apply_or_queue([det], registration_confidence=0.99, reg_min=OMR_REG_MIN)
+        assert auto == []
+        assert queue == [det]
+
+    def test_reg_min_defaults_to_omr_reg_min(self):
+        # Exactly at the floor is adequate (>=); reg_min falls back to OMR_REG_MIN.
+        det = self._det(confident_checked=True)
+        auto, _queue = auto_apply_or_queue([det], registration_confidence=OMR_REG_MIN)
+        assert auto == [det]
+
+    def test_single_axis_confidence_path_is_unchanged(self):
+        # Without ``registration_confidence`` the born-digital confidence split
+        # still applies and ``confident_checked`` is ignored.
+        hi = Detection(kind="signature", target_id=None, value=True, confidence=0.95)
+        lo = Detection(kind="handwritten", target_id=None, value="x", confidence=0.4)
+        auto, queue = auto_apply_or_queue([hi, lo], threshold=0.7)
+        assert auto == [hi]
+        assert queue == [lo]
+
+    def test_detections_from_result_flags_confident_checked_and_drops_empty(self):
+        result = OmrReadResult(
+            ok=True,
+            registration_confidence=1.0,
+            reads=[
+                OmrRegionRead("task_solid", "checkbox", True, 1.0, 0.90),  # confident checked
+                OmrRegionRead("task_amb", "checkbox", True, 0.6, 0.15),  # ambiguous
+                OmrRegionRead("task_blank", "checkbox", False, 0.98, 0.01),  # confident empty
+                OmrRegionRead("tech_initials", "ink", True, 1.0, 0.09),  # ink, confident
+            ],
+        )
+        dets = {d.target_id: d for d in detections_from_result(result)}
+        assert "task_blank" not in dets  # confidently-empty box dropped as a no-op
+        assert dets["task_solid"].confident_checked is True
+        assert dets["task_solid"].fill_ratio == pytest.approx(0.90)
+        assert dets["task_amb"].confident_checked is False
+        assert dets["tech_initials"].confident_checked is True  # 0.09 >= _INK_ON (0.05)


### PR DESCRIPTION
## Why

Techs fill the OMR checkboxes on a printed work order, scan/email it back, and the marks "don't get recorded." The scan-back path already writes marks through and shows them in the per-WO review panel — but the auto-apply gate was `confidence >= 0.999`, where `confidence = fill_certainty × registration_confidence`. Registration only rounds to ~1.0 on a flatbed scan, so any phone photo / skew kept every mark under the bar and routed the whole sheet to manual review. (That 0.999 bar was a deliberate 07-08 conservative choice; opted into auto-apply on 07-14.)

## What

Replace the single multiplicative bar with a **two-axis** policy in `auto_apply_or_queue`:

- **Registration axis (per scan):** `registration_confidence >= OMR_REG_MIN` (0.8). A 3-corner affine read is hard-capped at 0.7, so any read with < 4 recovered fiducials still routes wholesale to review.
- **Fill axis (per mark):** `confident_checked` — the box is marked AND its fill sits cleanly in the "on" band.
- A mark auto-applies **iff both** hold; every ambiguous fill, and every mark on an inadequately-registered scan, still queues to `pending_changes`.

The born-digital signature/OCR path is unchanged (still splits on `confidence >= threshold`).

## Safety (unchanged)

- A scan **never auto-closes** a WO — completion still requires the explicit human confirm.
- Auto-applied marks still appear in the review panel flagged `auto_applied` and stay reversible.
- The pending-review wire payload shape is unchanged (`Detection.to_dict` excludes the new internal scoring fields).

## Scope

Backend-only — the three OMR service files + tests. No new endpoint / model / migration, no PDF change, no inventory side-effects (deliberately deferred to follow-on PRs).

## Tests

`test_work_order_omr_reader.py` +232 lines across the matrix (solid fill + adequate reg → auto; solid fill + 3-corner → queue; ambiguous → queue; confident-empty → skipped) and asserting `OMR_REG_MIN > 0.7`.

Verified locally: **61 passed** (`test_work_order_omr_reader` / `test_work_order_ingest` / `test_work_order_omr`, `--reuse-db`). The 85% coverage line only reflects the 3-file subset run locally; full-suite coverage runs in CI.

Bead: `op-f034` · epic PR 1 of 4 (auto-apply → notify/verify → consumed-decrement → LOTO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)