### PR TITLE
fix(nginx): make Let's Encrypt first-class — follow the live cert, stop pinning -0001

### DIFF
--- a/docs/DEPLOYMENT.MD
+++ b/docs/DEPLOYMENT.MD
@@ -126,30 +126,43 @@ docker-compose -f docker-compose.prod.yml exec backend python manage.py createsu
 
 ## SSL/HTTPS Setup
 
-### Using Let's Encrypt (Recommended)
+Let's Encrypt is built into the `nginx` container — there is **no** manual
+certbot step and **no** hand-editing of cert paths. Set two env vars in `.env`
+and the container issues, installs, and renews the certificate automatically:
 
-1. Install certbot on your server:
 ```bash
-apt-get install certbot
+LETSENCRYPT_EMAIL=admin@oms.example.com        # ACME account / expiry notices
+LETSENCRYPT_DOMAINS=oms.example.com www.oms.example.com   # SAN list; first is canonical
 ```
 
-2. Get certificate:
-```bash
-certbot certonly --standalone -d dallas.openmakersuite.net
-```
+Prerequisites: DNS for each domain must resolve to this host, and ports 80/443
+must be reachable (the http-01 challenge is served from `/.well-known/acme-challenge/`).
 
-3. Copy certificates to nginx directory:
-```bash
-mkdir -p nginx/ssl
-cp /etc/letsencrypt/live/dallas.openmakersuite.net/fullchain.pem nginx/ssl/cert.pem
-cp /etc/letsencrypt/live/dallas.openmakersuite.net/privkey.pem nginx/ssl/key.pem
-```
+How it works (`nginx/docker-entrypoint.d/10-letsencrypt.sh`):
 
