### PR TITLE
fix(membership): repair migration to recreate missing inventory_membership tables

### DIFF
--- a/backend/membership/migrations/0011_ensure_inventory_membership_table.py
+++ b/backend/membership/migrations/0011_ensure_inventory_membership_table.py
@@ -1,0 +1,102 @@
+"""Repair migration: ensure the ``inventory_membership`` tables exist.
+
+Background
+----------
+``Membership`` (this app) maps to the legacy table ``inventory_membership``
+(its ``db_table``), a name preserved from when the model lived in the
+``inventory`` app. ``0001_initial`` adopts-or-creates that table (and its M2M
+``inventory_membership_users``) via ``_create_membership_table_if_not_exists``.
+
+On at least one production database ``0001_initial`` is recorded as **applied**
+while ``inventory_membership`` / ``inventory_membership_users`` are **absent** —
+fallout of the ``inventory -> membership`` app move (the table was adopted into
+migration state, then dropped, while the migration stayed marked applied).
+Because Django considers ``0001`` applied, ``migrate`` never re-runs its create
+step, so the tables stay missing and every query against ``Membership`` (auth's
+active-membership check, the ``membership.active`` analytics metric) raises
+``relation "inventory_membership" does not exist``.
+
+This migration re-asserts the two tables idempotently with ``CREATE TABLE IF NOT
+EXISTS``, using the exact schema from ``0001_initial``. It is a **no-op** on any
+healthy database (CI, dev, fresh installs) where the tables already exist, and
+recreates them (empty) where they are missing. The reverse is a deliberate
+no-op — we never drop a table that may hold data.
+"""
+
+from django.db import migrations
+
+# Verbatim from membership/0001_initial.py::_create_membership_table_if_not_exists,
+# with IF NOT EXISTS so this is safe to run on databases that already have the
+# tables. Order matters: the M2M references inventory_membership.
+_PG_CREATE = (
+    """
+    CREATE TABLE IF NOT EXISTS inventory_membership (
+        id SERIAL PRIMARY KEY,
+        membership_type VARCHAR(20) NOT NULL DEFAULT 'monthly',
+        status VARCHAR(20) NOT NULL DEFAULT 'inactive',
+        start_date DATE,
+        end_date DATE,
+        notes TEXT NOT NULL DEFAULT '',
+        created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+        updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS inventory_membership_users (
+        id SERIAL PRIMARY KEY,
+        membership_id INTEGER NOT NULL REFERENCES inventory_membership(id) ON DELETE CASCADE,
+        user_id INTEGER NOT NULL REFERENCES auth_user(id) ON DELETE CASCADE,
+        UNIQUE(membership_id, user_id)
+    );
+    """,
+)
+
+_SQLITE_CREATE = (
+    """
+    CREATE TABLE IF NOT EXISTS inventory_membership (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        membership_type VARCHAR(20) NOT NULL DEFAULT 'monthly',
+        status VARCHAR(20) NOT NULL DEFAULT 'inactive',
+        start_date DATE,
+        end_date DATE,
+        notes TEXT NOT NULL DEFAULT '',
+        created_at DATETIME NOT NULL,
+        updated_at DATETIME NOT NULL
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS inventory_membership_users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        membership_id INTEGER NOT NULL REFERENCES inventory_membership(id) ON DELETE CASCADE,
+        user_id INTEGER NOT NULL REFERENCES auth_user(id) ON DELETE CASCADE,
+        UNIQUE(membership_id, user_id)
+    );
+    """,
+)
+
+
+def ensure_inventory_membership_tables(apps, schema_editor):
+    vendor = schema_editor.connection.vendor
+    if vendor == "postgresql":
+        statements = _PG_CREATE
+    elif vendor == "sqlite":
+        statements = _SQLITE_CREATE
+    else:
+        # Unknown backend — leave table management to 0001 as before.
+        return
+    for sql in statements:
+        schema_editor.execute(sql)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("membership", "0010_user_tokens_valid_after"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            ensure_inventory_membership_tables,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/backend/membership/tests/test_repair_migration.py
+++ b/backend/membership/tests/test_repair_migration.py
@@ -1,0 +1,36 @@
+"""Tests for the 0011 inventory_membership repair migration.
+
+The repair migration must be a safe, idempotent no-op on databases that already
+have the tables (CI/dev/fresh), and must never disturb existing rows. The
+"recreate when missing" path is exercised against the affected production
+database; here we assert the critical safety property: running it where the
+tables already exist is harmless and repeatable.
+"""
+
+import importlib
+
+from django.db import connection
+from django.test import TestCase
+
+from membership.models import Membership
+
+_repair = importlib.import_module("membership.migrations.0011_ensure_inventory_membership_table")
+
+
+class EnsureInventoryMembershipTablesTest(TestCase):
+    def _run_repair(self):
+        with connection.schema_editor(atomic=False) as schema_editor:
+            _repair.ensure_inventory_membership_tables(None, schema_editor)
+
+    def test_idempotent_and_nondestructive_when_tables_exist(self):
+        # The migrated test DB already has inventory_membership (from 0001).
+        membership = Membership.objects.create()
+
+        # Running the repair once, then again, must not raise and must leave
+        # the existing table and its data untouched.
+        self._run_repair()
+        self._run_repair()
+
+        self.assertTrue(Membership.objects.filter(pk=membership.pk).exists())
+        self.assertIn("inventory_membership", connection.introspection.table_names())
+        self.assertIn("inventory_membership_users", connection.introspection.table_names())


### PR DESCRIPTION
## fix: recreate the missing `inventory_membership` tables (repair migration)

Fixes the `relation "inventory_membership" does not exist` error flooding the celery worker logs every 5 min (from the `membership.active` analytics metric), found while investigating the celery "unhealthy" issue.

### Root cause
`Membership` maps to the legacy table `inventory_membership` (a name kept from when the model lived in the `inventory` app). On prod, `membership.0001_initial` is **recorded as applied**, but `inventory_membership` and its M2M `inventory_membership_users` **don't exist** — while every other `membership_*` table does. This is fallout of the `inventory → membership` app move: the table was adopted into migration state, then dropped, while `0001` stayed marked applied. Because Django thinks `0001` is applied, a normal deploy's `migrate` never recreates it.

### Fix
`0011_ensure_inventory_membership_table` — an idempotent `RunPython` that re-asserts both tables with `CREATE TABLE IF NOT EXISTS`, using the **exact schema from `0001_initial`**:
- **No-op** on any healthy DB (CI, dev, fresh installs) where the tables already exist.
- **Recreates them (empty)** on the affected prod DB, on the next deploy.
- Reverse is a deliberate no-op — we never drop a table that may hold data.

### ⚠️ Data note
This recreates the tables **empty**. If prod's `inventory_membership` previously held membership rows that were lost when the table dropped, this does **not** restore them — that would be a separate backup-restore. (This is the repair-migration path, chosen over restore.)

### Verification
- black / isort / flake8 clean (verified locally against the backend venv).
- Idempotency test (`membership/tests/test_repair_migration.py`): running the repair twice on a DB that already has the tables is a no-op and leaves existing rows untouched.
- CI runs the full migration chain on a fresh Postgres DB + this test.
- Draft for your merge → repairs prod on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
