### PR TITLE
feat(accounting): committee settlement / period-close (op-j276, Phase 2 Bead 4)

### DIFF
--- a/backend/accounting/adapters.py
+++ b/backend/accounting/adapters.py
@@ -10,16 +10,23 @@ Phase 2 · Bead 1 ships the first one, :func:`post_supply_consumption`.
 """
 
 from decimal import Decimal
+from typing import Optional
+
+from django.utils import timezone
 
 from hordak.models import Transaction
 
 from .models import SourceType
-from .services import Line, post_entry
+from .services import Line, committee_balance, post_entry
 
 #: Committee supplies expense (debited when a committee consumes supplies).
 ACCOUNT_COMMITTEE_SUPPLIES_EXPENSE = "5100"
 #: Inventory — supplies on hand (credited as stock is drawn down).
 ACCOUNT_INVENTORY_SUPPLIES = "1300"
+#: Net assets / Fund balance — absorbs a committee's expense on an absorbed close.
+ACCOUNT_NET_ASSETS = "3000"
+#: Accounts Receivable — records the amount owed on a reimbursed close.
+ACCOUNT_ACCOUNTS_RECEIVABLE = "1200"
 
 
 def post_supply_consumption(
@@ -87,5 +94,78 @@ def post_supply_consumption(
         source_ref=source_ref,
         created_by=created_by,
         date=date,
+        description=description,
+    )
+
+
+def settle_committee(
+    *,
+    committee,
+    as_of=None,
+    reimbursed: bool = False,
+    created_by=None,
+    note: str = "",
+) -> Optional[Transaction]:
+    """Settle (period-close) a committee's outstanding balance. Append-only.
+
+    This is the privileged "reset a committee's expenses" reframed as an
+    *append-only settlement*: it never edits or deletes accumulated
+    ``SIG_CHARGE`` entries. It snapshots the committee's outstanding balance
+    (:func:`accounting.services.committee_balance` on **5100**) and posts one
+    balanced ``SETTLEMENT`` entry that zeroes it, carrying the committee
+    dimension on **both** legs::
+
+        CR 5100 Committee supplies expense   [sig=committee]   (removes the accrued expense)
+        DR <offset>                          [sig=committee]
+            offset = 3000 Net assets / Fund balance   (absorbed — the default), or
+                     1200 Accounts Receivable         (reimbursed=True — records they owe)
+
+    After it posts, ``committee_balance(committee, as_of=as_of)`` is ``0.00`` and
+    the trial balance still balances (the DR offset equals the CR on 5100).
+
+    The entry is idempotent per committee **and** close date
+    (``source_ref="settle:<committee.id>:<date>"``), so re-running the same close
+    does not double-post. When there is nothing to settle (balance is already
+    ``0.00``) this returns ``None`` — no empty entry is written.
+
+    Args:
+        committee: The ``auth.Group`` to close out.
+        as_of: Optional close date; the settlement is dated here and only
+            balances accrued on or before it are settled. Defaults to today.
+        reimbursed: When ``True``, debit **1200 Accounts Receivable** (the
+            committee owes the amount); otherwise debit **3000 Net assets**
+            (the space absorbs it). No cash movement in v1 — reimbursed stops
+            at AR.
+        created_by: Optional acting user recorded on the entry's provenance.
+        note: Optional human description for the entry.
+
+    Returns:
+        The posted ``SETTLEMENT`` ``Transaction``, or ``None`` when the balance
+        was already zero.
+
+    A mistaken settlement is corrected with :func:`accounting.services.reverse_entry`
+    (append-only), never by editing this entry.
+    """
+    balance = committee_balance(committee, as_of=as_of)
+    if balance == 0:
+        return None
+
+    effective_date = as_of or timezone.now().date()
+    offset_account = ACCOUNT_ACCOUNTS_RECEIVABLE if reimbursed else ACCOUNT_NET_ASSETS
+    description = note or f"Committee settlement: {committee.name}"
+
+    return post_entry(
+        lines=[
+            Line(
+                account=ACCOUNT_COMMITTEE_SUPPLIES_EXPENSE,
+                credit=balance,
+                sig=committee,
+            ),
+            Line(account=offset_account, debit=balance, sig=committee),
+        ],
+        source_type=SourceType.SETTLEMENT,
+        source_ref=f"settle:{committee.id}:{effective_date.isoformat()}",
+        created_by=created_by,
+        date=effective_date,
         description=description,
     )

--- a/backend/accounting/serializers.py
+++ b/backend/accounting/serializers.py
@@ -28,3 +28,57 @@ class AccountSerializer(serializers.ModelSerializer):
         if balance is None:
             balance = obj.get_balance()
         return str(balance[CURRENCY].amount.quantize(_CENTS))
+
+
+class CommitteeSettlementRequestSerializer(serializers.Serializer):
+    """Request body for ``POST /api/accounting/committee-settlement/``.
+
+    ``committee`` is a ``auth.Group`` id (the SIG being closed out). ``as_of``
+    optionally dates the close (defaults to today). ``reimbursed`` routes the
+    offset to Accounts Receivable instead of Net assets.
+    """
+
+    committee = serializers.IntegerField(
+        min_value=1, help_text="auth.Group id of the committee (SIG) to settle."
+    )
+    as_of = serializers.DateField(
+        required=False,
+        allow_null=True,
+        help_text="Close date; only balances accrued on or before it settle. Defaults to today.",
+    )
+    reimbursed = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="When true, debit 1200 Accounts Receivable (owed) instead of 3000 Net assets.",
+    )
+    note = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default="",
+        max_length=500,
+        help_text="Optional description recorded on the settlement entry.",
+    )
+
+
+class _SettlementCommitteeSerializer(serializers.Serializer):
+    """The settled committee, echoed back in the settlement response."""
+
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+
+
+class CommitteeSettlementResponseSerializer(serializers.Serializer):
+    """Response for a committee settlement.
+
+    ``transaction`` is the ``SETTLEMENT`` entry's uuid, or ``null`` when there
+    was nothing to settle (``settled_amount`` ``"0.00"``, with a ``detail``
+    note). ``new_balance`` is the committee's balance after the close (``0.00``
+    on a normal settlement).
+    """
+
+    settled_amount = serializers.DecimalField(max_digits=20, decimal_places=2)
+    reimbursed = serializers.BooleanField()
+    transaction = serializers.UUIDField(allow_null=True)
+    new_balance = serializers.DecimalField(max_digits=20, decimal_places=2)
+    committee = _SettlementCommitteeSerializer()
+    detail = serializers.CharField(required=False)

--- a/backend/accounting/services.py
+++ b/backend/accounting/services.py
@@ -214,6 +214,31 @@ def reverse_entry(
     )
 
 
+def committee_balance(committee, *, account_code="5100", as_of=None) -> Decimal:
+    """Return a committee's net outstanding balance on ``account_code`` (2dp).
+
+    A committee (an ``auth.Group``) accumulates expense as ``SIG_CHARGE`` debits
+    on account ``5100`` (recorded via each line's
+    :class:`~accounting.models.LegDimension` ``sig`` dimension). This helper is
+    the net (debit − credit) of every ledger leg tagged ``sig=committee`` on
+    ``account_code``, optionally limited to transactions dated on or before
+    ``as_of``.
+
+    A positive result is outstanding expense the committee has yet to settle; a
+    settlement (CR 5100) or a charge reversal drives it back toward ``0.00``.
+    Returns ``Decimal("0.00")`` when the committee has no attributed legs.
+    """
+    legs = Leg.objects.filter(
+        dimension__sig=committee,
+        account__code=str(account_code),
+    )
+    if as_of is not None:
+        legs = legs.filter(transaction__date__lte=as_of)
+    credits, debits = legs.sum_to_debit_and_credit()
+    net = debits[CURRENCY].amount - credits[CURRENCY].amount
+    return net.quantize(_CENTS)
+
+
 def type_word(account: Account) -> str:
     """Human account-type word ('asset', 'liability', ...) or '' for a child."""
     if not account.type:

--- a/backend/accounting/tests/test_settlement.py
+++ b/backend/accounting/tests/test_settlement.py
@@ -1,0 +1,275 @@
+"""Committee settlement / period-close (Phase 2 · Bead 4).
+
+Covers the balance helper (:func:`accounting.services.committee_balance`), the
+append-only settlement service (:func:`accounting.adapters.settle_committee`),
+and the staff-only ``POST /api/accounting/committee-settlement/`` endpoint.
+
+Postgres/hordak required (see :mod:`accounting`).
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth.models import Group
+
+import pytest
+from hordak.models import Transaction
+
+from accounting.adapters import post_supply_consumption, settle_committee
+from accounting.models import EntryMeta, LegDimension, SourceType
+from accounting.services import committee_balance, reverse_entry, trial_balance
+
+pytestmark = pytest.mark.django_db
+
+SETTLEMENT_URL = "/api/accounting/committee-settlement/"
+
+
+def _charge(committee, amount, ref, *, on=None):
+    """Post a SIG_CHARGE (DR 5100 [sig] / CR 1300) for ``committee``."""
+    return post_supply_consumption(
+        committee=committee,
+        amount=Decimal(amount),
+        source_ref=ref,
+        date=on,
+    )
+
+
+def _settlement_count():
+    return Transaction.objects.filter(meta__source_type=SourceType.SETTLEMENT).count()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# committee_balance
+# ─────────────────────────────────────────────────────────────────────────
+def test_committee_balance_is_net_of_that_committee_on_5100():
+    a = Group.objects.create(name="Balance A SIG")
+    b = Group.objects.create(name="Balance B SIG")
+    _charge(a, "10.00", "usage:a1")
+    _charge(a, "2.50", "usage:a2")
+    _charge(b, "99.00", "usage:b1")  # another committee must not leak in
+
+    assert committee_balance(a) == Decimal("12.50")
+    assert committee_balance(b) == Decimal("99.00")
+
+
+def test_committee_balance_is_zero_for_a_committee_with_no_ledger():
+    group = Group.objects.create(name="Fresh SIG")
+    assert committee_balance(group) == Decimal("0.00")
+
+
+def test_committee_balance_respects_as_of():
+    group = Group.objects.create(name="Timed SIG")
+    _charge(group, "5.00", "usage:t1", on=date(2026, 1, 1))
+    _charge(group, "7.00", "usage:t2", on=date(2026, 6, 1))
+
+    assert committee_balance(group, as_of=date(2026, 3, 1)) == Decimal("5.00")
+    assert committee_balance(group, as_of=date(2026, 6, 1)) == Decimal("12.00")
+    assert committee_balance(group) == Decimal("12.00")
+
+
+def test_committee_balance_reflects_charge_reversal():
+    """An append-only reversal of a charge drives the balance back down."""
+    group = Group.objects.create(name="Reversal SIG")
+    charge = _charge(group, "8.00", "usage:rev")
+    assert committee_balance(group) == Decimal("8.00")
+
+    reverse_entry(charge)
+    assert committee_balance(group) == Decimal("0.00")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# settle_committee — the append-only close
+# ─────────────────────────────────────────────────────────────────────────
+def test_settle_absorbed_zeroes_balance_and_keeps_books_balanced():
+    group = Group.objects.create(name="Woodshop SIG")
+    _charge(group, "12.50", "usage:1")
+    _charge(group, "7.50", "usage:2")
+    assert committee_balance(group) == Decimal("20.00")
+
+    txn = settle_committee(committee=group, note="Q2 close")
+
+    assert txn is not None
+    assert _settlement_count() == 1
+
+    credit_leg = txn.legs.get(credit__isnull=False)
+    debit_leg = txn.legs.get(debit__isnull=False)
+    # CR 5100 removes the accrued expense; DR 3000 absorbs it (default).
+    assert credit_leg.account.code == "5100"
+    assert credit_leg.credit.amount == Decimal("20.00")
+    assert debit_leg.account.code == "3000"
+    assert debit_leg.debit.amount == Decimal("20.00")
+
+    # Committee dimension on BOTH legs.
+    assert LegDimension.objects.get(leg=credit_leg).sig_id == group.id
+    assert LegDimension.objects.get(leg=debit_leg).sig_id == group.id
+
+    # Balance zeroed; the trial balance still balances.
+    assert committee_balance(group) == Decimal("0.00")
+    assert trial_balance()["balanced"] is True
+
+    meta = EntryMeta.objects.get(transaction=txn)
+    assert meta.source_type == SourceType.SETTLEMENT
+    assert meta.source_ref.startswith(f"settle:{group.id}:")
+    assert txn.description == "Q2 close"
+
+
+def test_settle_reimbursed_debits_accounts_receivable():
+    group = Group.objects.create(name="Metal SIG")
+    _charge(group, "30.00", "usage:r1")
+
+    txn = settle_committee(committee=group, reimbursed=True)
+
+    debit_leg = txn.legs.get(debit__isnull=False)
+    assert debit_leg.account.code == "1200"  # AR, not 3000
+    assert debit_leg.debit.amount == Decimal("30.00")
+    assert LegDimension.objects.get(leg=debit_leg).sig_id == group.id
+    assert committee_balance(group) == Decimal("0.00")
+    assert trial_balance()["balanced"] is True
+
+
+def test_settle_default_description_names_the_committee():
+    group = Group.objects.create(name="Named SIG")
+    _charge(group, "3.00", "usage:n1")
+    txn = settle_committee(committee=group)
+    assert txn.description == "Committee settlement: Named SIG"
+
+
+def test_settle_is_idempotent_per_committee_and_date():
+    group = Group.objects.create(name="Idem SIG")
+    _charge(group, "9.00", "usage:i1", on=date(2026, 6, 15))
+    as_of = date(2026, 6, 30)
+
+    first = settle_committee(committee=group, as_of=as_of)
+    second = settle_committee(committee=group, as_of=as_of)
+
+    assert first is not None
+    # The second close finds a zero balance and does not double-post.
+    assert second is None
+    assert _settlement_count() == 1
+    # The settlement is dated at the close date.
+    assert first.date == as_of
+    assert committee_balance(group, as_of=as_of) == Decimal("0.00")
+
+
+def test_settle_with_zero_balance_returns_none_and_posts_nothing():
+    group = Group.objects.create(name="Empty SIG")
+    assert settle_committee(committee=group) is None
+    assert _settlement_count() == 0
+
+
+def test_settle_only_settles_balance_accrued_on_or_before_as_of():
+    group = Group.objects.create(name="Partial SIG")
+    _charge(group, "5.00", "usage:p1", on=date(2026, 1, 1))
+    _charge(group, "40.00", "usage:p2", on=date(2026, 12, 1))  # after the close
+
+    txn = settle_committee(committee=group, as_of=date(2026, 6, 30))
+
+    assert txn.legs.get(credit__isnull=False).credit.amount == Decimal("5.00")
+    # As of the close date, the committee is settled; all-time still owes the rest.
+    assert committee_balance(group, as_of=date(2026, 6, 30)) == Decimal("0.00")
+    assert committee_balance(group) == Decimal("40.00")
+
+
+def test_fresh_charge_after_settlement_accumulates_from_zero():
+    group = Group.objects.create(name="Cycle SIG")
+    _charge(group, "15.00", "usage:c1")
+    settle_committee(committee=group)
+    assert committee_balance(group) == Decimal("0.00")
+
+    _charge(group, "4.00", "usage:c2")
+    assert committee_balance(group) == Decimal("4.00")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Endpoint: POST /api/accounting/committee-settlement/  (staff only)
+# ─────────────────────────────────────────────────────────────────────────
+def test_settlement_endpoint_rejects_anonymous(api_client):
+    group = Group.objects.create(name="Anon SIG")
+    resp = api_client.post(SETTLEMENT_URL, {"committee": group.id}, format="json")
+    assert resp.status_code in (401, 403)
+
+
+def test_settlement_endpoint_rejects_non_staff_sig_admin(api_client):
+    """A SIG admin of the committee may VIEW its statement but must NOT settle."""
+    from membership.models import SIGAdmin
+    from membership.tests.factories import UserFactory
+
+    group = Group.objects.create(name="Owned SIG")
+    user = UserFactory(is_staff=False)
+    SIGAdmin.objects.create(user=user, group=group, is_active=True)
+
+    api_client.force_authenticate(user)
+    resp = api_client.post(SETTLEMENT_URL, {"committee": group.id}, format="json")
+    assert resp.status_code == 403
+
+
+def test_settlement_endpoint_staff_settles(api_client, admin_user):
+    group = Group.objects.create(name="Staff-settle SIG")
+    _charge(group, "25.00", "usage:api1")
+
+    api_client.force_authenticate(admin_user)
+    resp = api_client.post(SETTLEMENT_URL, {"committee": group.id}, format="json")
+
+    assert resp.status_code == 200
+    assert resp.data["settled_amount"] == "25.00"
+    assert resp.data["new_balance"] == "0.00"
+    assert resp.data["reimbursed"] is False
+    assert resp.data["transaction"] is not None
+    assert resp.data["committee"] == {"id": group.id, "name": "Staff-settle SIG"}
+    assert committee_balance(group) == Decimal("0.00")
+
+
+def test_settlement_endpoint_reimbursed(api_client, admin_user):
+    group = Group.objects.create(name="Reimb SIG")
+    _charge(group, "40.00", "usage:api2")
+
+    api_client.force_authenticate(admin_user)
+    resp = api_client.post(
+        SETTLEMENT_URL, {"committee": group.id, "reimbursed": True}, format="json"
+    )
+
+    assert resp.status_code == 200
+    assert resp.data["reimbursed"] is True
+    txn = Transaction.objects.get(uuid=resp.data["transaction"])
+    assert txn.legs.get(debit__isnull=False).account.code == "1200"
+
+
+def test_settlement_endpoint_as_of_dates_the_entry(api_client, admin_user):
+    group = Group.objects.create(name="Dated SIG")
+    _charge(group, "11.00", "usage:api3", on=date(2026, 5, 1))
+
+    api_client.force_authenticate(admin_user)
+    resp = api_client.post(
+        SETTLEMENT_URL, {"committee": group.id, "as_of": "2026-05-31"}, format="json"
+    )
+
+    assert resp.status_code == 200
+    assert resp.data["settled_amount"] == "11.00"
+    txn = Transaction.objects.get(uuid=resp.data["transaction"])
+    assert txn.date == date(2026, 5, 31)
+
+
+def test_settlement_endpoint_nothing_to_settle(api_client, admin_user):
+    group = Group.objects.create(name="Zero SIG")
+
+    api_client.force_authenticate(admin_user)
+    resp = api_client.post(SETTLEMENT_URL, {"committee": group.id}, format="json")
+
+    assert resp.status_code == 200
+    assert resp.data["settled_amount"] == "0.00"
+    assert resp.data["new_balance"] == "0.00"
+    assert resp.data["transaction"] is None
+    assert "detail" in resp.data
+    assert _settlement_count() == 0
+
+
+def test_settlement_endpoint_unknown_committee_404(api_client, admin_user):
+    api_client.force_authenticate(admin_user)
+    resp = api_client.post(SETTLEMENT_URL, {"committee": 999999}, format="json")
+    assert resp.status_code == 404
+
+
+def test_settlement_endpoint_missing_committee_400(api_client, admin_user):
+    api_client.force_authenticate(admin_user)
+    resp = api_client.post(SETTLEMENT_URL, {}, format="json")
+    assert resp.status_code == 400

