### PR TITLE
fix(compose): stop celery + celery_beat false "unhealthy" (inherited web healthcheck)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -193,6 +193,16 @@ services:
     # --max-tasks-per-child mirrors the gunicorn --max-requests recycle so
     # per-task leaks in MQTT publish, image processing, etc. are bounded.
     command: celery -A config worker -l info --max-tasks-per-child=200
+    # celery reuses oms-backend:local, whose Dockerfile.prod bakes an HTTP
+    # liveness HEALTHCHECK (urlopen http://localhost:8000/api/health/livez/).
+    # A worker runs no web server, so that probe can never succeed and the
+    # container is reported perpetually "unhealthy" (op-cz8, same root cause as
+    # mqtt_consumer). Disable the inherited probe; the worker self-heals via the
+    # restart: unless-stopped policy below. (A real liveness check would ping the
+    # worker — deploy/helm uses `celery -A config inspect ping` — but a compose
+    # heartbeat check is tracked separately; the bogus web probe is the bug here.)
+    healthcheck:
+      disable: true
     deploy:
       resources:
         limits:
@@ -366,6 +376,13 @@ services:
       celery -A config beat -l info
       --schedule=/app/.beat-state/celerybeat-schedule
       --pidfile=/app/.beat-state/celerybeat.pid
+    # Beat reuses oms-backend:local and its baked-in HTTP livez HEALTHCHECK, but
+    # runs no web server — so the inherited probe is perpetually "unhealthy"
+    # (op-cz8, same as celery / mqtt_consumer). Disable it; beat is PID 1 here,
+    # so if the scheduler dies the container exits and restart: unless-stopped
+    # brings it back.
+    healthcheck:
+      disable: true
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## fix: celery + celery_beat perpetual "unhealthy" (inherited web healthcheck)

Fixes the celery "unhealthy" issue diagnosed while chasing the demand-forecast nightly task.

### Root cause
`oms-backend:local` bakes an HTTP liveness `HEALTHCHECK` (`urlopen http://localhost:8000/api/health/livez/`) in `Dockerfile.prod`. `celery` (worker) and `celery_beat` (scheduler) reuse that image but run **no web server**, so the probe can never succeed — `docker ps` shows both `(unhealthy)` even though they're fine (confirmed on prod: 2 worker nodes `ping → OK/pong`, scheduled tasks firing on time).

### Fix
Disable the inherited probe on `celery` and `celery_beat` — exactly what `mqtt_consumer` already does for the same **op-cz8** root cause (a sibling service reusing the same image). One file, +17 lines, additive.

### Why `disable`, not a ping probe
- Matches the existing in-file precedent (`mqtt_consumer`).
- Nothing depends on these being `service_healthy` — `celery_beat`/`flower` gate on `service_started`.
- `restart: unless-stopped` already recovers a crashed process (beat is PID 1 in its container).
- A real liveness probe (`deploy/helm` uses `celery -A config inspect ping`) is a separate enhancement; the bug here is the bogus web probe, not the absence of a real one.

### Verification
- YAML parses; the `disable` override lands on exactly `celery` + `celery_beat`; backend's real livez probe is untouched.
- No local docker in my env, so **CI's "Prod Stack Smoke" job is the authoritative validation** (it brings up the prod compose stack).
- Draft for your merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
