### PR TITLE
feat(reports): asset cost-recovery report generator page (op-wjmm, PR2)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import WorkspaceLayout from './components/WorkspaceLayout';
 import AdminDashboard from './pages/AdminDashboard';
 import AuditFeedPage from './pages/AuditFeedPage';
 import AnalyticsDashboardPage from './pages/AnalyticsDashboardPage';
+import AssetCostRecoveryPage from './pages/AssetCostRecoveryPage';
 import AssetDetailPage from './pages/AssetDetailPage';
 import AssetFormPage from './pages/AssetFormPage';
 import MaintenanceItemFormPage from './pages/MaintenanceItemFormPage';
@@ -379,6 +380,7 @@ function AppContent() {
           <Route path="/reports/inventory" element={<WorkspaceLayout><InventoryReportPage /></WorkspaceLayout>} />
           <Route path="/reports/purchasing" element={<WorkspaceLayout><PurchasingReportPage /></WorkspaceLayout>} />
           <Route path="/reports/assets" element={<WorkspaceLayout><AssetReportPage /></WorkspaceLayout>} />
+          <Route path="/reports/cost-recovery" element={<WorkspaceLayout><AssetCostRecoveryPage /></WorkspaceLayout>} />
 
           {/* Settings Workspace */}
           <Route path="/settings" element={<WorkspaceLayout><SettingsOverviewPage /></WorkspaceLayout>} />

--- a/frontend/src/__tests__/pages/AssetCostRecoveryPage.test.tsx
+++ b/frontend/src/__tests__/pages/AssetCostRecoveryPage.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Tests for AssetCostRecoveryPage — the cost-recovery report generator (op-wjmm).
+ *
+ * Covers: options load on mount; asset select + default preset build the right
+ * params and render per-asset line items + grand total; the custom date range
+ * sends start_date/end_date instead of a period; CSV/PDF buttons hit the
+ * format= endpoint and trigger a download; empty-state; and error surfacing.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+
+import AssetCostRecoveryPage from '../../pages/AssetCostRecoveryPage';
+import { assetsAPI, inventoryAPI, reportsAPI } from '../../services/api';
+import { networkError } from '../helpers/offline';
+
+vi.mock('../../services/api');
+
+const mockAssetsAPI = assetsAPI as jest.Mocked<typeof assetsAPI>;
+const mockInventoryAPI = inventoryAPI as jest.Mocked<typeof inventoryAPI>;
+const mockReportsAPI = reportsAPI as jest.Mocked<typeof reportsAPI>;
+
+const okResponse = <T,>(data: T) =>
+  ({ data, status: 200, statusText: 'OK', headers: {}, config: {} as never }) as never;
+
+const ASSETS = [
+  { id: 'a1', name: 'Laser Cutter', asset_tag: 'LC-1', serial_number: 'SN-1' },
+  { id: 'a2', name: 'CNC Mill', asset_tag: '', serial_number: 'SN-2' },
+];
+
+const CATEGORIES = [{ id: 3, name: 'Fabrication' }];
+
+const SAMPLE_REPORT = {
+  period: 'past_month',
+  start_date: '2026-06-16',
+  end_date: '2026-07-16',
+  asset_ids: ['a1'],
+  category_ids: [],
+  asset_count: 1,
+  service_count: 2,
+  grand_total_estimated: '40.00',
+  grand_total_actual: '250.00',
+  assets: [
+    {
+      asset_id: 'a1',
+      asset_tag: 'LC-1',
+      name: 'Laser Cutter',
+      serial_number: 'SN-1',
+      date_received: '2025-01-01',
+      status: 'operational',
+      status_display: 'Operational',
+      category: 'Fabrication',
+      services: [
+        {
+          date: '2026-06-20',
+          source: 'vendor',
+          description: 'Tube replacement (Acme)',
+          estimated_cost: null,
+          actual_cost: '250.00',
+        },
+        {
+          date: '2026-06-25',
+          source: 'pm',
+          description: 'Lens cleaning',
+          estimated_cost: '40.00',
+          actual_cost: null,
+        },
+      ],
+      subtotal_estimated: '40.00',
+      subtotal_actual: '250.00',
+    },
+  ],
+};
+
+const renderPage = () =>
+  render(
+    <MantineProvider env="test">
+      <AssetCostRecoveryPage />
+    </MantineProvider>,
+  );
+
+// Load the pickers so the selects enable; individual tests override the report
+// calls as needed.
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAssetsAPI.listAssets.mockResolvedValue(
+    okResponse({ count: ASSETS.length, next: null, previous: null, results: ASSETS }),
+  );
+  mockInventoryAPI.listCategories.mockResolvedValue(okResponse({ results: CATEGORIES }));
+  mockReportsAPI.getAssetCostRecovery.mockResolvedValue(okResponse(SAMPLE_REPORT));
+  mockReportsAPI.downloadAssetCostRecovery.mockResolvedValue(okResponse(new Blob(['x'])));
+});
+
+// Wait for the asset picker to finish loading, then select "Laser Cutter".
+const selectLaserCutter = async () => {
+  const assetInput = screen.getByPlaceholderText('Search assets');
+  await waitFor(() => expect(assetInput).not.toBeDisabled());
+  fireEvent.click(assetInput);
+  fireEvent.click(await screen.findByRole('option', { name: /Laser Cutter/i }));
+};
+
+describe('AssetCostRecoveryPage', () => {
+  it('loads asset + category pickers and shows the initial prompt', async () => {
+    renderPage();
+
+    expect(
+      await screen.findByText(/choose one or more assets or categories and a period/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Generate' })).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockAssetsAPI.listAssets).toHaveBeenCalledWith({ page_size: 500 });
+    });
+    expect(mockInventoryAPI.listCategories).toHaveBeenCalled();
+  });
+
+  it('generates with the default preset and renders per-asset line items + grand total', async () => {
+    renderPage();
+    await selectLaserCutter();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(mockReportsAPI.getAssetCostRecovery).toHaveBeenCalledWith(
+        expect.objectContaining({ asset_ids: ['a1'], period: 'past_month' }),
+      );
+    });
+
+    const results = await screen.findByTestId('cost-recovery-results');
+    expect(within(results).getByText('Tube replacement (Acme)')).toBeInTheDocument();
+    expect(within(results).getByText('Lens cleaning')).toBeInTheDocument();
+    expect(
+      within(results).getByText(/grand total recoverable: \$250\.00/i),
+    ).toBeInTheDocument();
+  });
+
+  it('sends start_date/end_date (not a period) when "These dates" is selected', async () => {
+    renderPage();
+    await selectLaserCutter();
+
+    fireEvent.click(screen.getByRole('radio', { name: /these dates/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => expect(mockReportsAPI.getAssetCostRecovery).toHaveBeenCalled());
+    const params = mockReportsAPI.getAssetCostRecovery.mock.calls[0][0];
+    expect(params.period).toBeUndefined();
+    expect(params.start_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(params.end_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(params.asset_ids).toEqual(['a1']);
+  });
+
+  it('Export CSV hits the csv endpoint and triggers a download', async () => {
+    const createObjectURL = vi.fn(() => 'blob:mock');
+    Object.defineProperty(window.URL, 'createObjectURL', {
+      value: createObjectURL,
+      writable: true,
+    });
+    Object.defineProperty(window.URL, 'revokeObjectURL', { value: vi.fn(), writable: true });
+
+    renderPage();
+    await selectLaserCutter();
+
+    fireEvent.click(screen.getByRole('button', { name: /export csv/i }));
+
+    await waitFor(() => {
+      expect(mockReportsAPI.downloadAssetCostRecovery).toHaveBeenCalledWith(
+        expect.objectContaining({ asset_ids: ['a1'], period: 'past_month' }),
+        'csv',
+      );
+    });
+    expect(createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+  });
+
+  it('Export PDF hits the pdf endpoint', async () => {
+    Object.defineProperty(window.URL, 'createObjectURL', {
+      value: vi.fn(() => 'blob:mock'),
+      writable: true,
+    });
+    Object.defineProperty(window.URL, 'revokeObjectURL', { value: vi.fn(), writable: true });
+
+    renderPage();
+    await selectLaserCutter();
+
+    fireEvent.click(screen.getByRole('button', { name: /export pdf/i }));
+
+    await waitFor(() => {
+      expect(mockReportsAPI.downloadAssetCostRecovery).toHaveBeenCalledWith(
+        expect.objectContaining({ asset_ids: ['a1'] }),
+        'pdf',
+      );
+    });
+  });
+
+  it('shows an empty state when the selection matches no assets', async () => {
+    mockReportsAPI.getAssetCostRecovery.mockResolvedValue(
+      okResponse({
+        ...SAMPLE_REPORT,
+        asset_count: 0,
+        service_count: 0,
+        grand_total_actual: '0.00',
+        grand_total_estimated: '0.00',
+        assets: [],
+      }),
+    );
+
+    renderPage();
+    await selectLaserCutter();
+    fireEvent.click(screen.getByRole('button', { name: 'Generate' }));
+
+    expect(
+      await screen.findByText(/no assets matched your selection for this period/i),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces an error when report generation fails', async () => {
+    mockReportsAPI.getAssetCostRecovery.mockRejectedValue(networkError());
+
+    renderPage();
+    await selectLaserCutter();
+    fireEvent.click(screen.getByRole('button', { name: 'Generate' }));
+
+    expect(await screen.findByText(/report error/i)).toBeInTheDocument();
+  });
+
+  it('keeps Generate disabled until an asset or category is chosen', async () => {
+    renderPage();
+    const generate = screen.getByRole('button', { name: 'Generate' });
+    expect(generate).toBeDisabled();
+    // Enable once loaded + a selection is made.
+    await selectLaserCutter();
+    await waitFor(() => expect(generate).not.toBeDisabled());
+  });
+});

--- a/frontend/src/__tests__/services/api.test.ts
+++ b/frontend/src/__tests__/services/api.test.ts
@@ -939,6 +939,71 @@ describe('API Service', () => {
       expect(response.data[0].source).toBe('serialized');
       expect(response.data[0].serial_number).toBe('SN-1001');
     });
+
+    test('getAssetCostRecovery comma-joins asset/category ids and echoes the report', async () => {
+      mock.onGet('/inventory/reports/assets/cost_recovery/').reply((config) => {
+        // Comma-joined so the backend getlist() reads them (axios would
+        // otherwise emit asset_ids[]=…, which the endpoint ignores).
+        expect(config.params).toEqual({
+          asset_ids: 'a1,a2',
+          category_ids: '3',
+          period: 'past_month',
+        });
+        return [
+          200,
+          {
+            period: 'past_month',
+            start_date: '2026-06-16',
+            end_date: '2026-07-16',
+            asset_ids: ['a1', 'a2'],
+            category_ids: [3],
+            asset_count: 1,
+            service_count: 1,
+            grand_total_estimated: '0.00',
+            grand_total_actual: '250.00',
+            assets: [],
+          },
+        ];
+      });
+
+      const response = await reportsAPI.getAssetCostRecovery({
+        asset_ids: ['a1', 'a2'],
+        category_ids: [3],
+        period: 'past_month',
+      });
+
+      expect(response.data.grand_total_actual).toBe('250.00');
+    });
+
+    test('downloadAssetCostRecovery requests the format as a blob', async () => {
+      mock.onGet('/inventory/reports/assets/cost_recovery/').reply((config) => {
+        expect(config.params).toEqual({ asset_ids: 'a1', period: 'past_month', format: 'csv' });
+        expect(config.responseType).toBe('blob');
+        return [200, 'asset_tag,actual_cost\n'];
+      });
+
+      const response = await reportsAPI.downloadAssetCostRecovery(
+        { asset_ids: ['a1'], period: 'past_month' },
+        'csv',
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    test('getAssetCostRecoveryUrl builds a shareable download URL with the same params', () => {
+      const url = reportsAPI.getAssetCostRecoveryUrl(
+        { asset_ids: ['a1', 'a2'], category_ids: [3], start_date: '2026-01-01', end_date: '2026-03-31' },
+        'pdf',
+      );
+      const decoded = decodeURIComponent(url);
+
+      expect(url).toContain('/inventory/reports/assets/cost_recovery/');
+      expect(url).toContain('format=pdf');
+      expect(decoded).toContain('asset_ids=a1,a2');
+      expect(decoded).toContain('category_ids=3');
+      expect(decoded).toContain('start_date=2026-01-01');
+      expect(decoded).toContain('end_date=2026-03-31');
+    });
   });
 
   describe('resolveApiBaseUrl (deployment-configurable API base URL)', () => {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -156,6 +156,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed = false, isMobileOpen = f
         { path: '/reports/inventory', label: 'Inventory Report', icon: '📦', requiresAuth: true },
         { path: '/reports/purchasing', label: 'Purchasing Report', icon: '🛒', requiresAuth: true },
         { path: '/reports/assets', label: 'Asset Report', icon: '🏢', requiresAuth: true },
+        { path: '/reports/cost-recovery', label: 'Cost Recovery', icon: '💰', requiresAuth: true },
       ],
     },
     {

--- a/frontend/src/navigation/routeMap.ts
+++ b/frontend/src/navigation/routeMap.ts
@@ -102,6 +102,7 @@ const ENTRIES: RouteEntry[] = [
   { path: 'reports/inventory', label: 'Inventory Report' },
   { path: 'reports/purchasing', label: 'Purchasing Report' },
   { path: 'reports/assets', label: 'Asset Report' },
+  { path: 'reports/cost-recovery', label: 'Cost Recovery Report' },
 
   { path: 'analytics', label: 'Analytics Pulse' },
 

--- a/frontend/src/pages/AssetCostRecoveryPage.tsx
+++ b/frontend/src/pages/AssetCostRecoveryPage.tsx
@@ -1,0 +1,376 @@
+/**
+ * Asset Cost-Recovery Report generator.
+ *
+ * Pick one or more assets and/or asset categories plus a reporting period,
+ * then Generate a per-asset service statement with Estimated (internal) and
+ * Actual (vendor-invoice / recorded) columns. The Actual total is the amount
+ * recoverable from the landlord. CSV and the landlord-ready PDF are produced
+ * server-side and downloaded as blobs.
+ *
+ * Consumes reports/assets/cost_recovery/ (PR1, backend) — see
+ * inventory/views.py AssetReportViewSet.cost_recovery.
+ */
+import { Alert, Button, Group, Loader, MultiSelect, Paper, SegmentedControl, Stack, Table, Text, Title } from '@mantine/core';
+import { DatePickerInput, DatesRangeValue } from '@mantine/dates';
+import { IconAlertTriangle, IconDownload } from '@tabler/icons-react';
+import dayjs from 'dayjs';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { assetsAPI, CostRecoveryParams, CostRecoveryPeriod, inventoryAPI, reportsAPI } from '../services/api';
+import { Asset, AssetCostRecoveryReport, Category } from '../types';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+type PeriodMode = CostRecoveryPeriod | 'custom';
+
+const PERIOD_OPTIONS: Array<{ label: string; value: PeriodMode }> = [
+  { label: 'Past week', value: 'past_week' },
+  { label: 'Past month', value: 'past_month' },
+  { label: 'Past year', value: 'past_year' },
+  { label: 'These dates', value: 'custom' },
+];
+
+const PERIOD_LABELS: Record<CostRecoveryPeriod, string> = {
+  past_week: 'Past week',
+  past_month: 'Past month',
+  past_year: 'Past year',
+};
+
+// Human labels for a service line's origin.
+const SOURCE_LABELS: Record<string, string> = {
+  pm: 'Internal PM',
+  vendor: 'Vendor',
+  manual: 'Recorded',
+};
+
+const formatMoney = (value: string | number | null): string => {
+  const num = typeof value === 'number' ? value : parseFloat(value || '0');
+  return Number.isFinite(num) ? num.toFixed(2) : '0.00';
+};
+
+const describeWindow = (report: AssetCostRecoveryReport): string =>
+  report.period ? PERIOD_LABELS[report.period] : `${report.start_date} → ${report.end_date}`;
+
+// Pre-fill the custom range with the trailing 30 days so switching to "These
+// dates" starts from a sensible, immediately-runnable window the user adjusts.
+const getDefaultDateRange = (): DatesRangeValue => [
+  dayjs().subtract(30, 'day').toDate(),
+  new Date(),
+];
+
+const AssetCostRecoveryPage: React.FC = () => {
+  const [assets, setAssets] = useState<Asset[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [loadingOptions, setLoadingOptions] = useState(true);
+
+  const [selectedAssetIds, setSelectedAssetIds] = useState<string[]>([]);
+  const [selectedCategoryIds, setSelectedCategoryIds] = useState<string[]>([]);
+  const [periodMode, setPeriodMode] = useState<PeriodMode>('past_month');
+  const [dateRange, setDateRange] = useState<DatesRangeValue>(getDefaultDateRange);
+
+  const [report, setReport] = useState<AssetCostRecoveryReport | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState<'csv' | 'pdf' | null>(null);
+
+  // Load the asset + category pickers once. Guard the responses so an
+  // undefined payload (e.g. a fully mocked API in tests) can't throw.
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingOptions(true);
+    Promise.all([assetsAPI.listAssets({ page_size: 500 }), inventoryAPI.listCategories()])
+      .then(([assetRes, catRes]) => {
+        if (cancelled) return;
+        setAssets(assetRes?.data?.results ?? []);
+        setCategories(catRes?.data?.results ?? []);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(extractErrorMessage(err, 'Failed to load assets and categories.'));
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingOptions(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const assetOptions = useMemo(
+    () =>
+      assets.map((a) => ({
+        value: a.id,
+        label: a.asset_tag ? `${a.asset_tag} — ${a.name}` : a.name,
+      })),
+    [assets],
+  );
+
+  const categoryOptions = useMemo(
+    () => categories.map((c) => ({ value: String(c.id), label: c.name })),
+    [categories],
+  );
+
+  const hasSelection = selectedAssetIds.length > 0 || selectedCategoryIds.length > 0;
+  const periodComplete = periodMode !== 'custom' || Boolean(dateRange[0] && dateRange[1]);
+  const canRun = hasSelection && periodComplete;
+
+  // Assemble the request params, or null if the selection/window is incomplete.
+  const buildParams = useCallback((): CostRecoveryParams | null => {
+    if (!hasSelection) return null;
+    const base: CostRecoveryParams = {
+      asset_ids: selectedAssetIds,
+      category_ids: selectedCategoryIds.map(Number),
+    };
+    if (periodMode === 'custom') {
+      if (!dateRange[0] || !dateRange[1]) return null;
+      return {
+        ...base,
+        start_date: dayjs(dateRange[0]).format('YYYY-MM-DD'),
+        end_date: dayjs(dateRange[1]).format('YYYY-MM-DD'),
+      };
+    }
+    return { ...base, period: periodMode };
+  }, [hasSelection, selectedAssetIds, selectedCategoryIds, periodMode, dateRange]);
+
+  const handleGenerate = async () => {
+    const params = buildParams();
+    if (!params) {
+      setError('Select at least one asset or category and a complete period.');
+      return;
+    }
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await reportsAPI.getAssetCostRecovery(params);
+      setReport(response.data);
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to generate the cost-recovery report.'));
+      setReport(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleExport = async (format: 'csv' | 'pdf') => {
+    const params = buildParams();
+    if (!params) {
+      setError('Select at least one asset or category and a complete period.');
+      return;
+    }
+    try {
+      setExporting(format);
+      setError(null);
+      const response = await reportsAPI.downloadAssetCostRecovery(params, format);
+      const mime = format === 'pdf' ? 'application/pdf' : 'text/csv';
+      const blob = new Blob([response.data], { type: mime });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `asset_cost_recovery.${format}`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      setError(extractErrorMessage(err, `Failed to export ${format.toUpperCase()}.`));
+    } finally {
+      setExporting(null);
+    }
+  };
+
+  return (
+    <Stack gap="md" p="md">
+      <Title order={2}>Asset Cost-Recovery Report</Title>
+      <Text size="sm" c="dimmed">
+        Build a per-asset service statement billed to the landlord. The Actual
+        (vendor-invoice / recorded) total is the recoverable amount; estimates
+        for internal preventive maintenance are shown as context only.
+      </Text>
+
+      <Paper withBorder p="md">
+        <Stack gap="md">
+          <MultiSelect
+            label="Assets"
+            placeholder="Search assets"
+            data={assetOptions}
+            value={selectedAssetIds}
+            onChange={setSelectedAssetIds}
+            searchable
+            clearable
+            disabled={loadingOptions}
+            data-testid="cost-recovery-assets"
+          />
+          <MultiSelect
+            label="Categories"
+            description="A category expands to all of its assets."
+            placeholder="Search categories"
+            data={categoryOptions}
+            value={selectedCategoryIds}
+            onChange={setSelectedCategoryIds}
+            searchable
+            clearable
+            disabled={loadingOptions}
+            data-testid="cost-recovery-categories"
+          />
+
+          <div>
+            <Text size="sm" fw={500} mb={4}>
+              Period
+            </Text>
+            <SegmentedControl
+              value={periodMode}
+              onChange={(value) => setPeriodMode(value as PeriodMode)}
+              data={PERIOD_OPTIONS}
+            />
+          </div>
+
+          {periodMode === 'custom' && (
+            <DatePickerInput
+              type="range"
+              label="Date range"
+              placeholder="Select start and end dates"
+              value={dateRange}
+              onChange={setDateRange}
+              allowSingleDateInRange
+              clearable
+              maxDate={new Date()}
+              style={{ maxWidth: 320 }}
+            />
+          )}
+
+          <Group>
+            <Button onClick={handleGenerate} loading={loading} disabled={!canRun}>
+              Generate
+            </Button>
+            <Button
+              variant="light"
+              leftSection={<IconDownload size={16} />}
+              onClick={() => handleExport('csv')}
+              loading={exporting === 'csv'}
+              disabled={!canRun}
+            >
+              Export CSV
+            </Button>
+            <Button
+              variant="light"
+              leftSection={<IconDownload size={16} />}
+              onClick={() => handleExport('pdf')}
+              loading={exporting === 'pdf'}
+              disabled={!canRun}
+            >
+              Export PDF
+            </Button>
+          </Group>
+        </Stack>
+      </Paper>
+
+      {error && (
+        <Alert color="red" icon={<IconAlertTriangle size={16} />} title="Report error">
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Group gap="xs">
+          <Loader size="sm" />
+          <Text>Generating statement…</Text>
+        </Group>
+      ) : report === null ? (
+        <Text c="dimmed">
+          Choose one or more assets or categories and a period, then Generate the statement.
+        </Text>
+      ) : report.assets.length === 0 ? (
+        <Paper withBorder p="md">
+          <Text c="dimmed">No assets matched your selection for this period.</Text>
+        </Paper>
+      ) : (
+        <Stack gap="md" data-testid="cost-recovery-results">
+          <Paper withBorder p="md">
+            <Group justify="space-between" wrap="wrap">
+              <div>
+                <Text fw={700} size="lg">
+                  Grand total recoverable: ${formatMoney(report.grand_total_actual)}
+                </Text>
+                <Text size="sm" c="dimmed">
+                  Estimated (internal, non-recoverable) context: $
+                  {formatMoney(report.grand_total_estimated)}
+                </Text>
+              </div>
+              <Text size="sm" c="dimmed">
+                {report.asset_count} asset{report.asset_count === 1 ? '' : 's'} ·{' '}
+                {report.service_count} service{report.service_count === 1 ? '' : 's'} ·{' '}
+                {describeWindow(report)}
+              </Text>
+            </Group>
+          </Paper>
+
+          {report.assets.map((asset) => (
+            <Paper key={asset.asset_id} withBorder p="md">
+              <Group justify="space-between" mb="xs" wrap="wrap">
+                <div>
+                  <Text fw={600}>
+                    {asset.name}
+                    {asset.asset_tag ? ` — ${asset.asset_tag}` : ''}
+                  </Text>
+                  <Text size="sm" c="dimmed">
+                    Serial: {asset.serial_number || '—'} · Installed:{' '}
+                    {asset.date_received ? dayjs(asset.date_received).format('YYYY-MM-DD') : '—'} ·
+                    Status: {asset.status_display}
+                    {asset.category ? ` · ${asset.category}` : ''}
+                  </Text>
+                </div>
+                <Text fw={600}>Recoverable: ${formatMoney(asset.subtotal_actual)}</Text>
+              </Group>
+              <Table.ScrollContainer minWidth={640}>
+                <Table highlightOnHover>
+                  <Table.Thead>
+                    <Table.Tr>
+                      <Table.Th>Date</Table.Th>
+                      <Table.Th>Source</Table.Th>
+                      <Table.Th>Description</Table.Th>
+                      <Table.Th ta="right">Estimated</Table.Th>
+                      <Table.Th ta="right">Actual (vendor)</Table.Th>
+                    </Table.Tr>
+                  </Table.Thead>
+                  <Table.Tbody>
+                    {asset.services.length === 0 ? (
+                      <Table.Tr>
+                        <Table.Td colSpan={5} ta="center">
+                          <Text c="dimmed">No services in this period</Text>
+                        </Table.Td>
+                      </Table.Tr>
+                    ) : (
+                      asset.services.map((svc, idx) => (
+                        <Table.Tr key={idx}>
+                          <Table.Td>{dayjs(svc.date).format('YYYY-MM-DD')}</Table.Td>
+                          <Table.Td>{SOURCE_LABELS[svc.source] ?? svc.source}</Table.Td>
+                          <Table.Td>{svc.description || '—'}</Table.Td>
+                          <Table.Td ta="right">
+                            {svc.estimated_cost != null ? `$${formatMoney(svc.estimated_cost)}` : '—'}
+                          </Table.Td>
+                          <Table.Td ta="right">
+                            {svc.actual_cost != null ? `$${formatMoney(svc.actual_cost)}` : '—'}
+                          </Table.Td>
+                        </Table.Tr>
+                      ))
+                    )}
+                  </Table.Tbody>
+                  <Table.Tfoot>
+                    <Table.Tr>
+                      <Table.Th colSpan={3} ta="right">
+                        Subtotal
+                      </Table.Th>
+                      <Table.Th ta="right">${formatMoney(asset.subtotal_estimated)}</Table.Th>
+                      <Table.Th ta="right">${formatMoney(asset.subtotal_actual)}</Table.Th>
+                    </Table.Tr>
+                  </Table.Tfoot>
+                </Table>
+              </Table.ScrollContainer>
+            </Paper>
+          ))}
+        </Stack>
+      )}
+    </Stack>
+  );
+};
+
+export default AssetCostRecoveryPage;

--- a/frontend/src/pages/ReportsOverviewPage.tsx
+++ b/frontend/src/pages/ReportsOverviewPage.tsx
@@ -6,6 +6,7 @@
 import {
   IconChartBar,
   IconReportAnalytics,
+  IconReportMoney,
   IconShoppingCart,
   IconStack,
 } from '@tabler/icons-react';
@@ -56,6 +57,14 @@ const ReportsOverviewPage: React.FC = () => (
       icon={<IconReportAnalytics size={22} stroke={1.8} />}
       eyebrow="Operational"
       testId="reports-overview-card-/reports/assets"
+    />
+    <CapabilityCard
+      to="/reports/cost-recovery"
+      title="Cost recovery report"
+      description="Per-asset service statement with the vendor-invoice total recoverable from the landlord. Exports a CSV and a landlord-ready PDF."
+      icon={<IconReportMoney size={22} stroke={1.8} />}
+      eyebrow="Operational"
+      testId="reports-overview-card-/reports/cost-recovery"
     />
   </WorkspaceLanding>
 );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,7 +2,7 @@
  * API service for communicating with the Django backend
  */
 import axios from 'axios';
-import { ActiveMaintenanceRow, Asset, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, InventoryItemMetrics, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderLotoCompletion, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
+import { ActiveMaintenanceRow, Asset, AssetCostRecoveryReport, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, InventoryItemMetrics, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderLotoCompletion, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
 
 /**
  * Resolves the API base URL based on environment.
@@ -2022,6 +2022,46 @@ export const notificationsAPI = {
 // Date range params type for reports
 type DateRangeParams = { start_date?: string; end_date?: string };
 
+export type CostRecoveryPeriod = 'past_week' | 'past_month' | 'past_year';
+
+// Selection + window for the asset cost-recovery report. Supply at least one
+// of asset_ids / category_ids, and exactly one of period OR start_date+end_date.
+export interface CostRecoveryParams {
+  asset_ids?: string[];
+  category_ids?: number[];
+  period?: CostRecoveryPeriod;
+  start_date?: string; // YYYY-MM-DD
+  end_date?: string; // YYYY-MM-DD
+}
+
+// Build the flat query object for the cost_recovery endpoint. The backend
+// accepts asset_ids / category_ids as comma-joined lists (it splits on ","),
+// which avoids axios's bracketed array serialization (asset_ids[]=) that the
+// endpoint would not read. Empty selections/windows are omitted so the caller
+// controls exactly which params are sent.
+const buildCostRecoveryQuery = (
+  params: CostRecoveryParams,
+  format?: 'csv' | 'pdf',
+): Record<string, string> => {
+  const query: Record<string, string> = {};
+  if (params.asset_ids && params.asset_ids.length > 0) {
+    query.asset_ids = params.asset_ids.join(',');
+  }
+  if (params.category_ids && params.category_ids.length > 0) {
+    query.category_ids = params.category_ids.join(',');
+  }
+  if (params.period) {
+    query.period = params.period;
+  } else if (params.start_date && params.end_date) {
+    query.start_date = params.start_date;
+    query.end_date = params.end_date;
+  }
+  if (format) {
+    query.format = format;
+  }
+  return query;
+};
+
 // Reports API
 export const reportsAPI = {
   // Inventory Reports
@@ -2081,6 +2121,29 @@ export const reportsAPI = {
 
   getAssetSuppliesUsed: (params?: DateRangeParams) =>
     api.get('/inventory/reports/assets/supplies_used/', { params }),
+
+  // Asset cost-recovery statement (landlord-billable). JSON for on-screen
+  // rendering; blob download for the server-generated CSV / landlord PDF.
+  getAssetCostRecovery: (params: CostRecoveryParams) =>
+    api.get<AssetCostRecoveryReport>('/inventory/reports/assets/cost_recovery/', {
+      params: buildCostRecoveryQuery(params),
+    }),
+
+  // Fetch the CSV/PDF as a blob so the request carries the Authorization
+  // header (and gets the interceptor's 401 refresh) rather than relying on the
+  // session cookie of a raw <a href> navigation.
+  downloadAssetCostRecovery: (params: CostRecoveryParams, format: 'csv' | 'pdf') =>
+    api.get('/inventory/reports/assets/cost_recovery/', {
+      params: buildCostRecoveryQuery(params, format),
+      responseType: 'blob',
+    }),
+
+  // Build the shareable download URL (same params + ?format=) for callers that
+  // want a direct link rather than a blob fetch.
+  getAssetCostRecoveryUrl: (params: CostRecoveryParams, format: 'csv' | 'pdf') => {
+    const search = new URLSearchParams(buildCostRecoveryQuery(params, format));
+    return `${API_BASE_URL}/inventory/reports/assets/cost_recovery/?${search.toString()}`;
+  },
 
   exportAssetReport: (type: 'assets_by_status' | 'maintenance_due' | 'utilization' | 'tco', params?: DateRangeParams) =>
     api.get('/inventory/reports/assets/export/', {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1206,6 +1206,48 @@ export interface AssetSuppliesUsed {
   estimated_cost?: string | null;
 }
 
+// Asset cost-recovery statement (reports/assets/cost_recovery). Mirrors the
+// merged backend serializers exactly (inventory/serializers.py:
+// AssetCostRecoveryServiceSerializer / AssetCostRecoveryReportSerializer). All
+// money fields are DRF DecimalField values, serialized as strings.
+export interface AssetCostRecoveryService {
+  date: string; // YYYY-MM-DD
+  source: 'pm' | 'vendor' | 'manual';
+  description: string;
+  // Internal PM carries an estimate but no actual; vendor/manual carry the
+  // actual (recoverable) but no estimate — hence each may be null.
+  estimated_cost: string | null;
+  actual_cost: string | null;
+}
+
+export interface AssetCostRecoveryAsset {
+  asset_id: string;
+  asset_tag: string;
+  name: string;
+  serial_number: string;
+  date_received: string | null; // "date installed" on the statement
+  status: string;
+  status_display: string;
+  category: string | null;
+  services: AssetCostRecoveryService[];
+  subtotal_estimated: string;
+  subtotal_actual: string; // recoverable amount for this asset
+}
+
+export interface AssetCostRecoveryReport {
+  // Echo of the request window/selection.
+  period: 'past_week' | 'past_month' | 'past_year' | null;
+  start_date: string;
+  end_date: string;
+  asset_ids: string[];
+  category_ids: number[];
+  asset_count: number;
+  service_count: number;
+  grand_total_estimated: string;
+  grand_total_actual: string; // recoverable total billed to the landlord
+  assets: AssetCostRecoveryAsset[];
+}
+
 // Dashboard Widget Types
 export type WidgetType = 'low_stock' | 'pending_reorders' | 'asset_problems' | 'qr_scans' | 'deliveries';
 


### PR DESCRIPTION
## What

PR2 (frontend) of the Asset Cost-Recovery Report — the **report-generator page** that drives the
`reports/assets/cost_recovery` endpoint merged in PR1 (#915). Consumes it; no backend change.

## The page (`/reports` → Asset Cost Recovery)

- **Select** assets and/or asset categories (searchable MultiSelect; ≥1 required; a category expands server-side).
- **Period**: SegmentedControl presets **Past week / Past month / Past year**, or **custom** start/end via a
  calendar date-range picker.
- **Generate** → on-screen statement grouped per asset: header (serial / installed / status) + a line per
  service (date, description, **Estimated**, **Actual vendor**), per-asset subtotal, and a **grand total**
  (Actual = the recoverable amount).
- **Export CSV** and **Export PDF** buttons (the landlord-ready statement) — hit the endpoint with `format=`.
- Loading / error / empty states.

Also: route + sidebar nav entry + a link from the Reports overview, api client (`costRecoveryReport` +
CSV/PDF download URLs) and response types (matched to PR1's serializer).

## Test

`AssetCostRecoveryPage.test.tsx` (8) + `api.test.ts` additions (client params / download URLs) — lint clean,
typecheck clean for the new files. Branched off current main (has #915).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
