### PR TITLE
feat(inventory): demand-forecast web v2 — relabel panel to restock-interval

### DIFF
--- a/frontend/src/__tests__/components/DemandForecastPanel.test.tsx
+++ b/frontend/src/__tests__/components/DemandForecastPanel.test.tsx
@@ -1,6 +1,11 @@
 /**
- * Tests for DemandForecastPanel (op-3) — the ML demand forecast + predictive
+ * Tests for DemandForecastPanel — the restock-cadence forecast + predictive
  * reorder alerts surfaced on the inventory + purchasing overviews.
+ *
+ * The v2 (restock-interval) model drives every column here: cadence, last
+ * restock, next due and days-until-due. The retired v1 usage-rate keys are
+ * still on the wire (written 0/null) and are deliberately not rendered — one
+ * test pins that so they cannot creep back in as columns of zeroes.
  */
 import { MantineProvider } from '@mantine/core';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
@@ -21,6 +26,11 @@ vi.mock('../../services/api', async () => {
 
 const mockReports = reportsAPI as jest.Mocked<typeof reportsAPI>;
 
+/**
+ * A populated v2 row. The v1 quantity fields are pinned at the 0/null the
+ * engine actually writes, so any test asserting on them would be asserting on
+ * dead data — exactly what the panel must not render.
+ */
 const buildRow = (overrides: Partial<DemandForecastRow> = {}): DemandForecastRow => ({
   id: 1,
   item: 'item-1',
@@ -28,21 +38,47 @@ const buildRow = (overrides: Partial<DemandForecastRow> = {}): DemandForecastRow
   sku: 'TP-1',
   category_name: 'Supplies',
   generated_at: '2026-07-19T04:00:00Z',
-  horizon_days: 14,
-  predicted_daily_demand: 0.5,
-  horizon_demand: 7,
-  horizon_demand_upper: 9,
+  // Restock-interval signal.
+  avg_interval_days: 47.6,
+  interval_samples: 4,
+  last_restock_date: '2026-07-01',
+  predicted_next_reorder_date: '2026-08-18',
+  days_until_due: 5,
+  // Retired v1 projection — 0/null on every current row.
+  horizon_days: 0,
+  predicted_daily_demand: 0,
+  horizon_demand: 0,
+  horizon_demand_upper: 0,
+  days_until_stockout: null,
+  projected_stockout_date: null,
+  predictive_reorder_point: 0,
+  safety_stock: 0,
   available_at_generation: 4,
-  days_until_stockout: 8,
-  projected_stockout_date: '2026-07-27',
-  predictive_reorder_point: 9,
   needs_reorder: true,
   lead_time_days: 7,
-  safety_stock: 2,
-  method: 'holtwinters',
-  model_version: 'holtwinters-1',
+  method: 'restock_interval',
+  model_version: 'interval-1',
   ...overrides,
 });
+
+/** An item the model has no cadence for: under two purchase events. */
+const buildNoHistoryRow = (
+  overrides: Partial<DemandForecastRow> = {},
+): DemandForecastRow =>
+  buildRow({
+    id: 99,
+    item: 'new-item',
+    item_name: 'Freshly added widget',
+    avg_interval_days: null,
+    interval_samples: 0,
+    last_restock_date: null,
+    predicted_next_reorder_date: null,
+    days_until_due: null,
+    needs_reorder: false,
+    method: 'insufficient_history',
+    model_version: 'interval-1',
+    ...overrides,
+  });
 
 const renderPanel = (props = {}) =>
   render(
@@ -76,72 +112,122 @@ describe('DemandForecastPanel', () => {
     renderPanel();
 
     expect(await screen.findByTestId('demand-forecast-empty')).toHaveTextContent(
-      /generated nightly/i,
+      /generated nightly from how often items are purchased/i,
     );
     // No forecast rows → no legend either.
     expect(screen.queryByTestId('demand-forecast-legend')).not.toBeInTheDocument();
   });
 
-  it('renders forecast rows with method badges and a due count', async () => {
+  it('maps an interval row onto the cadence / restock / due columns', async () => {
     mockReports.getDemandForecast.mockResolvedValue({
       data: [
-        buildRow({ id: 1, item: 'a', item_name: 'Toilet paper', needs_reorder: true }),
         buildRow({
-          id: 2,
-          item: 'b',
-          item_name: 'Trash bags',
-          method: 'fallback',
-          model_version: '',
-          needs_reorder: false,
-          available_at_generation: 50,
+          avg_interval_days: 47.6,
+          last_restock_date: '2026-07-01',
+          predicted_next_reorder_date: '2026-08-18',
+          days_until_due: 5,
         }),
       ],
     } as never);
 
     renderPanel();
 
-    expect(await screen.findByText('Toilet paper')).toBeInTheDocument();
-    expect(screen.getByText('Trash bags')).toBeInTheDocument();
-    // The seasonal model and the run-rate fallback are told apart at a glance.
-    expect(screen.getByText('Holt-Winters')).toBeInTheDocument();
-    expect(screen.getByText('Fallback')).toBeInTheDocument();
-    // One of the two rows is flagged → header badge reads "1 due".
-    expect(screen.getByText('1 due')).toBeInTheDocument();
-    expect(screen.getByText('Reorder')).toBeInTheDocument();
-    expect(screen.getByText('OK')).toBeInTheDocument();
+    const row = await screen.findByTestId('demand-forecast-row-item-1');
+    expect(within(row).getByText('Restock-interval')).toBeInTheDocument();
+    // Mean gap between purchases, rounded to whole days.
+    expect(within(row).getByText('~48d')).toBeInTheDocument();
+    expect(within(row).getByText('Jul 1, 2026')).toBeInTheDocument();
+    expect(within(row).getByText('Aug 18, 2026')).toBeInTheDocument();
+    expect(within(row).getByText('due in 5d')).toBeInTheDocument();
+    expect(within(row).getByText('Reorder')).toBeInTheDocument();
     expect(screen.getByTestId('demand-forecast-legend')).toBeInTheDocument();
   });
 
-  it('shows the snapshotted stock, reorder point and stockout for a row', async () => {
+  it('renders the interval column headers and none of the retired v1 ones', async () => {
+    mockReports.getDemandForecast.mockResolvedValue({
+      data: [buildRow()],
+    } as never);
+
+    renderPanel();
+
+    await screen.findByText('Toilet paper');
+    ['Cadence', 'Last restock', 'Next due', 'Days until due', 'Status'].forEach(
+      (header) => expect(screen.getByText(header)).toBeInTheDocument(),
+    );
+    // The usage-rate columns are gone — the backend writes those fields 0/null,
+    // so rendering them would show a column of zeroes.
+    expect(screen.queryByText('Avg/day')).not.toBeInTheDocument();
+    expect(screen.queryByText('Stockout')).not.toBeInTheDocument();
+    expect(screen.queryByText('Reorder pt')).not.toBeInTheDocument();
+    expect(screen.queryByText('Available')).not.toBeInTheDocument();
+  });
+
+  it('phrases days_until_due as due-in / today / overdue', async () => {
     mockReports.getDemandForecast.mockResolvedValue({
       data: [
-        buildRow({
-          predicted_daily_demand: 0.5,
-          days_until_stockout: 8,
-          predictive_reorder_point: 9,
-          available_at_generation: 4,
-        }),
+        buildRow({ id: 1, item: 'soon', days_until_due: 5 }),
+        buildRow({ id: 2, item: 'today', days_until_due: 0 }),
+        buildRow({ id: 3, item: 'late', days_until_due: -3 }),
       ],
     } as never);
 
     renderPanel();
 
-    const row = await screen.findByTestId('demand-forecast-row-item-1');
-    expect(within(row).getByText('0.50')).toBeInTheDocument();
-    expect(within(row).getByText('8 d')).toBeInTheDocument();
-    expect(within(row).getByText('9')).toBeInTheDocument();
-    expect(within(row).getByText('4')).toBeInTheDocument();
+    expect(
+      within(await screen.findByTestId('demand-forecast-row-soon')).getByText('due in 5d'),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('demand-forecast-row-today')).getByText('due today'),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('demand-forecast-row-late')).getByText('overdue 3d'),
+    ).toBeInTheDocument();
   });
 
-  it('renders an em dash when demand is flat and there is no stockout date', async () => {
+  it('marks an item with too little purchase history instead of clearing it', async () => {
     mockReports.getDemandForecast.mockResolvedValue({
-      data: [buildRow({ days_until_stockout: null, predicted_daily_demand: 0 })],
+      data: [buildNoHistoryRow()],
     } as never);
 
     renderPanel();
 
-    const row = await screen.findByTestId('demand-forecast-row-item-1');
-    expect(within(row).getByText('—')).toBeInTheDocument();
+    const row = await screen.findByTestId('demand-forecast-row-new-item');
+    expect(within(row).getByText('Insufficient history')).toBeInTheDocument();
+    expect(within(row).getByText('Not enough purchase history yet')).toBeInTheDocument();
+    // Neither a false all-clear nor an invented cadence.
+    expect(within(row).getByText('Unknown')).toBeInTheDocument();
+    expect(within(row).queryByText('OK')).not.toBeInTheDocument();
+    expect(within(row).queryByText('~0d')).not.toBeInTheDocument();
+    // It is not counted as due either.
+    expect(screen.getByText('0 due')).toBeInTheDocument();
+  });
+
+  it('counts only flagged rows as due and preserves the backend ordering', async () => {
+    mockReports.getDemandForecast.mockResolvedValue({
+      data: [
+        buildRow({ id: 1, item: 'overdue', days_until_due: -3, needs_reorder: true }),
+        buildRow({ id: 2, item: 'due-soon', days_until_due: 2, needs_reorder: true }),
+        buildRow({ id: 3, item: 'later', days_until_due: 30, needs_reorder: false }),
+        buildNoHistoryRow({ id: 4, item: 'no-history' }),
+      ],
+    } as never);
+
+    renderPanel();
+
+    await screen.findByTestId('demand-forecast-row-overdue');
+    // The API sorts (flagged first, then soonest due, nulls last); the panel
+    // renders that order as-is rather than re-sorting client-side.
+    expect(
+      screen
+        .getAllByTestId(/^demand-forecast-row-/)
+        .map((row) => row.getAttribute('data-testid')),
+    ).toEqual([
+      'demand-forecast-row-overdue',
+      'demand-forecast-row-due-soon',
+      'demand-forecast-row-later',
+      'demand-forecast-row-no-history',
+    ]);
+    expect(screen.getByText('2 due')).toBeInTheDocument();
   });
 
   it('refetches with low_stock_only when the switch is toggled', async () => {
@@ -182,9 +268,8 @@ describe('DemandForecastPanel', () => {
           id: 7,
           item: 'watched-1',
           item_name: 'Paper towels',
-          available_at_generation: 2,
-          predictive_reorder_point: 11,
-          days_until_stockout: 3,
+          days_until_due: -3,
+          predicted_next_reorder_date: '2026-07-16',
         }),
       ],
     } as never);
@@ -195,8 +280,12 @@ describe('DemandForecastPanel', () => {
     expect(within(alerts).getByText('Reorder alerts')).toBeInTheDocument();
     // Count badge next to the heading.
     expect(within(alerts).getByText('1')).toBeInTheDocument();
+    // Due-based wording, not the retired "N left, reorder at M".
+    expect(alerts).toHaveTextContent(
+      '1 watched item is due to reorder, based on how often they are normally bought.',
+    );
     expect(screen.getByTestId('demand-forecast-alert-watched-1')).toHaveTextContent(
-      'Paper towels — 2 left, reorder at 11 (out in 3 d)',
+      'Paper towels — overdue 3d (due Jul 16, 2026)',
     );
   });
 

--- a/frontend/src/components/inventory/DemandForecastPanel.tsx
+++ b/frontend/src/components/inventory/DemandForecastPanel.tsx
@@ -1,16 +1,24 @@
 /**
- * DemandForecastPanel — ML demand forecast + predictive reorder alerts for
- * *non-serialized* inventory items (op-3). Sibling of
- * <SerializedForecastPanel>, which does the same job for serialized
- * components; this one reads the rows the nightly forecasting task stores
- * (op-1 storage, op-2 engine) rather than computing anything client-side.
+ * DemandForecastPanel — restock-cadence forecast + predictive reorder alerts
+ * for *non-serialized* inventory items. Sibling of <SerializedForecastPanel>,
+ * which does the same job for serialized components; this one reads the rows
+ * the nightly forecasting task stores rather than computing anything
+ * client-side.
+ *
+ * The v2 model answers **"when is this due to be bought again"**, not "how much
+ * will be used": cadence is the mean gap between purchase events, the due date
+ * is last restock + cadence, and an item is flagged when that date falls inside
+ * the supplier lead time. The retired v1 usage-rate columns (avg/day, stockout,
+ * reorder point) are deliberately gone — the backend still sends those keys but
+ * writes them 0/null, so rendering them would only show zeroes.
  *
  * Two surfaces in one panel:
  *  - a reorder-alerts banner atop the table — the daily "pings" for items
  *    someone opted in via the item form's "Watch for reorder alerts" switch
  *    *and* that the forecast says are due;
- *  - the forecast table itself, most-urgent first (the backend sorts), with a
- *    "Due to reorder only" switch feeding `low_stock_only`.
+ *  - the forecast table itself, most-urgent first (the backend sorts; rows are
+ *    rendered in response order), with a "Due to reorder only" switch feeding
+ *    `low_stock_only`.
  *
  * Both endpoints return [] until the nightly task has run, so the empty state
  * says so rather than implying nothing needs reordering.
@@ -30,6 +38,7 @@ import { IconBellRinging } from '@tabler/icons-react';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { DemandForecastMethod, DemandForecastRow, reportsAPI } from '../../services/api';
+import { formatDateOnly } from '../../utils/dates';
 import { extractErrorMessage } from '../../utils/extractErrorMessage';
 
 interface Props {
@@ -41,22 +50,39 @@ interface Props {
 }
 
 const METHOD_LABELS: Record<DemandForecastMethod, string> = {
+  restock_interval: 'Restock-interval',
+  insufficient_history: 'Insufficient history',
+  // Retired v1 (usage-rate) methods — pre-v2 rows only.
   prophet: 'Prophet',
   holtwinters: 'Holt-Winters',
   fallback: 'Fallback',
 };
 
-// Holt-Winters means the item had enough history for the seasonal model;
-// fallback is a plain run-rate, so it gets a quieter badge.
+// A cadence the model could actually measure gets a live badge; everything
+// else — no history yet, or a retired v1 row — stays quiet.
 const METHOD_COLORS: Record<DemandForecastMethod, string> = {
-  prophet: 'grape',
-  holtwinters: 'blue',
+  restock_interval: 'blue',
+  insufficient_history: 'gray',
+  prophet: 'gray',
+  holtwinters: 'gray',
   fallback: 'gray',
 };
 
-const fmtDays = (n: number | null): string => (n === null ? '—' : `${n} d`);
+/** Mean days between purchases, e.g. "~48d". Null under two purchase events. */
+const fmtCadence = (days: number | null): string =>
+  days === null ? '—' : `~${Math.round(days)}d`;
 
-const fmtRate = (n: number): string => n.toFixed(2);
+/**
+ * Humanise `days_until_due` for the due column and the alert lines. Mirrors the
+ * backend digest's phrasing so the in-app alert and this panel read alike.
+ */
+const fmtDue = (days: number | null): string => {
+  if (days === null) return '—';
+  const whole = Math.round(days);
+  if (whole < 0) return `overdue ${-whole}d`;
+  if (whole === 0) return 'due today';
+  return `due in ${whole}d`;
+};
 
 const DemandForecastPanel: React.FC<Props> = ({
   defaultLowStockOnly = false,
@@ -129,7 +155,8 @@ const DemandForecastPanel: React.FC<Props> = ({
           data-testid="demand-forecast-alerts"
         >
           <Text size="sm" mb={4}>
-            Watched items the forecast says are due to reorder now.
+            {alerts.length} watched item{alerts.length === 1 ? ' is' : 's are'} due to
+            reorder, based on how often they are normally bought.
           </Text>
           {alerts.map((alert) => (
             <Text
@@ -139,10 +166,9 @@ const DemandForecastPanel: React.FC<Props> = ({
               onClick={onSelectItem ? () => onSelectItem(alert.item) : undefined}
               style={{ cursor: onSelectItem ? 'pointer' : undefined }}
             >
-              <b>{alert.item_name}</b> — {alert.available_at_generation} left,
-              reorder at {alert.predictive_reorder_point}
-              {alert.days_until_stockout !== null &&
-                ` (out in ${alert.days_until_stockout} d)`}
+              <b>{alert.item_name}</b> — {fmtDue(alert.days_until_due)}
+              {alert.predicted_next_reorder_date &&
+                ` (due ${formatDateOnly(alert.predicted_next_reorder_date)})`}
             </Text>
           ))}
         </Alert>
@@ -160,7 +186,7 @@ const DemandForecastPanel: React.FC<Props> = ({
         <Text c="dimmed" data-testid="demand-forecast-empty">
           {lowStockOnly
             ? 'No forecasted items are due to reorder.'
-            : 'No demand forecast yet — it is generated nightly once items have usage history.'}
+            : 'No demand forecast yet — it is generated nightly from how often items are purchased.'}
         </Text>
       ) : (
         <Table.ScrollContainer minWidth={800}>
@@ -169,58 +195,79 @@ const DemandForecastPanel: React.FC<Props> = ({
               <Table.Tr>
                 <Table.Th>Item</Table.Th>
                 <Table.Th>Method</Table.Th>
-                <Table.Th ta="right">Avg/day</Table.Th>
-                <Table.Th ta="right">Stockout</Table.Th>
-                <Table.Th ta="right">Reorder pt</Table.Th>
-                <Table.Th ta="right">Available</Table.Th>
+                <Table.Th ta="right">Cadence</Table.Th>
+                <Table.Th>Last restock</Table.Th>
+                <Table.Th>Next due</Table.Th>
+                <Table.Th>Days until due</Table.Th>
                 <Table.Th>Status</Table.Th>
               </Table.Tr>
             </Table.Thead>
             <Table.Tbody>
-              {rows.map((row) => (
-                <Table.Tr
-                  key={row.id}
-                  data-testid={`demand-forecast-row-${row.item}`}
-                  onClick={onSelectItem ? () => onSelectItem(row.item) : undefined}
-                  style={{
-                    cursor: onSelectItem ? 'pointer' : undefined,
-                    background: row.needs_reorder
-                      ? 'var(--mantine-color-orange-0)'
-                      : undefined,
-                  }}
-                >
-                  <Table.Td>
-                    <Text fw={500} lineClamp={1}>
-                      {row.item_name}
-                    </Text>
-                    <Text size="xs" c="dimmed">
-                      {row.sku || 'no SKU'}
-                    </Text>
-                  </Table.Td>
-                  <Table.Td>
-                    <Badge color={METHOD_COLORS[row.method] ?? 'gray'} variant="light">
-                      {METHOD_LABELS[row.method] ?? row.method}
-                    </Badge>
-                  </Table.Td>
-                  <Table.Td ta="right">{fmtRate(row.predicted_daily_demand)}</Table.Td>
-                  <Table.Td ta="right">{fmtDays(row.days_until_stockout)}</Table.Td>
-                  <Table.Td ta="right">{row.predictive_reorder_point}</Table.Td>
-                  <Table.Td ta="right" fw={600}>
-                    {row.available_at_generation}
-                  </Table.Td>
-                  <Table.Td>
-                    {row.needs_reorder ? (
-                      <Badge color="orange" variant="filled">
-                        Reorder
+              {rows.map((row) => {
+                // No measured cadence: say why rather than print a bogus number,
+                // and withhold the green all-clear — the model has no opinion.
+                const noHistory = row.method === 'insufficient_history';
+                return (
+                  <Table.Tr
+                    key={row.id}
+                    data-testid={`demand-forecast-row-${row.item}`}
+                    onClick={onSelectItem ? () => onSelectItem(row.item) : undefined}
+                    style={{
+                      cursor: onSelectItem ? 'pointer' : undefined,
+                      background: row.needs_reorder
+                        ? 'var(--mantine-color-orange-0)'
+                        : undefined,
+                    }}
+                  >
+                    <Table.Td>
+                      <Text fw={500} lineClamp={1} c={noHistory ? 'dimmed' : undefined}>
+                        {row.item_name}
+                      </Text>
+                      <Text size="xs" c="dimmed">
+                        {row.sku || 'no SKU'}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge color={METHOD_COLORS[row.method] ?? 'gray'} variant="light">
+                        {METHOD_LABELS[row.method] ?? row.method}
                       </Badge>
+                    </Table.Td>
+                    {noHistory ? (
+                      <Table.Td colSpan={4}>
+                        <Text size="sm" c="dimmed">
+                          Not enough purchase history yet
+                        </Text>
+                      </Table.Td>
                     ) : (
-                      <Badge color="green" variant="light">
-                        OK
-                      </Badge>
+                      <>
+                        <Table.Td ta="right">{fmtCadence(row.avg_interval_days)}</Table.Td>
+                        <Table.Td>{formatDateOnly(row.last_restock_date)}</Table.Td>
+                        <Table.Td>
+                          {formatDateOnly(row.predicted_next_reorder_date)}
+                        </Table.Td>
+                        <Table.Td fw={row.needs_reorder ? 600 : undefined}>
+                          {fmtDue(row.days_until_due)}
+                        </Table.Td>
+                      </>
                     )}
-                  </Table.Td>
-                </Table.Tr>
-              ))}
+                    <Table.Td>
+                      {noHistory ? (
+                        <Badge color="gray" variant="light">
+                          Unknown
+                        </Badge>
+                      ) : row.needs_reorder ? (
+                        <Badge color="orange" variant="filled">
+                          Reorder
+                        </Badge>
+                      ) : (
+                        <Badge color="green" variant="light">
+                          OK
+                        </Badge>
+                      )}
+                    </Table.Td>
+                  </Table.Tr>
+                );
+              })}
             </Table.Tbody>
           </Table>
         </Table.ScrollContainer>
@@ -228,8 +275,9 @@ const DemandForecastPanel: React.FC<Props> = ({
 
       {!loading && !error && rows.length > 0 && (
         <Text size="xs" c="dimmed" mt="xs" data-testid="demand-forecast-legend">
-          Reorder is driven by <b>available</b> stock versus the demand predicted
-          over the lead time, snapshotted when the forecast ran.
+          Cadence is the average gap between purchases of an item. It is due when{' '}
+          <b>last restock + cadence</b> falls inside the supplier lead time,
+          snapshotted when the forecast ran.
         </Text>
       )}
     </Paper>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -877,18 +877,23 @@ export interface SerializedForecastRow {
   needs_reorder: boolean;
 }
 
-// How a demand forecast was produced. `holtwinters` is the seasonal smoother
-// used when an item has enough usage history; `fallback` is the statistical
-// run-rate used when it does not. `prophet` is reserved for a future engine
-// swap and is not emitted today.
-export type DemandForecastMethod = 'prophet' | 'holtwinters' | 'fallback';
+// How a demand forecast was produced. `restock_interval` means the item had
+// enough purchase history to average a buying cadence from; when it did not,
+// the row is `insufficient_history` and carries no cadence at all. The other
+// three are the retired v1 usage-rate methods — historical rows only, kept so
+// pre-v2 rows still resolve a display label.
+export type DemandForecastMethod =
+  | 'restock_interval'
+  | 'insufficient_history'
+  | 'prophet'
+  | 'holtwinters'
+  | 'fallback';
 
 // One stored forecast row (the latest run) for a non-serialized item, from
 // InventoryReportViewSet.demand_forecast / .reorder_alerts (op-1 storage,
-// op-2 nightly engine). Every value is a snapshot taken at generation time —
-// later stock movements never rewrite a row, so `available_at_generation` can
-// lag the item's live stock. Rows only exist once the nightly task has run;
-// both endpoints return [] until then.
+// op-2 nightly engine, v2 restock-interval model). Every value is a snapshot
+// taken at generation time — later purchases never rewrite a row. Rows only
+// exist once the nightly task has run; both endpoints return [] until then.
 export interface DemandForecastRow {
   // The forecast row's own id; `item` is the inventory item's UUID.
   id: number;
@@ -897,20 +902,35 @@ export interface DemandForecastRow {
   sku: string;
   category_name: string | null;
   generated_at: string;
+
+  // --- restock-interval signal (v2) — how often this item actually gets
+  // bought, and therefore when it is due to be bought again. All of these are
+  // null/0 on an `insufficient_history` row (under two purchase events there
+  // is no gap to average), so never render them as a number without checking.
+  avg_interval_days: number | null;
+  interval_samples: number;
+  last_restock_date: string | null;
+  predicted_next_reorder_date: string | null;
+  // Days from generation to the predicted date; negative when overdue.
+  days_until_due: number | null;
+
+  // --- retired v1 usage-rate projection. The backend still emits these keys,
+  // written 0/null on every current row, so they stay typed but are not
+  // rendered anywhere. Do not build new UI on them.
   horizon_days: number;
-  // Mean predicted demand per day, and its sum over the horizon. `_upper` is
-  // the upper prediction band — the gap between it and `horizon_demand` is
-  // what becomes safety stock.
   predicted_daily_demand: number;
   horizon_demand: number;
   horizon_demand_upper: number;
-  available_at_generation: number;
   days_until_stockout: number | null;
   projected_stockout_date: string | null;
   predictive_reorder_point: number;
+  safety_stock: number;
+
+  // --- decision + provenance (both generations). `available_at_generation` is
+  // informational under the interval model — it does not drive needs_reorder.
+  available_at_generation: number;
   needs_reorder: boolean;
   lead_time_days: number | null;
-  safety_stock: number;
   method: DemandForecastMethod;
   model_version: string;
 }
@@ -2120,9 +2140,11 @@ export const reportsAPI = {
       { params },
     ),
 
-  // ML demand forecast for non-serialized items — the latest stored row per
-  // item, most-urgent first. `low_stock_only` narrows it to rows flagged
-  // `needs_reorder`. Returns [] until the nightly forecasting task has run.
+  // Restock-cadence forecast for non-serialized items — the latest stored row
+  // per item, already sorted most-urgent first (flagged rows, then soonest
+  // due, nulls last), so render the response order as-is. `low_stock_only`
+  // narrows it to rows flagged `needs_reorder`. Returns [] until the nightly
+  // forecasting task has run.
   getDemandForecast: (params?: { low_stock_only?: boolean }) =>
     api.get<DemandForecastRow[]>(
       '/inventory/reports/inventory/demand_forecast/',


### PR DESCRIPTION
Follow-on to the v2 backend (#932). Relabels `DemandForecastPanel` from the retired rate columns (avg/day, reorder-point) to interval columns: **Item | Method | Cadence (~48d) | Last restock | Next due | Days until due ("due in 5d" / "overdue 3d") | Status**. `insufficient_history` rows show "Not enough purchase history yet"; the reorder-alerts banner is due-based. Frontend only, no backend changes. Worker-verified: `npm run lint` 0 errors, `test:fast` 1184 green, typecheck clean; CI validates. Draft for your merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)