### PR TITLE
feat(reports): asset cost-recovery statement — endpoint + CSV + landlord PDF (op-2z4n, PR1)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -1152,6 +1152,9 @@ views:
       assets_by_status:
         permission_classes:
         - IsAuthenticated
+      cost_recovery:
+        permission_classes:
+        - IsAuthenticated
       export:
         permission_classes:
         - IsAuthenticated

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -2337,6 +2337,43 @@ class AssetTcoReportSerializer(serializers.Serializer):
     total_maintenance_cost_90d = serializers.DecimalField(max_digits=12, decimal_places=2)
 
 
+class AssetCostRecoveryServiceSerializer(serializers.Serializer):
+    """One itemized service line in the asset cost-recovery statement.
+
+    ``estimated_cost`` is the internal estimate (present for internal PM,
+    null for vendor/manual work that has no per-asset estimate).
+    ``actual_cost`` is the vendor-invoice / recorded actual (present for
+    vendor and manual work, null for internal PM which carries no actual).
+    The recoverable amount is the sum of the ``actual_cost`` column.
+    """
+
+    date = serializers.DateField()
+    source = serializers.ChoiceField(choices=["pm", "vendor", "manual"])
+    description = serializers.CharField(allow_blank=True)
+    estimated_cost = serializers.DecimalField(max_digits=12, decimal_places=2, allow_null=True)
+    actual_cost = serializers.DecimalField(max_digits=12, decimal_places=2, allow_null=True)
+
+
+class AssetCostRecoveryReportSerializer(serializers.Serializer):
+    """One asset block in the cost-recovery statement: asset info + services.
+
+    ``subtotal_actual`` is the recoverable amount for this asset; the report's
+    ``grand_total_actual`` is the recoverable total billed to the landlord.
+    """
+
+    asset_id = serializers.UUIDField()
+    asset_tag = serializers.CharField(allow_blank=True)
+    name = serializers.CharField()
+    serial_number = serializers.CharField(allow_blank=True)
+    date_received = serializers.DateField(allow_null=True)
+    status = serializers.CharField()
+    status_display = serializers.CharField()
+    category = serializers.CharField(allow_null=True, allow_blank=True)
+    services = AssetCostRecoveryServiceSerializer(many=True)
+    subtotal_estimated = serializers.DecimalField(max_digits=12, decimal_places=2)
+    subtotal_actual = serializers.DecimalField(max_digits=12, decimal_places=2)
+
+
 class LocationReconcileItemSerializer(serializers.ModelSerializer):
     """Single item row in the location reconcile grid payload."""
 

