### PR TITLE
feat(accounting): committee statement report — JSON/CSV/PDF (op-sp0s, Phase 2 Bead 3)

### DIFF
--- a/backend/accounting/reports.py
+++ b/backend/accounting/reports.py
@@ -1,0 +1,204 @@
+"""Treasurer-readable reports over the committee (SIG) ledger.
+
+Phase 2 · Bead 3 ships the first one: :func:`committee_statement`, the
+per-committee statement over the double-entry ledger — what a committee
+**consumed** (the ``SIG_CHARGE`` entries from Bead 1), with a running balance
+and a period filter.
+
+It mirrors the asset cost-recovery report
+(``inventory.views.AssetReportViewSet.cost_recovery``) in structure: a pure
+builder returning a plain dict, passthrough renderers so DRF's reserved
+``?format=csv|pdf`` content-negotiates cleanly, and a flat one-row-per-line CSV
+writer. The PDF generator lives in :mod:`accounting.utils.committee_statement_pdf`.
+"""
+
+import csv
+from decimal import Decimal
+
+from django.http import HttpResponse
+from django.utils import timezone
+
+from rest_framework.renderers import BaseRenderer
+
+from .models import LegDimension, SourceType
+
+_CENTS = Decimal("0.01")
+_ZERO = Decimal("0.00")
+
+#: ``source_type`` -> the totals bucket it accumulates into. Only ``SIG_CHARGE``
+#: is produced today (Bead 1); ``PO_RECEIPT`` / ``SETTLEMENT`` light up
+#: automatically once Beads 4-5 post committee-attributed purchase / settlement
+#: entries. Any other source_type (e.g. a ``REVERSAL`` of a charge) lands in no
+#: named bucket but still moves ``net`` via the running balance.
+_TOTALS_BUCKET = {
+    SourceType.SIG_CHARGE.value: "consumed",
+    SourceType.PO_RECEIPT.value: "purchased",
+    SourceType.SETTLEMENT.value: "settled",
+}
+
+
+def _q(value) -> Decimal:
+    """Coerce ``value`` to a 2dp ``Decimal`` (USD cents)."""
+    amount = value if isinstance(value, Decimal) else Decimal(str(value))
+    return amount.quantize(_CENTS)
+
+
+def committee_statement(*, committee, start, end, period=None) -> dict:
+    """Build the committee (SIG) statement over the ledger for a date window.
+
+    Queries every :class:`~accounting.models.LegDimension` attributed to
+    ``committee`` whose transaction ``date`` falls in ``[start, end]``
+    (inclusive), ordered by date, and emits one row per ledger line with a
+    running balance of the committee's net position (debit increases it, credit
+    decreases it). Totals are bucketed by ``source_type`` — ``consumed``
+    (``SIG_CHARGE``), plus the forward-compatible ``purchased`` (``PO_RECEIPT``)
+    and ``settled`` (``SETTLEMENT``) buckets that stay ``0.00`` until later beads
+    post those entries. ``net`` is the final running balance, so it also nets out
+    any reversals/adjustments that carry the committee dimension.
+
+    Args:
+        committee: the ``auth.Group`` (SIG) to report on.
+        start: inclusive lower ``date`` bound of the reporting window.
+        end: inclusive upper ``date`` bound of the reporting window.
+        period: optional preset label (``past_week`` / ``past_month`` /
+            ``past_year``) recorded on the report; ``None`` for a custom range.
+
+    Returns:
+        A dict mirroring the cost-recovery report shape::
+
+            {committee: {id, name}, period, start_date, end_date, generated_at,
+             lines: [{date, source_type, account_code, account_name,
+                      description, debit, credit, amount, running_balance}, ...],
+             totals: {consumed, purchased, settled, net}}
+
+        Money values are raw ``Decimal`` (a line's ``debit``/``credit`` is
+        ``None`` on the side it does not use). The API layer stringifies them for
+        JSON; the CSV/PDF writers format them.
+    """
+    dimensions = (
+        LegDimension.objects.filter(
+            sig=committee,
+            leg__transaction__date__range=(start, end),
+        )
+        .select_related(
+            "leg",
+            "leg__account",
+            "leg__transaction",
+            "leg__transaction__meta",
+        )
+        .order_by("leg__transaction__date", "leg__transaction_id", "leg_id")
+    )
+
+    lines = []
+    running = _ZERO
+    totals = {"consumed": _ZERO, "purchased": _ZERO, "settled": _ZERO, "net": _ZERO}
+
+    for dimension in dimensions:
+        leg = dimension.leg
+        txn = leg.transaction
+        # ``meta`` is a reverse OneToOne; Django's descriptor raises an
+        # AttributeError subclass when absent, so ``getattr(..., None)`` is safe.
+        meta = getattr(txn, "meta", None)
+        source_type = meta.source_type if meta is not None else ""
+
+        debit = _q(leg.debit.amount) if leg.debit is not None else None
+        credit = _q(leg.credit.amount) if leg.credit is not None else None
+        amount = (debit or _ZERO) - (credit or _ZERO)
+        running += amount
+
+        bucket = _TOTALS_BUCKET.get(source_type)
+        if bucket is not None:
+            totals[bucket] += amount
+
+        lines.append(
+            {
+                "date": txn.date,
+                "source_type": source_type,
+                "account_code": leg.account.code,
+                "account_name": leg.account.name,
+                "description": leg.description or txn.description or "",
+                "debit": debit,
+                "credit": credit,
+                "amount": amount,
+                "running_balance": running,
+            }
+        )
+
+    totals["net"] = running
+
+    return {
+        "committee": {"id": committee.id, "name": committee.name},
+        "period": period,
+        "start_date": start,
+        "end_date": end,
+        "generated_at": timezone.now(),
+        "lines": lines,
+        "totals": totals,
+    }
+
+
+class CommitteeStatementCSVRenderer(BaseRenderer):
+    """Passthrough renderer registering the ``csv`` format for content negotiation.
+
+    ``CommitteeStatementView`` returns a fully-formed ``HttpResponse`` for the
+    CSV/PDF formats, so ``render`` is never invoked — these renderers exist only
+    so DRF accepts ``?format=csv`` / ``?format=pdf`` (its reserved format query
+    param) instead of 404-ing on an unregistered format.
+    """
+
+    media_type = "text/csv"
+    format = "csv"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        return data
+
+
+class CommitteeStatementPDFRenderer(BaseRenderer):
+    """Passthrough renderer registering the ``pdf`` format (see CSV renderer)."""
+
+    media_type = "application/pdf"
+    format = "pdf"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        return data
+
+
+def _money_cell(value) -> str:
+    """Render a ``Decimal`` cell as a plain 2dp string; blank for ``None``."""
+    if value is None:
+        return ""
+    return f"{value:.2f}"
+
+
+def committee_statement_csv(report: dict) -> HttpResponse:
+    """Flat one-row-per-line CSV for the committee statement.
+
+    Columns: ``date, source_type, account, description, debit, credit,
+    running_balance``. An empty statement emits just the header row.
+    """
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = 'attachment; filename="committee_statement.csv"'
+    fieldnames = [
+        "date",
+        "source_type",
+        "account",
+        "description",
+        "debit",
+        "credit",
+        "running_balance",
+    ]
+    writer = csv.DictWriter(response, fieldnames=fieldnames)
+    writer.writeheader()
+    for line in report["lines"]:
+        writer.writerow(
+            {
+                "date": line["date"].isoformat(),
+                "source_type": line["source_type"],
+                "account": line["account_code"],
+                "description": line["description"],
+                "debit": _money_cell(line["debit"]),
+                "credit": _money_cell(line["credit"]),
+                "running_balance": _money_cell(line["running_balance"]),
+            }
+        )
+    return response