-4. Uncomment HTTPS server block in `nginx/conf.d/default.conf`
+1. On start, nginx serves a self-signed **bootstrap** cert (kept in
+   `/etc/letsencrypt/bootstrap/`, outside certbot's namespace) so it can come up
+   and serve the ACME challenge before a real cert exists.
+2. certbot requests the certificate under a fixed `--cert-name` (the canonical
+   domain) into `/etc/letsencrypt/live/<domain>/`.
+3. A deploy hook points the stable path nginx actually reads —
+   `/etc/letsencrypt/nginx/{fullchain,privkey}.pem` (symlinks) — at the live
+   lineage and reloads nginx.
+4. A daily cron (`certbot renew`) renews within 30 days of expiry; the same
+   deploy hook re-points the symlinks and reloads nginx. **Renewals never
+   require a redeploy or config edit** — nginx follows the live lineage by
+   symlink instead of a pinned `-00NN` number.
 
-5. Restart nginx:
+Everything persists in the `letsencrypt_certs` Docker volume, so certificates
+survive container rebuilds and `deploy.sh` runs.
+
+To verify:
 ```bash
-docker-compose -f docker-compose.prod.yml restart nginx
+# Which lineage nginx is serving right now:
+docker compose -f docker-compose.prod.yml exec nginx \
+    readlink -f /etc/letsencrypt/nginx/fullchain.pem
+# certbot's view of managed certs + expiry:
+docker compose -f docker-compose.prod.yml exec nginx certbot certificates
 ```
 
 ## Troubleshooting

--- a/nginx/docker-entrypoint.d/10-letsencrypt.sh
+++ b/nginx/docker-entrypoint.d/10-letsencrypt.sh
@@ -1,90 +1,170 @@
 #!/bin/sh
+# Let's Encrypt lifecycle for the nginx container — a first-class citizen.
+#
+# nginx serves TLS from a STABLE, entrypoint-managed path:
+#
+#     /etc/letsencrypt/nginx/fullchain.pem
+#     /etc/letsencrypt/nginx/privkey.pem
+#
+# Those two files are symlinks this script points at whichever certbot lineage
+# is actually current on this box — regardless of the archive/suffix certbot
+# landed on. certbot renews the lineage in place under a fixed --cert-name, and
+# a deploy hook (installed below, in /etc/letsencrypt/renewal-hooks/deploy/)
+# re-points these symlinks and reloads nginx on every issuance/renewal. Because
+# the nginx config never hard-codes a lineage directory, a renewal — or an
+# already-forked "-00NN" lineage from before this was fixed — can no longer
+# strand nginx on a stale certificate.
+#
+# History: nginx used to point straight at /etc/letsencrypt/live/${DOMAIN}-0001,
+# a hard-coded lineage number. Renewals marched the real lineage on to -0032
+# while nginx stayed pinned to the long-dead -0001, so every deploy required
+# hand-editing the cert path (regression from #256; original config was correct).
+# The fork itself was caused by seeding a self-signed cert INTO the certbot
+# namespace (/etc/letsencrypt/live/<domain>/); certbot refuses to write a lineage
+# over a directory it doesn't own and forks "<domain>-00NN" instead. This script
+# fixes both: the bootstrap self-signed lives OUTSIDE live/, and nginx follows
+# the live lineage via symlink instead of a pinned number.
 set -eu
 
 DOMAIN="${DOMAIN:-oms.example.com}"
 LETSENCRYPT_DOMAINS="${LETSENCRYPT_DOMAINS:-}"
+[ -n "$LETSENCRYPT_DOMAINS" ] || LETSENCRYPT_DOMAINS="$DOMAIN"
 
-if [ -z "$LETSENCRYPT_DOMAINS" ]; then
-    LETSENCRYPT_DOMAINS="$DOMAIN"
-    export LETSENCRYPT_DOMAINS
-fi
-
+# certbot lineage name — stable for the life of the deployment so renewals stay
+# in a single lineage. The first domain in the SAN list is the canonical name.
 PRIMARY_DOMAIN=$(printf '%s\n' $LETSENCRYPT_DOMAINS | awk 'NR==1')
-CERT_PATH="/etc/letsencrypt/live/${PRIMARY_DOMAIN}"
+CERT_NAME="$PRIMARY_DOMAIN"
+
 WEBROOT="/var/www/certbot"
+LE_DIR="/etc/letsencrypt"
+NGINX_CERT_DIR="$LE_DIR/nginx"          # stable path nginx reads (two symlinks)
+BOOTSTRAP_DIR="$LE_DIR/bootstrap"       # self-signed, so nginx can boot pre-LE
+DEPLOY_HOOK_DIR="$LE_DIR/renewal-hooks/deploy"
 
-mkdir -p "$WEBROOT"
+mkdir -p "$WEBROOT" "$NGINX_CERT_DIR" "$BOOTSTRAP_DIR" "$DEPLOY_HOOK_DIR"
 
-# Check if valid certificates already exist
-cert_exists_and_valid() {
-    if [ ! -f "$CERT_PATH/fullchain.pem" ] || [ ! -f "$CERT_PATH/privkey.pem" ]; then
-        return 1
-    fi
-
-    # Check if certificate is valid and not expiring soon (within 30 days)
-    # Use openssl to check certificate validity
-    if openssl x509 -in "$CERT_PATH/fullchain.pem" -noout -checkend 2592000 >/dev/null 2>&1; then
-        # Certificate is valid for at least 30 days (2592000 seconds)
-        return 0
-    fi
-
-    return 1
+# Point the stable nginx cert path at a directory holding fullchain/privkey.
+activate() {
+    ln -sf "$1/fullchain.pem" "$NGINX_CERT_DIR/fullchain.pem"
+    ln -sf "$1/privkey.pem"   "$NGINX_CERT_DIR/privkey.pem"
 }
 
-# Generate temporary self-signed certificate only if no valid certificate exists
-if ! cert_exists_and_valid; then
-    if [ ! -f "$CERT_PATH/fullchain.pem" ] || [ ! -f "$CERT_PATH/privkey.pem" ]; then
-        echo "[letsencrypt] Generating temporary self-signed certificate for $PRIMARY_DOMAIN"
-        mkdir -p "$CERT_PATH"
-        openssl req -x509 -nodes -newkey rsa:2048 \
-            -days 1 \
-            -keyout "$CERT_PATH/privkey.pem" \
-            -out "$CERT_PATH/fullchain.pem" \
+# Echo the current, valid, CA-issued lineage dir for CERT_NAME (highest suffix
+# first, then the unsuffixed canonical dir). Skips self-signed leftovers and
+# expired lineages. Returns non-zero when none qualifies (fresh box / not yet
+# issued), so callers fall back to the bootstrap cert.
+resolve_live_dir() {
+    _best=""
+    for _d in $(ls -d "$LE_DIR/live/$CERT_NAME"-* "$LE_DIR/live/$CERT_NAME" 2>/dev/null | sort -r); do
+        [ -f "$_d/fullchain.pem" ] && [ -f "$_d/privkey.pem" ] || continue
+        _subj=$(openssl x509 -in "$_d/fullchain.pem" -noout -subject 2>/dev/null) || _subj=""
+        _iss=$(openssl x509 -in "$_d/fullchain.pem" -noout -issuer 2>/dev/null) || _iss=""
+        [ -n "$_iss" ] || continue
+        # A self-signed bootstrap cert has subject == issuer; a real LE cert does
+        # not. Strip the "subject="/"issuer=" prefixes and compare.
+        _subj=${_subj#subject=}
+        _iss=${_iss#issuer=}
+        [ "$_subj" != "$_iss" ] || continue
+        openssl x509 -in "$_d/fullchain.pem" -noout -checkend 0 >/dev/null 2>&1 || continue
+        _best="$_d"
+        break
+    done
+    [ -n "$_best" ] || return 1
+    printf '%s\n' "$_best"
+}
+
+# A self-signed bootstrap so nginx can start (and serve the ACME http-01
+# challenge on :80) before a real certificate exists. Kept OUTSIDE
+# /etc/letsencrypt/live/ so it can never collide with certbot's lineage naming.
+# 90-day validity means a prolonged LE outage degrades to a browser warning
+# rather than an outright expired-cert failure while issuance keeps retrying.
+ensure_bootstrap() {
+    if [ ! -f "$BOOTSTRAP_DIR/fullchain.pem" ] || [ ! -f "$BOOTSTRAP_DIR/privkey.pem" ] \
+       || ! openssl x509 -in "$BOOTSTRAP_DIR/fullchain.pem" -noout -checkend 0 >/dev/null 2>&1; then
+        echo "[letsencrypt] generating self-signed bootstrap certificate for $PRIMARY_DOMAIN"
+        openssl req -x509 -nodes -newkey rsa:2048 -days 90 \
+            -keyout "$BOOTSTRAP_DIR/privkey.pem" \
+            -out    "$BOOTSTRAP_DIR/fullchain.pem" \
             -subj "/CN=$PRIMARY_DOMAIN" >/dev/null 2>&1
     fi
+}
+
+# Deploy hook — runs on every certbot issuance/renewal (both the boot-time
+# `certonly` below and the daily `certbot renew` cron). certbot exports
+# $RENEWED_LINEAGE = the live dir of the cert it just wrote. Lives on the
+# persisted volume because a file baked into the image would be shadowed by the
+# /etc/letsencrypt volume mount at runtime.
+install_deploy_hook() {
+    cat > "$DEPLOY_HOOK_DIR/10-nginx.sh" <<'HOOK'
+#!/bin/sh
+set -eu
+NGINX_CERT_DIR="/etc/letsencrypt/nginx"
+ln -sf "$RENEWED_LINEAGE/fullchain.pem" "$NGINX_CERT_DIR/fullchain.pem"
+ln -sf "$RENEWED_LINEAGE/privkey.pem"   "$NGINX_CERT_DIR/privkey.pem"
+# Reload only if the master is already running; ignore failure during the very
+# first issuance when nginx may still be starting (the boot path activates the
+# symlink regardless, so nginx picks the cert up when it comes up).
+nginx -s reload 2>/dev/null || true
+HOOK
+    chmod +x "$DEPLOY_HOOK_DIR/10-nginx.sh"
+}
+
+# --- point nginx at the best certificate available right now ------------------
+ensure_bootstrap
+install_deploy_hook
+if live_dir=$(resolve_live_dir); then
+    echo "[letsencrypt] activating existing lineage: $live_dir"
+    activate "$live_dir"
+else
+    echo "[letsencrypt] no valid Let's Encrypt certificate yet; serving self-signed bootstrap"
+    activate "$BOOTSTRAP_DIR"
 fi
 
+# --- request / renew in the background so nginx can serve the ACME challenge ---
 request_cert() {
-    domain_args=""
-    for domain in $LETSENCRYPT_DOMAINS; do
-        domain_args="$domain_args -d $domain"
-    done
-
     if [ -z "${LETSENCRYPT_EMAIL:-}" ]; then
-        echo "[letsencrypt] LETSENCRYPT_EMAIL is not set; skipping automatic certificate request." >&2
-        return 1
-    fi
-
-    # Only request if certificate doesn't exist or is expiring soon
-    if cert_exists_and_valid; then
-        echo "[letsencrypt] Valid certificate already exists for $PRIMARY_DOMAIN; skipping request."
+        echo "[letsencrypt] LETSENCRYPT_EMAIL unset; skipping automatic issuance." >&2
         return 0
     fi
 
-    echo "[letsencrypt] Requesting certificates for: $LETSENCRYPT_DOMAINS"
-    if certbot certonly --webroot -w "$WEBROOT" $domain_args \
-        --cert-name "$PRIMARY_DOMAIN" \
-        --email "${LETSENCRYPT_EMAIL}" \
+    domain_args=""
+    for d in $LETSENCRYPT_DOMAINS; do
+        domain_args="$domain_args -d $d"
+    done
+
+    echo "[letsencrypt] requesting/renewing certificate for: $LETSENCRYPT_DOMAINS (cert-name=$CERT_NAME)"
+    # --keep-until-expiring makes this a no-op when the cert isn't near expiry.
+    # No --deploy-hook here on purpose: the renewal-hooks/deploy/ script fires
+    # for both this issuance and the cron renew, so the reload path is identical.
+    if ! certbot certonly --webroot -w "$WEBROOT" $domain_args \
+        --cert-name "$CERT_NAME" \
+        --email "$LETSENCRYPT_EMAIL" \
         --agree-tos --no-eff-email \
         --keep-until-expiring \
         --rsa-key-size 4096 \
-        --deploy-hook "nginx -s reload"; then
-        echo "[letsencrypt] Certificate request completed"
+        --non-interactive; then
+        echo "[letsencrypt] certbot run failed; keeping current certificate." >&2
         return 0
-    else
-        echo "[letsencrypt] Initial certificate request failed; continuing with existing certificates." >&2
-        return 1
+    fi
+
+    # Safety net: if certbot was a no-op (keep-until-expiring) the deploy hook
+    # did not fire, so re-resolve and activate in case boot-time resolution ran
+    # before the lineage was valid.
+    if live_dir=$(resolve_live_dir); then
+        activate "$live_dir"
+        nginx -s reload 2>/dev/null || true
     fi
 }
 
-# Only request certificate in background if email is set and certificate doesn't exist or is expiring
 if [ -n "${LETSENCRYPT_EMAIL:-}" ]; then
     (
         sleep 5
         request_cert || true
     ) &
 
-    # Set up cron job to renew certificates daily (certbot renew only renews if expiring within 30 days)
-    printf '0 3 * * * certbot renew --cert-name %s --webroot -w %s --quiet --deploy-hook "nginx -s reload"\n' "$PRIMARY_DOMAIN" "$WEBROOT" > /etc/crontabs/root
+    # Daily renewal. `certbot renew` renews only lineages within 30 days of
+    # expiry and reuses each lineage's stored authenticator/webroot; the
+    # deploy hook above handles the nginx symlink swap + reload.
+    printf '0 3 * * * certbot renew --quiet\n' > /etc/crontabs/root
     crond -b -l 2
 fi

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -29,8 +29,11 @@ server {
     listen 443 ssl http2;
     server_name ${LETSENCRYPT_DOMAINS};
 
-    ssl_certificate /etc/letsencrypt/live/${DOMAIN}-0001/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}-0001/privkey.pem;
+    # Stable path maintained by docker-entrypoint.d/10-letsencrypt.sh — symlinks
+    # that always point at the current Let's Encrypt lineage (never a pinned
+    # -00NN number), so renewals require no config edit or hand redeploy.
+    ssl_certificate /etc/letsencrypt/nginx/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/nginx/privkey.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
     ssl_prefer_server_ciphers on;

--- a/nginx/templates/mtls.conf.template.disabled
+++ b/nginx/templates/mtls.conf.template.disabled
@@ -18,8 +18,10 @@ server {
 
     # Server cert (the public LE chain) — same as :443; devices verify
     # they're talking to the real OMS before presenting their own cert.
-    ssl_certificate /etc/letsencrypt/live/${DOMAIN}-0001/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}-0001/privkey.pem;
+    # Stable symlinks maintained by docker-entrypoint.d/10-letsencrypt.sh
+    # (follows the live lineage; never a pinned -00NN number).
+    ssl_certificate /etc/letsencrypt/nginx/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/nginx/privkey.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
     ssl_prefer_server_ciphers on;


### PR DESCRIPTION
## Problem

nginx's TLS config hard-codes the cert path to lineage **`-0001`**:

```nginx
ssl_certificate     /etc/letsencrypt/live/${DOMAIN}-0001/fullchain.pem;
ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}-0001/privkey.pem;
```

But certbot has forked the real lineage all the way to **`-0032`**, so nginx serves a long-dead cert and **every deploy requires hand-editing the path + reloading nginx**.

### Root cause (two bugs)

1. **Pinned lineage number.** `git blame` shows the template originally used the correct unsuffixed `live/${DOMAIN}/` path; #256 ("Chore(Nginx): Cleanup") changed it to `-0001` to match the then-current fork — hard-coding a moving target.
2. **Why it keeps forking.** The entrypoint seeded its bootstrap **self-signed cert into certbot's own namespace** (`/etc/letsencrypt/live/<domain>/`). certbot refuses to write a lineage over a directory it doesn't own, so it forks `<domain>-00NN` instead — again and again.

## Fix — Let's Encrypt as a first-class citizen

- **nginx reads a stable path it never has to edit:** `/etc/letsencrypt/nginx/{fullchain,privkey}.pem` — two symlinks the entrypoint points at whatever lineage is actually current.
- **Bootstrap self-signed moves OUT of `live/`** → `/etc/letsencrypt/bootstrap/`, eliminating the collision that caused the forks. Validity bumped 1d → 90d so a prolonged LE outage degrades to a browser warning, not an expired-cert outage.
- **Entrypoint resolves the current valid CA lineage on boot** (skips self-signed leftovers + expired lineages, highest suffix first) and installs a `renewal-hooks/deploy/` hook that re-points the symlinks + reloads nginx on **every** issuance/renewal — both the boot-time `certonly` and the daily `certbot renew` cron.
- Same fix applied to the disabled **mTLS** template; **DEPLOYMENT.MD** SSL section rewritten (the old manual `certbot --standalone` + copy-PEM steps were stale and didn't match the container).

### No prod surgery required
On the current box, nginx **auto-follows `-0032`** on next deploy with zero hand-editing — the resolver is read-only and non-destructive. Going forward certbot renews in place under a fixed `--cert-name`, so no new forks.

## Verification (CI does **not** boot nginx — `prod-stack-smoke` skips it — so this was verified out-of-band)
- `dash -n` + `sh -n` on the entrypoint and the embedded deploy hook.
- **Functional test of the actual `resolve_live_dir` / `activate` / `ensure_bootstrap` functions** against a realistic fixture (throwaway CA-signed leaves at `-0001` and `-0032` + a self-signed leftover in `live/<domain>/`, mirroring prod):
  - picks `-0032`, skips the self-signed and the lower suffix ✅
  - symlinks resolve to a readable valid cert ✅
  - only-self-signed → returns non-zero → falls back to bootstrap ✅
  - `ensure_bootstrap` produces a valid self-signed ✅
- `envsubst` render check: `ssl_certificate` → static `/etc/letsencrypt/nginx/…`, no stray `-0001` in any rendered config.

## Deploy note
Just rebuild + redeploy nginx normally (`deploy.sh`). No volume changes, no manual cert steps. To confirm afterward:
```bash
docker compose -f docker-compose.prod.yml exec nginx readlink -f /etc/letsencrypt/nginx/fullchain.pem
docker compose -f docker-compose.prod.yml exec nginx certbot certificates
```

## Out of scope (flagging, not fixing here)
`20-mtls.sh` sorts **after** nginx's `20-envsubst-on-templates.sh`, so its template rename lands too late for the default envsubst pass. mTLS ships disabled, so it's latent — happy to file/fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)