### PR TITLE
feat(inventory): demand-forecast web panel + reorder alerts + item toggle (op-3)

### DIFF
--- a/frontend/src/__tests__/components/DemandForecastPanel.test.tsx
+++ b/frontend/src/__tests__/components/DemandForecastPanel.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Tests for DemandForecastPanel (op-3) — the ML demand forecast + predictive
+ * reorder alerts surfaced on the inventory + purchasing overviews.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+
+import DemandForecastPanel from '../../components/inventory/DemandForecastPanel';
+import { DemandForecastRow, reportsAPI } from '../../services/api';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    reportsAPI: {
+      getDemandForecast: jest.fn(),
+      getReorderAlerts: jest.fn(),
+    },
+  };
+});
+
+const mockReports = reportsAPI as jest.Mocked<typeof reportsAPI>;
+
+const buildRow = (overrides: Partial<DemandForecastRow> = {}): DemandForecastRow => ({
+  id: 1,
+  item: 'item-1',
+  item_name: 'Toilet paper',
+  sku: 'TP-1',
+  category_name: 'Supplies',
+  generated_at: '2026-07-19T04:00:00Z',
+  horizon_days: 14,
+  predicted_daily_demand: 0.5,
+  horizon_demand: 7,
+  horizon_demand_upper: 9,
+  available_at_generation: 4,
+  days_until_stockout: 8,
+  projected_stockout_date: '2026-07-27',
+  predictive_reorder_point: 9,
+  needs_reorder: true,
+  lead_time_days: 7,
+  safety_stock: 2,
+  method: 'holtwinters',
+  model_version: 'holtwinters-1',
+  ...overrides,
+});
+
+const renderPanel = (props = {}) =>
+  render(
+    <MantineProvider env="test">
+      <DemandForecastPanel {...props} />
+    </MantineProvider>,
+  );
+
+describe('DemandForecastPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReports.getReorderAlerts.mockResolvedValue({ data: [] } as never);
+  });
+
+  it('requests the forecast and the alert set on mount', async () => {
+    mockReports.getDemandForecast.mockResolvedValue({ data: [] } as never);
+
+    renderPanel();
+
+    await waitFor(() =>
+      expect(mockReports.getDemandForecast).toHaveBeenCalledWith({
+        low_stock_only: false,
+      }),
+    );
+    expect(mockReports.getReorderAlerts).toHaveBeenCalled();
+  });
+
+  it('shows an engine-has-not-run empty state when there are no rows', async () => {
+    mockReports.getDemandForecast.mockResolvedValue({ data: [] } as never);
+
+    renderPanel();
+
+    expect(await screen.findByTestId('demand-forecast-empty')).toHaveTextContent(
+      /generated nightly/i,
+    );
+    // No forecast rows → no legend either.
+    expect(screen.queryByTestId('demand-forecast-legend')).not.toBeInTheDocument();
+  });
+
+  it('renders forecast rows with method badges and a due count', async () => {
+    mockReports.getDemandForecast.mockResolvedValue({
+      data: [
+        buildRow({ id: 1, item: 'a', item_name: 'Toilet paper', needs_reorder: true }),
+        buildRow({
+          id: 2,
+          item: 'b',
+          item_name: 'Trash bags',
+          method: 'fallback',
+          model_version: '',
+          needs_reorder: false,
+          available_at_generation: 50,
+        }),
+      ],
+    } as never);
+
+    renderPanel();
+
+    expect(await screen.findByText('Toilet paper')).toBeInTheDocument();
+    expect(screen.getByText('Trash bags')).toBeInTheDocument();
+    // The seasonal model and the run-rate fallback are told apart at a glance.
+    expect(screen.getByText('Holt-Winters')).toBeInTheDocument();
+    expect(screen.getByText('Fallback')).toBeInTheDocument();
+    // One of the two rows is flagged → header badge reads "1 due".
+    expect(screen.getByText('1 due')).toBeInTheDocument();
+    expect(screen.getByText('Reorder')).toBeInTheDocument();
+    expect(screen.getByText('OK')).toBeInTheDocument();
+    expect(screen.getByTestId('demand-forecast-legend')).toBeInTheDocument();
+  });
+
+  it('shows the snapshotted stock, reorder point and stockout for a row', async () => {
+    mockReports.getDemandForecast.mockResolvedValue({
+      data: [
+        buildRow({
+          predicted_daily_demand: 0.5,
+          days_until_stockout: 8,
+          predictive_reorder_point: 9,
+          available_at_generation: 4,
+        }),
+      ],
+    } as never);
+
+    renderPanel();
+
+    const row = await screen.findByTestId('demand-forecast-row-item-1');
+    expect(within(row).getByText('0.50')).toBeInTheDocument();
+    expect(within(row).getByText('8 d')).toBeInTheDocument();
+    expect(within(row).getByText('9')).toBeInTheDocument();
+    expect(within(row).getByText('4')).toBeInTheDocument();
+  });
+
+  it('renders an em dash when demand is flat and there is no stockout date', async () => {
+    mockReports.getDemandForecast.mockResolvedValue({
+      data: [buildRow({ days_until_stockout: null, predicted_daily_demand: 0 })],
+    } as never);
+
+    renderPanel();
+
+    const row = await screen.findByTestId('demand-forecast-row-item-1');
+    expect(within(row).getByText('—')).toBeInTheDocument();
+  });
+
+  it('refetches with low_stock_only when the switch is toggled', async () => {
+    mockReports.getDemandForecast.mockResolvedValue({ data: [buildRow()] } as never);
+
+    renderPanel();
+    await screen.findByText('Toilet paper');
+
+    fireEvent.click(screen.getByLabelText('Due to reorder only'));
+
+    await waitFor(() =>
+      expect(mockReports.getDemandForecast).toHaveBeenLastCalledWith({
+        low_stock_only: true,
+      }),
+    );
+  });
+
+  it('starts filtered when defaultLowStockOnly is set', async () => {
+    mockReports.getDemandForecast.mockResolvedValue({ data: [] } as never);
+
+    renderPanel({ defaultLowStockOnly: true });
+
+    await waitFor(() =>
+      expect(mockReports.getDemandForecast).toHaveBeenCalledWith({
+        low_stock_only: true,
+      }),
+    );
+    expect(await screen.findByTestId('demand-forecast-empty')).toHaveTextContent(
+      'No forecasted items are due to reorder.',
+    );
+  });
+
+  it('surfaces the reorder alerts — the watched, due items — above the table', async () => {
+    mockReports.getDemandForecast.mockResolvedValue({ data: [buildRow()] } as never);
+    mockReports.getReorderAlerts.mockResolvedValue({
+      data: [
+        buildRow({
+          id: 7,
+          item: 'watched-1',
+          item_name: 'Paper towels',
+          available_at_generation: 2,
+          predictive_reorder_point: 11,
+          days_until_stockout: 3,
+        }),
+      ],
+    } as never);
+
+    renderPanel();
+
+    const alerts = await screen.findByTestId('demand-forecast-alerts');
+    expect(within(alerts).getByText('Reorder alerts')).toBeInTheDocument();
+    // Count badge next to the heading.
+    expect(within(alerts).getByText('1')).toBeInTheDocument();
+    expect(screen.getByTestId('demand-forecast-alert-watched-1')).toHaveTextContent(
+      'Paper towels — 2 left, reorder at 11 (out in 3 d)',
+    );
+  });
+
+  it('hides the alert banner when nothing is both watched and due', async () => {
+    mockReports.getDemandForecast.mockResolvedValue({ data: [buildRow()] } as never);
+    mockReports.getReorderAlerts.mockResolvedValue({ data: [] } as never);
+
+    renderPanel();
+
+    await screen.findByText('Toilet paper');
+    expect(screen.queryByTestId('demand-forecast-alerts')).not.toBeInTheDocument();
+  });
+
+  it('invokes onSelectItem when a row is clicked', async () => {
+    mockReports.getDemandForecast.mockResolvedValue({ data: [buildRow()] } as never);
+    const onSelectItem = vi.fn();
+
+    renderPanel({ onSelectItem });
+
+    fireEvent.click(await screen.findByTestId('demand-forecast-row-item-1'));
+    expect(onSelectItem).toHaveBeenCalledWith('item-1');
+  });
+
+  it('shows an error message when the report fails to load', async () => {
+    mockReports.getDemandForecast.mockRejectedValue({
+      response: { data: { detail: 'Nope.' } },
+    } as never);
+
+    renderPanel();
+
+    expect(await screen.findByText('Nope.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/InventoryItemFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemFormPage.test.tsx
@@ -700,4 +700,94 @@ describe('InventoryItemFormPage', () => {
     const formData = (api.inventoryAPI.updateItem as jest.Mock).mock.calls[0][1] as FormData;
     expect(formData.get('is_retired')).toBe('true');
   });
+
+  // ---- op-3: reorder-alerts opt-in toggle ----
+
+  it('renders the reorder-alerts switch, off by default', async () => {
+    renderCreatePage();
+
+    const toggle = (await screen.findByTestId(
+      'item-reorder-alerts-enabled'
+    )) as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+    expect(screen.getByLabelText(/Watch for reorder alerts/i)).toBeInTheDocument();
+  });
+
+  it('sends reorder_alerts_enabled=false by default', async () => {
+    (api.inventoryAPI.createItem as jest.Mock).mockResolvedValue({
+      data: { ...mockItem, id: 'new-id' },
+    });
+
+    renderCreatePage();
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(/Name/i).length).toBeGreaterThan(0);
+    });
+    fillRequiredFields();
+    fireEvent.click(screen.getByText('Create Item'));
+
+    await waitFor(() => {
+      expect(api.inventoryAPI.createItem).toHaveBeenCalled();
+    });
+
+    const formData = (api.inventoryAPI.createItem as jest.Mock).mock.calls[0][0] as FormData;
+    expect(formData.get('reorder_alerts_enabled')).toBe('false');
+  });
+
+  it('includes reorder_alerts_enabled=true in the create payload when toggled on', async () => {
+    (api.inventoryAPI.createItem as jest.Mock).mockResolvedValue({
+      data: { ...mockItem, id: 'new-id' },
+    });
+
+    renderCreatePage();
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(/Name/i).length).toBeGreaterThan(0);
+    });
+    fillRequiredFields();
+
+    fireEvent.click(screen.getByTestId('item-reorder-alerts-enabled'));
+    fireEvent.click(screen.getByText('Create Item'));
+
+    await waitFor(() => {
+      expect(api.inventoryAPI.createItem).toHaveBeenCalled();
+    });
+
+    const formData = (api.inventoryAPI.createItem as jest.Mock).mock.calls[0][0] as FormData;
+    expect(formData.get('reorder_alerts_enabled')).toBe('true');
+  });
+
+  it('hydrates reorder_alerts_enabled in edit mode and includes it on update', async () => {
+    (api.inventoryAPI.getItem as jest.Mock).mockResolvedValue({
+      data: { ...mockItem, reorder_alerts_enabled: true },
+    });
+    (api.inventoryAPI.updateItem as jest.Mock).mockResolvedValue({ data: mockItem });
+
+    render(
+      <MantineProvider env="test">
+        <MemoryRouter initialEntries={['/inventory/items/test-id/edit']}>
+          <Routes>
+            <Route path="/inventory/items/:id/edit" element={<InventoryItemFormPage />} />
+          </Routes>
+        </MemoryRouter>
+      </MantineProvider>
+    );
+
+    // The switch hydrates on from the fetched item.
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Test Item')).toBeInTheDocument();
+    });
+    expect(
+      (screen.getByTestId('item-reorder-alerts-enabled') as HTMLInputElement).checked
+    ).toBe(true);
+
+    fireEvent.click(screen.getByText('Save Changes'));
+
+    await waitFor(() => {
+      expect(api.inventoryAPI.updateItem).toHaveBeenCalled();
+    });
+
+    const formData = (api.inventoryAPI.updateItem as jest.Mock).mock.calls[0][1] as FormData;
+    expect(formData.get('reorder_alerts_enabled')).toBe('true');
+  });
 });

