### PR TITLE
feat(omr): scan-review notification + per-WO badge + paper-scan verification (op-o6rs)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -1777,6 +1777,9 @@ views:
       retrieve:
         permission_classes:
         - IsAuthenticatedOrStaffSigAdminWrite
+      scan_image:
+        permission_classes:
+        - IsAuthenticated
       toggle_material:
         permission_classes:
         - IsAuthenticatedOrStaffSigAdminWrite

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -2040,6 +2040,21 @@ class WorkOrderValidationSerializer(serializers.ModelSerializer):
         return None
 
 
+def _pending_review_count(work_order) -> int:
+    """Count a WO's PENDING_REVIEW submissions from the prefetched cache.
+
+    Reads ``work_order.submissions.all()`` with no filter/order override so it
+    hits the ``prefetch_related("submissions")`` cache on the list/detail
+    queryset instead of firing a query per row (N+1). Drives the "N scanned
+    marks to review" badge on the WO list rows + detail header (op-o6rs).
+    """
+    return sum(
+        1
+        for s in work_order.submissions.all()
+        if s.status == WorkOrderSubmission.Status.PENDING_REVIEW
+    )
+
+
 class WorkOrderSerializer(serializers.ModelSerializer):
     """Full serializer for a work order, including nested completions and photos."""
 
@@ -2054,6 +2069,8 @@ class WorkOrderSerializer(serializers.ModelSerializer):
     material_usage = WorkOrderMaterialUsageSerializer(many=True, read_only=True)
     photos = WorkOrderPhotoSerializer(many=True, read_only=True)
     submissions = serializers.SerializerMethodField()
+    pending_review_count = serializers.SerializerMethodField()
+    has_pending_review = serializers.SerializerMethodField()
     electrical = serializers.SerializerMethodField()
     loto = serializers.SerializerMethodField()
     validation = serializers.SerializerMethodField()
@@ -2080,6 +2097,8 @@ class WorkOrderSerializer(serializers.ModelSerializer):
             "material_usage",
             "photos",
             "submissions",
+            "pending_review_count",
+            "has_pending_review",
             "electrical",
             "loto",
             "validation",
@@ -2095,10 +2114,18 @@ class WorkOrderSerializer(serializers.ModelSerializer):
             "material_usage",
             "photos",
             "submissions",
+            "pending_review_count",
+            "has_pending_review",
             "electrical",
             "loto",
             "validation",
         ]
+
+    def get_pending_review_count(self, obj):
+        return _pending_review_count(obj)
+
+    def get_has_pending_review(self, obj):
+        return _pending_review_count(obj) > 0
 
     def get_submissions(self, obj):
         qs = obj.submissions.all().order_by("-received_at")
@@ -2137,6 +2164,8 @@ class WorkOrderListSerializer(serializers.ModelSerializer):
     is_overdue = serializers.ReadOnlyField()
     task_completion_count = serializers.SerializerMethodField()
     task_total_count = serializers.SerializerMethodField()
+    pending_review_count = serializers.SerializerMethodField()
+    has_pending_review = serializers.SerializerMethodField()
 
     class Meta:
         model = WorkOrder
@@ -2155,6 +2184,8 @@ class WorkOrderListSerializer(serializers.ModelSerializer):
             "completed_at",
             "task_completion_count",
             "task_total_count",
+            "pending_review_count",
+            "has_pending_review",
             "created_at",
             "updated_at",
         ]
@@ -2164,6 +2195,12 @@ class WorkOrderListSerializer(serializers.ModelSerializer):
 
     def get_task_total_count(self, obj):
         return obj.task_completions.count()
+
+    def get_pending_review_count(self, obj):
+        return _pending_review_count(obj)
+
+    def get_has_pending_review(self, obj):
+        return _pending_review_count(obj) > 0
 
 
 class StockReconciliationSerializer(serializers.ModelSerializer):