--- a/backend/accounting/urls.py
+++ b/backend/accounting/urls.py
@@ -2,12 +2,17 @@ from django.urls import include, path
 
 from rest_framework.routers import DefaultRouter
 
-from .views import AccountViewSet, TrialBalanceView
+from .views import AccountViewSet, CommitteeSettlementView, TrialBalanceView
 
 router = DefaultRouter()
 router.register(r"accounts", AccountViewSet, basename="account")
 
 urlpatterns = [
     path("trial-balance/", TrialBalanceView.as_view(), name="trial-balance"),
+    path(
+        "committee-settlement/",
+        CommitteeSettlementView.as_view(),
+        name="committee-settlement",
+    ),
     path("", include(router.urls)),
 ]

--- a/backend/accounting/views.py
+++ b/backend/accounting/views.py
@@ -3,8 +3,15 @@
 Committee-scoped reads arrive in Phase 2; for now everything is
 ``IsAdminUser``. We deliberately do NOT expose hordak's own URLs/UI — these are
 OMS-native endpoints over the chart of accounts and the trial balance.
+
+Phase 2 · Bead 4 adds the one *write* endpoint here: committee settlement /
+period-close (:class:`CommitteeSettlementView`), still staff-only.
 """
 
+from decimal import Decimal
+
+from django.contrib.auth.models import Group
+from django.shortcuts import get_object_or_404
 from django.utils.dateparse import parse_date
 
 from drf_spectacular.types import OpenApiTypes
@@ -15,8 +22,15 @@ from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .serializers import AccountSerializer
-from .services import trial_balance
+from .adapters import ACCOUNT_COMMITTEE_SUPPLIES_EXPENSE, settle_committee
+from .serializers import (
+    AccountSerializer,
+    CommitteeSettlementRequestSerializer,
+    CommitteeSettlementResponseSerializer,
+)
+from .services import committee_balance, trial_balance
+
+_CENTS = Decimal("0.01")
 
 
 class AccountViewSet(viewsets.ReadOnlyModelViewSet):
@@ -57,6 +71,58 @@ class TrialBalanceView(APIView):
                     status=400,
                 )
         return Response(_serialize_trial_balance(trial_balance(as_of=as_of)))
+
+
+class CommitteeSettlementView(APIView):
+    """Settle (period-close) a committee's outstanding balance. **Staff only.**
+
+    ``POST /api/accounting/committee-settlement/`` posts one append-only
+    ``SETTLEMENT`` entry that zeroes the committee's **5100** balance (CR 5100 /
+    DR 3000 absorbed, or DR 1200 when ``reimbursed``). This is the
+    destructive-feeling close, so it is ``IsAdminUser`` (staff/superuser) — a
+    SIG admin may *view* its statement but not settle. Nothing is ever edited or
+    deleted; a mistaken settlement is corrected with a reversal.
+    """
+
+    permission_classes = [IsAdminUser]
+
+    @extend_schema(
+        request=CommitteeSettlementRequestSerializer,
+        responses=CommitteeSettlementResponseSerializer,
+    )
+    def post(self, request):
+        serializer = CommitteeSettlementRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        committee = get_object_or_404(Group, pk=data["committee"])
+        as_of = data.get("as_of")
+        reimbursed = data.get("reimbursed", False)
+        note = data.get("note", "")
+
+        txn = settle_committee(
+            committee=committee,
+            as_of=as_of,
+            reimbursed=reimbursed,
+            created_by=request.user,
+            note=note,
+        )
+        new_balance = committee_balance(committee, as_of=as_of)
+
+        body = {
+            "reimbursed": reimbursed,
+            "new_balance": str(new_balance),
+            "committee": {"id": committee.id, "name": committee.name},
+        }
+        if txn is None:
+            body["settled_amount"] = "0.00"
+            body["transaction"] = None
+            body["detail"] = "Nothing to settle — the committee balance is already 0.00."
+        else:
+            settled_leg = txn.legs.get(account__code=ACCOUNT_COMMITTEE_SUPPLIES_EXPENSE)
+            body["settled_amount"] = str(settled_leg.credit.amount.quantize(_CENTS))
+            body["transaction"] = str(txn.uuid)
+        return Response(body)
 
 
 def _serialize_trial_balance(report: dict) -> dict:

--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -14,6 +14,9 @@ views:
       retrieve:
         permission_classes:
         - IsAdminUser
+  accounting.views.CommitteeSettlementView:
+    permission_classes:
+    - IsAdminUser
   accounting.views.TrialBalanceView:
     permission_classes:
     - IsAdminUser

--- a/docs/accounting.md
+++ b/docs/accounting.md
@@ -164,9 +164,80 @@ unauthorized or anonymous caller who supplies a committee gets `403`. With **no*
 `charged_group` the endpoint behaves exactly as before — same stock math, same
 (public) permissions, no ledger entry.
 
+## Committee settlement / period-close (Phase 2)
+
+The privileged "reset a committee's expenses" — reframed as an **append-only
+settlement**. It never edits or deletes the accumulated `SIG_CHARGE` entries;
+instead it snapshots the committee's outstanding balance, posts one closing
+`SETTLEMENT` entry that zeroes it, and starts the next period at zero, with the
+full charge history preserved.
+
+### The balance (`accounting/services.py`)
+
+A committee's **outstanding balance** is the net (debit − credit) of every ledger
+leg tagged `sig = committee` on account **5100**:
+
+```python
+from accounting.services import committee_balance
+
+owed = committee_balance(group)                    # all-time, account 5100
+owed = committee_balance(group, as_of=some_date)   # only entries dated <= some_date
+```
+
+Charges (`DR 5100`) push it up; a settlement (`CR 5100`) or a charge reversal
+(`CR 5100`, via `reverse_entry`) push it back toward `0.00`.
+
+### The settlement (`accounting/adapters.py`)
+
+```python
+from accounting.adapters import settle_committee
+
+txn = settle_committee(
+    committee=group,        # auth.Group to close out
+    as_of=None,             # optional close date; defaults to today
+    reimbursed=False,       # absorb (default) vs. record a receivable
+    created_by=request.user,
+    note="Q2 close",
+)                           # -> Transaction, or None when nothing to settle
+```
+
+It computes `balance = committee_balance(committee, as_of=as_of)` and posts one
+balanced entry with the committee dimension on **both** legs:
+
+```
+CR 5100 Committee supplies expense   [sig = committee]   (removes the accrued expense)
+DR <offset>                          [sig = committee]
+    offset = 3000 Net assets / Fund balance   (absorbed — the default), or
+             1200 Accounts Receivable         (reimbursed=True — records they owe)
+```
+
+After it posts, `committee_balance(committee, as_of=as_of)` is `0.00` and the
+trial balance still balances (the DR offset equals the CR on 5100). A
+**reimbursed** close stops at Accounts Receivable — there is no Cash account in
+v1, so the actual cash receipt is a later concern.
+
+- **Nothing to settle** → returns `None`; no empty entry is written.
+- **Idempotent per committee + close date** (`source_ref="settle:<id>:<date>"`):
+  re-running the same close does not double-post. A committee is settled **once
+  per date** — a charge that lands after that date's settlement is closed on the
+  next settlement date.
+- **Corrections are append-only.** A mistaken settlement is fixed with
+  `accounting.services.reverse_entry` (Phase 1), never by editing the entry.
+
+### The endpoint & permissions
+
+`POST /api/accounting/committee-settlement/` (`CommitteeSettlementView`) —
+**staff/superuser only** (`IsAdminUser`). This is the destructive-feeling close,
+so a SIG admin may *view* its statement but **not** settle. Body: `committee`
+(Group id, required), optional `as_of` (date), `reimbursed` (bool), `note` (str).
+Response: `{settled_amount, reimbursed, transaction, new_balance, committee}`;
+when the balance is already zero it returns `200` with `settled_amount "0.00"`,
+`transaction: null`, and a `detail` note (a no-op close is fine, not an error).
+
 ## Out of scope (Phase 2+)
 
-Web committee-picker UI + ScanTTY consume-and-charge flow; the committee statement
-report; settlement / period-close; PO / vendor / donation / asset adapters;
+Web "settle" button (a later bead); ScanTTY (a privileged financial close is not a
+TUI flow); the actual cash receipt of a reimbursement (no Cash account in v1 —
+reimbursed stops at AR); PO / vendor / donation / asset adapters;
 serialized-consume + work-order material-usage charge paths (they will reuse
 `post_supply_consumption`).


### PR DESCRIPTION
## Phase 2 · Bead 4 — Committee settlement / period-close

The privileged "reset a committee's expenses," reframed as an **append-only settlement** (never edits/deletes accrued entries). Snapshots a committee's outstanding balance and posts one balanced `SETTLEMENT` entry that zeroes it. Bead: **op-j276**.

### What's in it
- **`committee_balance(committee, account_code="5100", as_of=)`** (`services.py`) — the committee's net outstanding expense.
- **`settle_committee(committee, as_of=, reimbursed=, created_by=, note=)`** (`adapters.py`) — posts `CR 5100 [sig=committee] / DR 3000` (absorbed, default) or `DR 1200` (reimbursed=True), committee dimension on **both** legs; idempotent per committee+date (`settle:<id>:<date>`); returns `None` when the balance is already 0 (no empty entry).
- **`CommitteeSettlementView`** — `POST /api/accounting/committee-settlement/`, **staff/superuser only** (`IsAdminUser`). Body: `committee`, optional `as_of`/`reimbursed`/`note`. Returns settled amount + new balance (`0.00`); nothing-to-settle → 200 no-op.
- Request/response serializers, permission-matrix regenerated (+1 endpoint), docs. **No migration** (post-only).

### Verification (independent, on PostgreSQL)
`manage.py check` clean · `check_permission_matrix` OK (872) · **`pytest accounting/tests` — 50 passed** (19 new settlement tests: absorbed + reimbursed, balance → 0, idempotency, nothing-to-settle no-op, staff-vs-SIG-admin-403, fresh accrual after a close) · bandit clean · reviewed `settle_committee` (CR 5100 / DR 3000|1200, both legs dim=committee, idempotent, `None` on zero).

Independent of Bead 3 (its own balance helper, so 3/4 merge in any order). **Note:** touches `accounting/adapters.py` + `docs/accounting.md`, which Bead 5's PR also touches — expect trivial *additive* conflicts at merge (keep both).

Draft — merging is the owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