--- a/backend/accounting/serializers.py
+++ b/backend/accounting/serializers.py
@@ -28,3 +28,55 @@ class AccountSerializer(serializers.ModelSerializer):
         if balance is None:
             balance = obj.get_balance()
         return str(balance[CURRENCY].amount.quantize(_CENTS))
+
+
+class CommitteeStatementLineSerializer(serializers.Serializer):
+    """One ledger line in a committee (SIG) statement.
+
+    ``debit``/``credit`` is null on the side the line does not use; ``amount``
+    is the signed net effect on the committee (a debit is positive), and
+    ``running_balance`` is the cumulative net through this line. Every money
+    field renders as a USD decimal string.
+    """
+
+    date = serializers.DateField()
+    source_type = serializers.CharField(allow_blank=True)
+    account_code = serializers.CharField()
+    account_name = serializers.CharField()
+    description = serializers.CharField(allow_blank=True)
+    debit = serializers.DecimalField(max_digits=12, decimal_places=2, allow_null=True)
+    credit = serializers.DecimalField(max_digits=12, decimal_places=2, allow_null=True)
+    amount = serializers.DecimalField(max_digits=12, decimal_places=2)
+    running_balance = serializers.DecimalField(max_digits=12, decimal_places=2)
+
+
+class CommitteeStatementTotalsSerializer(serializers.Serializer):
+    """Period totals bucketed by source type; ``net`` is the ending balance."""
+
+    consumed = serializers.DecimalField(max_digits=12, decimal_places=2)
+    purchased = serializers.DecimalField(max_digits=12, decimal_places=2)
+    settled = serializers.DecimalField(max_digits=12, decimal_places=2)
+    net = serializers.DecimalField(max_digits=12, decimal_places=2)
+
+
+class CommitteeStatementCommitteeSerializer(serializers.Serializer):
+    """The committee (``auth.Group``) a statement is drawn for."""
+
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+
+
+class CommitteeStatementReportSerializer(serializers.Serializer):
+    """The full committee statement payload (mirrors the cost-recovery report).
+
+    ``totals['net']`` is the recoverable/owed net for the committee over the
+    window; ``lines`` is the itemized ledger activity backing it.
+    """
+
+    committee = CommitteeStatementCommitteeSerializer()
+    period = serializers.CharField(allow_null=True)
+    start_date = serializers.DateField()
+    end_date = serializers.DateField()
+    generated_at = serializers.DateTimeField()
+    lines = CommitteeStatementLineSerializer(many=True)
+    totals = CommitteeStatementTotalsSerializer()

