### PR TITLE
fix(inventory): scope serialized-component install picker to compatible assets (op-sk0s)

### DIFF
--- a/backend/inventory/tests/test_asset_consumable_for_item_filter.py
+++ b/backend/inventory/tests/test_asset_consumable_for_item_filter.py
@@ -1,0 +1,110 @@
+"""
+Tests for the AssetViewSet ``consumable_for_item`` list filter (op-sk0s).
+
+A serialized component installs only into the assets its inventory item is a
+consumable/part for (via the AssetPart through-model) — e.g. an ink cartridge
+only into its printers. The install picker scopes itself with
+``?consumable_for_item=<item id>``; this covers the backend contract behind it.
+"""
+
+from django.contrib.auth import get_user_model
+
+import pytest
+from rest_framework.test import APIClient
+
+from inventory.tests.factories import (
+    AssetFactory,
+    AssetPartFactory,
+    InventoryItemFactory,
+)
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+ASSETS_URL = "/api/inventory/assets/"
+
+
+def _client():
+    """A plain authenticated user — LIST ownership policy shows them all assets,
+    so the filter (not visibility scoping) is what's under test."""
+    user = User.objects.create_user(username="picker", email="p@x.test", password="x")
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _ids(response):
+    data = response.data
+    results = data["results"] if isinstance(data, dict) and "results" in data else data
+    return [str(row["id"]) for row in results]
+
+
+class TestConsumableForItemFilter:
+    def test_returns_only_assets_the_item_is_a_part_for(self):
+        """?consumable_for_item=<item> → only assets linked to that item via
+        AssetPart; an asset without the part is absent."""
+        item = InventoryItemFactory()
+        printer = AssetFactory(name="UV Printer")
+        AssetPartFactory(asset=printer, part=item)
+        unrelated = AssetFactory(name="Table Saw")  # no AssetPart for `item`
+
+        resp = _client().get(ASSETS_URL, {"consumable_for_item": str(item.id)})
+
+        assert resp.status_code == 200, resp.content
+        ids = _ids(resp)
+        assert str(printer.id) in ids
+        assert str(unrelated.id) not in ids
+
+    def test_excludes_assets_that_are_a_part_for_a_different_item(self):
+        """An asset linked to a *different* item's part is not returned."""
+        item = InventoryItemFactory()
+        other_item = InventoryItemFactory()
+        printer = AssetFactory(name="Printer")
+        AssetPartFactory(asset=printer, part=item)
+        saw = AssetFactory(name="Saw")
+        AssetPartFactory(asset=saw, part=other_item)
+
+        ids = _ids(_client().get(ASSETS_URL, {"consumable_for_item": str(item.id)}))
+
+        assert str(printer.id) in ids
+        assert str(saw.id) not in ids
+
+    def test_distinct_no_duplicate_rows(self):
+        """An asset that uses the item (and also has other parts) appears exactly
+        once — the join doesn't multiply it (.distinct())."""
+        item = InventoryItemFactory()
+        other_item = InventoryItemFactory()
+        printer = AssetFactory(name="Printer")
+        AssetPartFactory(asset=printer, part=item)
+        AssetPartFactory(asset=printer, part=other_item)  # extra part, same asset
+
+        ids = _ids(_client().get(ASSETS_URL, {"consumable_for_item": str(item.id)}))
+
+        assert ids.count(str(printer.id)) == 1
+
+    def test_blank_value_is_unfiltered(self):
+        """A blank value is ignored — the list is not filtered by compatibility."""
+        item = InventoryItemFactory()
+        printer = AssetFactory(name="Printer")
+        AssetPartFactory(asset=printer, part=item)
+        unrelated = AssetFactory(name="Saw")
+
+        ids = _ids(_client().get(ASSETS_URL, {"consumable_for_item": ""}))
+
+        # Both assets are present — the filter did not apply.
+        assert str(printer.id) in ids
+        assert str(unrelated.id) in ids
+
+    def test_garbage_value_is_ignored_not_a_500(self):
+        """A non-UUID value is ignored gracefully (unfiltered), not a server error."""
+        item = InventoryItemFactory()
+        printer = AssetFactory(name="Printer")
+        AssetPartFactory(asset=printer, part=item)
+        unrelated = AssetFactory(name="Saw")
+
+        resp = _client().get(ASSETS_URL, {"consumable_for_item": "not-a-uuid"})
+
+        assert resp.status_code == 200, resp.content
+        ids = _ids(resp)
+        assert str(printer.id) in ids
+        assert str(unrelated.id) in ids

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -4,6 +4,7 @@ Views for inventory API.
 
 import csv
 import io
