### PR TITLE
feat(accounting): PO-received adapter — committee purchasing → ledger (op-3dj5, Phase 2 Bead 5)

### DIFF
--- a/backend/accounting/adapters.py
+++ b/backend/accounting/adapters.py
@@ -6,7 +6,8 @@ PO, recording a donation, …) and the double-entry engine in
 callers post money without hardcoding account codes or hand-writing balanced
 legs — they describe the business event, the adapter builds the entry.
 
-Phase 2 · Bead 1 ships the first one, :func:`post_supply_consumption`.
+Phase 2 · Bead 1 ships the first one, :func:`post_supply_consumption`;
+Bead 5 adds :func:`post_po_receipt`.
 """
 
 from decimal import Decimal
@@ -18,8 +19,11 @@ from .services import Line, post_entry
 
 #: Committee supplies expense (debited when a committee consumes supplies).
 ACCOUNT_COMMITTEE_SUPPLIES_EXPENSE = "5100"
-#: Inventory — supplies on hand (credited as stock is drawn down).
+#: Inventory — supplies on hand (credited as stock is drawn down; debited as a
+#: committee-owned PO is received).
 ACCOUNT_INVENTORY_SUPPLIES = "1300"
+#: Accounts payable (credited when committee-owned stock is received on a PO).
+ACCOUNT_ACCOUNTS_PAYABLE = "2000"
 
 
 def post_supply_consumption(
@@ -84,6 +88,71 @@ def post_supply_consumption(
             Line(account=ACCOUNT_INVENTORY_SUPPLIES, credit=amount),
         ],
         source_type=SourceType.SIG_CHARGE,
+        source_ref=source_ref,
+        created_by=created_by,
+        date=date,
+        description=description,
+    )
+
+
+def post_po_receipt(
+    *,
+    committee,
+    amount: Decimal,
+    source_ref: str,
+    item=None,
+    created_by=None,
+    date=None,
+    description: str = "",
+) -> Transaction:
+    """Post a committee PO-receipt (purchasing) entry and return its ``Transaction``.
+
+    Records that ``amount`` (USD) of stock owned by ``committee`` (an
+    ``auth.Group``) was received against a purchase order, adding it to inventory
+    on the committee's tab::
+
+        DR 1300 Inventory — Supplies on hand   (dimension: sig=committee)
+        CR 2000 Accounts Payable
+
+    This is the mirror bookend of :func:`post_supply_consumption`: purchasing
+    fills the committee's on-hand supplies (a payable is incurred), consuming
+    later draws them down (an expense is booked). The entry carries
+    ``source_type=PO_RECEIPT`` and is idempotent on ``source_ref`` (see
+    :func:`accounting.services.post_entry`), so re-driving the same receipt (keyed
+    on the ``DeliveryItem``) returns the original transaction instead of
+    double-posting.
+
+    Args:
+        committee: The ``auth.Group`` that owns the received item; recorded as the
+            debit line's SIG dimension.
+        amount: Positive USD amount received (``Decimal``), i.e. quantity ×
+            unit cost.
+        source_ref: Idempotency key for this receipt, e.g.
+            ``"po_receipt:<delivery_item_pk>"``.
+        item: Optional ``InventoryItem`` — used only to describe the entry.
+        created_by: Optional acting user recorded on the entry's provenance.
+        date: Optional posting date (defaults to today via hordak).
+        description: Optional human description; a sensible default is derived
+            from ``item`` when omitted.
+
+    Returns:
+        The posted (or pre-existing, when idempotent) ``hordak.Transaction``.
+    """
+    if not description:
+        description = (
+            f"Committee PO receipt: {item}" if item is not None else "Committee PO receipt"
+        )
+
+    return post_entry(
+        lines=[
+            Line(
+                account=ACCOUNT_INVENTORY_SUPPLIES,
+                debit=amount,
+                sig=committee,
+            ),
+            Line(account=ACCOUNT_ACCOUNTS_PAYABLE, credit=amount),
+        ],
+        source_type=SourceType.PO_RECEIPT,
         source_ref=source_ref,
         created_by=created_by,
         date=date,

--- a/backend/accounting/tests/test_adapters.py
+++ b/backend/accounting/tests/test_adapters.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import Group
 import pytest
 from hordak.models import Transaction
 
-from accounting.adapters import post_supply_consumption
+from accounting.adapters import post_po_receipt, post_supply_consumption
 from accounting.models import EntryMeta, LegDimension, SourceType
 from accounting.services import trial_balance
 
@@ -89,3 +89,53 @@ def test_post_supply_consumption_is_idempotent_on_source_ref():
 
     assert first.pk == second.pk
     assert Transaction.objects.filter(meta__source_ref="usage:idem").count() == 1
+
+
+def test_post_po_receipt_builds_correct_balanced_entry_and_dimension():
+    """DR 1300 (sig dimension) / CR 2000, PO_RECEIPT, and the ledger balances."""
+    group = Group.objects.create(name="Print SIG")
+    user = User.objects.create_user(username="receiver", password="x")
+
+    txn = post_po_receipt(
+        committee=group,
+        amount=Decimal("40.00"),
+        source_ref="po_receipt:1",
+        created_by=user,
+    )
+
+    assert txn.legs.count() == 2
+    debit_leg = txn.legs.get(debit__isnull=False)
+    credit_leg = txn.legs.get(credit__isnull=False)
+
+    # Inventory debited (stock added on the committee's tab), payable credited.
+    assert debit_leg.account.code == "1300"
+    assert debit_leg.debit.amount == Decimal("40.00")
+    assert str(debit_leg.debit.currency) == "USD"
+    assert credit_leg.account.code == "2000"
+    assert credit_leg.credit.amount == Decimal("40.00")
+
+    # SIG dimension on the inventory (debit) leg only; the payable is unattributed.
+    dim = LegDimension.objects.get(leg=debit_leg)
+    assert dim.sig_id == group.id
+    assert dim.asset_id is None
+    assert not LegDimension.objects.filter(leg=credit_leg).exists()
+
+    # Provenance / idempotency key.
+    meta = EntryMeta.objects.get(transaction=txn)
+    assert meta.source_type == SourceType.PO_RECEIPT
+    assert meta.source_ref == "po_receipt:1"
+    assert meta.created_by_id == user.id
+
+    # The books still balance.
+    assert trial_balance()["balanced"] is True
+
+
+def test_post_po_receipt_is_idempotent_on_source_ref():
+    """Replaying the same delivery-item key returns the original entry."""
+    group = Group.objects.create(name="PO Idem SIG")
+
+    first = post_po_receipt(committee=group, amount=Decimal("7.00"), source_ref="po_receipt:idem")
+    second = post_po_receipt(committee=group, amount=Decimal("7.00"), source_ref="po_receipt:idem")
+
+    assert first.pk == second.pk
+    assert Transaction.objects.filter(meta__source_ref="po_receipt:idem").count() == 1

--- a/backend/reorder_queue/services/receiving.py
+++ b/backend/reorder_queue/services/receiving.py
@@ -83,7 +83,7 @@ def receive_delivery(
         )
 
         for po_item, quantity in line_quantities:
-            DeliveryItem.objects.create(
+            delivery_item = DeliveryItem.objects.create(
                 delivery=delivery,
                 purchase_order_item=po_item,
                 quantity_received=quantity,
@@ -96,6 +96,25 @@ def receive_delivery(
             if inventory_item is not None:
                 inventory_item.current_stock += quantity
                 inventory_item.save()
+
+                # Committee-owned purchasing hits the ledger (Phase 2 · Bead 5):
+                # DR 1300 Inventory (dim=committee) / CR 2000 Accounts Payable
+                # for quantity × unit cost, in this same receive transaction. An
+                # item with no owning committee or no unit cost posts nothing, so
+                # ordinary receives behave exactly as before. Local import avoids
+                # a reorder_queue <-> accounting import cycle.
+                if inventory_item.owning_group_id:
+                    unit_cost = po_item.unit_cost_actual or po_item.unit_cost_ordered
+                    if unit_cost:
+                        from accounting.adapters import post_po_receipt
+
+                        post_po_receipt(
+                            committee=inventory_item.owning_group,
+                            amount=quantity * unit_cost,
+                            source_ref=f"po_receipt:{delivery_item.id}",
+                            item=inventory_item,
+                            created_by=received_by,
+                        )
 
             if po_item.is_fully_received:
                 create_lead_time_log(po_item, delivery.delivery_date)

--- a/backend/reorder_queue/tests/test_receiving_ledger.py
+++ b/backend/reorder_queue/tests/test_receiving_ledger.py
@@ -1,0 +1,155 @@
+"""PO receipt → committee purchasing ledger wiring (Phase 2 · Bead 5).
+
+``receive_delivery`` posts ``DR 1300`` (dim=committee) / ``CR 2000`` for each
+committee-owned line that carries a unit cost, atomically inside the receive
+transaction. Non-committee lines and zero-cost lines post nothing, leaving the
+receipt behaviour unchanged. The accounting engine is Postgres/hordak-only.
+"""
+
+from decimal import Decimal
+
+from django.contrib.auth.models import Group
+from django.utils import timezone
+
+import pytest
+from hordak.models import Transaction
+
+from accounting.adapters import post_po_receipt
+from accounting.models import LegDimension
+from accounting.services import trial_balance
+from inventory.tests.factories import ItemSupplierFactory, SupplierFactory
+from reorder_queue import services
+from reorder_queue.models import DeliveryItem, PurchaseOrder, PurchaseOrderItem
+from reorder_queue.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+PO_RECEIPT = "PO_RECEIPT"
+
+
+def _committee_po(user, *, group=None, qty=10, unit_cost=None, stock=0):
+    """A SENT PO with one inventory line whose item is owned by ``group``.
+
+    ``group=None`` leaves the item Space-owned (no committee). ``unit_cost``
+    defaults to ``2.00`` and sets the line's ordered cost (the charge driver);
+    pass ``Decimal("0")`` for the no-cost case. The item_supplier's own unit cost
+    is irrelevant to the hook — it reads the PO line's actual-or-ordered cost —
+    so it just gets a valid positive value.
+    """
+    if unit_cost is None:
+        unit_cost = Decimal("2.00")
+    supplier = SupplierFactory()
+    po = PurchaseOrder.objects.create(
+        supplier=supplier,
+        status=PurchaseOrder.Status.SENT,
+        created_by=user,
+        sent_at=timezone.now(),
+    )
+    item_supplier = ItemSupplierFactory(
+        supplier=supplier, unit_cost=unit_cost or Decimal("1.00"), average_lead_time=5
+    )
+    item = item_supplier.item
+    item.current_stock = stock
+    if group is not None:
+        item.owning_group = group
+        item.ownership_type = "group"
+    item.save()
+    line = PurchaseOrderItem.objects.create(
+        purchase_order=po,
+        item_supplier=item_supplier,
+        quantity_ordered=qty,
+        unit_cost_ordered=unit_cost,
+    )
+    return po, line, item
+
+
+def test_committee_receipt_posts_one_balanced_po_receipt_entry():
+    """Committee item + unit cost → one DR 1300 (dim=committee) / CR 2000 entry."""
+    user = UserFactory()
+    group = Group.objects.create(name="Laser SIG")
+    po, line, item = _committee_po(user, group=group, qty=5, unit_cost=Decimal("4.00"), stock=0)
+
+    services.receive_delivery(po, [(line, 5)], received_by=user, delivery_datetime=timezone.now())
+
+    # Stock still moved (the receipt behaviour is unchanged).
+    item.refresh_from_db()
+    assert item.current_stock == 5
+
+    entries = Transaction.objects.filter(meta__source_type=PO_RECEIPT)
+    assert entries.count() == 1
+    txn = entries.get()
+
+    debit_leg = txn.legs.get(debit__isnull=False)
+    credit_leg = txn.legs.get(credit__isnull=False)
+    assert debit_leg.account.code == "1300"
+    assert debit_leg.debit.amount == Decimal("20.00")  # 5 × 4.00
+    assert credit_leg.account.code == "2000"
+    assert credit_leg.credit.amount == Decimal("20.00")
+
+    # Committee attribution on the inventory (debit) leg.
+    dim = LegDimension.objects.get(leg=debit_leg)
+    assert dim.sig_id == group.id
+
+    # The books still balance.
+    assert trial_balance()["balanced"] is True
+
+
+def test_receipt_prefers_actual_unit_cost_over_ordered():
+    """unit_cost_actual, when present, drives the charge instead of ordered."""
+    user = UserFactory()
+    group = Group.objects.create(name="CNC SIG")
+    po, line, _item = _committee_po(user, group=group, qty=3, unit_cost=Decimal("2.00"), stock=0)
+    line.unit_cost_actual = Decimal("2.50")
+    line.save()
+
+    services.receive_delivery(po, [(line, 3)], received_by=user, delivery_datetime=timezone.now())
+
+    txn = Transaction.objects.get(meta__source_type=PO_RECEIPT)
+    assert txn.legs.get(debit__isnull=False).debit.amount == Decimal("7.50")  # 3 × 2.50
+
+
+def test_receipt_is_idempotent_on_delivery_item():
+    """Re-driving the same delivery_item does not double-post."""
+    user = UserFactory()
+    group = Group.objects.create(name="Idem SIG")
+    po, line, item = _committee_po(user, group=group, qty=4, unit_cost=Decimal("3.00"), stock=0)
+
+    delivery = services.receive_delivery(
+        po, [(line, 4)], received_by=user, delivery_datetime=timezone.now()
+    )
+    assert Transaction.objects.filter(meta__source_type=PO_RECEIPT).count() == 1
+
+    # Replay the post for the very same DeliveryItem (its id is the source key).
+    delivery_item = DeliveryItem.objects.get(delivery=delivery, purchase_order_item=line)
+    post_po_receipt(
+        committee=group,
+        amount=Decimal("12.00"),
+        source_ref=f"po_receipt:{delivery_item.id}",
+        item=item,
+    )
+    assert Transaction.objects.filter(meta__source_type=PO_RECEIPT).count() == 1
+
+
+def test_non_committee_item_posts_nothing_but_still_increments_stock():
+    """Space-owned item (no committee) → no ledger entry; stock still moves."""
+    user = UserFactory()
+    po, line, item = _committee_po(user, group=None, qty=6, unit_cost=Decimal("2.00"), stock=1)
+
+    services.receive_delivery(po, [(line, 6)], received_by=user, delivery_datetime=timezone.now())
+
+    item.refresh_from_db()
+    assert item.current_stock == 7
+    assert not Transaction.objects.filter(meta__source_type=PO_RECEIPT).exists()
+
+
+def test_committee_item_without_unit_cost_posts_nothing():
+    """Committee item with a zero unit cost → no entry; stock still moves."""
+    user = UserFactory()
+    group = Group.objects.create(name="Free SIG")
+    po, line, item = _committee_po(user, group=group, qty=2, unit_cost=Decimal("0"), stock=0)
+
+    services.receive_delivery(po, [(line, 2)], received_by=user, delivery_datetime=timezone.now())
+
+    item.refresh_from_db()
+    assert item.current_stock == 2
+    assert not Transaction.objects.filter(meta__source_type=PO_RECEIPT).exists()

--- a/docs/accounting.md
+++ b/docs/accounting.md
@@ -164,9 +164,61 @@ unauthorized or anonymous caller who supplies a committee gets `403`. With **no*
 `charged_group` the endpoint behaves exactly as before — same stock math, same
 (public) permissions, no ledger entry.
 
+## PO receipt → committee purchasing (Phase 2)
+
+The mirror bookend of the chargeback. When inventory is received against a
+purchase order through `receive_delivery` (the `receive` / `mark-delivered`
+actions), OMS posts a balanced entry **for each received line whose item is owned
+by a committee**, in the **same DB transaction** as the stock increment:
+
+```
+DR 1300 Inventory — Supplies on hand   (dimension: sig = the committee)
+CR 2000 Accounts Payable
+```
+
+The committee is `item.owning_group` (an `auth.Group`) recorded as the debit
+line's **SIG dimension**. The amount is `quantity × unit_cost`, where
+`unit_cost = po_item.unit_cost_actual or po_item.unit_cost_ordered` — the actual
+charged cost wins over the ordered estimate when known. This is the *purchasing*
+side of a committee's tab: receiving **fills** on-hand supplies (and incurs a
+payable), while consuming later **draws them down** as an expense (the 5100/1300
+chargeback above). Vendor payment (DR 2000 / CR Cash) is a future bead — there is
+no Cash account in v1.
+
+### The adapter (`accounting/adapters.py`)
+
+```python
+from accounting.adapters import post_po_receipt
+
+txn = post_po_receipt(
+    committee=item.owning_group,          # auth.Group -> debit line's SIG dimension
+    amount=quantity * unit_cost,          # positive USD Decimal
+    source_ref=f"po_receipt:{delivery_item.id}",
+    item=item,                            # only used to describe the entry
+    created_by=received_by,
+)
+```
+
+It wraps `accounting.services.post_entry` with the fixed **1300 / 2000** mapping
+and `source_type=SourceType.PO_RECEIPT`. `receive_delivery` imports it **lazily**
+(a local import inside the function) to avoid any `reorder_queue` ↔ `accounting`
+import cycle.
+
+### Idempotency & backward compatibility
+
+- **Idempotent** on `source_ref=f"po_receipt:{delivery_item.id}"`: every receipt
+  mints exactly one `DeliveryItem`, so its pk keys the entry — re-driving the
+  same receipt returns the original transaction instead of double-posting
+  (enforced by `EntryMeta`'s partial-unique `(source_type, source_ref)`).
+- **Backward compatible.** A line whose item has **no owning committee**
+  (`owning_group` is null) or **no unit cost** (the resolved actual-or-ordered
+  cost is zero) posts nothing — the stock increment and every other receipt side
+  effect behave exactly as before. Only committee-owned, priced lines touch the
+  ledger.
+
 ## Out of scope (Phase 2+)
 
 Web committee-picker UI + ScanTTY consume-and-charge flow; the committee statement
-report; settlement / period-close; PO / vendor / donation / asset adapters;
+report; settlement / period-close; vendor / donation / asset adapters;
 serialized-consume + work-order material-usage charge paths (they will reuse
 `post_supply_consumption`).


### PR DESCRIPTION
## Phase 2 · Bead 5 — PO-received adapter (committee purchasing → ledger)

Posts a `PO_RECEIPT` entry when inventory is received against a PO for a committee-owned item, so committee **purchasing** shows up in the ledger (fills the `purchased` bucket in the Bead 3 statement). Bead: **op-3dj5**.

### What's in it
- **`post_po_receipt(committee, amount, source_ref, item=, created_by=)`** (`accounting/adapters.py`) — DR 1300 Inventory `[dim=committee]` / CR 2000 Accounts Payable, `source_type=PO_RECEIPT`, idempotent on `source_ref`.
- **Wired into `receive_delivery`** (`reorder_queue/services/receiving.py`) inside its existing atomic block: for each received committee-owned line with a unit cost, posts `qty × (unit_cost_actual or unit_cost_ordered)`, keyed idempotently on `po_receipt:<delivery_item.id>` (lazy import avoids a reorder_queue↔accounting cycle). **No owning committee or no unit cost → nothing posted, receive is byte-for-byte unchanged.**
- New `reorder_queue/tests/test_receiving_ledger.py` + adapter unit tests; docs. **No endpoint, no migration.**

### Verification (independent, on PostgreSQL)
`manage.py check` clean · `check_permission_matrix` OK (871, no shift — no new endpoint) · **10 targeted tests pass** (adapter + receiving-ledger; worker's full accounting + reorder_queue suite: 258) · bandit clean · reviewed the hook (atomic, backward-compatible, idempotent per delivery line).

Completes the **Phase-2 backend**: charge (Bead 1) → statement (Bead 3) → settle (Bead 4) → purchasing (Bead 5). **Note:** trivial *additive* conflicts with Bead 4's PR (#923) on `accounting/adapters.py` + `docs/accounting.md` — keep both at merge.

Draft — merging is the owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