--- a/backend/accounting/tests/test_reports.py
+++ b/backend/accounting/tests/test_reports.py
@@ -1,0 +1,395 @@
+"""Committee statement report — builder + JSON/CSV/PDF endpoint.
+
+Postgres/hordak required (the ledger uses Postgres balance functions), so the
+whole module is ``django_db`` and runs on the omstest Postgres, not sqlite.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth.models import Group
+from django.utils import timezone
+
+import pytest
+
+from accounting.adapters import post_supply_consumption
+from accounting.reports import committee_statement
+from accounting.services import reverse_entry
+
+pytestmark = pytest.mark.django_db
+
+STATEMENT_URL = "/api/accounting/committee-statement/"
+
+
+def _charge(committee, amount, day, ref, **kwargs):
+    """Post one SIG_CHARGE for ``committee`` dated ``day`` and return its txn."""
+    return post_supply_consumption(
+        committee=committee,
+        amount=Decimal(amount),
+        source_ref=ref,
+        date=day,
+        **kwargs,
+    )
+
+
+# ── builder ──────────────────────────────────────────────────────────────────
+
+
+def test_builder_lines_running_balance_and_totals():
+    committee = Group.objects.create(name="Woodshop SIG")
+    _charge(committee, "10.00", date(2026, 1, 10), "usage:1")
+    _charge(committee, "5.00", date(2026, 1, 12), "usage:2")
+    _charge(committee, "7.00", date(2026, 1, 15), "usage:3")
+
+    report = committee_statement(committee=committee, start=date(2026, 1, 1), end=date(2026, 1, 31))
+
+    assert report["committee"] == {"id": committee.id, "name": "Woodshop SIG"}
+    assert report["period"] is None
+    assert report["start_date"] == date(2026, 1, 1)
+    assert report["end_date"] == date(2026, 1, 31)
+
+    # Lines are ordered by date; each SIG_CHARGE is a debit to 5100.
+    assert [line["date"] for line in report["lines"]] == [
+        date(2026, 1, 10),
+        date(2026, 1, 12),
+        date(2026, 1, 15),
+    ]
+    for line in report["lines"]:
+        assert line["source_type"] == "SIG_CHARGE"
+        assert line["account_code"] == "5100"
+        assert line["account_name"] == "Committee supplies expense"
+        assert line["credit"] is None
+    assert [line["debit"] for line in report["lines"]] == [
+        Decimal("10.00"),
+        Decimal("5.00"),
+        Decimal("7.00"),
+    ]
+    assert [line["amount"] for line in report["lines"]] == [
+        Decimal("10.00"),
+        Decimal("5.00"),
+        Decimal("7.00"),
+    ]
+    assert [line["running_balance"] for line in report["lines"]] == [
+        Decimal("10.00"),
+        Decimal("15.00"),
+        Decimal("22.00"),
+    ]
+    assert report["totals"] == {
+        "consumed": Decimal("22.00"),
+        "purchased": Decimal("0.00"),
+        "settled": Decimal("0.00"),
+        "net": Decimal("22.00"),
+    }
+
+
+def test_builder_respects_window():
+    committee = Group.objects.create(name="Metal SIG")
+    _charge(committee, "10.00", date(2026, 1, 5), "usage:before")  # before window
+    _charge(committee, "20.00", date(2026, 2, 10), "usage:inside")  # inside
+    _charge(committee, "30.00", date(2026, 3, 20), "usage:after")  # after window
+
+    report = committee_statement(committee=committee, start=date(2026, 2, 1), end=date(2026, 2, 28))
+
+    assert len(report["lines"]) == 1
+    assert report["lines"][0]["debit"] == Decimal("20.00")
+    assert report["totals"]["consumed"] == Decimal("20.00")
+    assert report["totals"]["net"] == Decimal("20.00")
+
+
+def test_builder_scopes_to_requested_committee():
+    a = Group.objects.create(name="SIG A")
+    b = Group.objects.create(name="SIG B")
+    _charge(a, "10.00", date(2026, 1, 10), "usage:a")
+    _charge(b, "99.00", date(2026, 1, 11), "usage:b")
+
+    report = committee_statement(committee=a, start=date(2026, 1, 1), end=date(2026, 1, 31))
+
+    assert len(report["lines"]) == 1
+    assert report["lines"][0]["debit"] == Decimal("10.00")
+    assert report["totals"]["net"] == Decimal("10.00")
+
+
+def test_builder_reversal_nets_out_but_consumed_is_gross():
+    committee = Group.objects.create(name="Reversal SIG")
+    txn = _charge(committee, "12.00", date(2026, 1, 10), "usage:rev")
+    reverse_entry(txn, date=date(2026, 1, 11))
+
+    report = committee_statement(committee=committee, start=date(2026, 1, 1), end=date(2026, 1, 31))
+
+    assert len(report["lines"]) == 2
+    charge_line, reversal_line = report["lines"]
+    assert charge_line["source_type"] == "SIG_CHARGE"
+    assert charge_line["debit"] == Decimal("12.00")
+    assert reversal_line["source_type"] == "REVERSAL"
+    assert reversal_line["credit"] == Decimal("12.00")
+    assert reversal_line["debit"] is None
+    assert reversal_line["amount"] == Decimal("-12.00")
+    # Gross consumed is the charge; net is zero after the reversal.
+    assert report["totals"]["consumed"] == Decimal("12.00")
+    assert report["totals"]["net"] == Decimal("0.00")
+    assert report["lines"][-1]["running_balance"] == Decimal("0.00")
+
+
+def test_builder_empty_statement():
+    committee = Group.objects.create(name="Quiet SIG")
+
+    report = committee_statement(committee=committee, start=date(2026, 1, 1), end=date(2026, 1, 31))
+
+    assert report["lines"] == []
+    assert report["totals"] == {
+        "consumed": Decimal("0.00"),
+        "purchased": Decimal("0.00"),
+        "settled": Decimal("0.00"),
+        "net": Decimal("0.00"),
+    }
+
+
+# ── endpoint: permissions ────────────────────────────────────────────────────
+
+
+def test_endpoint_rejects_anonymous(api_client):
+    committee = Group.objects.create(name="Anon SIG")
+    resp = api_client.get(STATEMENT_URL, {"committee": committee.id, "period": "past_month"})
+    assert resp.status_code in (401, 403)
+
+
+def test_endpoint_staff_sees_any_committee(api_client, admin_user):
+    committee = Group.objects.create(name="Staff-view SIG")
+    _charge(committee, "10.00", timezone.now().date(), "usage:staff")
+
+    api_client.force_authenticate(admin_user)
+    resp = api_client.get(STATEMENT_URL, {"committee": committee.id, "period": "past_year"})
+
+    assert resp.status_code == 200
+    data = resp.data
+    assert data["committee"] == {"id": committee.id, "name": "Staff-view SIG"}
+    assert data["period"] == "past_year"
+    assert data["generated_at"]  # present + serialized
+    assert len(data["lines"]) == 1
+    assert data["lines"][0]["debit"] == "10.00"  # decimal string
+    assert data["lines"][0]["running_balance"] == "10.00"
+    assert data["totals"]["consumed"] == "10.00"
+    assert data["totals"]["net"] == "10.00"
+
+
+def test_endpoint_sig_admin_sees_own_committee(api_client):
+    from membership.models import SIGAdmin
+    from membership.tests.factories import UserFactory
+
+    committee = Group.objects.create(name="Own SIG")
+    user = UserFactory(is_staff=False)
+    SIGAdmin.objects.create(user=user, group=committee, is_active=True)
+    _charge(committee, "4.00", timezone.now().date(), "usage:own")
+
+    api_client.force_authenticate(user)
+    resp = api_client.get(STATEMENT_URL, {"committee": committee.id, "period": "past_month"})
+
+    assert resp.status_code == 200
+    assert resp.data["totals"]["consumed"] == "4.00"
+
+
+def test_endpoint_non_admin_forbidden(api_client):
+    from membership.tests.factories import UserFactory
+
+    committee = Group.objects.create(name="Guarded SIG")
+    user = UserFactory(is_staff=False)  # not an admin of committee
+
+    api_client.force_authenticate(user)
+    resp = api_client.get(STATEMENT_URL, {"committee": committee.id, "period": "past_month"})
+
+    assert resp.status_code == 403
+
+
+def test_endpoint_admin_of_other_committee_forbidden(api_client):
+    """The gate is per-committee: admin of SIG X cannot read SIG Y."""
+    from membership.models import SIGAdmin
+    from membership.tests.factories import UserFactory
+
+    own = Group.objects.create(name="Their SIG")
+    other = Group.objects.create(name="Not their SIG")
+    user = UserFactory(is_staff=False)
+    SIGAdmin.objects.create(user=user, group=own, is_active=True)
+
+    api_client.force_authenticate(user)
+    resp = api_client.get(STATEMENT_URL, {"committee": other.id, "period": "past_month"})
+
+    assert resp.status_code == 403
+
+
+# ── endpoint: validation ─────────────────────────────────────────────────────
+
+
+def test_endpoint_missing_committee_400(api_client, admin_user):
+    api_client.force_authenticate(admin_user)
+    resp = api_client.get(STATEMENT_URL, {"period": "past_month"})
+    assert resp.status_code == 400
+
+
+def test_endpoint_invalid_committee_400(api_client, admin_user):
+    api_client.force_authenticate(admin_user)
+    resp = api_client.get(STATEMENT_URL, {"committee": "not-an-int", "period": "past_month"})
+    assert resp.status_code == 400
+
+
+def test_endpoint_unknown_committee_404(api_client, admin_user):
+    api_client.force_authenticate(admin_user)
+    resp = api_client.get(STATEMENT_URL, {"committee": 999999, "period": "past_month"})
+    assert resp.status_code == 404
+
+
+def test_endpoint_bad_period_400(api_client, admin_user):
+    committee = Group.objects.create(name="Bad-period SIG")
+    api_client.force_authenticate(admin_user)
+    resp = api_client.get(STATEMENT_URL, {"committee": committee.id, "period": "past_decade"})
+    assert resp.status_code == 400
+
+
+def test_endpoint_requires_period_or_range_400(api_client, admin_user):
+    committee = Group.objects.create(name="No-window SIG")
+    api_client.force_authenticate(admin_user)
+    resp = api_client.get(STATEMENT_URL, {"committee": committee.id})
+    assert resp.status_code == 400
+
+
+def test_endpoint_custom_range(api_client, admin_user):
+    committee = Group.objects.create(name="Range SIG")
+    _charge(committee, "6.00", date(2026, 2, 10), "usage:range")
+
+    api_client.force_authenticate(admin_user)
+    resp = api_client.get(
+        STATEMENT_URL,
+        {"committee": committee.id, "start": "2026-02-01", "end": "2026-02-28"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.data["period"] is None
+    assert resp.data["start_date"] == "2026-02-01"
+    assert resp.data["end_date"] == "2026-02-28"
+    assert resp.data["totals"]["consumed"] == "6.00"
+
+
+def test_endpoint_bad_custom_range_400(api_client, admin_user):
+    committee = Group.objects.create(name="Bad-range SIG")
+    api_client.force_authenticate(admin_user)
+    resp = api_client.get(
+        STATEMENT_URL,
+        {"committee": committee.id, "start": "2026-03-01", "end": "2026-02-01"},
+    )
+    assert resp.status_code == 400
+
+
+# ── endpoint: CSV / PDF ──────────────────────────────────────────────────────
+
+
+def test_endpoint_csv(api_client, admin_user):
+    committee = Group.objects.create(name="CSV SIG")
+    _charge(committee, "10.00", date(2026, 2, 10), "usage:csv1")
+    _charge(committee, "5.00", date(2026, 2, 12), "usage:csv2")
+
+    api_client.force_authenticate(admin_user)
+    resp = api_client.get(
+        STATEMENT_URL,
+        {
+            "committee": committee.id,
+            "start": "2026-02-01",
+            "end": "2026-02-28",
+            "format": "csv",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp["Content-Type"] == "text/csv"
+    assert "committee_statement.csv" in resp["Content-Disposition"]
+    body = resp.content.decode()
+    assert "date,source_type,account,description,debit,credit,running_balance" in body
+    assert "SIG_CHARGE" in body
+    assert "5100" in body
+    assert "15.00" in body  # running balance accumulates 10 -> 15
+
+
+def test_endpoint_pdf(api_client, admin_user):
+    committee = Group.objects.create(name="PDF SIG")
+    _charge(committee, "10.00", date(2026, 2, 10), "usage:pdf")
+
+    api_client.force_authenticate(admin_user)
+    resp = api_client.get(
+        STATEMENT_URL,
+        {
+            "committee": committee.id,
+            "start": "2026-02-01",
+            "end": "2026-02-28",
+            "format": "pdf",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp["Content-Type"] == "application/pdf"
+    assert "committee_statement.pdf" in resp["Content-Disposition"]
+    assert resp.content[:5] == b"%PDF-"
+    assert len(resp.content) > 1000
+
+
+def test_endpoint_pdf_empty_statement(api_client, admin_user):
+    committee = Group.objects.create(name="Empty PDF SIG")
+    api_client.force_authenticate(admin_user)
+    resp = api_client.get(
+        STATEMENT_URL,
+        {"committee": committee.id, "period": "past_month", "format": "pdf"},
+    )
+    assert resp.status_code == 200
+    assert resp.content[:5] == b"%PDF-"
+
+
+# ── units: passthrough renderers + PDF helper branches ───────────────────────
+
+
+def test_passthrough_renderers_return_data_unchanged():
+    """The CSV/PDF renderers only register the format; ``render`` is a no-op
+    passthrough (the view returns a ready HttpResponse for those formats)."""
+    from accounting.reports import (
+        CommitteeStatementCSVRenderer,
+        CommitteeStatementPDFRenderer,
+    )
+
+    sentinel = object()
+    assert CommitteeStatementCSVRenderer().render(sentinel) is sentinel
+    assert CommitteeStatementPDFRenderer().render(sentinel) is sentinel
+    assert CommitteeStatementCSVRenderer.format == "csv"
+    assert CommitteeStatementPDFRenderer.format == "pdf"
+
+
+def test_pdf_generator_covers_preset_and_nondate_and_escaping():
+    """Exercise the PDF helper branches without a DB round-trip: a preset period
+    label, a non-date ``generated_at`` (str fallback), a REVERSAL source label,
+    and an ``&``/``<`` in a description (paragraph escaping)."""
+    from accounting.utils.committee_statement_pdf import generate_committee_statement_pdf
+
+    report = {
+        "committee": {"id": 1, "name": "Unit SIG"},
+        "period": "past_week",  # preset branch in _period_display
+        "start_date": date(2026, 1, 1),
+        "end_date": date(2026, 1, 7),
+        "generated_at": "2026-01-07",  # str -> _fmt_date str fallback
+        "lines": [
+            {
+                "date": date(2026, 1, 3),
+                "source_type": "REVERSAL",  # _source_label alias branch
+                "account_code": "5100",
+                "account_name": "Committee supplies expense",
+                "description": "reverse x & y < z",  # escaped in _para
+                "debit": None,
+                "credit": Decimal("3.00"),
+                "amount": Decimal("-3.00"),
+                "running_balance": Decimal("-3.00"),
+            }
+        ],
+        "totals": {
+            "consumed": Decimal("0.00"),
+            "purchased": Decimal("0.00"),
+            "settled": Decimal("0.00"),
+            "net": Decimal("-3.00"),
+        },
+    }
+
+    pdf = generate_committee_statement_pdf(report)
+    assert pdf[:5] == b"%PDF-"

--- a/backend/accounting/urls.py
+++ b/backend/accounting/urls.py
@@ -2,12 +2,17 @@ from django.urls import include, path
 
 from rest_framework.routers import DefaultRouter
 
-from .views import AccountViewSet, TrialBalanceView
+from .views import AccountViewSet, CommitteeStatementView, TrialBalanceView
 
 router = DefaultRouter()
 router.register(r"accounts", AccountViewSet, basename="account")
 
 urlpatterns = [
     path("trial-balance/", TrialBalanceView.as_view(), name="trial-balance"),
+    path(
+        "committee-statement/",
+        CommitteeStatementView.as_view(),
+        name="committee-statement",
+    ),
     path("", include(router.urls)),
 ]

--- a/backend/accounting/utils/committee_statement_pdf.py
+++ b/backend/accounting/utils/committee_statement_pdf.py
@@ -1,0 +1,215 @@
+"""PDF generation for the committee (SIG) statement.
+
+Renders a treasurer-readable statement of a committee's ledger activity over a
+period: a header (committee + window), a lines table with Debit / Credit /
+running Balance columns, and a totals footer (Consumed / Purchased / Settled /
+Net).
+
+Mirrors the reportlab conventions in ``inventory/utils/cost_recovery_pdf.py``
+(SimpleDocTemplate + platypus flowables, built-in Helvetica fonts so no font
+files are required, greyscale table styling). Text is kept to plain ASCII/
+Latin-1 so the built-in fonts render every glyph — the "DejaVu-safe" practice
+from the other generators, achieved here by not emitting characters outside
+that range.
+"""
+
+import io
+from datetime import date, datetime
+from decimal import Decimal
+from html import escape
+from typing import Optional
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    HRFlowable,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+_PERIOD_LABELS = {
+    "past_week": "Past week",
+    "past_month": "Past month",
+    "past_year": "Past year",
+}
+
+#: Human labels for the ``source_type`` column (unknown types pass through).
+_SOURCE_LABELS = {
+    "SIG_CHARGE": "Consumed",
+    "PO_RECEIPT": "Purchased",
+    "SETTLEMENT": "Settled",
+    "REVERSAL": "Reversal",
+}
+
+
+def _money(value: Optional[Decimal]) -> str:
+    """Render a Decimal as ``$X.XX``; blank for a missing (null) value."""
+    if value is None:
+        return ""
+    return f"${Decimal(value):,.2f}"
+
+
+def _fmt_date(value) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, (date, datetime)):
+        return value.strftime("%b %d, %Y")
+    return str(value)
+
+
+def _para(text, style) -> Paragraph:
+    """Wrap free text in a Paragraph, XML-escaping first so an ``&``/``<``/``>``
+    in a committee name or description can't break reportlab's paragraph
+    parser."""
+    return Paragraph(escape(str(text), quote=False), style)
+
+
+def _source_label(source_type) -> str:
+    return _SOURCE_LABELS.get(source_type, source_type or "")
+
+
+def _period_display(report: dict) -> str:
+    """Human summary of the reporting window for the statement header."""
+    start = _fmt_date(report.get("start_date"))
+    end = _fmt_date(report.get("end_date"))
+    preset = _PERIOD_LABELS.get(report.get("period"))
+    if preset:
+        return f"{preset} ({start} - {end})"
+    return f"{start} - {end}"
+
+
+def generate_committee_statement_pdf(report: dict) -> bytes:
+    """Generate a treasurer-readable committee statement PDF.
+
+    Args:
+        report: the assembled report dict produced by
+            ``accounting.reports.committee_statement`` — the committee, the
+            reporting window, the ordered ``lines`` (each with raw
+            ``Decimal``/``None`` money), and the bucketed ``totals``.
+
+    Returns:
+        PDF content as bytes.
+    """
+    buf = io.BytesIO()
+    committee = report.get("committee") or {}
+    committee_name = committee.get("name") or "(unnamed committee)"
+
+    doc = SimpleDocTemplate(
+        buf,
+        pagesize=letter,
+        rightMargin=0.5 * inch,
+        leftMargin=0.5 * inch,
+        topMargin=0.5 * inch,
+        bottomMargin=0.5 * inch,
+        title="Committee Statement",
+    )
+
+    styles = getSampleStyleSheet()
+    heading_style = ParagraphStyle(
+        "CSHeading", parent=styles["Heading1"], fontSize=16, spaceAfter=2
+    )
+    small_style = ParagraphStyle(
+        "CSSmall", parent=styles["Normal"], fontSize=9, textColor=colors.HexColor("#444444")
+    )
+    cell_style = ParagraphStyle("CSCell", parent=styles["Normal"], fontSize=8, leading=10)
+
+    story = []
+
+    # -- Header ---------------------------------------------------------------
+    story.append(_para(f"Committee Statement: {committee_name}", heading_style))
+    story.append(Paragraph(f"Period: {_period_display(report)}", small_style))
+    story.append(Paragraph(f"Generated: {_fmt_date(report.get('generated_at'))}", small_style))
+    story.append(Paragraph(f"{len(report.get('lines', []))} ledger line(s)", small_style))
+    story.append(HRFlowable(width="100%", thickness=1, color=colors.black))
+    story.append(Spacer(1, 6))
+
+    # -- Lines table ----------------------------------------------------------
+    rows = [["Date", "Type", "Account", "Description", "Debit", "Credit", "Balance"]]
+    for line in report.get("lines", []):
+        account = line.get("account_code") or ""
+        if line.get("account_name"):
+            account = f"{account} {line['account_name']}"
+        rows.append(
+            [
+                _fmt_date(line.get("date")),
+                _source_label(line.get("source_type")),
+                _para(account, cell_style),
+                _para(line.get("description") or "", cell_style),
+                _money(line.get("debit")),
+                _money(line.get("credit")),
+                _money(line.get("running_balance")),
+            ]
+        )
+    if len(rows) == 1:
+        rows.append(["-", "-", "", Paragraph("No activity in period", cell_style), "", "", ""])
+
+    table = Table(
+        rows,
+        colWidths=[
+            0.85 * inch,
+            0.75 * inch,
+            1.35 * inch,
+            2.0 * inch,
+            0.85 * inch,
+            0.85 * inch,
+            0.85 * inch,
+        ],
+        repeatRows=1,
+    )
+    table.setStyle(
+        TableStyle(
+            [
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 8),
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#e8e8e8")),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#cccccc")),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("ALIGN", (4, 0), (6, -1), "RIGHT"),
+                ("PADDING", (0, 0), (-1, -1), 3),
+            ]
+        )
+    )
+    story.append(table)
+
+    # -- Totals footer --------------------------------------------------------
+    totals = report.get("totals") or {}
+    story.append(Spacer(1, 8))
+    story.append(HRFlowable(width="100%", thickness=1, color=colors.black))
+    total_rows = [
+        ["Consumed (charges)", _money(totals.get("consumed"))],
+        ["Purchased", _money(totals.get("purchased"))],
+        ["Settled", _money(totals.get("settled"))],
+        ["Net balance", _money(totals.get("net"))],
+    ]
+    totals_table = Table(total_rows, colWidths=[5.5 * inch, 2.0 * inch])
+    totals_table.setStyle(
+        TableStyle(
+            [
+                ("FONTNAME", (0, 0), (-1, -1), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, 2), 10),
+                ("FONTSIZE", (0, 3), (-1, 3), 13),
+                ("ALIGN", (1, 0), (1, -1), "RIGHT"),
+                ("TEXTCOLOR", (0, 3), (-1, 3), colors.HexColor("#0b6b2e")),
+                ("LINEABOVE", (0, 3), (-1, 3), 1, colors.black),
+                ("PADDING", (0, 0), (-1, -1), 5),
+            ]
+        )
+    )
+    story.append(totals_table)
+    story.append(Spacer(1, 6))
+    story.append(
+        Paragraph(
+            "Consumed is the committee's gross supply charges (DR 5100) for the "
+            "period. Net balance is the committee's running net position across "
+            "all attributed ledger lines, including any reversals or settlements.",
+            small_style,
+        )
+    )
+
+    doc.build(story)
+    return buf.getvalue()

--- a/backend/accounting/views.py
+++ b/backend/accounting/views.py
@@ -1,21 +1,37 @@
-"""Read-only, staff-only DRF surface for the accounting ledger (Phase 1).
+"""DRF surface for the accounting ledger.
 
-Committee-scoped reads arrive in Phase 2; for now everything is
-``IsAdminUser``. We deliberately do NOT expose hordak's own URLs/UI — these are
-OMS-native endpoints over the chart of accounts and the trial balance.
+The chart-of-accounts + trial-balance reads are staff-only (``IsAdminUser``) —
+we deliberately do NOT expose hordak's own URLs/UI. Phase 2 adds the first
+committee-scoped read: :class:`CommitteeStatementView`, where a committee's own
+SIG admin (not just staff) can pull that committee's statement.
 """
 