+import uuid
 from datetime import date, timedelta
 from decimal import Decimal, InvalidOperation
 
@@ -1462,6 +1463,20 @@ class AssetViewSet(viewsets.ModelViewSet):
         inventory_item = self.request.query_params.get("inventory_item")
         if inventory_item:
             queryset = queryset.filter(inventory_item_id=inventory_item)
+
+        # Filter to assets that use a given inventory item as a consumable/part
+        # (AssetPart through-model). Drives the serialized-component install
+        # picker: a serialized unit installs only into assets its item is a
+        # part for (e.g. an ink cartridge → only its printers) (op-sk0s). Ignore
+        # a blank/non-UUID value gracefully rather than 500 on a bad filter.
+        consumable_for_item = self.request.query_params.get("consumable_for_item")
+        if consumable_for_item:
+            try:
+                uuid.UUID(str(consumable_for_item))
+            except (ValueError, TypeError):
+                pass  # Not a valid item id — ignore the filter.
+            else:
+                queryset = queryset.filter(asset_parts__part_id=consumable_for_item).distinct()
 
         # Filter by manufacturer if specified
         manufacturer = self.request.query_params.get("manufacturer")

--- a/frontend/src/__tests__/components/SerializedComponentsPanel.test.tsx
+++ b/frontend/src/__tests__/components/SerializedComponentsPanel.test.tsx
@@ -275,4 +275,59 @@ describe('SerializedComponentsPanel', () => {
     );
     expect(await screen.findByText('Disposed')).toBeInTheDocument();
   });