--- a/backend/inventory/tests/test_cost_recovery.py
+++ b/backend/inventory/tests/test_cost_recovery.py
@@ -1,0 +1,420 @@
+"""
+Tests for the Asset Cost-Recovery report endpoint.
+
+Covers the cost walk (internal PM estimate vs vendor/manual actual, correct
+columns), period presets + custom range filtering, asset selection AND
+category expansion, an asset with no in-window services, the recoverable
+grand-total, and the CSV + PDF exports.
+"""
+
+import csv
+import io
+from datetime import timedelta
+from decimal import Decimal
+
+from django.utils import timezone
+
+import pytest
+from rest_framework import status
+
+from inventory.models import (
+    MaintenanceItem,
+    MaintenanceMaterial,
+    MaintenanceRecord,
+    WorkOrder,
+    WorkOrderMaterialUsage,
+)
+from inventory.tests.factories import AssetFactory, CategoryFactory
+
+URL = "/api/inventory/reports/assets/cost_recovery/"
+
+
+def _completed_wo(maintenance_item, *, completed_at):
+    return WorkOrder.objects.create(
+        maintenance_item=maintenance_item,
+        status=WorkOrder.Status.COMPLETED,
+        completed_at=completed_at,
+    )
+
+
+def _closed_vendor_link(asset, *, allocated_cost, closed_days_ago=5, title="Vendor work"):
+    """Create a closed ThirdPartyWorkOrder + per-asset link (bypasses the state
+    machine) so vendor allocated_cost rolls into the Actual column."""
+    from maintenance_orders.models import ThirdPartyWorkOrder, ThirdPartyWorkOrderAsset
+    from vendors.models import Vendor
+
+    vendor, _ = Vendor.objects.get_or_create(
+        name="CR Test Vendor", defaults={"vendor_kind": Vendor.KIND_HVAC}
+    )
+    wo = ThirdPartyWorkOrder.objects.create(title=title, vendor=vendor, asset=asset)
+    wo.status = ThirdPartyWorkOrder.STATUS_CLOSED
+    wo.closed_at = timezone.now() - timedelta(days=closed_days_ago)
+    wo.save(update_fields=["status", "closed_at"])
+    return ThirdPartyWorkOrderAsset.objects.create(
+        work_order=wo,
+        asset=asset,
+        share_pct=Decimal("100"),
+        allocated_cost=allocated_cost,
+    )
+
+
+def _assets_by_id(response):
+    return {block["asset_id"]: block for block in response.data["assets"]}
+
+
+@pytest.mark.integration
+class TestCostRecoveryAccessAndParams:
+    def test_requires_auth(self, api_client):
+        response = api_client.get(URL, {"asset_ids": "x", "period": "past_month"})
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_requires_selection(self, authenticated_client):
+        client, _ = authenticated_client
+        response = client.get(URL, {"period": "past_month"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_requires_period(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory()
+        response = client.get(URL, {"asset_ids": str(asset.id)})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_invalid_period_rejected(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory()
+        response = client.get(URL, {"asset_ids": str(asset.id), "period": "past_decade"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_invalid_asset_id_rejected(self, authenticated_client):
+        client, _ = authenticated_client
+        response = client.get(URL, {"asset_ids": "not-a-uuid", "period": "past_month"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_start_after_end_rejected(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory()
+        response = client.get(
+            URL,
+            {
+                "asset_ids": str(asset.id),
+                "start_date": "2026-05-01",
+                "end_date": "2026-04-01",
+            },
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.integration
+class TestCostRecoveryCostWalk:
+    def test_internal_pm_is_estimated_only(self, authenticated_client):
+        """Scheduled PM estimate = MaintenanceItem.estimated_cost; unscheduled
+        estimate = used-material sum. Both feed Estimated with actual null."""
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Mill", asset_tag="A-PM")
+        now = timezone.now()
+
+        scheduled = MaintenanceItem.objects.create(
+            asset=asset,
+            title="Quarterly oil change",
+            interval_days=90,
+            estimated_cost=Decimal("75.00"),
+        )
+        _completed_wo(scheduled, completed_at=now - timedelta(days=10))
+
+        unscheduled = MaintenanceItem.objects.create(
+            asset=asset,
+            title="Belt replacement",
+            interval_days=None,
+            estimated_cost=Decimal("0.00"),
+        )
+        wo = _completed_wo(unscheduled, completed_at=now - timedelta(days=5))
+        belt = MaintenanceMaterial.objects.create(
+            maintenance_item=unscheduled,
+            name="Drive belt",
+            quantity=Decimal("1.00"),
+            estimated_cost_per_unit=Decimal("42.50"),
+        )
+        WorkOrderMaterialUsage.objects.create(
+            work_order=wo,
+            material=belt,
+            material_name=belt.name,
+            quantity_planned=Decimal("2.00"),
+            was_used=True,
+        )
+
+        response = client.get(URL, {"asset_ids": str(asset.id), "period": "past_month"})
+        assert response.status_code == status.HTTP_200_OK
+
+        block = _assets_by_id(response)[str(asset.id)]
+        by_desc = {svc["description"]: svc for svc in block["services"]}
+
+        oil = by_desc["Quarterly oil change"]
+        assert oil["source"] == "pm"
+        assert Decimal(oil["estimated_cost"]) == Decimal("75.00")
+        assert oil["actual_cost"] is None
+
+        belt_line = by_desc["Belt replacement"]
+        assert belt_line["source"] == "pm"
+        assert Decimal(belt_line["estimated_cost"]) == Decimal("85.00")
+        assert belt_line["actual_cost"] is None
+
+        assert Decimal(block["subtotal_estimated"]) == Decimal("160.00")
+        assert Decimal(block["subtotal_actual"]) == Decimal("0.00")
+        # Internal PM never contributes to the recoverable total.
+        assert Decimal(response.data["grand_total_actual"]) == Decimal("0.00")
+
+    def test_vendor_actual_is_recoverable(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Compressor", asset_tag="A-VEN")
+        _closed_vendor_link(asset, allocated_cost=Decimal("250.00"), closed_days_ago=5)
+
+        response = client.get(URL, {"asset_ids": str(asset.id), "period": "past_month"})
+        assert response.status_code == status.HTTP_200_OK
+
+        block = _assets_by_id(response)[str(asset.id)]
+        assert len(block["services"]) == 1
+        svc = block["services"][0]
+        assert svc["source"] == "vendor"
+        assert svc["estimated_cost"] is None
+        assert Decimal(svc["actual_cost"]) == Decimal("250.00")
+        assert Decimal(block["subtotal_actual"]) == Decimal("250.00")
+        assert Decimal(response.data["grand_total_actual"]) == Decimal("250.00")
+
+    def test_manual_record_actual(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Boiler", asset_tag="A-MAN")
+        MaintenanceRecord.objects.create(
+            asset=asset,
+            title="Annual HVAC service",
+            description="Vendor annual service",
+            completed_on=(timezone.now() - timedelta(days=3)).date(),
+            cost=Decimal("410.00"),
+        )
+
+        response = client.get(URL, {"asset_ids": str(asset.id), "period": "past_month"})
+        assert response.status_code == status.HTTP_200_OK
+
+        block = _assets_by_id(response)[str(asset.id)]
+        svc = block["services"][0]
+        assert svc["source"] == "manual"
+        assert svc["estimated_cost"] is None
+        assert Decimal(svc["actual_cost"]) == Decimal("410.00")
+        assert Decimal(response.data["grand_total_actual"]) == Decimal("410.00")
+
+    def test_services_sorted_by_date(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(asset_tag="A-SORT")
+        now = timezone.now()
+        mi = MaintenanceItem.objects.create(
+            asset=asset, title="Older PM", interval_days=30, estimated_cost=Decimal("5.00")
+        )
+        _completed_wo(mi, completed_at=now - timedelta(days=20))
+        _closed_vendor_link(asset, allocated_cost=Decimal("10.00"), closed_days_ago=2)
+
+        response = client.get(URL, {"asset_ids": str(asset.id), "period": "past_month"})
+        block = _assets_by_id(response)[str(asset.id)]
+        dates = [svc["date"] for svc in block["services"]]
+        assert dates == sorted(dates)
+
+
+@pytest.mark.integration
+class TestCostRecoveryWindow:
+    def test_period_preset_filters_window(self, authenticated_client):
+        """past_week keeps a 3-day-old service and drops a 20-day-old one."""
+        client, _ = authenticated_client
+        asset = AssetFactory(asset_tag="A-WIN")
+        now = timezone.now()
+        mi = MaintenanceItem.objects.create(
+            asset=asset, title="Check", interval_days=7, estimated_cost=Decimal("9.00")
+        )
+        _completed_wo(mi, completed_at=now - timedelta(days=3))  # inside past_week
+        _completed_wo(mi, completed_at=now - timedelta(days=20))  # outside past_week
+
+        response = client.get(URL, {"asset_ids": str(asset.id), "period": "past_week"})
+        block = _assets_by_id(response)[str(asset.id)]
+        assert len(block["services"]) == 1
+        assert response.data["period"] == "past_week"
+
+    def test_custom_range_filters_window(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(asset_tag="A-RANGE")
+        inside = MaintenanceRecord.objects.create(
+            asset=asset,
+            title="Inside",
+            description="in range",
+            completed_on=timezone.datetime(2026, 4, 15).date(),
+            cost=Decimal("100.00"),
+        )
+        MaintenanceRecord.objects.create(
+            asset=asset,
+            title="Outside",
+            description="out of range",
+            completed_on=timezone.datetime(2026, 6, 1).date(),
+            cost=Decimal("999.00"),
+        )
+
+        response = client.get(
+            URL,
+            {
+                "asset_ids": str(asset.id),
+                "start_date": "2026-04-01",
+                "end_date": "2026-04-30",
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        block = _assets_by_id(response)[str(asset.id)]
+        assert [svc["description"] for svc in block["services"]] == [inside.title]
+        assert response.data["period"] is None
+        assert response.data["start_date"] == "2026-04-01"
+        assert response.data["end_date"] == "2026-04-30"
+
+
+@pytest.mark.integration
+class TestCostRecoverySelection:
+    def test_category_expansion(self, authenticated_client):
+        client, _ = authenticated_client
+        category = CategoryFactory(name="HVAC Units")
+        a1 = AssetFactory(category=category, asset_tag="A-CAT1")
+        a2 = AssetFactory(category=category, asset_tag="A-CAT2")
+        other = AssetFactory(asset_tag="A-OTHER")
+
+        response = client.get(URL, {"category_ids": str(category.id), "period": "past_month"})
+        assert response.status_code == status.HTTP_200_OK
+        ids = set(_assets_by_id(response))
+        assert {str(a1.id), str(a2.id)} <= ids
+        assert str(other.id) not in ids
+        assert response.data["category_ids"] == [category.id]
+
+    def test_asset_and_category_union_dedupes(self, authenticated_client):
+        client, _ = authenticated_client
+        category = CategoryFactory(name="Pumps")
+        a1 = AssetFactory(category=category, asset_tag="A-U1")
+        a2 = AssetFactory(asset_tag="A-U2")
+
+        response = client.get(
+            URL,
+            {
+                "asset_ids": f"{a1.id},{a2.id}",
+                "category_ids": str(category.id),
+                "period": "past_month",
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        ids = list(_assets_by_id(response))
+        # a1 is in both the explicit list and the category — must appear once.
+        assert ids.count(str(a1.id)) == 1
+        assert {str(a1.id), str(a2.id)} == set(ids)
+        assert response.data["asset_count"] == 2
+
+    def test_asset_with_no_services_appears_zero(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Quiet", asset_tag="A-QUIET")
+
+        response = client.get(URL, {"asset_ids": str(asset.id), "period": "past_month"})
+        assert response.status_code == status.HTTP_200_OK
+        block = _assets_by_id(response)[str(asset.id)]
+        assert block["services"] == []
+        assert Decimal(block["subtotal_estimated"]) == Decimal("0.00")
+        assert Decimal(block["subtotal_actual"]) == Decimal("0.00")
+        assert response.data["service_count"] == 0
+
+    def test_grand_total_actual_is_recoverable_sum(self, authenticated_client):
+        client, _ = authenticated_client
+        a1 = AssetFactory(asset_tag="A-G1")
+        a2 = AssetFactory(asset_tag="A-G2")
+        _closed_vendor_link(a1, allocated_cost=Decimal("120.00"), closed_days_ago=3)
+        MaintenanceRecord.objects.create(
+            asset=a2,
+            title="Repair",
+            description="manual",
+            completed_on=(timezone.now() - timedelta(days=2)).date(),
+            cost=Decimal("80.00"),
+        )
+
+        response = client.get(URL, {"asset_ids": f"{a1.id},{a2.id}", "period": "past_month"})
+        assert response.status_code == status.HTTP_200_OK
+        assert Decimal(response.data["grand_total_actual"]) == Decimal("200.00")
+        assert response.data["asset_count"] == 2
+        assert response.data["service_count"] == 2
+
+
+@pytest.mark.integration
+class TestCostRecoveryExports:
+    def test_csv_export(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Exporter", asset_tag="A-CSV", serial_number="SN-CSV")
+        _closed_vendor_link(asset, allocated_cost=Decimal("321.00"), closed_days_ago=4)
+
+        response = client.get(
+            URL, {"asset_ids": str(asset.id), "period": "past_month", "format": "csv"}
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response["Content-Type"] == "text/csv"
+        assert "asset_cost_recovery.csv" in response["Content-Disposition"]
+
+        reader = csv.DictReader(io.StringIO(response.content.decode("utf-8")))
+        assert reader.fieldnames == [
+            "asset_tag",
+            "serial_number",
+            "status",
+            "date_received",
+            "service_date",
+            "source",
+            "description",
+            "estimated_cost",
+            "actual_cost",
+        ]
+        rows = [r for r in reader if r["asset_tag"] == "A-CSV"]
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["serial_number"] == "SN-CSV"
+        assert row["source"] == "vendor"
+        assert row["actual_cost"] == "321.00"
+        assert row["estimated_cost"] == ""
+
+    def test_csv_empty_asset_emits_blank_service_row(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(asset_tag="A-CSV0")
+
+        response = client.get(
+            URL, {"asset_ids": str(asset.id), "period": "past_month", "format": "csv"}
+        )
+        assert response.status_code == status.HTTP_200_OK
+        reader = csv.DictReader(io.StringIO(response.content.decode("utf-8")))
+        rows = [r for r in reader if r["asset_tag"] == "A-CSV0"]
+        assert len(rows) == 1
+        assert rows[0]["service_date"] == ""
+        assert rows[0]["actual_cost"] == ""
+
+    def test_pdf_export(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(name="Statement Asset", asset_tag="A-PDF")
+        _closed_vendor_link(asset, allocated_cost=Decimal("555.00"), closed_days_ago=4)
+
+        response = client.get(
+            URL, {"asset_ids": str(asset.id), "period": "past_month", "format": "pdf"}
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response["Content-Type"] == "application/pdf"
+        assert "asset_cost_recovery.pdf" in response["Content-Disposition"]
+        content = response.content
+        assert content.startswith(b"%PDF")
+
+        # Extract text so we can assert a known value is present in the statement.
+        from pypdf import PdfReader
+
+        text = "".join(page.extract_text() or "" for page in PdfReader(io.BytesIO(content)).pages)
+        assert "Cost-Recovery" in text
+        assert "Amount to recover" in text
+        assert "A-PDF" in text
+
+    def test_unknown_format_404s_in_negotiation(self, authenticated_client):
+        """``format`` is DRF's reserved content-negotiation param; an
+        unregistered value (not json/csv/pdf) is rejected by negotiation
+        with a 404 before the view body runs."""
+        client, _ = authenticated_client
+        asset = AssetFactory()
+        response = client.get(
+            URL, {"asset_ids": str(asset.id), "period": "past_month", "format": "xml"}
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/inventory/utils/cost_recovery_pdf.py
+++ b/backend/inventory/utils/cost_recovery_pdf.py
@@ -15,8 +15,8 @@ generators, achieved here by not emitting characters outside that range.
 import io
 from datetime import date, datetime
 from decimal import Decimal
+from html import escape
 from typing import Optional
-from xml.sax.saxutils import escape
 
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import letter
@@ -64,7 +64,7 @@ def _para(text, style) -> Paragraph:
     """Wrap free text in a Paragraph, XML-escaping first so an ``&``/``<``/``>``
     in an asset name, vendor name, or description can't break reportlab's
     paragraph parser."""
-    return Paragraph(escape(str(text)), style)
+    return Paragraph(escape(str(text), quote=False), style)
 
 
 def _period_display(report: dict) -> str:

--- a/backend/inventory/utils/cost_recovery_pdf.py
+++ b/backend/inventory/utils/cost_recovery_pdf.py
@@ -1,0 +1,240 @@
+"""
+PDF generation for the asset cost-recovery statement.
+
+Renders a landlord-ready statement of per-asset service history with
+Estimated and Actual (vendor-invoice) cost columns. The Actual total is the
+recoverable amount ("Amount to recover").
+
+Mirrors the reportlab conventions used in ``work_order_pdf.py`` (SimpleDoc-
+Template + platypus flowables, built-in Helvetica fonts so no font files are
+required, greyscale table styling). Text is kept to plain ASCII/Latin-1 so the
+built-in fonts render every glyph — the "DejaVu-safe" practice from the other
+generators, achieved here by not emitting characters outside that range.
+"""
+
+import io
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Optional
+from xml.sax.saxutils import escape
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    HRFlowable,
+    KeepTogether,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+_SOURCE_LABELS = {
+    "pm": "Internal PM",
+    "vendor": "Vendor",
+    "manual": "Manual",
+}
+
+_PERIOD_LABELS = {
+    "past_week": "Past week",
+    "past_month": "Past month",
+    "past_year": "Past year",
+}
+
+
+def _money(value: Optional[Decimal]) -> str:
+    """Render a Decimal as ``$X.XX``; blank for a missing (null) value."""
+    if value is None:
+        return ""
+    return f"${Decimal(value):,.2f}"
+
+
+def _fmt_date(value) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, (date, datetime)):
+        return value.strftime("%b %d, %Y")
+    return str(value)
+
+
+def _para(text, style) -> Paragraph:
+    """Wrap free text in a Paragraph, XML-escaping first so an ``&``/``<``/``>``
+    in an asset name, vendor name, or description can't break reportlab's
+    paragraph parser."""
+    return Paragraph(escape(str(text)), style)
+
+
+def _period_display(report: dict) -> str:
+    """Human summary of the reporting window for the statement header."""
+    start = _fmt_date(report.get("start_date"))
+    end = _fmt_date(report.get("end_date"))
+    preset = _PERIOD_LABELS.get(report.get("period"))
+    if preset:
+        return f"{preset} ({start} - {end})"
+    return f"{start} - {end}"
+
+
+def generate_cost_recovery_pdf(report: dict) -> bytes:
+    """Generate a landlord-ready cost-recovery statement PDF.
+
+    Args:
+        report: The assembled report dict produced by
+            ``AssetReportViewSet.cost_recovery`` — carries the reporting
+            window, the selected assets (each with its ``services`` list and
+            subtotals), and the grand totals. Costs are raw ``Decimal``/``None``
+            (not yet serialized to strings).
+
+    Returns:
+        PDF content as bytes.
+    """
+    buf = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buf,
+        pagesize=letter,
+        rightMargin=0.5 * inch,
+        leftMargin=0.5 * inch,
+        topMargin=0.5 * inch,
+        bottomMargin=0.5 * inch,
+        title="Asset Cost-Recovery Statement",
+    )
+
+    styles = getSampleStyleSheet()
+    heading_style = ParagraphStyle(
+        "CRHeading", parent=styles["Heading1"], fontSize=16, spaceAfter=2
+    )
+    subheading_style = ParagraphStyle(
+        "CRSubHeading", parent=styles["Heading2"], fontSize=12, spaceBefore=10, spaceAfter=2
+    )
+    small_style = ParagraphStyle(
+        "CRSmall", parent=styles["Normal"], fontSize=9, textColor=colors.HexColor("#444444")
+    )
+    asset_info_style = ParagraphStyle(
+        "CRAssetInfo", parent=styles["Normal"], fontSize=9, spaceBefore=2
+    )
+    cell_style = ParagraphStyle("CRCell", parent=styles["Normal"], fontSize=8, leading=10)
+
+    story = []
+
+    # ── Header ───────────────────────────────────────────────────────────────
+    story.append(Paragraph("Asset Cost-Recovery Statement", heading_style))
+    story.append(Paragraph(f"Period: {_period_display(report)}", small_style))
+    generated_at = report.get("generated_at")
+    story.append(Paragraph(f"Generated: {_fmt_date(generated_at)}", small_style))
+
+    selection_bits = []
+    asset_ids = report.get("asset_ids") or []
+    category_ids = report.get("category_ids") or []
+    if asset_ids:
+        selection_bits.append(f"{len(asset_ids)} asset(s) selected")
+    if category_ids:
+        selection_bits.append(f"{len(category_ids)} category(ies) selected")
+    selection_bits.append(f"{report.get('asset_count', 0)} asset(s) in statement")
+    selection_bits.append(f"{report.get('service_count', 0)} service line(s)")
+    story.append(Paragraph("; ".join(selection_bits), small_style))
+    story.append(HRFlowable(width="100%", thickness=1, color=colors.black))
+    story.append(Spacer(1, 4))
+
+    # ── Per-asset sections ───────────────────────────────────────────────────
+    for asset in report.get("assets", []):
+        block = []
+        title_bits = [asset.get("name") or "(unnamed asset)"]
+        if asset.get("asset_tag"):
+            title_bits.append(f"[{asset['asset_tag']}]")
+        block.append(_para(" ".join(title_bits), subheading_style))
+
+        info_bits = [
+            f"Serial: {asset.get('serial_number') or '-'}",
+            f"Status: {asset.get('status_display') or asset.get('status') or '-'}",
+            f"Category: {asset.get('category') or '-'}",
+            f"Date installed: {_fmt_date(asset.get('date_received'))}",
+        ]
+        block.append(_para(" | ".join(info_bits), asset_info_style))
+        block.append(Spacer(1, 2))
+
+        rows = [["Date", "Source", "Description", "Estimated", "Actual"]]
+        for svc in asset.get("services", []):
+            rows.append(
+                [
+                    _fmt_date(svc.get("date")),
+                    _SOURCE_LABELS.get(svc.get("source"), svc.get("source") or ""),
+                    _para(svc.get("description") or "", cell_style),
+                    _money(svc.get("estimated_cost")),
+                    _money(svc.get("actual_cost")),
+                ]
+            )
+        if len(rows) == 1:
+            rows.append(["-", "-", Paragraph("No services in period", cell_style), "", ""])
+        rows.append(
+            [
+                "",
+                "",
+                "Subtotal",
+                _money(asset.get("subtotal_estimated")),
+                _money(asset.get("subtotal_actual")),
+            ]
+        )
+
+        table = Table(
+            rows,
+            colWidths=[0.9 * inch, 0.9 * inch, 3.3 * inch, 1.1 * inch, 1.1 * inch],
+        )
+        table.setStyle(
+            TableStyle(
+                [
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, -1), 8),
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#e8e8e8")),
+                    ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#cccccc")),
+                    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                    ("ALIGN", (3, 0), (4, -1), "RIGHT"),
+                    ("PADDING", (0, 0), (-1, -1), 3),
+                    # Subtotal row emphasis.
+                    ("FONTNAME", (2, -1), (-1, -1), "Helvetica-Bold"),
+                    ("LINEABOVE", (0, -1), (-1, -1), 0.75, colors.black),
+                    ("BACKGROUND", (0, -1), (-1, -1), colors.HexColor("#f5f5f5")),
+                ]
+            )
+        )
+        block.append(table)
+        block.append(Spacer(1, 6))
+        # Keep each asset's heading + table together where it fits on a page.
+        story.append(KeepTogether(block))
+
+    # ── Grand total ──────────────────────────────────────────────────────────
+    story.append(Spacer(1, 4))
+    story.append(HRFlowable(width="100%", thickness=1, color=colors.black))
+    grand_rows = [
+        ["Grand total estimated", _money(report.get("grand_total_estimated"))],
+        ["Amount to recover (Actual)", _money(report.get("grand_total_actual"))],
+    ]
+    grand_table = Table(grand_rows, colWidths=[5.3 * inch, 2.0 * inch])
+    grand_table.setStyle(
+        TableStyle(
+            [
+                ("FONTNAME", (0, 0), (-1, -1), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, 0), 10),
+                ("FONTSIZE", (0, 1), (-1, 1), 13),
+                ("ALIGN", (1, 0), (1, -1), "RIGHT"),
+                ("TEXTCOLOR", (0, 1), (-1, 1), colors.HexColor("#0b6b2e")),
+                ("LINEABOVE", (0, 1), (-1, 1), 1, colors.black),
+                ("PADDING", (0, 0), (-1, -1), 5),
+            ]
+        )
+    )
+    story.append(grand_table)
+    story.append(Spacer(1, 6))
+    story.append(
+        Paragraph(
+            "The Actual column reflects vendor invoices and recorded actual costs "
+            "and is the amount billed to the landlord for recovery. Internal "
+            "preventive-maintenance estimates are shown for reference only and are "
+            "not part of the recoverable total.",
+            small_style,
+        )
+    )
+
+    doc.build(story)
+    return buf.getvalue()

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -23,6 +23,7 @@ from rest_framework.permissions import (
     IsAuthenticated,
     IsAuthenticatedOrReadOnly,
 )
+from rest_framework.renderers import BaseRenderer, JSONRenderer
 from rest_framework.response import Response
 
 from config.api_errors import ErrorCode, error_response
@@ -5285,6 +5286,32 @@ class MaintenanceDashboardViewSet(viewsets.ViewSet):
         return Response({"results": rows, "count": len(rows)})
 
 
+class _CostRecoveryCSVRenderer(BaseRenderer):
+    """Passthrough renderer registering the ``csv`` format for content negotiation.
+
+    ``AssetReportViewSet.cost_recovery`` returns a fully-formed ``HttpResponse``
+    for the CSV/PDF formats, so ``render`` is never invoked — these renderers
+    exist only so DRF accepts ``?format=csv`` / ``?format=pdf`` (its reserved
+    format query param) instead of 404-ing on an unregistered format.
+    """
+
+    media_type = "text/csv"
+    format = "csv"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        return data
+
+
+class _CostRecoveryPDFRenderer(BaseRenderer):
+    """Passthrough renderer registering the ``pdf`` format (see CSV renderer)."""
+
+    media_type = "application/pdf"
+    format = "pdf"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        return data
+
+
 class AssetReportViewSet(viewsets.ViewSet):
     """API endpoint for asset reports."""
 
@@ -5684,6 +5711,377 @@ class AssetReportViewSet(viewsets.ViewSet):
             row["used_at"] = row["used_at"].isoformat()
 
         return Response(rows)
+
+    @staticmethod
+    def _cost_recovery_selection(request):
+        """Parse and validate the asset/category selection for cost_recovery.
+
+        ``asset_ids`` (Asset UUIDs) and ``category_ids`` (integer Category PKs)
+        are each accepted as repeated params and/or comma-joined lists. At
+        least one asset or category must be supplied. Returns
+        ``(asset_ids, category_ids)`` as validated lists (UUID strings / ints).
+        Raises DRF ValidationError on malformed ids or an empty selection.
+        """
+        import uuid
+
+        def _collect(param):
+            values = []
+            for chunk in request.query_params.getlist(param):
+                values.extend(piece.strip() for piece in chunk.split(",") if piece.strip())
+            return values
+
+        raw_asset_ids = _collect("asset_ids")
+        raw_category_ids = _collect("category_ids")
+
+        if not raw_asset_ids and not raw_category_ids:
+            raise serializers.ValidationError(
+                "Select at least one asset (asset_ids) or category (category_ids)."
+            )
+
+        asset_ids = []
+        for value in raw_asset_ids:
+            try:
+                asset_ids.append(str(uuid.UUID(value)))
+            except (ValueError, AttributeError, TypeError):
+                raise serializers.ValidationError({"asset_ids": f"Invalid asset id: {value!r}."})
+
+        category_ids = []
+        for value in raw_category_ids:
+            try:
+                category_ids.append(int(value))
+            except (ValueError, TypeError):
+                raise serializers.ValidationError(
+                    {"category_ids": f"Invalid category id: {value!r}."}
+                )
+
+        return asset_ids, category_ids
+
+    @staticmethod
+    def _cost_recovery_window(request):
+        """Resolve the cost_recovery reporting window.
+
+        Either a ``period`` preset (``past_week``/``past_month``/``past_year`` —
+        trailing windows of 7/30/365 days ending today) OR an explicit
+        ``start_date`` & ``end_date`` pair (``YYYY-MM-DD``). Returns
+        ``(start_date, end_date, period_label)`` where ``period_label`` is the
+        preset name, or ``None`` for a custom range. Raises DRF ValidationError
+        on malformed or missing input.
+        """
+        from datetime import datetime
+
+        presets = {
+            "past_week": timedelta(days=7),
+            "past_month": timedelta(days=30),
+            "past_year": timedelta(days=365),
+        }
+        today = timezone.now().date()
+
+        period = request.query_params.get("period")
+        if period:
+            span = presets.get(period)
+            if span is None:
+                raise serializers.ValidationError(
+                    {"period": "Must be one of past_week, past_month, past_year."}
+                )
+            return today - span, today, period
+
+        start_str = request.query_params.get("start_date")
+        end_str = request.query_params.get("end_date")
+        if start_str and end_str:
+            try:
+                start_date = datetime.strptime(start_str, "%Y-%m-%d").date()
+                end_date = datetime.strptime(end_str, "%Y-%m-%d").date()
+            except ValueError:
+                raise serializers.ValidationError(
+                    {"start_date": "start_date and end_date must be YYYY-MM-DD."}
+                )
+            if start_date > end_date:
+                raise serializers.ValidationError(
+                    {"start_date": "start_date must not be after end_date."}
+                )
+            return start_date, end_date, None
+
+        raise serializers.ValidationError(
+            "Provide either 'period' (past_week/past_month/past_year) or both "
+            "'start_date' and 'end_date' (YYYY-MM-DD)."
+        )
+
+    @staticmethod
+    def _pm_estimated_cost(maintenance_item, work_order):
+        """Estimated cost of one completed internal PM work order.
+
+        Mirrors the ``tco`` cost walk: a scheduled task (``interval_days`` set)
+        contributes its ``MaintenanceItem.estimated_cost``; an unscheduled or
+        one-off task contributes the sum of its used materials
+        (``quantity_planned * material.estimated_cost_per_unit``). Internal PM
+        has no actual-cost source, so this feeds the Estimated column only.
+        """
+        if maintenance_item.interval_days is not None:
+            return maintenance_item.estimated_cost or Decimal("0.00")
+        total = Decimal("0.00")
+        for usage in work_order.material_usage.all():
+            if usage.was_used and usage.material is not None:
+                total += usage.quantity_planned * usage.material.estimated_cost_per_unit
+        return total
+
+    @staticmethod
+    def _cost_recovery_csv(asset_blocks):
+        """Flat one-row-per-service CSV for the cost-recovery report.
+
+        Every selected asset appears; an asset with no in-window services emits
+        a single row with the service columns left blank.
+        """
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = 'attachment; filename="asset_cost_recovery.csv"'
+        fieldnames = [
+            "asset_tag",
+            "serial_number",
+            "status",
+            "date_received",
+            "service_date",
+            "source",
+            "description",
+            "estimated_cost",
+            "actual_cost",
+        ]
+        writer = csv.DictWriter(response, fieldnames=fieldnames)
+        writer.writeheader()
+        for block in asset_blocks:
+            base = {
+                "asset_tag": block["asset_tag"],
+                "serial_number": block["serial_number"],
+                "status": block["status"],
+                "date_received": (
+                    block["date_received"].isoformat() if block["date_received"] else ""
+                ),
+            }
+            services = block["services"]
+            if not services:
+                writer.writerow(
+                    {
+                        **base,
+                        "service_date": "",
+                        "source": "",
+                        "description": "",
+                        "estimated_cost": "",
+                        "actual_cost": "",
+                    }
+                )
+                continue
+            for svc in services:
+                writer.writerow(
+                    {
+                        **base,
+                        "service_date": svc["date"].isoformat(),
+                        "source": svc["source"],
+                        "description": svc["description"],
+                        "estimated_cost": (
+                            "" if svc["estimated_cost"] is None else f'{svc["estimated_cost"]:.2f}'
+                        ),
+                        "actual_cost": (
+                            "" if svc["actual_cost"] is None else f'{svc["actual_cost"]:.2f}'
+                        ),
+                    }
+                )
+        return response
+
+    @action(
+        detail=False,
+        methods=["get"],
+        renderer_classes=[JSONRenderer, _CostRecoveryCSVRenderer, _CostRecoveryPDFRenderer],
+    )
+    def cost_recovery(self, request):
+        """Per-asset cost-recovery statement billed to the landlord.
+
+        Select assets/categories + a period and get, per asset, an itemized
+        service history with Estimated (internal) and Actual (vendor-invoice /
+        recorded) cost columns. The Actual total is the recoverable amount.
+
+        Query params:
+        - Selection (>=1 required): ``asset_ids`` (Asset UUIDs) and/or
+          ``category_ids`` (integer Category PKs); each repeatable and/or
+          comma-joined. Categories expand to ``category.assets`` and the union
+          is de-duped.
+        - Period (one of): ``period`` in {past_week, past_month, past_year}
+          (trailing window ending today) OR ``start_date`` & ``end_date``
+          (YYYY-MM-DD).
+        - ``format`` in {json (default), csv, pdf}.
+
+        Service sources:
+        - ``pm`` — completed internal WorkOrders (estimated only; actual null).
+        - ``vendor`` — closed ThirdPartyWorkOrder allocations to the asset
+          (actual = allocated_cost; the recoverable spend).
+        - ``manual`` — MaintenanceRecord rows (actual = recorded cost).
+        """
+        from django.db.models import Prefetch
+
+        from maintenance_orders.models import ThirdPartyWorkOrder, ThirdPartyWorkOrderAsset
+
+        from .serializers import AssetCostRecoveryReportSerializer
+
+        asset_ids, category_ids = self._cost_recovery_selection(request)
+        start_date, end_date, period_label = self._cost_recovery_window(request)
+
+        # ``format`` is DRF's reserved content-negotiation query param; the
+        # action-scoped renderers above register json/csv/pdf so it negotiates
+        # cleanly (an unknown format 404s in negotiation before we get here).
+        fmt = request.accepted_renderer.format
+
+        # Resolve the selected asset set: explicit ids UNION category expansion.
+        selected_ids = set(asset_ids)
+        if category_ids:
+            selected_ids.update(
+                str(pk)
+                for pk in Asset.objects.filter(category_id__in=category_ids).values_list(
+                    "id", flat=True
+                )
+            )
+
+        # Window-scoped prefetch querysets — one pass per source, no N+1.
+        pm_wo_qs = WorkOrder.objects.filter(
+            status=WorkOrder.Status.COMPLETED,
+            completed_at__date__gte=start_date,
+            completed_at__date__lte=end_date,
+        ).prefetch_related("material_usage__material")
+        vendor_link_qs = ThirdPartyWorkOrderAsset.objects.select_related(
+            "work_order", "work_order__vendor"
+        ).filter(
+            work_order__status=ThirdPartyWorkOrder.STATUS_CLOSED,
+            work_order__closed_at__date__gte=start_date,
+            work_order__closed_at__date__lte=end_date,
+        )
+        manual_qs = MaintenanceRecord.objects.select_related("vendor").filter(
+            completed_on__gte=start_date,
+            completed_on__lte=end_date,
+        )
+
+        assets = (
+            Asset.objects.filter(id__in=selected_ids)
+            .select_related("category")
+            .prefetch_related(
+                Prefetch("maintenance_items__work_orders", queryset=pm_wo_qs),
+                Prefetch(
+                    "third_party_work_order_links",
+                    queryset=vendor_link_qs,
+                    to_attr="_cr_vendor_links",
+                ),
+                Prefetch("maintenance_records", queryset=manual_qs, to_attr="_cr_manual_records"),
+            )
+            .order_by("name")
+        )
+
+        asset_blocks = []
+        grand_estimated = Decimal("0.00")
+        grand_actual = Decimal("0.00")
+        service_count = 0
+
+        for asset in assets:
+            services = []
+            # Internal PM — estimated only (no actual-cost source).
+            for mi in asset.maintenance_items.all():
+                for wo in mi.work_orders.all():
+                    services.append(
+                        {
+                            "date": wo.completed_at.date(),
+                            "source": "pm",
+                            "description": mi.title,
+                            "estimated_cost": self._pm_estimated_cost(mi, wo),
+                            "actual_cost": None,
+                        }
+                    )
+            # Vendor — actual = per-asset allocated_cost (the recoverable spend).
+            for link in getattr(asset, "_cr_vendor_links", []):
+                wo = link.work_order
+                vendor_name = wo.vendor.name if wo.vendor_id else ""
+                description = f"{wo.title} ({vendor_name})" if vendor_name else wo.title
+                services.append(
+                    {
+                        "date": wo.closed_at.date(),
+                        "source": "vendor",
+                        "description": description,
+                        "estimated_cost": None,
+                        "actual_cost": link.allocated_cost,
+                    }
+                )
+            # Manual — actual = recorded cost (may be null when unknown).
+            for record in getattr(asset, "_cr_manual_records", []):
+                vendor_name = record.vendor.name if record.vendor_id else ""
+                description = f"{record.title} ({vendor_name})" if vendor_name else record.title
+                services.append(
+                    {
+                        "date": record.completed_on,
+                        "source": "manual",
+                        "description": description,
+                        "estimated_cost": None,
+                        "actual_cost": record.cost,
+                    }
+                )
+
+            services.sort(key=lambda s: s["date"])
+            subtotal_estimated = sum(
+                (s["estimated_cost"] or Decimal("0.00") for s in services), Decimal("0.00")
+            )
+            subtotal_actual = sum(
+                (s["actual_cost"] or Decimal("0.00") for s in services), Decimal("0.00")
+            )
+            grand_estimated += subtotal_estimated
+            grand_actual += subtotal_actual
+            service_count += len(services)
+
+            asset_blocks.append(
+                {
+                    "asset_id": str(asset.id),
+                    "asset_tag": asset.asset_tag or "",
+                    "name": asset.name,
+                    "serial_number": asset.serial_number or "",
+                    "date_received": asset.date_received,
+                    "status": asset.status,
+                    "status_display": asset.get_status_display(),
+                    "category": asset.category.name if asset.category_id else None,
+                    "services": services,
+                    "subtotal_estimated": subtotal_estimated,
+                    "subtotal_actual": subtotal_actual,
+                }
+            )
+
+        if fmt == "csv":
+            return self._cost_recovery_csv(asset_blocks)
+
+        if fmt == "pdf":
+            from .utils.cost_recovery_pdf import generate_cost_recovery_pdf
+
+            report = {
+                "period": period_label,
+                "start_date": start_date,
+                "end_date": end_date,
+                "generated_at": timezone.now(),
+                "asset_ids": asset_ids,
+                "category_ids": category_ids,
+                "asset_count": len(asset_blocks),
+                "service_count": service_count,
+                "grand_total_estimated": grand_estimated,
+                "grand_total_actual": grand_actual,
+                "assets": asset_blocks,
+            }
+            pdf_bytes = generate_cost_recovery_pdf(report)
+            response = HttpResponse(pdf_bytes, content_type="application/pdf")
+            response["Content-Disposition"] = 'attachment; filename="asset_cost_recovery.pdf"'
+            return response
+
+        # JSON (default). Decimals render as strings for parity with tco.
+        payload = {
+            "period": period_label,
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+            "asset_ids": asset_ids,
+            "category_ids": category_ids,
+            "asset_count": len(asset_blocks),
+            "service_count": service_count,
+            "grand_total_estimated": f"{grand_estimated:.2f}",
+            "grand_total_actual": f"{grand_actual:.2f}",
+            "assets": AssetCostRecoveryReportSerializer(asset_blocks, many=True).data,
+        }
+        return Response(payload)
 
     @action(detail=False, methods=["get"])
     def export(self, request):


### PR DESCRIPTION
## What

PR1 (backend) of the **Asset Cost-Recovery Report** — a statement of per-asset service
history + cost for **billing specific assets back to the landlord**. Extends the existing
`reports/assets/` TCO cost-walk into per-service line items over a selectable window.

`GET reports/assets/cost_recovery/`:
- **Select** `asset_ids` and/or `category_ids` (a category expands to its assets; ≥1 required)
- **Period**: preset `past_week` / `past_month` / `past_year`, or custom `start_date` & `end_date`
- Per asset: serial / date installed (`date_received`) / status, then a line per service
  (date, source, description, **estimated** cost, **actual vendor** cost), + per-asset subtotal
- Grand total with the **Actual (vendor invoice) total as the recoverable amount**; estimates shown as context
- **Three outputs**: JSON (default), `?format=csv`, `?format=pdf` (landlord-ready statement via reportlab)

## Cost basis (per Ian)

Both columns: **Estimated** (internal PM: `MaintenanceItem.estimated_cost` + material estimates)
and **Actual** (vendor `ThirdPartyWorkOrderAsset.allocated_cost` + manual `MaintenanceRecord.cost`).
Actual = recoverable. **Labor + materials actuals are deliberately out of scope** (a separate
second report).

## Notes

- Read-only report — **no model changes / no migration**.
- New landlord PDF in `inventory/utils/cost_recovery_pdf.py`; `work_order_pdf.py` is untouched
  (the #914 legibility fix is preserved — verified).
- New endpoint registered in `api_permission_matrix.yaml`.

## Test

`inventory/tests/test_cost_recovery.py` (cost walk, period presets + custom range, asset + category
selection, est vs actual columns, empty-window asset, grand-total recoverable, CSV + PDF smoke) +
`config/tests/test_permission_matrix.py`.

Frontend generator page (asset/category select, period picker, on-screen table, CSV/PDF buttons) is **PR2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