+from datetime import datetime, timedelta
+
+from django.contrib.auth.models import Group
+from django.http import HttpResponse
+from django.utils import timezone
 from django.utils.dateparse import parse_date
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from hordak.models import Account
-from rest_framework import viewsets
-from rest_framework.permissions import IsAdminUser
+from rest_framework import serializers, viewsets
+from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.permissions import IsAdminUser, IsAuthenticated
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .serializers import AccountSerializer
+from membership.services import is_owning_group_admin
+
+from .reports import (
+    CommitteeStatementCSVRenderer,
+    CommitteeStatementPDFRenderer,
+    committee_statement,
+    committee_statement_csv,
+)
+from .serializers import AccountSerializer, CommitteeStatementReportSerializer
 from .services import trial_balance
 
 
@@ -75,3 +91,135 @@ def _serialize_trial_balance(report: dict) -> dict:
         "total_credit": str(report["total_credit"]),
         "balanced": report["balanced"],
     }
+
+
+_PERIOD_PRESETS = {
+    "past_week": timedelta(days=7),
+    "past_month": timedelta(days=30),
+    "past_year": timedelta(days=365),
+}
+
+
+class CommitteeStatementView(APIView):
+    """Per-committee (SIG) statement over the ledger. JSON / CSV / PDF.
+
+    Select a committee + a period and get its statement: every ledger line
+    attributed to that committee in the window (the ``SIG_CHARGE`` consumption
+    from Bead 1 today; purchases/settlements once later beads land), with a
+    running balance and source-type totals. Mirrors the asset cost-recovery
+    report's structure and content-negotiation.
+
+    Query params:
+    - ``committee`` (required): the ``auth.Group`` (SIG) id.
+    - Period (one of): ``period`` in {past_week, past_month, past_year}
+      (trailing window ending today) OR ``start`` & ``end`` (YYYY-MM-DD).
+    - ``format`` in {json (default), csv, pdf}.
+
+    Permissions: authenticated; **staff/superuser** may read any committee; a
+    non-staff user must be an **admin of the requested committee**
+    (``membership.services.is_owning_group_admin``), else 403. A missing/invalid
+    ``committee`` is 400, an unknown one 404.
+    """
+
+    permission_classes = [IsAuthenticated]
+    renderer_classes = [
+        JSONRenderer,
+        CommitteeStatementCSVRenderer,
+        CommitteeStatementPDFRenderer,
+    ]
+
+    @staticmethod
+    def _resolve_committee(request) -> Group:
+        """Resolve the ``committee`` query param to a ``Group`` (400/404)."""
+        raw = request.query_params.get("committee")
+        if not raw:
+            raise serializers.ValidationError(
+                {"committee": "This query parameter is required (a Group id)."}
+            )
+        try:
+            committee_id = int(raw)
+        except (TypeError, ValueError):
+            raise serializers.ValidationError({"committee": f"Invalid committee id: {raw!r}."})
+        try:
+            return Group.objects.get(pk=committee_id)
+        except Group.DoesNotExist:
+            raise NotFound(f"No committee (Group) with id {committee_id}.")
+
+    @staticmethod
+    def _window(request):
+        """Resolve the reporting window from ``period`` or ``start``/``end``.
+
+        Mirrors ``AssetReportViewSet._cost_recovery_window`` (preset trailing
+        windows of 7/30/365 days, or an explicit ``YYYY-MM-DD`` range). Returns
+        ``(start_date, end_date, period_label)`` — ``period_label`` is the preset
+        name, or ``None`` for a custom range.
+        """
+        today = timezone.now().date()
+
+        period = request.query_params.get("period")
+        if period:
+            span = _PERIOD_PRESETS.get(period)
+            if span is None:
+                raise serializers.ValidationError(
+                    {"period": "Must be one of past_week, past_month, past_year."}
+                )
+            return today - span, today, period
+
+        start_str = request.query_params.get("start")
+        end_str = request.query_params.get("end")
+        if start_str and end_str:
+            try:
+                start_date = datetime.strptime(start_str, "%Y-%m-%d").date()
+                end_date = datetime.strptime(end_str, "%Y-%m-%d").date()
+            except ValueError:
+                raise serializers.ValidationError({"start": "start and end must be YYYY-MM-DD."})
+            if start_date > end_date:
+                raise serializers.ValidationError({"start": "start must not be after end."})
+            return start_date, end_date, None
+
+        raise serializers.ValidationError(
+            "Provide either 'period' (past_week/past_month/past_year) or both "
+            "'start' and 'end' (YYYY-MM-DD)."
+        )
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter("committee", OpenApiTypes.INT, OpenApiParameter.QUERY, required=True),
+            OpenApiParameter("period", OpenApiTypes.STR, OpenApiParameter.QUERY, required=False),
+            OpenApiParameter("start", OpenApiTypes.DATE, OpenApiParameter.QUERY, required=False),
+            OpenApiParameter("end", OpenApiTypes.DATE, OpenApiParameter.QUERY, required=False),
+            OpenApiParameter("format", OpenApiTypes.STR, OpenApiParameter.QUERY, required=False),
+        ],
+        responses=CommitteeStatementReportSerializer,
+    )
+    def get(self, request):
+        committee = self._resolve_committee(request)
+
+        user = request.user
+        is_staff = bool(user.is_staff or user.is_superuser)
+        if not is_staff and not is_owning_group_admin(user, committee):
+            raise PermissionDenied("You must be an admin of this committee to view its statement.")
+
+        start_date, end_date, period_label = self._window(request)
+
+        # ``format`` is DRF's reserved content-negotiation query param; the
+        # renderers above register json/csv/pdf so it negotiates cleanly (an
+        # unknown format 404s in negotiation before we get here).
+        fmt = request.accepted_renderer.format
+
+        report = committee_statement(
+            committee=committee, start=start_date, end=end_date, period=period_label
+        )
+
+        if fmt == "csv":
+            return committee_statement_csv(report)
+
+        if fmt == "pdf":
+            from .utils.committee_statement_pdf import generate_committee_statement_pdf
+
+            pdf_bytes = generate_committee_statement_pdf(report)
+            response = HttpResponse(pdf_bytes, content_type="application/pdf")
+            response["Content-Disposition"] = 'attachment; filename="committee_statement.pdf"'
+            return response
+
+        return Response(CommitteeStatementReportSerializer(report).data)