+
+  it('scopes the install picker to assets the unit item is a part for', async () => {
+    // A unit ready to install (offers the `install` action).
+    mockAPI.list.mockResolvedValue(
+      listResponse([
+        buildUnit({
+          status: 'in_stock',
+          status_display: 'In Stock',
+          available_actions: ['install'],
+        }),
+      ]),
+    );
+    mockAssets.listAssets.mockResolvedValue({
+      data: {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [{ id: 'asset-1', name: 'UV Printer', asset_tag: 'AST-1' }],
+      },
+    } as never);
+
+    renderPanel();
+    fireEvent.click(await screen.findByTestId('serialized-action-install-unit-1'));
+
+    // The picker asks only for assets this unit's item is a consumable/part for.
+    await waitFor(() =>
+      expect(mockAssets.listAssets).toHaveBeenCalledWith(
+        expect.objectContaining({ consumable_for_item: ITEM_ID }),
+      ),
+    );
+    // No empty-state hint when compatible assets exist.
+    expect(screen.queryByTestId('serialized-install-empty-hint')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty-state hint when the item has no compatible assets', async () => {
+    mockAPI.list.mockResolvedValue(
+      listResponse([
+        buildUnit({
+          status: 'in_stock',
+          status_display: 'In Stock',
+          available_actions: ['install'],
+        }),
+      ]),
+    );
+    // No AssetPart links → the picker comes back empty.
+    mockAssets.listAssets.mockResolvedValue({
+      data: { count: 0, next: null, previous: null, results: [] },
+    } as never);
+
+    renderPanel();
+    fireEvent.click(await screen.findByTestId('serialized-action-install-unit-1'));
+
+    // Instead of a bare empty dropdown, the user gets a friendly next step.
+    expect(await screen.findByTestId('serialized-install-empty-hint')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/inventory/SerializedComponentsPanel.tsx
+++ b/frontend/src/components/inventory/SerializedComponentsPanel.tsx
@@ -221,7 +221,15 @@ const SerializedComponentsPanel: React.FC<Props> = ({
       if (assets.length === 0) {
         setAssetsLoading(true);
         try {
-          const res = await assetsAPI.listAssets({ page_size: 500, is_active: true });
+          // Scope the picker to assets this unit's item is a consumable/part
+          // for (AssetPart), not every asset — an ink cartridge only installs
+          // into its printers (op-sk0s). All units in this panel share one
+          // item, so the fetched list is reused across installs.
+          const res = await assetsAPI.listAssets({
+            page_size: 500,
+            is_active: true,
+            consumable_for_item: unit.item,
+          });
           setAssets(res.data.results ?? []);
         } catch {
           setAssets([]);
@@ -614,10 +622,19 @@ const SerializedComponentsPanel: React.FC<Props> = ({
             value={selectedAssetId}
             onChange={setSelectedAssetId}
             searchable
-            disabled={assetsLoading}
+            disabled={assetsLoading || assetOptions.length === 0}
             nothingFoundMessage="No assets found"
             data-testid="serialized-install-asset"
           />
+          {/* Compatibility is defined via AssetPart: an empty list means the
+              item isn't registered as a part of any asset yet. Explain that and
+              point to the fix instead of showing a bare, unusable dropdown. */}
+          {!assetsLoading && assetOptions.length === 0 && (
+            <Alert color="yellow" variant="light" data-testid="serialized-install-empty-hint">
+              No compatible assets. This item isn&apos;t listed as a part of any asset yet —
+              add it as a part first (Asset → Parts), then it will appear here.
+            </Alert>
+          )}
           <Group justify="flex-end">
             <Button variant="default" onClick={() => setInstallUnit(null)}>
               Cancel

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -489,6 +489,10 @@ export const assetsAPI = {
     search?: string;
     owning_group?: number;
     inventory_item?: string;
+    // Restrict to assets that use this inventory item as a consumable/part
+    // (AssetPart through-model) — scopes the serialized-component install
+    // picker to compatible assets only (op-sk0s).
+    consumable_for_item?: string;
     manufacturer?: number;
     is_active?: boolean;
     date_received_after?: string;


### PR DESCRIPTION
## What

Fixes a bug in the serialized-component **install** flow: the asset picker listed **every** asset.
It now lists only the assets the component's inventory item is a **consumable/part for** — e.g. an
ink cartridge shows only the printers it fits.

## How

The relationship already exists — `AssetPart` (the Asset → Parts M2M, "consumable parts/supplies used
by assets"). No schema change.

- **Backend** (`AssetViewSet.get_queryset`): new `consumable_for_item=<inventory_item_id>` query param →
  `queryset.filter(asset_parts__part_id=…).distinct()` (UUID-validated; ignored when blank). Existing
  endpoint, new param — no permission-matrix change.
- **Frontend** (`SerializedComponentsPanel`): the install picker passes the unit's `item` id via
  `listAssets({ consumable_for_item })`, so it only offers compatible assets. `api.ts` gains the param.
- **Empty state:** if the item isn't registered as a part of any asset yet, the picker would be empty —
  instead of a bare dropdown it shows an Alert ("No compatible assets — add it as a part first
  (Asset → Parts)") and disables install. So compatibility is driven by the AssetPart data.

## Not changed

- The `install` action still accepts any asset server-side (Ian asked to scope the picker, not hard-block
  installs; hard enforcement risks blocking legit edge cases).
- **ScanTTY:** N/A — its install path is a manual "enter asset UUID" field, not a list.

## Test

Backend `test_asset_consumable_for_item_filter.py` (filter returns only AssetPart-linked assets; distinct;
blank ignored) + frontend `SerializedComponentsPanel.test.tsx` (picker passes the filter; empty-state hint).

_Branched pre-#915; rebased onto current main (cost-recovery code preserved, verified)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