--- a/backend/inventory/services/work_order_ingest.py
+++ b/backend/inventory/services/work_order_ingest.py
@@ -611,6 +611,49 @@ def omr_confirm_completion(
     return True
 
 
+def _notify_wo_scanned(
+    submission: WorkOrderSubmission, work_order: Optional[WorkOrder], *, degraded: bool
+) -> None:
+    """Fire an app-wide "a scan needs review" notification for a scanned-in WO.
+
+    Registered via ``transaction.on_commit`` at each terminal PENDING_REVIEW
+    save (the clean read at the end of ``_apply_omr_submission`` and the
+    degraded ``_omr_review`` path) so it fires exactly once per ingest and only
+    after the ingest actually commits — never on a rolled-back atomic block, and
+    never from ``_omr_fail`` (a hard failure is out of scope). Wrapped so a
+    notification failure can never break ingest (precedent: ``inventory/views``
+    ``add_photo``). Consumers: the existing header bell / notification centre,
+    which polls; the ``action_url`` deep-links to the WO review screen.
+    """
+    if work_order is None:
+        return
+    try:
+        from notifications.services import notify_admins
+
+        count = len(submission.pending_changes or [])
+        if degraded:
+            message = (
+                f"{work_order.short_id} scanned in but could not be read cleanly "
+                "— open it to review by hand."
+            )
+        else:
+            noun = "mark" if count == 1 else "marks"
+            message = f"{work_order.short_id} scanned in — {count} {noun} to confirm."
+        notify_admins(
+            type="warning",
+            title="Work order scanned — needs review",
+            message=message,
+            action_url=f"/maintenance/work-orders/{work_order.id}",
+            metadata={
+                "work_order_id": str(work_order.id),
+                "submission_id": str(submission.id),
+                "kind": "work_order_scanned",
+            },
+        )
+    except Exception:  # noqa: BLE001 - a notification must never break ingest
+        logger.exception("Failed to emit scan-in notification for submission %s", submission.id)
+
+
 def _omr_fail(submission: WorkOrderSubmission, message: str) -> WorkOrderSubmission:
     """Unrecoverable scan (no WO id / WO missing): mark FAILED."""
     submission.status = WorkOrderSubmission.Status.FAILED
@@ -629,6 +672,8 @@ def _omr_review(
     submission.parse_error = message
     submission.pending_changes = []
     submission.save(update_fields=["status", "parse_error", "work_order", "pending_changes"])
+    # Degraded scans still need a human — surface them app-wide too (op-o6rs).
+    transaction.on_commit(lambda: _notify_wo_scanned(submission, work_order, degraded=True))
     return submission
 
 
@@ -753,6 +798,9 @@ def _apply_omr_submission(submission: WorkOrderSubmission, raw_bytes: bytes) -> 
     submission.save(
         update_fields=["status", "work_order", "parsed_fields", "parse_error", "pending_changes"]
     )
+    # A scanned WO is back and awaiting a human confirm — notify app-wide once
+    # the atomic ingest commits (op-o6rs). on_commit avoids notifying on rollback.
+    transaction.on_commit(lambda: _notify_wo_scanned(submission, work_order, degraded=False))
     return submission
 
 

--- a/backend/inventory/tests/test_work_order_omr_reader.py
+++ b/backend/inventory/tests/test_work_order_omr_reader.py
@@ -18,7 +18,11 @@ from __future__ import annotations
 
 import io
 
+from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.utils.crypto import get_random_string
 
 import cv2
 import numpy as np
@@ -52,8 +56,11 @@ from inventory.tests.test_work_order_omr import (
     _make_work_order,
     _staff_client,
 )
+from notifications.models import Notification
 
 pytestmark = pytest.mark.django_db
+
+User = get_user_model()
 
 DPI = omr.CANON_DPI
 FID_SIZE_PT = 30.0
@@ -521,6 +528,22 @@ class TestReviewFlow:
         assert resp["Content-Type"] == "image/png"
         assert resp.content[:8] == b"\x89PNG\r\n\x1a\n"
 
+    def test_scan_image_endpoint_returns_full_page_png(self):
+        # op-o6rs: the reviewer verifies the marks against the whole paper form,
+        # so the endpoint renders the full scanned page (not a per-mark crop).
+        wo, sub, _tasks = self._staged()
+        client, _user = _staff_client()
+        resp = client.get(f"/api/inventory/work-orders/{wo.id}/submissions/{sub.id}/scan-image/")
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp["Content-Type"] == "image/png"
+        assert resp.content[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_scan_image_endpoint_404s_unknown_submission(self):
+        wo, _sub, _tasks = self._staged()
+        client, _user = _staff_client()
+        resp = client.get(f"/api/inventory/work-orders/{wo.id}/submissions/{wo.id}/scan-image/")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
     def test_per_row_reject_undoes_autoapply(self):
         wo, sub, tasks = self._staged(mark_count=1)
         tc0 = WorkOrderTaskCompletion.objects.get(id=tasks[0][len("task_") :])
@@ -636,3 +659,180 @@ class TestAutoApplyPolicy:
         assert dets["task_solid"].fill_ratio == pytest.approx(0.90)
         assert dets["task_amb"].confident_checked is False
         assert dets["tech_initials"].confident_checked is True  # 0.09 >= _INK_ON (0.05)
+
+
+# ---------------------------------------------------------------------------
+# scan-in notification (op-o6rs): a scan landing in review notifies app-wide
+# ---------------------------------------------------------------------------
+NOTIFY_TITLE = "Work order scanned — needs review"
+
+
+class TestScanNotification:
+    """A SCAN → PENDING_REVIEW ingest fans out exactly one app-wide notification
+    (one row per staff user, not duplicated across the pipeline's several
+    saves); the degraded ``_omr_review`` path notifies too; the ``_omr_fail``
+    hard-failure path does not; and a notification failure never breaks ingest.
+    """
+
+    def _staff(self, n=2):
+        return [
+            User.objects.create_user(
+                username=f"staff_{i}_{get_random_string(5)}",
+                email=f"staff{i}@example.com",
+                password=get_random_string(24),
+                is_staff=True,
+                is_active=True,
+            )
+            for i in range(n)
+        ]
+
+    def test_clean_scan_notifies_admins_exactly_once(self, django_capture_on_commit_callbacks):
+        staff = self._staff(2)
+        wo = _make_work_order(num_tasks=3)
+        template = _persisted(wo)
+        tasks = _task_target_ids(template)
+        scan = _synth_scan(template, wo_id=wo.id, marks={tasks[0]: "full"})
+        sub = _submission_for(wo, scan)
+
+        with django_capture_on_commit_callbacks(execute=True) as callbacks:
+            apply_submission(sub)
+
+        # exactly one on_commit hook despite the pipeline's several saves
+        assert len(callbacks) == 1
+        notes = Notification.objects.filter(title=NOTIFY_TITLE)
+        # one row per staff user — not duplicated
+        assert notes.count() == len(staff)
+        n = notes.first()
+        assert n.type == "warning"
+        assert n.action_url == f"/maintenance/work-orders/{wo.id}"
+        assert n.metadata["work_order_id"] == str(wo.id)
+        assert n.metadata["submission_id"] == str(sub.id)
+        assert n.metadata["kind"] == "work_order_scanned"
+
+    def test_notification_is_deferred_until_commit(self, django_capture_on_commit_callbacks):
+        # No notification exists until the ingest transaction actually commits —
+        # a rolled-back ingest must never notify (on_commit, not inline).
+        self._staff(1)
+        wo = _make_work_order(num_tasks=2)
+        template = _persisted(wo)
+        scan = _synth_scan(template, wo_id=wo.id, marks={_task_target_ids(template)[0]: "full"})
+        sub = _submission_for(wo, scan)
+
+        with django_capture_on_commit_callbacks(execute=False):
+            apply_submission(sub)
+            # inside the block the commit hasn't run yet
+            assert not Notification.objects.filter(title=NOTIFY_TITLE).exists()
+
+    def test_degraded_scan_notifies(self, django_capture_on_commit_callbacks):
+        staff = self._staff(1)
+        wo = _make_work_order(num_tasks=2)
+        template = _persisted(wo)
+        scan = _synth_scan(template, wo_id=wo.id, marks={_task_target_ids(template)[0]: "full"})
+        wo.omr_templates.all().delete()  # no template on file → _omr_review path
+        sub = _submission_for(wo, scan)
+
+        with django_capture_on_commit_callbacks(execute=True):
+            apply_submission(sub)
+        sub.refresh_from_db()
+
+        assert sub.status == WorkOrderSubmission.Status.PENDING_REVIEW
+        assert Notification.objects.filter(title=NOTIFY_TITLE, user__in=staff).count() == len(staff)
+
+    def test_failed_scan_does_not_notify(self, django_capture_on_commit_callbacks):
+        import uuid
+
+        self._staff(1)
+        wo = _make_work_order(num_tasks=2)
+        template = _persisted(wo)
+        scan = _synth_scan(template, wo_id=uuid.uuid4(), marks={})  # unresolvable WO id
+        sub = _submission_for(wo, scan)
+
+        with django_capture_on_commit_callbacks(execute=True):
+            apply_submission(sub)
+        sub.refresh_from_db()
+
+        assert sub.status == WorkOrderSubmission.Status.FAILED
+        assert not Notification.objects.filter(title=NOTIFY_TITLE).exists()
+
+    def test_notification_failure_does_not_break_ingest(
+        self, monkeypatch, django_capture_on_commit_callbacks
+    ):
+        self._staff(1)
+        wo = _make_work_order(num_tasks=2)
+        template = _persisted(wo)
+        scan = _synth_scan(template, wo_id=wo.id, marks={_task_target_ids(template)[0]: "full"})
+        sub = _submission_for(wo, scan)
+
+        def _boom(*a, **k):
+            raise RuntimeError("notification backend down")
+
+        # notify_admins is imported lazily inside the hook; patch it at source.
+        monkeypatch.setattr("notifications.services.notify_admins", _boom)
+
+        with django_capture_on_commit_callbacks(execute=True):
+            apply_submission(sub)
+        sub.refresh_from_db()
+
+        # ingest still succeeded even though the notification blew up
+        assert sub.status == WorkOrderSubmission.Status.PENDING_REVIEW
+        assert not Notification.objects.filter(title=NOTIFY_TITLE).exists()
+
+
+# ---------------------------------------------------------------------------
+# per-WO pending-review badge (op-o6rs): serializer field + prefetch (no N+1)
+# ---------------------------------------------------------------------------
+class TestPendingReviewBadge:
+    def _sub(self, wo, status_value):
+        return WorkOrderSubmission.objects.create(
+            work_order=wo,
+            kind=WorkOrderSubmission.Kind.PM_COMPLETION,
+            source=WorkOrderSubmission.Source.SCAN,
+            status=status_value,
+        )
+
+    def test_list_row_exposes_pending_review_count(self):
+        wo = _make_work_order(num_tasks=1)
+        self._sub(wo, WorkOrderSubmission.Status.PENDING_REVIEW)
+        self._sub(wo, WorkOrderSubmission.Status.APPLIED)  # not counted
+        client, _user = _staff_client()
+        resp = client.get("/api/inventory/work-orders/")
+        assert resp.status_code == status.HTTP_200_OK
+        row = next(r for r in resp.data["results"] if r["id"] == str(wo.id))
+        assert row["pending_review_count"] == 1
+        assert row["has_pending_review"] is True
+
+    def test_detail_header_exposes_pending_review_count(self):
+        wo = _make_work_order(num_tasks=1)
+        self._sub(wo, WorkOrderSubmission.Status.PENDING_REVIEW)
+        client, _user = _staff_client()
+        resp = client.get(f"/api/inventory/work-orders/{wo.id}/")
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["pending_review_count"] == 1
+        assert resp.data["has_pending_review"] is True
+
+    def test_no_pending_review_reads_zero(self):
+        wo = _make_work_order(num_tasks=1)
+        self._sub(wo, WorkOrderSubmission.Status.APPLIED)
+        client, _user = _staff_client()
+        resp = client.get(f"/api/inventory/work-orders/{wo.id}/")
+        assert resp.data["pending_review_count"] == 0
+        assert resp.data["has_pending_review"] is False
+
+    def test_pending_review_count_has_no_nplus1(self):
+        # Submissions are prefetched, so listing WOs that each carry submissions
+        # costs the same number of queries as listing WOs with none — the count
+        # never fires a per-row query.
+        client, _user = _staff_client()
+
+        def _list_queries(n_subs_each):
+            WorkOrder.objects.all().delete()
+            for _ in range(3):
+                wo = _make_work_order(num_tasks=1)
+                for _ in range(n_subs_each):
+                    self._sub(wo, WorkOrderSubmission.Status.PENDING_REVIEW)
+            with CaptureQueriesContext(connection) as ctx:
+                resp = client.get("/api/inventory/work-orders/")
+                assert resp.status_code == status.HTTP_200_OK
+            return len(ctx.captured_queries)
+
+        assert _list_queries(0) == _list_queries(2)

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -3819,6 +3819,9 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
             "material_usage__material",
             "photos__uploaded_by",
             "maintenance_item__materials",
+            # op-o6rs: feed the pending-review badge (pending_review_count) from
+            # a single prefetch instead of a per-row submissions query (N+1).
+            "submissions",
         )
         .all()
     )
@@ -4556,6 +4559,71 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
             )
         response = HttpResponse(png, content_type="image/png")
         response["Content-Disposition"] = f'inline; filename="omr-{target_id}.png"'