--- a/frontend/src/__tests__/pages/InventoryOverviewPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryOverviewPage.test.tsx
@@ -9,7 +9,7 @@ import { MantineProvider } from '@mantine/core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import InventoryOverviewPage from '../../pages/InventoryOverviewPage';
-import { inventoryAPI } from '../../services/api';
+import { inventoryAPI, reportsAPI } from '../../services/api';
 
 vi.mock('../../services/api', async () => {
   const actual = await vi.importActual('../../services/api');
@@ -20,10 +20,17 @@ vi.mock('../../services/api', async () => {
       listItems: jest.fn(),
       listCategories: jest.fn(),
     },
+    // The page mounts <DemandForecastPanel>, which reads these on mount (op-3).
+    reportsAPI: {
+      ...(actual as any).reportsAPI,
+      getDemandForecast: jest.fn(),
+      getReorderAlerts: jest.fn(),
+    },
   };
 });
 
 const mockInv = inventoryAPI as jest.Mocked<typeof inventoryAPI>;
+const mockReports = reportsAPI as jest.Mocked<typeof reportsAPI>;
 
 const buildItem = (overrides: Partial<any> = {}) => ({
   id: 'item-1',
@@ -50,6 +57,8 @@ const renderPage = () =>
 describe('InventoryOverviewPage search', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockReports.getDemandForecast.mockResolvedValue({ data: [] } as any);
+    mockReports.getReorderAlerts.mockResolvedValue({ data: [] } as any);
     mockInv.listCategories.mockResolvedValue({
       data: { results: [{ id: 1, name: 'Fasteners' }] },
     } as any);

--- a/frontend/src/components/inventory/DemandForecastPanel.tsx
+++ b/frontend/src/components/inventory/DemandForecastPanel.tsx
@@ -1,0 +1,239 @@
+/**
+ * DemandForecastPanel — ML demand forecast + predictive reorder alerts for
+ * *non-serialized* inventory items (op-3). Sibling of
+ * <SerializedForecastPanel>, which does the same job for serialized
+ * components; this one reads the rows the nightly forecasting task stores
+ * (op-1 storage, op-2 engine) rather than computing anything client-side.
+ *
+ * Two surfaces in one panel:
+ *  - a reorder-alerts banner atop the table — the daily "pings" for items
+ *    someone opted in via the item form's "Watch for reorder alerts" switch
+ *    *and* that the forecast says are due;
+ *  - the forecast table itself, most-urgent first (the backend sorts), with a
+ *    "Due to reorder only" switch feeding `low_stock_only`.
+ *
+ * Both endpoints return [] until the nightly task has run, so the empty state
+ * says so rather than implying nothing needs reordering.
+ */
+import {
+  Alert,
+  Badge,
+  Group,
+  Loader,
+  Paper,
+  Switch,
+  Table,
+  Text,
+  Title,
+} from '@mantine/core';
+import { IconBellRinging } from '@tabler/icons-react';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { DemandForecastMethod, DemandForecastRow, reportsAPI } from '../../services/api';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
+
+interface Props {
+  /** Start with the due-to-reorder-only filter on (e.g. the purchasing view). */
+  defaultLowStockOnly?: boolean;
+  title?: string;
+  /** Called when a row is activated, e.g. to navigate to the item. */
+  onSelectItem?: (itemId: string) => void;
+}
+
+const METHOD_LABELS: Record<DemandForecastMethod, string> = {
+  prophet: 'Prophet',
+  holtwinters: 'Holt-Winters',
+  fallback: 'Fallback',
+};
+
+// Holt-Winters means the item had enough history for the seasonal model;
+// fallback is a plain run-rate, so it gets a quieter badge.
+const METHOD_COLORS: Record<DemandForecastMethod, string> = {
+  prophet: 'grape',
+  holtwinters: 'blue',
+  fallback: 'gray',
+};
+
+const fmtDays = (n: number | null): string => (n === null ? '—' : `${n} d`);
+
+const fmtRate = (n: number): string => n.toFixed(2);
+
+const DemandForecastPanel: React.FC<Props> = ({
+  defaultLowStockOnly = false,
+  title = 'Demand forecast',
+  onSelectItem,
+}) => {
+  const [rows, setRows] = useState<DemandForecastRow[]>([]);
+  const [alerts, setAlerts] = useState<DemandForecastRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lowStockOnly, setLowStockOnly] = useState(defaultLowStockOnly);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [forecastRes, alertsRes] = await Promise.all([
+        reportsAPI.getDemandForecast({ low_stock_only: lowStockOnly }),
+        reportsAPI.getReorderAlerts(),
+      ]);
+      setRows(forecastRes?.data ?? []);
+      setAlerts(alertsRes?.data ?? []);
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Could not load the demand forecast.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [lowStockOnly]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const dueCount = rows.filter((r) => r.needs_reorder).length;
+
+  return (
+    <Paper withBorder p="md" data-testid="demand-forecast-panel">
+      <Group justify="space-between" align="center" mb="sm" wrap="wrap">
+        <Group gap="xs">
+          <Title order={4}>{title}</Title>
+          {!loading && (
+            <Badge color={dueCount > 0 ? 'orange' : 'gray'} variant="light">
+              {dueCount} due
+            </Badge>
+          )}
+        </Group>
+        <Switch
+          size="sm"
+          label="Due to reorder only"
+          checked={lowStockOnly}
+          onChange={(e) => setLowStockOnly(e.currentTarget.checked)}
+          data-testid="demand-forecast-low-only"
+        />
+      </Group>
+
+      {!loading && !error && alerts.length > 0 && (
+        <Alert
+          color="orange"
+          variant="light"
+          mb="sm"
+          icon={<IconBellRinging size={18} />}
+          title={
+            <Group gap="xs">
+              <span>Reorder alerts</span>
+              <Badge color="orange" variant="filled" radius="sm">
+                {alerts.length}
+              </Badge>
+            </Group>
+          }
+          data-testid="demand-forecast-alerts"
+        >
+          <Text size="sm" mb={4}>
+            Watched items the forecast says are due to reorder now.
+          </Text>
+          {alerts.map((alert) => (
+            <Text
+              key={alert.id}
+              size="sm"
+              data-testid={`demand-forecast-alert-${alert.item}`}
+              onClick={onSelectItem ? () => onSelectItem(alert.item) : undefined}
+              style={{ cursor: onSelectItem ? 'pointer' : undefined }}
+            >
+              <b>{alert.item_name}</b> — {alert.available_at_generation} left,
+              reorder at {alert.predictive_reorder_point}
+              {alert.days_until_stockout !== null &&
+                ` (out in ${alert.days_until_stockout} d)`}
+            </Text>
+          ))}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Group justify="center" py="lg">
+          <Loader size="sm" />
+        </Group>
+      ) : error ? (
+        <Text c="red" size="sm">
+          {error}
+        </Text>
+      ) : rows.length === 0 ? (
+        <Text c="dimmed" data-testid="demand-forecast-empty">
+          {lowStockOnly
+            ? 'No forecasted items are due to reorder.'
+            : 'No demand forecast yet — it is generated nightly once items have usage history.'}
+        </Text>
+      ) : (
+        <Table.ScrollContainer minWidth={800}>
+          <Table highlightOnHover verticalSpacing="xs">
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Item</Table.Th>
+                <Table.Th>Method</Table.Th>
+                <Table.Th ta="right">Avg/day</Table.Th>
+                <Table.Th ta="right">Stockout</Table.Th>
+                <Table.Th ta="right">Reorder pt</Table.Th>
+                <Table.Th ta="right">Available</Table.Th>
+                <Table.Th>Status</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {rows.map((row) => (
+                <Table.Tr
+                  key={row.id}
+                  data-testid={`demand-forecast-row-${row.item}`}
+                  onClick={onSelectItem ? () => onSelectItem(row.item) : undefined}
+                  style={{
+                    cursor: onSelectItem ? 'pointer' : undefined,
+                    background: row.needs_reorder
+                      ? 'var(--mantine-color-orange-0)'
+                      : undefined,
+                  }}
+                >
+                  <Table.Td>
+                    <Text fw={500} lineClamp={1}>
+                      {row.item_name}
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                      {row.sku || 'no SKU'}
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Badge color={METHOD_COLORS[row.method] ?? 'gray'} variant="light">
+                      {METHOD_LABELS[row.method] ?? row.method}
+                    </Badge>
+                  </Table.Td>
+                  <Table.Td ta="right">{fmtRate(row.predicted_daily_demand)}</Table.Td>
+                  <Table.Td ta="right">{fmtDays(row.days_until_stockout)}</Table.Td>
+                  <Table.Td ta="right">{row.predictive_reorder_point}</Table.Td>
+                  <Table.Td ta="right" fw={600}>
+                    {row.available_at_generation}
+                  </Table.Td>
+                  <Table.Td>
+                    {row.needs_reorder ? (
+                      <Badge color="orange" variant="filled">
+                        Reorder
+                      </Badge>
+                    ) : (
+                      <Badge color="green" variant="light">
+                        OK
+                      </Badge>
+                    )}
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </Table.ScrollContainer>
+      )}
+
+      {!loading && !error && rows.length > 0 && (
+        <Text size="xs" c="dimmed" mt="xs" data-testid="demand-forecast-legend">
+          Reorder is driven by <b>available</b> stock versus the demand predicted
+          over the lead time, snapshotted when the forecast ran.
+        </Text>
+      )}
+    </Paper>
+  );
+};
+
+export default DemandForecastPanel;

--- a/frontend/src/pages/InventoryItemFormPage.tsx
+++ b/frontend/src/pages/InventoryItemFormPage.tsx
@@ -62,6 +62,7 @@ const InventoryItemFormPage: React.FC = () => {
       use_case_based_reorder: false,
       minimum_cases: null,
       reorder_cases: null,
+      reorder_alerts_enabled: false,
       category: null,
       location: null,
       shelf_position: '',
@@ -131,6 +132,7 @@ const InventoryItemFormPage: React.FC = () => {
         use_case_based_reorder: item.use_case_based_reorder,
         minimum_cases: item.minimum_cases || null,
         reorder_cases: item.reorder_cases || null,
+        reorder_alerts_enabled: item.reorder_alerts_enabled ?? false,
         category: item.category,
         location: item.location ? String(item.location) : null,
         shelf_position: (item as any).shelf_position || '',
@@ -386,6 +388,17 @@ const InventoryItemFormPage: React.FC = () => {
                           />
                         </>
                       )}
+                    </div>
+                    <div>
+                      <Switch
+                        label="Watch for reorder alerts"
+                        description="Include this item in the nightly demand forecast's reorder alerts — for supplies that run out on a schedule (toilet paper, paper towels, trash bags)."
+                        checked={watch('reorder_alerts_enabled')}
+                        onChange={(e) =>
+                          setValue('reorder_alerts_enabled', e.currentTarget.checked)
+                        }
+                        data-testid="item-reorder-alerts-enabled"
+                      />
                     </div>
                   </>
                 ),

--- a/frontend/src/pages/InventoryOverviewPage.tsx
+++ b/frontend/src/pages/InventoryOverviewPage.tsx
@@ -35,6 +35,7 @@ import {
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import DemandForecastPanel from '../components/inventory/DemandForecastPanel';
 import SerializedForecastPanel from '../components/inventory/SerializedForecastPanel';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import { inventoryAPI } from '../services/api';
@@ -261,6 +262,7 @@ const InventoryOverviewPage: React.FC = () => {
           aria-label="Search inventory"
         />
       )}
+      <DemandForecastPanel title="Demand forecast" onSelectItem={goItem} />
       {hasSerialized && (
         <SerializedForecastPanel
           title="Serialized-component forecast"

--- a/frontend/src/pages/PurchasingOverviewPage.tsx
+++ b/frontend/src/pages/PurchasingOverviewPage.tsx
@@ -3,10 +3,12 @@
  * Refactored in nav-cohesion PR2 to use the shared <WorkspaceLanding>
  * + <CapabilityCard> primitives so it matches the homepage rhythm.
  */
+import { Stack } from '@mantine/core';
 import { IconClipboardList, IconPlus, IconReceipt } from '@tabler/icons-react';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import DemandForecastPanel from '../components/inventory/DemandForecastPanel';
 import SerializedForecastPanel from '../components/inventory/SerializedForecastPanel';
 import CapabilityCard from '../components/landing/CapabilityCard';
 import WorkspaceLanding from '../components/landing/WorkspaceLanding';
@@ -23,11 +25,18 @@ const PurchasingOverviewPage: React.FC = () => {
         'Manage purchase orders, reorder requests, and the public transparency ledger.',
     }}
     footer={
-      <SerializedForecastPanel
-        title="Serialized components to reorder"
-        defaultLowStockOnly
-        onSelectItem={(itemId) => navigate(`/inventory/items/${itemId}`)}
-      />
+      <Stack gap="md">
+        <DemandForecastPanel
+          title="Supplies to reorder"
+          defaultLowStockOnly
+          onSelectItem={(itemId) => navigate(`/inventory/items/${itemId}`)}
+        />
+        <SerializedForecastPanel
+          title="Serialized components to reorder"
+          defaultLowStockOnly
+          onSelectItem={(itemId) => navigate(`/inventory/items/${itemId}`)}
+        />
+      </Stack>
     }
   >
     <CapabilityCard

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -877,6 +877,44 @@ export interface SerializedForecastRow {
   needs_reorder: boolean;
 }
 
+// How a demand forecast was produced. `holtwinters` is the seasonal smoother
+// used when an item has enough usage history; `fallback` is the statistical
+// run-rate used when it does not. `prophet` is reserved for a future engine
+// swap and is not emitted today.
+export type DemandForecastMethod = 'prophet' | 'holtwinters' | 'fallback';
+
+// One stored forecast row (the latest run) for a non-serialized item, from
+// InventoryReportViewSet.demand_forecast / .reorder_alerts (op-1 storage,
+// op-2 nightly engine). Every value is a snapshot taken at generation time —
+// later stock movements never rewrite a row, so `available_at_generation` can
+// lag the item's live stock. Rows only exist once the nightly task has run;
+// both endpoints return [] until then.
+export interface DemandForecastRow {
+  // The forecast row's own id; `item` is the inventory item's UUID.
+  id: number;
+  item: string;
+  item_name: string;
+  sku: string;
+  category_name: string | null;
+  generated_at: string;
+  horizon_days: number;
+  // Mean predicted demand per day, and its sum over the horizon. `_upper` is
+  // the upper prediction band — the gap between it and `horizon_demand` is
+  // what becomes safety stock.
+  predicted_daily_demand: number;
+  horizon_demand: number;
+  horizon_demand_upper: number;
+  available_at_generation: number;
+  days_until_stockout: number | null;
+  projected_stockout_date: string | null;
+  predictive_reorder_point: number;
+  needs_reorder: boolean;
+  lead_time_days: number | null;
+  safety_stock: number;
+  method: DemandForecastMethod;
+  model_version: string;
+}
+
 // Asset Maintenance History (oms-0xxlp2)
 export interface MaintenanceHistoryRow {
   id: string;
@@ -2081,6 +2119,20 @@ export const reportsAPI = {
       '/inventory/reports/inventory/serialized_forecast/',
       { params },
     ),
+
+  // ML demand forecast for non-serialized items — the latest stored row per
+  // item, most-urgent first. `low_stock_only` narrows it to rows flagged
+  // `needs_reorder`. Returns [] until the nightly forecasting task has run.
+  getDemandForecast: (params?: { low_stock_only?: boolean }) =>
+    api.get<DemandForecastRow[]>(
+      '/inventory/reports/inventory/demand_forecast/',
+      { params },
+    ),
+
+  // The predictive reorder-alert notify set: items whose owner opted in
+  // (`reorder_alerts_enabled`) *and* that the forecast says are due.
+  getReorderAlerts: () =>
+    api.get<DemandForecastRow[]>('/inventory/reports/inventory/reorder_alerts/'),
 
   exportInventoryReport: (type: 'stock_by_category' | 'reorder_frequency' | 'value_by_location', params?: DateRangeParams) =>
     api.get('/inventory/reports/inventory/export/', {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -151,6 +151,10 @@ export interface InventoryItem {
   // set by the retire/unretire actions.
   is_retired: boolean;
   retired_at: string | null;
+  // Per-item opt-in for ML reorder alerts (op-1). Writable from the item form:
+  // when on, the nightly demand forecast surfaces this item in the
+  // `reorder_alerts` notify set once it is due to reorder.
+  reorder_alerts_enabled: boolean;
   notes: string;
   needs_reorder: boolean;
   total_value: string;

--- a/frontend/src/utils/formSchemas.ts
+++ b/frontend/src/utils/formSchemas.ts
@@ -70,6 +70,9 @@ export const inventoryItemSchema = z
 
     // Case-based reordering
     use_case_based_reorder: z.boolean().default(false),
+    // Opt-in for ML reorder alerts (op-3). Like `is_retired`, it must be in
+    // the schema or the resolver strips it from the submit payload.
+    reorder_alerts_enabled: z.boolean().default(false),
     minimum_cases: z
       .number()
       .int()


### PR DESCRIPTION
## Web: demand-forecast panel + reorder alerts + item toggle — op-3 (Bead 3 of 4)

Surfaces the ML demand forecast (op-1 storage + op-2 nightly engine) in the web UI and adds the per-item opt-in that decides who gets alerted. **Frontend only — read-only API consumption, no backend changes.**

### What's in the PR
- **`DemandForecastPanel`** (sibling of `SerializedForecastPanel`, for non-serialized items): item + method badge (Holt-Winters vs run-rate Fallback), avg/day, days-until-stockout, reorder point, snapshotted available, and a Reorder/OK status with an orange row for anything due. A "Due to reorder only" switch feeds `low_stock_only`; the empty state says the forecast is generated nightly (not implying all-clear).
- **Reorder-alerts** banner + count badge listing watched-and-due items (the daily pings), from `getReorderAlerts()`.
- **Item form:** a "Watch for reorder alerts" switch writing `reorder_alerts_enabled` (added to the zod schema, hydrated in edit) — this is the switch to flag toilet paper / paper towels / trash bags.
- **api.ts:** `DemandForecastRow` / `DemandForecastMethod` types + `reportsAPI.getDemandForecast({ low_stock_only })` + `getReorderAlerts()`. (Caught that the serializer emits `item` = UUID, not `item_id` — mirrored correctly.)
- Rendered on both the inventory and purchasing overviews.

### Verification
- Worker: `npm run lint` (0 errors), `npm run test:fast` (151 files / 1182 tests green), tsc error count unchanged from main (71 pre-existing).
- Mayor re-ran `npm run lint` independently (node24): **0 errors** (26 pre-existing warnings in unrelated Supplier/Webhook files). New DemandForecastPanel suite: 11 cases; item-form toggle: 4 cases.
- **Draft for your merge.** CI is the authoritative rollup.

### Note
Forecast panels are **empty until the first nightly run** (`generate_demand_forecasts` @ 04:00). I can trigger it once by hand after merge so you see real numbers immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