--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -14,6 +14,9 @@ views:
       retrieve:
         permission_classes:
         - IsAdminUser
+  accounting.views.CommitteeStatementView:
+    permission_classes:
+    - IsAuthenticated
   accounting.views.TrialBalanceView:
     permission_classes:
     - IsAdminUser

--- a/docs/accounting.md
+++ b/docs/accounting.md
@@ -164,9 +164,75 @@ unauthorized or anonymous caller who supplies a committee gets `403`. With **no*
 `charged_group` the endpoint behaves exactly as before — same stock math, same
 (public) permissions, no ledger entry.
 
+## Committee statement report (Phase 2)
+
+The treasurer-readable payoff over the ledger: given a committee (SIG) and a date
+range, produce its **statement** — every ledger line attributed to that committee,
+with a running balance and period totals — as on-screen **JSON + CSV + PDF**. It
+mirrors the asset [cost-recovery report](../backend/inventory/views.py) in
+structure (a pure builder, passthrough renderers so `?format=` negotiates, a flat
+CSV writer, a reportlab PDF).
+
+### The builder (`accounting/reports.py`)
+
+```python
+from accounting.reports import committee_statement
+
+report = committee_statement(
+    committee=group,           # auth.Group (SIG)
+    start=start_date,          # inclusive date bounds
+    end=end_date,
+    period="past_month",       # optional preset label; None for a custom range
+)
+```
+
+It queries `LegDimension.objects.filter(sig=committee, leg__transaction__date__range=(start, end))`
+(`select_related` down to the leg's account, transaction, and `EntryMeta`), orders
+by date, and emits one row per ledger line:
+
+```
+{date, source_type, account_code, account_name, description,
+ debit, credit, amount, running_balance}
+```
+
+`amount` is the signed net effect on the committee (a **debit increases** the
+balance, a **credit decreases** it) and `running_balance` accumulates it. Money is
+raw `Decimal` in the builder; the API stringifies it (the JSON contract is decimal
+strings), and the CSV/PDF format it.
+
+### Totals, bucketed by source type
+
+`totals` is `{consumed, purchased, settled, net}`:
+
+- **`consumed`** — the `SIG_CHARGE` lines (Bead 1). This is the only bucket that
+  populates today.
+- **`purchased`** (`PO_RECEIPT`) / **`settled`** (`SETTLEMENT`) — forward-compatible
+  and computed **now**, so they light up automatically once Beads 4–5 post those
+  committee-attributed entries. Until then they are `0.00`.
+- **`net`** — the ending running balance across **all** attributed lines. Because it
+  is the running balance (not `consumed + purchased + settled`), it also nets out a
+  `REVERSAL` of a charge: `consumed` stays gross, `net` reflects the reversal.
+
+### The endpoint
+
+`GET /api/accounting/committee-statement/`:
+
+- `committee` (required) — the `auth.Group` id. Missing/invalid → **400**; unknown
+  → **404**.
+- Period: either `period` in `{past_week, past_month, past_year}` (trailing window
+  ending today) **or** `start` & `end` (`YYYY-MM-DD`). Neither → 400.
+- `format` in `{json (default), csv, pdf}` — DRF content-negotiated via the reserved
+  `?format=` query param against passthrough renderers (an unknown format 404s in
+  negotiation, the same pattern the cost-recovery report uses).
+
+**Permissions.** Authenticated; **staff/superuser** may read any committee; a
+non-staff user must be an **admin of the requested committee**
+(`membership.services.is_owning_group_admin`) — this is a *per-committee* gate, so
+an admin of SIG X cannot read SIG Y's statement. Otherwise **403**.
+
 ## Out of scope (Phase 2+)
 
-Web committee-picker UI + ScanTTY consume-and-charge flow; the committee statement
-report; settlement / period-close; PO / vendor / donation / asset adapters;
-serialized-consume + work-order material-usage charge paths (they will reuse
-`post_supply_consumption`).
+Web committee-picker UI + ScanTTY consume-and-charge flow; the **web statement
+page** (a follow-on bead, mirroring the cost-recovery generator page); settlement /
+period-close; PO / vendor / donation / asset adapters; serialized-consume +
+work-order material-usage charge paths (they will reuse `post_supply_consumption`).


### PR DESCRIPTION
## Phase 2 · Bead 3 — Committee statement report (JSON / CSV / PDF)

The treasurer-readable report over the committee ledger. `GET /api/accounting/committee-statement/?committee=<id>&period=…` returns a committee's statement — every ledger line attributed to it in the window (the `SIG_CHARGE` consumption from Bead 1), with a running balance and totals — as JSON, CSV, or PDF (`?format=`). Mirrors the cost-recovery report. Bead: **op-sp0s**.

### What's in it
- **`accounting/reports.py`** — `committee_statement(committee, start, end)` builder over `LegDimension.sig` + `EntryMeta.source_type`; per-line running balance; totals **bucketed by source_type** (`consumed` now; `purchased`/`settled` are wired and stay `0.00` until Beads 4–5 post those entries — no rework later). Passthrough CSV/PDF renderers + a flat CSV writer.
- **`accounting/utils/committee_statement_pdf.py`** — reportlab statement PDF (uses `html.escape`, no bandit B406).
- **`CommitteeStatementView`** (`GET /api/accounting/committee-statement/`, json/csv/pdf) — **staff/superuser → any committee; a committee's own SIG-admin → its own; else 403**; bad committee → 400/404. Period presets (past week / month / year) + custom start/end.
- Serializers, permission-matrix regenerated (+1 → 872 endpoints), docs. **Read-only — no migration.**

### Verification (independent, on PostgreSQL)
`manage.py check` clean · `check_permission_matrix` OK (872) · **`pytest accounting/tests` — 53 passed** (21 new report tests: lines / running-balance / totals, period window, staff-vs-SIG-admin-vs-403, CSV 200, PDF 200) · bandit clean on the new reportlab / report / view files.

The web statement *page* is a follow-on bead; the report's `purchased`/`settled` buckets auto-populate once Beads 4–5 land.

Draft — merging is the owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