+        return response
+
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path="submissions/(?P<submission_id>[^/.]+)/scan-image",
+        permission_classes=[IsAuthenticated],
+    )
+    def scan_image(self, request, pk=None, submission_id=None):
+        """Serve the full scanned page as a PNG for paper-form verification.
+
+        op-o6rs: the per-mark ``mark_crop`` shows only a 72×44 warp of one box;
+        to verify the marks against the actual paper the reviewer needs to see
+        the whole page. Pulls the embedded page image out of the submission's
+        raw scan (falling back to the WO's ``completed_scan``) — no PDF
+        rasteriser in the venv, so we read the embedded image the same way
+        ``mark_crop`` does — and normalises it to PNG for a stable content-type.
+        Authenticated read-only: rendering the page can never mutate state.
+        """
+        from PIL import Image
+
+        from .services.work_order_ingest import _omr_scan_inputs
+
+        work_order = self.get_object()
+        try:
+            submission = work_order.submissions.get(id=submission_id)
+        except WorkOrderSubmission.DoesNotExist:
+            return Response(
+                {"detail": "Submission not found for this work order."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        source = submission.attachment or work_order.completed_scan
+        if not source:
+            return Response(
+                {"detail": "No scanned page available for this submission."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        source.open("rb")
+        try:
+            raw_bytes = source.read()
+        finally:
+            source.close()
+
+        _wo_id, _err, image_bytes = _omr_scan_inputs(raw_bytes)
+        if image_bytes is None:
+            return Response(
+                {"detail": "No scanned page image available for this submission."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        try:
+            with Image.open(io.BytesIO(image_bytes)) as img:
+                buf = io.BytesIO()
+                img.convert("RGB").save(buf, format="PNG")
+            png = buf.getvalue()
+        except Exception:  # noqa: BLE001 - unreadable/odd embedded image
+            return Response(
+                {"detail": "Could not render the scanned page."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        response = HttpResponse(png, content_type="image/png")
+        response["Content-Disposition"] = f'inline; filename="wo-scan-{submission_id}.png"'
         return response
 
     @action(detail=True, methods=["patch"], url_path="materials/(?P<material_id>[^/.]+)/toggle")

--- a/frontend/src/__tests__/pages/MaintenanceDashboard.test.tsx
+++ b/frontend/src/__tests__/pages/MaintenanceDashboard.test.tsx
@@ -220,3 +220,45 @@ describe('MaintenanceDashboard manual PDF upload', () => {
     ).not.toBeInTheDocument();
   });
 });
+
+describe('MaintenanceDashboard pending-review badge (op-o6rs)', () => {
+  const wo = (overrides: Record<string, unknown> = {}) => ({
+    id: 'wo-9',
+    short_id: 'WO-ABC123',
+    status: 'in_progress',
+    is_overdue: false,
+    maintenance_item_title: 'Belt inspection',
+    asset_name: 'Bandsaw',
+    due_date: null,
+    pending_review_count: 0,
+    has_pending_review: false,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWorkOrderAPI.getDueThisWeek.mockResolvedValue({ data: [] } as any);
+    mockWorkOrderAPI.getDueThisMonth.mockResolvedValue({ data: [] } as any);
+  });
+
+  test('shows a "to review" badge on a WO with pending scanned marks', async () => {
+    mockWorkOrderAPI.listWorkOrders.mockResolvedValue({
+      data: { results: [wo({ pending_review_count: 2, has_pending_review: true })] },
+    } as any);
+
+    renderDashboard();
+
+    expect(await screen.findByText(/2 to review/i)).toBeInTheDocument();
+  });
+
+  test('omits the badge when nothing is pending review', async () => {
+    mockWorkOrderAPI.listWorkOrders.mockResolvedValue({
+      data: { results: [wo({ short_id: 'WO-DEF456' })] },
+    } as any);
+
+    renderDashboard();
+
+    expect(await screen.findByText('WO-DEF456')).toBeInTheDocument();
+    expect(screen.queryByText(/to review/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/WorkOrderPageOmrReview.test.tsx
+++ b/frontend/src/__tests__/pages/WorkOrderPageOmrReview.test.tsx
@@ -99,6 +99,8 @@ beforeEach(() => {
   (URL as unknown as { createObjectURL: () => string }).createObjectURL = vi.fn(() => 'blob:mock');
   (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = vi.fn();
   mockWorkOrderAPI.getMarkCrop.mockResolvedValue(okResponse(new Blob(['png'])));
+  // op-o6rs: the review panel also fetches the full scanned page (authed blob).
+  mockWorkOrderAPI.getScanImage.mockResolvedValue(okResponse(new Blob(['png'])));
   mockWorkOrderAPI.applyPendingChanges.mockResolvedValue(okResponse({ work_order_completed: false }));
   mockWorkOrderAPI.discardPendingChanges.mockResolvedValue(okResponse({}));
 });
@@ -114,6 +116,20 @@ describe('OMR scan review (bead-2)', () => {
     expect(screen.getByText('Lubricate bearings')).toBeInTheDocument();
     // the high-confidence mark shows it was pre-checked
     expect(screen.getByText(/marked · pre-checked/i)).toBeInTheDocument();
+  });
+
+  it('shows the full scanned page for paper-form verification', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(okResponse(scanWorkOrder()));
+    renderPage();
+
+    // the whole scanned page is rendered (not just the per-mark crops) and is
+    // sourced from the authed scan-image endpoint.
+    expect(
+      await screen.findByRole('img', { name: /scanned work order page/i }),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockWorkOrderAPI.getScanImage).toHaveBeenCalledWith('wo-1', 'sub-1');
+    });
   });
 
   it('accepts a single mark via its per-row button', async () => {

--- a/frontend/src/pages/MaintenanceDashboard.tsx
+++ b/frontend/src/pages/MaintenanceDashboard.tsx
@@ -29,6 +29,7 @@ import {
   IconFileText,
   IconPlus,
   IconRefresh,
+  IconScan,
   IconUpload,
 } from '@tabler/icons-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -178,6 +179,18 @@ const WorkOrderRow: React.FC<{ wo: WorkOrder }> = ({ wo }) => {
             </Badge>
             {wo.is_overdue && (
               <Badge color="red" size="xs">Overdue</Badge>
+            )}
+            {(wo.pending_review_count ?? 0) > 0 && (
+              <Tooltip label={`${wo.pending_review_count} scanned submission(s) awaiting review`}>
+                <Badge
+                  color="orange"
+                  size="xs"
+                  variant="filled"
+                  leftSection={<IconScan size={10} />}
+                >
+                  {wo.pending_review_count} to review
+                </Badge>
+              </Tooltip>
             )}
           </Group>
           <Text size="xs" c="dimmed" truncate>

--- a/frontend/src/pages/WorkOrderPage.tsx
+++ b/frontend/src/pages/WorkOrderPage.tsx
@@ -18,6 +18,7 @@ import {
   Textarea,
   Title,
   Tooltip,
+  UnstyledButton,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import {
@@ -60,7 +61,7 @@ const STATUS_COLORS: Record<WorkOrderStatus, string> = {
 // OMR bead-2: a small warped crop of one scanned mark so the reviewer can
 // eyeball the ink. The crop endpoint is authenticated, so we fetch the PNG as
 // a blob (Bearer token) and render it from an object URL rather than a bare
-// <img src> (which would send no auth header).
+// <img src> (which would send no auth header). op-o6rs: click to zoom.
 const OmrMarkCrop: React.FC<{
   workOrderId: string;
   submissionId: string;
@@ -68,6 +69,7 @@ const OmrMarkCrop: React.FC<{
 }> = ({ workOrderId, submissionId, targetId }) => {
   const [url, setUrl] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
+  const [zoomed, setZoomed] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -91,15 +93,99 @@ const OmrMarkCrop: React.FC<{
   if (failed) return null;
   if (!url) return <Loader size="xs" />;
   return (
-    <Image
-      src={url}
-      alt={`Scanned mark ${targetId}`}
-      w={72}
-      h={44}
-      fit="contain"
-      radius="sm"
-      style={{ border: '1px solid #dee2e6', backgroundColor: '#fff', flexShrink: 0 }}
-    />
+    <>
+      <UnstyledButton
+        onClick={() => setZoomed(true)}
+        aria-label={`Zoom scanned mark ${targetId}`}
+        style={{ flexShrink: 0, lineHeight: 0 }}
+      >
+        <Image
+          src={url}
+          alt={`Scanned mark ${targetId}`}
+          w={72}
+          h={44}
+          fit="contain"
+          radius="sm"
+          style={{ border: '1px solid #dee2e6', backgroundColor: '#fff', cursor: 'zoom-in' }}
+        />
+      </UnstyledButton>
+      <Modal
+        opened={zoomed}
+        onClose={() => setZoomed(false)}
+        size="lg"
+        title="Scanned mark"
+        centered
+      >
+        <Image src={url} alt={`Scanned mark ${targetId} (enlarged)`} fit="contain" />
+      </Modal>
+    </>
+  );
+};
+
+// op-o6rs: the FULL scanned page, so the reviewer verifies the detected marks
+// against the actual paper form. Same authed-blob → object-URL pattern as the
+// per-mark crop; click to open a full-size lightbox. The getScanImage call is
+// wrapped in Promise.resolve so an auto-mocked api (tests) that returns
+// undefined degrades to "no image" instead of throwing.
+const OmrScanImage: React.FC<{
+  workOrderId: string;
+  submissionId: string;
+}> = ({ workOrderId, submissionId }) => {
+  const [url, setUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [zoomed, setZoomed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    Promise.resolve(workOrderAPI.getScanImage(workOrderId, submissionId))
+      .then((res) => {
+        if (cancelled) return;
+        const blob = (res as { data?: Blob } | undefined)?.data;
+        if (!blob) {
+          setFailed(true);
+          return;
+        }
+        objectUrl = URL.createObjectURL(blob);
+        setUrl(objectUrl);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [workOrderId, submissionId]);
+
+  if (failed) return null;
+  if (!url) return <Loader size="sm" />;
+  return (
+    <>
+      <UnstyledButton
+        onClick={() => setZoomed(true)}
+        aria-label="Zoom scanned page"
+        style={{ width: '100%', lineHeight: 0 }}
+      >
+        <Image
+          src={url}
+          alt="Scanned work order page"
+          fit="contain"
+          radius="sm"
+          mah={320}
+          style={{ border: '1px solid #dee2e6', backgroundColor: '#fff', cursor: 'zoom-in' }}
+        />
+      </UnstyledButton>
+      <Modal
+        opened={zoomed}
+        onClose={() => setZoomed(false)}
+        size="xl"
+        title="Scanned work order page"
+        centered
+      >
+        <Image src={url} alt="Scanned work order page (enlarged)" fit="contain" />
+      </Modal>
+    </>
   );
 };
 
@@ -482,6 +568,11 @@ const WorkOrderPage: React.FC = () => {
                   </Group>
                 </Badge>
               )}
+              {(workOrder.pending_review_count ?? 0) > 0 && (
+                <Badge color="orange" variant="filled" size="sm" leftSection={<IconScan size={12} />}>
+                  {workOrder.pending_review_count} to review
+                </Badge>
+              )}
             </Group>
             <Text fw={600} size="sm" truncate>{workOrder.maintenance_item_title}</Text>
             <Text size="xs" c="dimmed">
@@ -666,6 +757,16 @@ const WorkOrderPage: React.FC = () => {
                       >
                         {sub.parse_error}
                       </Alert>
+                    )}
+
+                    {/* op-o6rs: the full scanned page for paper-form verification. */}
+                    {isScan && (
+                      <Box mb="sm">
+                        <Text size="xs" c="dimmed" mb={4}>
+                          Scanned form — verify the marks below against the paper (click to zoom):
+                        </Text>
+                        <OmrScanImage workOrderId={workOrder.id} submissionId={sub.id} />
+                      </Box>
                     )}
 
                     <Stack gap={6} mb="sm">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1379,6 +1379,14 @@ export const workOrderAPI = {
       { responseType: 'blob' },
     ),
 
+  // op-o6rs: authed PNG of the FULL scanned page so the reviewer can verify the
+  // detected marks against the actual paper form (returns a Blob for object-URL).
+  getScanImage: (workOrderId: string, submissionId: string) =>
+    api.get(
+      `/inventory/work-orders/${workOrderId}/submissions/${submissionId}/scan-image/`,
+      { responseType: 'blob' },
+    ),
+
   getDueThisWeek: () =>
     api.get<MaintenanceItem[]>('/inventory/maintenance-items/due_this_week/'),
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -803,6 +803,10 @@ export interface WorkOrder {
   validation?: WorkOrderValidationRecord | null;
   task_completion_count?: number;
   task_total_count?: number;
+  // op-o6rs: number of submissions still awaiting human review (drives the
+  // per-WO "scanned — needs review" badge on the list row + detail header).
+  pending_review_count?: number;
+  has_pending_review?: boolean;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## What

PR2 of the work-order OMR follow-up (after #908 auto-apply). When a work order is
scanned back in, staff now **know** it landed and can **verify** the marks against
the paper form.

Ian's three asks:

1. **App-wide notification** — a scanned-in WO fires `notify_admins(...)` (warning),
   deep-linking to the WO review screen. Fans out to all staff via the existing
   header bell / notification centre (which already polls). Degraded/unreadable
   scans get their own "could not be read cleanly — review by hand" message.
2. **Per-WO pending-review badge** — `pending_review_count` + `has_pending_review`
   on **both** the list and detail serializers, so the badge shows on WO list rows
   and the detail header.
3. **Paper-form verification on drill-down** — new `scan_image` endpoint serves the
   **full scanned page** as PNG (the existing per-mark crop is only a 72×44 warp of
   one box), so the reviewer can confirm/reject marks against the actual paper in the
   drill-down panel that already exists.

## How / notes

- The notification system was already fully built (`notifications/` app + frontend
  bell/centre/toasts). The scan-in path emitted **nothing** — this wires into it, it
  does **not** rebuild any of it.
- Notification fires on `transaction.on_commit`, so it **never** fires on a rolled-back
  ingest, and is wrapped so a notification failure can't break ingest.
- Badge counts read the `prefetch_related("submissions")` cache (added to the viewset
  queryset) — no N+1 per row.
- `scan_image` is authenticated, read-only, and registered in
  `api_permission_matrix.yaml`.
- **Safety:** unchanged — a scan never auto-closes a WO; this is notify + verify only.

## Test

- Backend: `inventory/tests/test_work_order_omr_reader.py` (new coverage) +
  `config/tests/test_permission_matrix.py` (new endpoint registered).
- Frontend: `MaintenanceDashboard.test.tsx` + `WorkOrderPageOmrReview.test.tsx`;
  lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
