### PR TITLE
feat(inventory): work-order Tools Required list + LOTO up front

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -1670,6 +1670,26 @@ views:
       update:
         permission_classes:
         - IsAuthenticated
+  inventory.views.MaintenanceToolViewSet:
+    actions:
+      create:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      destroy:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      list:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      partial_update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      retrieve:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
+      update:
+        permission_classes:
+        - IsAuthenticatedOrReadOnly
   inventory.views.PriceHistoryViewSet:
     actions:
       list:

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -2322,31 +2322,13 @@ class WorkOrderSerializer(serializers.ModelSerializer):
         """Tools the tech needs to gather before starting, required ones first.
 
         A flat reference list (no OMR checkbox — nothing here is scanned back)
-        carried on every work order so the web detail page and the printed PDF
-        can show "what to grab" up front. Pinned payload keys — ScanTTY decodes
-        these. Sorted in Python off ``.all()`` so the
-        ``maintenance_item__tools`` prefetch is used instead of firing a query
-        per row; an ``order_by()`` here would bypass that cache.
-
-        Only the primary ``maintenance_item``'s tools: work orders that bundle
-        ``additional_maintenance_items`` keep the up-front list short and
-        unambiguous.
+        carried on every work order so the web detail page can show "what to
+        grab" up front. Built by the same helper the printed form uses, so the
+        two surfaces cannot drift.
         """
-        tools = sorted(
-            obj.maintenance_item.tools.all(),
-            key=lambda tool: (not tool.is_required, tool.name),
-        )
-        return [
-            {
-                "id": str(tool.id),
-                "name": tool.name,
-                "quantity": tool.quantity,
-                "location_hint": tool.location_hint,
-                "is_required": tool.is_required,
-                "notes": tool.notes,
-            }
-            for tool in tools
-        ]
+        from .services.work_order_context import build_tools_context
+
+        return build_tools_context(obj.maintenance_item)
 
     def get_electrical(self, obj):
         from .services.work_order_context import build_electrical_context

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -36,6 +36,7 @@ from .models import (
     MaintenanceMaterial,
     MaintenanceRecord,
     MaintenanceTask,
+    MaintenanceTool,
     PriceHistory,
     SerializedComponent,
     StockReconciliation,
@@ -1725,6 +1726,46 @@ class MaintenanceMaterialSerializer(serializers.ModelSerializer):
         }
 
 
+class MaintenanceToolSerializer(serializers.ModelSerializer):
+    """Serializer for tools needed to perform a maintenance task.
+
+    Mirrors its consumable sibling :class:`MaintenanceMaterialSerializer`
+    field-for-field in style. The field names are a pinned contract: ScanTTY
+    decodes this exact payload to print the tool list on the e-paper work
+    order, so do not rename them.
+    """
+
+    inventory_item_detail = serializers.SerializerMethodField()
+
+    class Meta:
+        model = MaintenanceTool
+        fields = [
+            "id",
+            "maintenance_item",
+            "inventory_item",
+            "inventory_item_detail",
+            "name",
+            "quantity",
+            "location_hint",
+            "is_required",
+            "notes",
+            "created_at",
+        ]
+        read_only_fields = ["id", "inventory_item_detail", "created_at"]
+
+    def get_inventory_item_detail(self, obj):
+        item = obj.inventory_item
+        if item is None:
+            return None
+        return {
+            "id": str(item.id),
+            "name": item.name,
+            "current_stock": item.current_stock,
+            "minimum_stock": item.minimum_stock,
+            "reorder_quantity": item.reorder_quantity,
+        }
+
+
 class MaintenanceTaskSerializer(serializers.ModelSerializer):
     """Serializer for ordered sub-task steps within a maintenance item."""
 
@@ -1748,6 +1789,7 @@ class MaintenanceItemSerializer(serializers.ModelSerializer):
     asset_name = serializers.CharField(source="asset.name", read_only=True)
     asset_tag = serializers.CharField(source="asset.asset_tag", read_only=True)
     materials = MaintenanceMaterialSerializer(many=True, read_only=True)
+    tools = MaintenanceToolSerializer(many=True, read_only=True)
     tasks = MaintenanceTaskSerializer(many=True, read_only=True)
     is_overdue = serializers.ReadOnlyField()
     days_overdue = serializers.ReadOnlyField()
@@ -1772,6 +1814,7 @@ class MaintenanceItemSerializer(serializers.ModelSerializer):
             "days_overdue",
             "next_due_at",
             "materials",
+            "tools",
             "tasks",
             "created_at",
             "updated_at",
@@ -2201,6 +2244,7 @@ class WorkOrderSerializer(serializers.ModelSerializer):
     material_usage = WorkOrderMaterialUsageSerializer(many=True, read_only=True)
     loto_completions = WorkOrderLotoCompletionSerializer(many=True, read_only=True)
     photos = WorkOrderPhotoSerializer(many=True, read_only=True)
+    tools = serializers.SerializerMethodField()
     submissions = serializers.SerializerMethodField()
     pending_review_count = serializers.SerializerMethodField()
     has_pending_review = serializers.SerializerMethodField()
@@ -2231,6 +2275,7 @@ class WorkOrderSerializer(serializers.ModelSerializer):
             "material_usage",
             "loto_completions",
             "photos",
+            "tools",
             "submissions",
             "pending_review_count",
             "has_pending_review",
@@ -2249,6 +2294,7 @@ class WorkOrderSerializer(serializers.ModelSerializer):
             "material_usage",
             "loto_completions",
             "photos",
+            "tools",
             "submissions",
             "pending_review_count",
             "has_pending_review",
@@ -2271,6 +2317,36 @@ class WorkOrderSerializer(serializers.ModelSerializer):
         if obj.assigned_to:
             return obj.assigned_to.get_full_name() or obj.assigned_to.username
         return None
+
+    def get_tools(self, obj):
+        """Tools the tech needs to gather before starting, required ones first.
+
+        A flat reference list (no OMR checkbox — nothing here is scanned back)
+        carried on every work order so the web detail page and the printed PDF
+        can show "what to grab" up front. Pinned payload keys — ScanTTY decodes
+        these. Sorted in Python off ``.all()`` so the
+        ``maintenance_item__tools`` prefetch is used instead of firing a query
+        per row; an ``order_by()`` here would bypass that cache.
+
+        Only the primary ``maintenance_item``'s tools: work orders that bundle
+        ``additional_maintenance_items`` keep the up-front list short and
+        unambiguous.
+        """
+        tools = sorted(
+            obj.maintenance_item.tools.all(),
+            key=lambda tool: (not tool.is_required, tool.name),
+        )
+        return [
+            {
+                "id": str(tool.id),
+                "name": tool.name,
+                "quantity": tool.quantity,
+                "location_hint": tool.location_hint,
+                "is_required": tool.is_required,
+                "notes": tool.notes,
+            }
+            for tool in tools
+        ]
 
     def get_electrical(self, obj):
         from .services.work_order_context import build_electrical_context

--- a/backend/inventory/services/work_order_context.py
+++ b/backend/inventory/services/work_order_context.py
@@ -27,6 +27,7 @@ the digital view shows the empty-state messages required by AC-1 / AC-2):
                                                    # real LOTO/lockout choice
             "is_empty":              bool          # True iff is_required False
         },
+        "tools": list[ToolDict]                    # required-first, then name
     }
 """
 
@@ -35,7 +36,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from inventory.models import Asset, WorkOrder
+    from inventory.models import Asset, MaintenanceItem, MaintenanceTool, WorkOrder
 
 
 def _build_electrical_rows(asset: "Asset") -> list[list[str]]:
@@ -160,6 +161,41 @@ def build_loto_context(asset: "Asset") -> dict[str, Any]:
     }
 
 
+def sorted_maintenance_tools(maintenance_item: "MaintenanceItem") -> list["MaintenanceTool"]:
+    """A PM template's tools in display order: required first, then by name.
+
+    Sorted in Python off ``.all()`` so a ``tools`` prefetch is used rather than
+    a query per work order — an ``order_by()`` here would bypass that cache.
+    Case-folded so ``Wrench`` and ``wrench`` sort together (a DB collation would
+    do the same); the raw name breaks ties so the order is total.
+    """
+    return sorted(
+        maintenance_item.tools.all(),
+        key=lambda tool: (not tool.is_required, tool.name.casefold(), tool.name),
+    )
+
+
+def build_tools_context(maintenance_item: "MaintenanceItem") -> list[dict[str, Any]]:
+    """The tool list both the WO detail page and the printed form render.
+
+    Keys are a pinned contract — ScanTTY decodes this payload for the e-paper
+    work order, so do not rename them. Only the primary maintenance item's
+    tools: work orders that bundle ``additional_maintenance_items`` keep the
+    up-front list short and unambiguous.
+    """
+    return [
+        {
+            "id": str(tool.id),
+            "name": tool.name,
+            "quantity": tool.quantity,
+            "location_hint": tool.location_hint,
+            "is_required": tool.is_required,
+            "notes": tool.notes,
+        }
+        for tool in sorted_maintenance_tools(maintenance_item)
+    ]
+
+
 def build_electrical_context(asset: "Asset") -> dict[str, Any]:
     """Combine asset CharField stubs with electrical_circuits records.
 
@@ -209,4 +245,5 @@ def build_work_order_context(work_order: "WorkOrder") -> dict[str, Any]:
     return {
         "electrical": build_electrical_context(asset),
         "loto": build_loto_context(asset),
+        "tools": build_tools_context(work_order.maintenance_item),
     }

--- a/backend/inventory/tests/test_maintenance_tools.py
+++ b/backend/inventory/tests/test_maintenance_tools.py
@@ -276,6 +276,18 @@ class TestWorkOrderSerializerTools:
             "Zip ties",
         ]
 
+    def test_name_ordering_ignores_case(self):
+        """Case-folded, so ``wrench`` does not sort after every capitalized name."""
+        item = _make_item()
+        for name in ("zip ties", "Allen key", "wrench"):
+            MaintenanceTool.objects.create(maintenance_item=item, name=name)
+        wo = WorkOrder.objects.create(maintenance_item=item)
+        assert [t["name"] for t in WorkOrderSerializer(wo).data["tools"]] == [
+            "Allen key",
+            "wrench",
+            "zip ties",
+        ]
+
     def test_empty_when_the_template_defines_no_tools(self):
         wo = WorkOrder.objects.create(maintenance_item=_make_item())
         assert WorkOrderSerializer(wo).data["tools"] == []
@@ -364,6 +376,22 @@ class TestWorkOrderPdfToolsSection:
         MaintenanceTool.objects.create(maintenance_item=item, name="Multimeter", inventory_item=inv)
         text = _pdf_text(generate_work_order_pdf(self._work_order(item), base_url="http://x"))
         assert "Bay 4" in text
+
+    def test_printed_list_matches_the_digital_one(self):
+        """Parity: both surfaces read the same builder, so neither can drift."""
+        item = _make_item()
+        MaintenanceTool.objects.create(maintenance_item=item, name="zip ties", is_required=False)
+        MaintenanceTool.objects.create(maintenance_item=item, name="Torque wrench")
+        MaintenanceTool.objects.create(maintenance_item=item, name="Allen key")
+        wo = self._work_order(item)
+
+        digital = [t["name"] for t in WorkOrderSerializer(wo).data["tools"]]
+        text = _pdf_text(generate_work_order_pdf(wo, base_url="http://x"))
+        printed_positions = [text.index(name) for name in digital]
+
+        assert digital == ["Allen key", "Torque wrench", "zip ties"]
+        # Every digital tool is printed, in the same order.
+        assert printed_positions == sorted(printed_positions)
 
     def test_renders_a_placeholder_when_no_tools_are_specified(self):
         text = _pdf_text(generate_work_order_pdf(self._work_order(), base_url="http://x"))

--- a/backend/inventory/tests/test_maintenance_tools.py
+++ b/backend/inventory/tests/test_maintenance_tools.py
@@ -1,0 +1,399 @@
+"""
+Tests for the "Tools Required" surface (op-67q5).
+
+``MaintenanceTool`` has existed (migration 0063) but was wired only into Django
+admin. This covers the plumbing that surfaces it everywhere a maintainer looks
+before starting a job:
+
+- ``MaintenanceToolSerializer`` read + write (pinned field contract — ScanTTY
+  decodes these exact keys);
+- ``MaintenanceToolViewSet`` CRUD + ``?maintenance_item=`` filter;
+- the nested ``tools`` on ``MaintenanceItemSerializer``;
+- ``WorkOrderSerializer.tools`` (the pinned per-WO shape + ordering);
+- the printed work-order PDF's up-front Tools Required table.
+"""
+
+import io
+from datetime import date, timedelta
+
+from django.urls import reverse
+
+import pytest
+from pypdf import PdfReader
+from rest_framework import status
+
+from inventory.models import MaintenanceItem, MaintenanceTool, WorkOrder
+from inventory.serializers import (
+    MaintenanceItemSerializer,
+    MaintenanceToolSerializer,
+    WorkOrderSerializer,
+)
+from inventory.tests.factories import AssetFactory, InventoryItemFactory, LocationFactory
+from inventory.utils.work_order_pdf import generate_work_order_pdf
+
+pytestmark = pytest.mark.django_db
+
+
+def _make_item(**kwargs) -> MaintenanceItem:
+    return MaintenanceItem.objects.create(
+        asset=kwargs.pop("asset", None) or AssetFactory(),
+        title=kwargs.pop("title", "Quarterly safety check"),
+        description=kwargs.pop("description", "Standard safety inspection."),
+        interval_days=kwargs.pop("interval_days", 90),
+        **kwargs,
+    )
+
+
+def _pdf_text(pdf_bytes: bytes) -> str:
+    """Extract concatenated visible text from a generated work-order PDF."""
+    reader = PdfReader(io.BytesIO(pdf_bytes))
+    return "\n".join(page.extract_text() or "" for page in reader.pages)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Serializer — pinned field contract
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMaintenanceToolSerializer:
+    def test_exposes_the_pinned_field_set(self):
+        item = _make_item()
+        tool = MaintenanceTool.objects.create(
+            maintenance_item=item,
+            name="Torque wrench",
+            quantity=2,
+            location_hint="Tool crib, drawer 3",
+            notes="Calibrated 2026-01",
+        )
+        data = MaintenanceToolSerializer(tool).data
+        assert set(data) == {
+            "id",
+            "maintenance_item",
+            "inventory_item",
+            "inventory_item_detail",
+            "name",
+            "quantity",
+            "location_hint",
+            "is_required",
+            "notes",
+            "created_at",
+        }
+        assert data["name"] == "Torque wrench"
+        assert data["quantity"] == 2
+        assert data["location_hint"] == "Tool crib, drawer 3"
+        assert data["is_required"] is True
+        assert data["notes"] == "Calibrated 2026-01"
+
+    def test_inventory_item_detail_is_null_when_fk_unset(self):
+        item = _make_item()
+        tool = MaintenanceTool.objects.create(maintenance_item=item, name="Hex key set")
+        data = MaintenanceToolSerializer(tool).data
+        assert data["inventory_item"] is None
+        assert data["inventory_item_detail"] is None
+
+    def test_inventory_item_detail_populated_when_fk_set(self):
+        inv = InventoryItemFactory(
+            name="Torque wrench",
+            current_stock=3,
+            minimum_stock=1,
+            reorder_quantity=2,
+        )
+        item = _make_item()
+        tool = MaintenanceTool.objects.create(
+            maintenance_item=item, name="Torque wrench", inventory_item=inv
+        )
+        detail = MaintenanceToolSerializer(tool).data["inventory_item_detail"]
+        assert detail["id"] == str(inv.id)
+        assert detail["name"] == "Torque wrench"
+        assert detail["current_stock"] == 3
+        assert detail["minimum_stock"] == 1
+        assert detail["reorder_quantity"] == 2
+
+    def test_write_creates_a_tool(self):
+        item = _make_item()
+        serializer = MaintenanceToolSerializer(
+            data={
+                "maintenance_item": str(item.id),
+                "name": "Feeler gauge",
+                "quantity": 1,
+                "location_hint": "Bench 2",
+                "is_required": False,
+                "notes": "0.002in blade",
+            }
+        )
+        assert serializer.is_valid(), serializer.errors
+        tool = serializer.save()
+        assert tool.maintenance_item_id == item.id
+        assert tool.name == "Feeler gauge"
+        assert tool.is_required is False
+
+    def test_read_only_fields_are_not_writable(self):
+        item = _make_item()
+        tool = MaintenanceTool.objects.create(maintenance_item=item, name="Pry bar")
+        original_created_at = tool.created_at
+        serializer = MaintenanceToolSerializer(
+            tool,
+            data={"created_at": "2000-01-01T00:00:00Z", "name": "Pry bar"},
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+        serializer.save()
+        tool.refresh_from_db()
+        assert tool.created_at == original_created_at
+
+
+class TestMaintenanceItemSerializerTools:
+    def test_nested_tools_are_returned(self):
+        item = _make_item()
+        MaintenanceTool.objects.create(maintenance_item=item, name="Multimeter")
+        data = MaintenanceItemSerializer(item).data
+        assert [t["name"] for t in data["tools"]] == ["Multimeter"]
+
+    def test_tools_key_present_and_empty_when_none_defined(self):
+        data = MaintenanceItemSerializer(_make_item()).data
+        assert data["tools"] == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Viewset CRUD
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+class TestMaintenanceToolViewSet:
+    LIST_URL = "/api/inventory/maintenance-tools/"
+
+    def test_route_is_registered(self):
+        assert reverse("maintenancetool-list") == self.LIST_URL
+
+    def test_create_requires_authentication(self, api_client):
+        item = _make_item()
+        response = api_client.post(
+            self.LIST_URL, {"maintenance_item": str(item.id), "name": "Nut driver"}
+        )
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+        assert not MaintenanceTool.objects.exists()
+
+    def test_create_and_list(self, authenticated_client):
+        client, _user = authenticated_client
+        item = _make_item()
+        response = client.post(
+            self.LIST_URL,
+            {
+                "maintenance_item": str(item.id),
+                "name": "Torque wrench",
+                "quantity": 2,
+                "location_hint": "Tool crib, drawer 3",
+                "is_required": True,
+                "notes": "",
+            },
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        assert MaintenanceTool.objects.filter(maintenance_item=item).count() == 1
+
+        listing = client.get(self.LIST_URL)
+        assert listing.status_code == status.HTTP_200_OK
+        results = listing.data["results"] if "results" in listing.data else listing.data
+        assert [t["name"] for t in results] == ["Torque wrench"]
+
+    def test_list_filters_by_maintenance_item(self, authenticated_client):
+        client, _user = authenticated_client
+        mine = _make_item(title="Mine")
+        other = _make_item(title="Other")
+        MaintenanceTool.objects.create(maintenance_item=mine, name="Mine tool")
+        MaintenanceTool.objects.create(maintenance_item=other, name="Other tool")
+
+        response = client.get(self.LIST_URL, {"maintenance_item": str(mine.id)})
+        assert response.status_code == status.HTTP_200_OK
+        results = response.data["results"] if "results" in response.data else response.data
+        assert [t["name"] for t in results] == ["Mine tool"]
+
+    def test_retrieve_and_partial_update(self, authenticated_client):
+        client, _user = authenticated_client
+        item = _make_item()
+        tool = MaintenanceTool.objects.create(maintenance_item=item, name="Old name")
+        detail_url = f"{self.LIST_URL}{tool.id}/"
+
+        assert client.get(detail_url).data["name"] == "Old name"
+
+        response = client.patch(
+            detail_url, {"name": "New name", "is_required": False}, format="json"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        tool.refresh_from_db()
+        assert tool.name == "New name"
+        assert tool.is_required is False
+
+    def test_destroy(self, authenticated_client):
+        client, _user = authenticated_client
+        item = _make_item()
+        tool = MaintenanceTool.objects.create(maintenance_item=item, name="Doomed")
+        response = client.delete(f"{self.LIST_URL}{tool.id}/")
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not MaintenanceTool.objects.filter(id=tool.id).exists()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# WorkOrderSerializer.tools — pinned shape + ordering
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestWorkOrderSerializerTools:
+    def test_shape_is_the_pinned_key_set(self):
+        item = _make_item()
+        tool = MaintenanceTool.objects.create(
+            maintenance_item=item,
+            name="Torque wrench",
+            quantity=2,
+            location_hint="Tool crib, drawer 3",
+            notes="Calibrated 2026-01",
+        )
+        wo = WorkOrder.objects.create(maintenance_item=item)
+        tools = WorkOrderSerializer(wo).data["tools"]
+        assert tools == [
+            {
+                "id": str(tool.id),
+                "name": "Torque wrench",
+                "quantity": 2,
+                "location_hint": "Tool crib, drawer 3",
+                "is_required": True,
+                "notes": "Calibrated 2026-01",
+            }
+        ]
+
+    def test_required_tools_sort_first_then_by_name(self):
+        item = _make_item()
+        MaintenanceTool.objects.create(maintenance_item=item, name="Zip ties", is_required=False)
+        MaintenanceTool.objects.create(maintenance_item=item, name="Wrench", is_required=True)
+        MaintenanceTool.objects.create(maintenance_item=item, name="Allen key", is_required=True)
+        wo = WorkOrder.objects.create(maintenance_item=item)
+        assert [t["name"] for t in WorkOrderSerializer(wo).data["tools"]] == [
+            "Allen key",
+            "Wrench",
+            "Zip ties",
+        ]
+
+    def test_empty_when_the_template_defines_no_tools(self):
+        wo = WorkOrder.objects.create(maintenance_item=_make_item())
+        assert WorkOrderSerializer(wo).data["tools"] == []
+
+    def test_only_the_primary_maintenance_items_tools_are_included(self):
+        asset = AssetFactory()
+        primary = _make_item(asset=asset, title="Primary")
+        extra = _make_item(asset=asset, title="Bundled")
+        MaintenanceTool.objects.create(maintenance_item=primary, name="Primary tool")
+        MaintenanceTool.objects.create(maintenance_item=extra, name="Bundled tool")
+        wo = WorkOrder.objects.create(maintenance_item=primary)
+        wo.additional_maintenance_items.add(extra)
+        assert [t["name"] for t in WorkOrderSerializer(wo).data["tools"]] == ["Primary tool"]
+
+    def test_list_serializer_stays_lean(self):
+        from inventory.serializers import WorkOrderListSerializer
+
+        wo = WorkOrder.objects.create(maintenance_item=_make_item())
+        assert "tools" not in WorkOrderListSerializer(wo).data
+
+
+@pytest.mark.integration
+class TestWorkOrderDetailApiTools:
+    def test_detail_endpoint_carries_tools(self, authenticated_client):
+        client, _user = authenticated_client
+        item = _make_item()
+        MaintenanceTool.objects.create(
+            maintenance_item=item, name="Torque wrench", location_hint="Drawer 3"
+        )
+        wo = WorkOrder.objects.create(maintenance_item=item)
+        response = client.get(f"/api/inventory/work-orders/{wo.id}/")
+        assert response.status_code == status.HTTP_200_OK
+        assert [t["name"] for t in response.data["tools"]] == ["Torque wrench"]
+        assert response.data["tools"][0]["location_hint"] == "Drawer 3"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Printed work-order PDF
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestWorkOrderPdfToolsSection:
+    def _work_order(self, item=None) -> WorkOrder:
+        return WorkOrder.objects.create(
+            maintenance_item=item or _make_item(),
+            due_date=date.today() + timedelta(days=14),
+        )
+
+    def test_tools_table_lists_name_qty_and_location(self):
+        item = _make_item()
+        MaintenanceTool.objects.create(
+            maintenance_item=item,
+            name="Torque wrench",
+            quantity=2,
+            location_hint="Tool crib, drawer 3",
+        )
+        text = _pdf_text(generate_work_order_pdf(self._work_order(item), base_url="http://x"))
+        assert "Tools Required" in text
+        assert "Torque wrench" in text
+        assert "Tool crib, drawer 3" in text
+        assert "REQ" in text
+
+    def test_tools_section_prints_before_the_lockout_safety_block(self):
+        """ "Tools + LOTO up front": the tool list must precede the safety block."""
+        asset = AssetFactory(
+            breaker_location="A-12",
+            lockout_instructions="LOTO breaker A-12 before service.",
+        )
+        item = _make_item(asset=asset)
+        MaintenanceTool.objects.create(maintenance_item=item, name="Torque wrench")
+        text = _pdf_text(generate_work_order_pdf(self._work_order(item), base_url="http://x"))
+        assert text.index("Asset Information") < text.index("Tools Required")
+        assert text.index("Tools Required") < text.index("Lockout Safety")
+        assert "LOTO breaker A-12 before service." in text
+
+    def test_optional_tools_are_not_marked_required(self):
+        item = _make_item()
+        MaintenanceTool.objects.create(maintenance_item=item, name="Shop vacuum", is_required=False)
+        text = _pdf_text(generate_work_order_pdf(self._work_order(item), base_url="http://x"))
+        assert "Shop vacuum" in text
+        assert "REQ" not in text
+
+    def test_falls_back_to_the_linked_inventory_items_location(self):
+        inv = InventoryItemFactory(name="Multimeter", location=LocationFactory(name="Bay 4"))
+        item = _make_item()
+        MaintenanceTool.objects.create(maintenance_item=item, name="Multimeter", inventory_item=inv)
+        text = _pdf_text(generate_work_order_pdf(self._work_order(item), base_url="http://x"))
+        assert "Bay 4" in text
+
+    def test_renders_a_placeholder_when_no_tools_are_specified(self):
+        text = _pdf_text(generate_work_order_pdf(self._work_order(), base_url="http://x"))
+        assert "Tools Required" in text
+        assert "No tools specified." in text
+
+    def test_tool_text_with_xml_metacharacters_does_not_break_the_pdf(self):
+        item = _make_item()
+        MaintenanceTool.objects.create(
+            maintenance_item=item,
+            name="1/2 <drive> & socket",
+            location_hint="Bin <A> & <B>",
+        )
+        text = _pdf_text(generate_work_order_pdf(self._work_order(item), base_url="http://x"))
+        assert "1/2 <drive> & socket" in text
+        assert "Bin <A> & <B>" in text
+
+    def test_tools_add_no_omr_marks(self):
+        """Reference-only: the section must not touch the OMR template map."""
+        from inventory.utils.work_order_pdf import RegionCollector
+
+        item = _make_item()
+        wo = self._work_order(item)
+        without = RegionCollector()
+        generate_work_order_pdf(wo, base_url="http://x", region_collector=without)
+
+        MaintenanceTool.objects.create(maintenance_item=item, name="Torque wrench")
+        with_tools = RegionCollector()
+        generate_work_order_pdf(wo, base_url="http://x", region_collector=with_tools)
+
+        assert {r["target_id"] for r in with_tools.regions} == {
+            r["target_id"] for r in without.regions
+        }

--- a/backend/inventory/tests/test_work_order_parity.py
+++ b/backend/inventory/tests/test_work_order_parity.py
@@ -486,7 +486,7 @@ def test_pdf_and_serializer_share_the_same_context_builder():
     wo = _build_wo(asset=asset)
 
     ctx = build_work_order_context(wo)
-    assert set(ctx.keys()) == {"electrical", "loto"}
+    assert set(ctx.keys()) == {"electrical", "loto", "tools"}
 
     # Re-derive the PDF row set through its public helper and confirm every
     # asset-level row from the shared electrical context appears.

--- a/backend/inventory/urls.py
+++ b/backend/inventory/urls.py
@@ -33,6 +33,7 @@ from .views import (
     MaintenanceMaterialViewSet,
     MaintenanceRecordViewSet,
     MaintenanceTaskViewSet,
+    MaintenanceToolViewSet,
     PriceHistoryViewSet,
     SerializedComponentViewSet,
     SupplierViewSet,
@@ -66,6 +67,7 @@ router.register(r"maintenance-materials", MaintenanceMaterialViewSet)
 router.register(r"maintenance-logs", MaintenanceLogViewSet)
 router.register(r"maintenance-records", MaintenanceRecordViewSet, basename="maintenance-record")
 router.register(r"maintenance-tasks", MaintenanceTaskViewSet)
+router.register(r"maintenance-tools", MaintenanceToolViewSet)
 router.register(r"work-orders", WorkOrderViewSet)
 router.register(
     r"serialized-components", SerializedComponentViewSet, basename="serialized-component"

--- a/backend/inventory/utils/work_order_pdf.py
+++ b/backend/inventory/utils/work_order_pdf.py
@@ -4,12 +4,14 @@ PDF generation for preventive maintenance work orders.
 Generates a printable work order form that includes:
 - Asset summary (name, tag, location, purchase info)
 - QR code linking to the digital work order
+- Tools required (reference list, printed up front with the lockout info)
 - Materials checklist
 - Task step checklist
 - Completion sign-off fields
 """
 
 import io
+from html import escape
 from typing import TYPE_CHECKING, Optional
 
 import qrcode
@@ -488,6 +490,66 @@ def generate_work_order_pdf(
         )
     )
     story.append(asset_table)
+    story.append(Spacer(1, 8))
+
+    # ── Job prep: tools to gather ─────────────────────────────────────────────
+    # Printed up front — right after the asset and immediately before the
+    # power/lockout safety block — so the tech gathers what they need and reads
+    # the LOTO reference *before* walking to the machine. Reference only: no
+    # AcroCheckbox, so this section adds nothing to ``region_collector`` and
+    # leaves the OMR target ids / template drift signature untouched.
+    story.append(Paragraph("Tools Required", subheading_style))
+    tools = sorted(
+        item.tools.all(),
+        key=lambda tool: (not tool.is_required, tool.name),
+    )
+    if tools:
+        tool_rows = [
+            [
+                Paragraph("Tool", label_style),
+                Paragraph("Qty", label_style),
+                Paragraph("Location", label_style),
+                Paragraph("Required", label_style),
+            ]
+        ]
+        for tool in tools:
+            # Tool text is operator-entered and lands in a reportlab Paragraph,
+            # which parses a mini-XML dialect — escape it. ``html.escape`` (not
+            # ``xml.sax.saxutils.escape``, which trips bandit B406).
+            location = tool.location_hint or (
+                tool.inventory_item.location.name
+                if tool.inventory_item and tool.inventory_item.location
+                else ""
+            )
+            tool_rows.append(
+                [
+                    Paragraph(escape(tool.name, quote=False), normal_style),
+                    str(tool.quantity),
+                    Paragraph(escape(location, quote=False) or "—", small_style),
+                    "REQ" if tool.is_required else "—",
+                ]
+            )
+        tools_table = Table(
+            tool_rows,
+            colWidths=[2.6 * inch, 0.6 * inch, 2.9 * inch, 1.1 * inch],
+        )
+        tools_table.setStyle(
+            TableStyle(
+                [
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, -1), 9),
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#e8e8e8")),
+                    ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#cccccc")),
+                    ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                    ("PADDING", (0, 0), (-1, -1), 4),
+                    ("ALIGN", (1, 0), (1, -1), "CENTER"),
+                    ("ALIGN", (3, 0), (3, -1), "CENTER"),
+                ]
+            )
+        )
+        story.append(tools_table)
+    else:
+        story.append(Paragraph("No tools specified.", small_style))
     story.append(Spacer(1, 8))
 
     # ── Electrical / Lockout safety section ───────────────────────────────────

--- a/backend/inventory/utils/work_order_pdf.py
+++ b/backend/inventory/utils/work_order_pdf.py
@@ -498,11 +498,10 @@ def generate_work_order_pdf(
     # the LOTO reference *before* walking to the machine. Reference only: no
     # AcroCheckbox, so this section adds nothing to ``region_collector`` and
     # leaves the OMR target ids / template drift signature untouched.
+    from inventory.services.work_order_context import sorted_maintenance_tools
+
     story.append(Paragraph("Tools Required", subheading_style))
-    tools = sorted(
-        item.tools.all(),
-        key=lambda tool: (not tool.is_required, tool.name),
-    )
+    tools = sorted_maintenance_tools(item)
     if tools:
         tool_rows = [
             [

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -55,6 +55,7 @@ from .models import (
     MaintenanceMaterial,
     MaintenanceRecord,
     MaintenanceTask,
+    MaintenanceTool,
     PriceHistory,
     SerializedComponent,
     StockReconciliation,
@@ -94,6 +95,7 @@ from .serializers import (
     MaintenanceMaterialSerializer,
     MaintenanceRecordSerializer,
     MaintenanceTaskSerializer,
+    MaintenanceToolSerializer,
     PriceHistorySerializer,
     SerializedComponentSerializer,
     StockReconciliationBatchSerializer,
@@ -3915,6 +3917,23 @@ class MaintenanceMaterialViewSet(viewsets.ModelViewSet):
         return queryset
 
 
+class MaintenanceToolViewSet(viewsets.ModelViewSet):
+    """API endpoint for maintenance tools (what to grab before starting)."""
+
+    queryset = MaintenanceTool.objects.select_related(
+        "maintenance_item__asset", "inventory_item"
+    ).all()
+    serializer_class = MaintenanceToolSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        maintenance_item = self.request.query_params.get("maintenance_item")
+        if maintenance_item:
+            queryset = queryset.filter(maintenance_item_id=maintenance_item)
+        return queryset
+
+
 class MaintenanceLogViewSet(viewsets.ReadOnlyModelViewSet):
     """API endpoint for maintenance completion logs (read-only list/detail)."""
 
@@ -3968,6 +3987,9 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
             "loto_completions__energy_source",
             "photos__uploaded_by",
             "maintenance_item__materials",
+            # op-67q5: feed WorkOrderSerializer.get_tools (the up-front "Tools
+            # Required" list) from one prefetch instead of a query per row.
+            "maintenance_item__tools",
             # op-o6rs: feed the pending-review badge (pending_review_count) from
             # a single prefetch instead of a per-row submissions query (N+1).
             "submissions",
@@ -4887,7 +4909,9 @@ class MaintenanceItemViewSet(viewsets.ModelViewSet):
     """API endpoint for asset maintenance items (PM tasks)."""
 
     queryset = (
-        MaintenanceItem.objects.prefetch_related("materials", "tasks").select_related("asset").all()
+        MaintenanceItem.objects.prefetch_related("materials", "tools", "tasks")
+        .select_related("asset")
+        .all()
     )
     serializer_class = MaintenanceItemSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]

--- a/docs/API_PERMISSION_MATRIX.md
+++ b/docs/API_PERMISSION_MATRIX.md
@@ -94,7 +94,7 @@ below are public.
 | any  | `inventory/items/...` (CRUD) | member-rw | `IsAuthenticatedOrReadOnly` — list/retrieve open to anonymous callers, write requires login. Staff-level gating is enforced inside `perform_create/_update/_destroy` via `_check_staff()`. |
 | GET  | `inventory/work-orders/...` | member | `IsAuthenticatedOrStaffSigAdminWrite` on `WorkOrderViewSet` — any authenticated user can read open + completed standard PM work orders (gh #374). |
 | POST/PATCH/PUT/DELETE | `inventory/work-orders/...` | staff-or-sig-admin | `IsAuthenticatedOrStaffSigAdminWrite` denies writes to volunteers; staff and SIG leaders may add or modify (gh #374). |
-| any  | `inventory/maintenance-*` (CRUD) | member-rw | `IsAuthenticated` for log/task/dashboard; `IsAuthenticatedOrReadOnly` for material catalog. |
+| any  | `inventory/maintenance-*` (CRUD) | member-rw | `IsAuthenticated` for log/task/dashboard; `IsAuthenticatedOrReadOnly` for the material and tool catalogs. |
 | GET  | `inventory/assets/<id>/maintenance-history/` | member | `IsAuthenticated` — unified per-asset history (backdated `MaintenanceRecord` rows + closed third-party work orders) with `since`/`until`/`source` filters. |
 | any  | `inventory/maintenance-records/...` (CRUD) | staff-or-sig-admin | `IsAuthenticatedOrStaffSigAdminWrite` — anyone authenticated can read; staff and SIG leaders can create/update; staff-only delete. |
 | POST | `inventory/assets/<id>/log-hours/` | staff-or-sig-admin | `IsStaffOrSigAdmin` — atomically increments `Asset.hours_used` for utilization metrics + maintenance forecast. |

--- a/frontend/src/__tests__/pages/MaintenanceItemFormPageTools.test.tsx
+++ b/frontend/src/__tests__/pages/MaintenanceItemFormPageTools.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Tools editor on the PM-template form (op-67q5).
+ *
+ * A maintainer enters the tools a task needs here; they persist against the
+ * template and are what the work order prints up front. The editor mirrors the
+ * materials editor: add rows, remove rows, and diff against what was loaded so
+ * an edit only creates what is new and deletes what was dropped.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import MaintenanceItemFormPage from '../../pages/MaintenanceItemFormPage';
+import { maintenanceAPI, maintenanceToolAPI } from '../../services/api';
+import { MaintenanceItem, MaintenanceTool } from '../../types';
+
+vi.mock('../../services/api');
+
+const mockUseParams = vi.fn<() => { assetId?: string; id?: string }>(() => ({
+  assetId: 'a-1',
+}));
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useParams: () => mockUseParams(),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockMaintenanceAPI = maintenanceAPI as jest.Mocked<typeof maintenanceAPI>;
+const mockToolAPI = maintenanceToolAPI as jest.Mocked<typeof maintenanceToolAPI>;
+
+const okResponse = <T,>(data: T) =>
+  ({ data, status: 200, statusText: 'OK', headers: {}, config: {} as never }) as never;
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <MaintenanceItemFormPage />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+const buildTool = (overrides: Partial<MaintenanceTool> = {}): MaintenanceTool => ({
+  id: 't-1',
+  maintenance_item: 'mi-1',
+  inventory_item: null,
+  inventory_item_detail: null,
+  name: 'Torque wrench',
+  quantity: 1,
+  location_hint: 'Tool crib, drawer 3',
+  is_required: true,
+  notes: '',
+  ...overrides,
+});
+
+const buildItem = (tools: MaintenanceTool[]): MaintenanceItem =>
+  ({
+    id: 'mi-1',
+    asset: 'a-1',
+    title: 'Quarterly belt inspection',
+    description: '',
+    instructions: '',
+    estimated_time_minutes: null,
+    estimated_cost: '0.00',
+    interval_days: 90,
+    is_active: true,
+    materials: [],
+    tools,
+    tasks: [],
+  }) as unknown as MaintenanceItem;
+
+/** Fill the "Add Tool" row and click Add. */
+const addTool = (name: string, location = '') => {
+  fireEvent.change(screen.getByLabelText('Tool'), { target: { value: name } });
+  if (location) {
+    fireEvent.change(screen.getByLabelText('Location'), { target: { value: location } });
+  }
+  fireEvent.click(screen.getByRole('button', { name: /add tool/i }));
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseParams.mockReturnValue({ assetId: 'a-1' });
+  mockToolAPI.create.mockResolvedValue(okResponse(buildTool()));
+  mockToolAPI.delete.mockResolvedValue(okResponse({}));
+});
+
+describe('MaintenanceItemFormPage — tools editor (op-67q5)', () => {
+  it('adds a tool row and clears the entry fields', async () => {
+    renderPage();
+
+    await screen.findByLabelText(/title/i);
+    addTool('Torque wrench', 'Tool crib, drawer 3');
+
+    const table = screen.getByRole('table');
+    expect(within(table).getByText('Torque wrench')).toBeInTheDocument();
+    expect(within(table).getByText('Tool crib, drawer 3')).toBeInTheDocument();
+    // The entry row resets so the next tool can be typed straight in.
+    expect((screen.getByLabelText('Tool') as HTMLInputElement).value).toBe('');
+    expect((screen.getByLabelText('Location') as HTMLInputElement).value).toBe('');
+  });
+
+  it('will not add a nameless tool', async () => {
+    renderPage();
+
+    await screen.findByLabelText(/title/i);
+    expect(screen.getByRole('button', { name: /add tool/i })).toBeDisabled();
+  });
+
+  it('removes a tool row', async () => {
+    renderPage();
+
+    await screen.findByLabelText(/title/i);
+    addTool('Torque wrench');
+    addTool('Shop vacuum');
+
+    fireEvent.click(screen.getAllByRole('button', { name: /remove tool/i })[0]);
+
+    expect(screen.queryByText('Torque wrench')).not.toBeInTheDocument();
+    expect(screen.getByText('Shop vacuum')).toBeInTheDocument();
+  });
+
+  it('creates the tools entered on a new task once the task is saved', async () => {
+    mockMaintenanceAPI.createItem.mockResolvedValue(okResponse({ id: 'mi-new' }));
+
+    renderPage();
+
+    fireEvent.change(await screen.findByLabelText(/title/i), {
+      target: { value: 'Replace air filter' },
+    });
+    addTool('Torque wrench', 'Tool crib, drawer 3');
+    fireEvent.click(screen.getByRole('button', { name: /create task/i }));
+
+    await waitFor(() => {
+      expect(mockToolAPI.create).toHaveBeenCalledWith({
+        maintenance_item: 'mi-new',
+        name: 'Torque wrench',
+        quantity: 1,
+        location_hint: 'Tool crib, drawer 3',
+        is_required: true,
+        notes: '',
+      });
+    });
+  });
+
+  it('loads the template tools when editing and deletes only the removed ones', async () => {
+    mockUseParams.mockReturnValue({ assetId: 'a-1', id: 'mi-1' });
+    mockMaintenanceAPI.getItem.mockResolvedValue(
+      okResponse(
+        buildItem([
+          buildTool(),
+          buildTool({ id: 't-2', name: 'Shop vacuum', location_hint: 'Under bench 2' }),
+        ]),
+      ),
+    );
+    mockMaintenanceAPI.updateItem.mockResolvedValue(okResponse({ id: 'mi-1' }));
+
+    renderPage();
+
+    // Both persisted tools render on load.
+    expect(await screen.findByText('Torque wrench')).toBeInTheDocument();
+    expect(screen.getByText('Shop vacuum')).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: /remove tool/i })[0]);
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockToolAPI.delete).toHaveBeenCalledWith('t-1');
+    });
+    // The surviving row is untouched — no delete, no redundant re-create.
+    expect(mockToolAPI.delete).toHaveBeenCalledTimes(1);
+    expect(mockToolAPI.create).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/pages/WorkOrderPageTools.test.tsx
+++ b/frontend/src/__tests__/pages/WorkOrderPageTools.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * "Tools Required" panel on the work-order detail page (op-67q5).
+ *
+ * The tech must see what to gather — and where it lives — before walking to
+ * the machine, so the panel renders near the top of the page (above the
+ * electrical / lockout cards, matching the printed form's running order) and
+ * accounts for itself even when the template names no tools.
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import WorkOrderPage from '../../pages/WorkOrderPage';
+import { workOrderAPI } from '../../services/api';
+import { WorkOrder, WorkOrderTool } from '../../types';
+
+vi.mock('../../services/api');
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useParams: () => ({ id: 'wo-1' }),
+  useNavigate: () => jest.fn(),
+}));
+
+const mockWorkOrderAPI = workOrderAPI as jest.Mocked<typeof workOrderAPI>;
+
+const okResponse = <T,>(data: T) =>
+  ({ data, status: 200, statusText: 'OK', headers: {}, config: {} as never }) as never;
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <WorkOrderPage />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+const buildWorkOrder = (tools?: WorkOrderTool[]): WorkOrder =>
+  ({
+    id: 'wo-1',
+    short_id: 'wo-001',
+    maintenance_item: 'mi-1',
+    maintenance_item_title: 'Quarterly belt inspection',
+    asset_name: 'Bandsaw',
+    asset_tag: 'TAG001',
+    asset_id: 'a-1',
+    status: 'open',
+    due_date: null,
+    assigned_to: null,
+    assigned_to_name: 'Alice',
+    completed_by_name: null,
+    completed_at: null,
+    notes: '',
+    loto_completion_note: '',
+    is_overdue: false,
+    task_completions: [],
+    material_usage: [],
+    loto_completions: [],
+    photos: [],
+    submissions: [],
+    tools,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  }) as WorkOrder;
+
+const tool = (overrides: Partial<WorkOrderTool> = {}): WorkOrderTool => ({
+  id: 't-1',
+  name: 'Torque wrench',
+  quantity: 1,
+  location_hint: 'Tool crib, drawer 3',
+  is_required: true,
+  notes: '',
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('WorkOrderPage — Tools Required (op-67q5)', () => {
+  it('lists each tool with its location and a Required badge', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(
+        buildWorkOrder([
+          tool(),
+          tool({ id: 't-2', name: 'Shop vacuum', location_hint: 'Under bench 2' }),
+        ]),
+      ),
+    );
+
+    renderPage();
+
+    const heading = await screen.findByText('Tools Required');
+    const panel = heading.closest('.mantine-Card-root') as HTMLElement;
+    expect(within(panel).getByText('Torque wrench')).toBeInTheDocument();
+    expect(within(panel).getByText('Tool crib, drawer 3')).toBeInTheDocument();
+    expect(within(panel).getByText('Shop vacuum')).toBeInTheDocument();
+    expect(within(panel).getAllByText('Required')).toHaveLength(2);
+  });
+
+  it('shows the quantity only when more than one is needed', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(buildWorkOrder([tool({ quantity: 2 }), tool({ id: 't-2', name: 'Pry bar' })])),
+    );
+
+    renderPage();
+
+    const panel = (await screen.findByText('Tools Required')).closest(
+      '.mantine-Card-root',
+    ) as HTMLElement;
+    expect(within(panel).getByText('×2')).toBeInTheDocument();
+    expect(within(panel).queryByText('×1')).not.toBeInTheDocument();
+  });
+
+  it('does not badge an optional tool as Required', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(buildWorkOrder([tool({ name: 'Shop vacuum', is_required: false })])),
+    );
+
+    renderPage();
+
+    const panel = (await screen.findByText('Tools Required')).closest(
+      '.mantine-Card-root',
+    ) as HTMLElement;
+    expect(within(panel).getByText('Shop vacuum')).toBeInTheDocument();
+    expect(within(panel).queryByText('Required')).not.toBeInTheDocument();
+  });
+
+  it('accounts for itself when the template names no tools', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(okResponse(buildWorkOrder([])));
+
+    renderPage();
+
+    const panel = (await screen.findByText('Tools Required')).closest(
+      '.mantine-Card-root',
+    ) as HTMLElement;
+    expect(within(panel).getByText('No tools specified.')).toBeInTheDocument();
+  });
+
+  it('renders on an older payload that omits the tools key', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(okResponse(buildWorkOrder(undefined)));
+
+    renderPage();
+
+    expect(await screen.findByText('No tools specified.')).toBeInTheDocument();
+  });
+
+  it('places the tools panel above the lockout card, as on the printed form', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(okResponse(buildWorkOrder([tool()])));
+
+    renderPage();
+
+    const toolsHeading = await screen.findByText('Tools Required');
+    const lotoHeading = screen.getByText('Lockout / Tagout');
+    expect(
+      toolsHeading.compareDocumentPosition(lotoHeading) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/MaintenanceItemFormPage.tsx
+++ b/frontend/src/pages/MaintenanceItemFormPage.tsx
@@ -23,8 +23,8 @@ import { FormLayout } from '../components/forms/FormLayout';
 import { FormNumberInput } from '../components/forms/FormNumberInput';
 import { FormTextarea } from '../components/forms/FormTextarea';
 import WorkspacePage from '../components/landing/WorkspacePage';
-import { maintenanceAPI } from '../services/api';
-import { MaintenanceMaterial } from '../types';
+import { maintenanceAPI, maintenanceToolAPI } from '../services/api';
+import { MaintenanceMaterial, MaintenanceTool } from '../types';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
 import { MaintenanceItemFormData, maintenanceItemFormSchema } from '../utils/formSchemas';
 
@@ -37,6 +37,26 @@ interface PendingMaterial {
   estimated_cost_per_unit: number;
   notes: string;
 }
+
+/** A tool row being edited. Persisted rows carry `id`; new ones only `localId`. */
+interface PendingTool {
+  localId: string;
+  id?: string;
+  name: string;
+  quantity: number;
+  location_hint: string;
+  is_required: boolean;
+  notes: string;
+}
+
+const EMPTY_TOOL: PendingTool = {
+  localId: '',
+  name: '',
+  quantity: 1,
+  location_hint: '',
+  is_required: true,
+  notes: '',
+};
 
 const MaintenanceItemFormPage: React.FC = () => {
   const { assetId, id } = useParams<{ assetId: string; id: string }>();
@@ -56,6 +76,9 @@ const MaintenanceItemFormPage: React.FC = () => {
     estimated_cost_per_unit: 0,
     notes: '',
   });
+  const [tools, setTools] = useState<PendingTool[]>([]);
+  const [originalToolIds, setOriginalToolIds] = useState<string[]>([]);
+  const [newTool, setNewTool] = useState<PendingTool>(EMPTY_TOOL);
 
   const { control, handleSubmit, reset, setValue } = useForm<MaintenanceItemFormData>({
     // v5 resolvers infer the schema's Zod *input* type (fields with `.default()`
@@ -106,6 +129,17 @@ const MaintenanceItemFormPage: React.FC = () => {
       }));
       setMaterials(loaded);
       setOriginalMaterialIds(loaded.map((m: PendingMaterial) => m.id!).filter(Boolean));
+      const loadedTools = (item.tools ?? []).map((t: MaintenanceTool) => ({
+        localId: t.id,
+        id: t.id,
+        name: t.name,
+        quantity: t.quantity,
+        location_hint: t.location_hint,
+        is_required: t.is_required,
+        notes: t.notes,
+      }));
+      setTools(loadedTools);
+      setOriginalToolIds(loadedTools.map((t: PendingTool) => t.id!).filter(Boolean));
     } catch (err) {
       console.error('Error loading maintenance item:', err);
       setError('Failed to load maintenance item.');
@@ -122,6 +156,16 @@ const MaintenanceItemFormPage: React.FC = () => {
 
   const removeMaterial = (index: number) => {
     setMaterials(materials.filter((_, i) => i !== index));
+  };
+
+  const addTool = () => {
+    if (!newTool.name.trim()) return;
+    setTools([...tools, { ...newTool, localId: crypto.randomUUID() }]);
+    setNewTool(EMPTY_TOOL);
+  };
+
+  const removeTool = (index: number) => {
+    setTools(tools.filter((_, i) => i !== index));
   };
 
   const onSubmit = async (data: MaintenanceItemFormData) => {
@@ -144,6 +188,10 @@ const MaintenanceItemFormPage: React.FC = () => {
         const keepIds = materials.filter((m) => m.id).map((m) => m.id!);
         const toDelete = originalMaterialIds.filter((eid) => !keepIds.includes(eid));
         await Promise.all(toDelete.map((mid) => maintenanceAPI.deleteMaterial(mid)));
+
+        const keepToolIds = tools.filter((t) => t.id).map((t) => t.id!);
+        const toolsToDelete = originalToolIds.filter((eid) => !keepToolIds.includes(eid));
+        await Promise.all(toolsToDelete.map((tid) => maintenanceToolAPI.delete(tid)));
       } else {
         const response = await maintenanceAPI.createItem(apiPayload);
         savedItemId = response.data.id;
@@ -159,6 +207,20 @@ const MaintenanceItemFormPage: React.FC = () => {
             unit: m.unit,
             estimated_cost_per_unit: String(m.estimated_cost_per_unit),
             notes: m.notes,
+          })
+        )
+      );
+
+      const newTools = tools.filter((t) => !t.id);
+      await Promise.all(
+        newTools.map((t) =>
+          maintenanceToolAPI.create({
+            maintenance_item: savedItemId,
+            name: t.name,
+            quantity: t.quantity,
+            location_hint: t.location_hint,
+            is_required: t.is_required,
+            notes: t.notes,
           })
         )
       );
@@ -352,6 +414,96 @@ const MaintenanceItemFormPage: React.FC = () => {
                   variant="light"
                 >
                   Add
+                </Button>
+              </Group>
+            </Paper>
+          </Stack>
+
+          {/* Tools are gathered and returned (materials get consumed). They
+              print at the top of the work order next to the lockout info so
+              the tech collects everything before walking to the machine. */}
+          <Divider my="md" label="Tools" labelPosition="left" />
+          <Stack gap="sm">
+            {tools.length > 0 && (
+              <Table striped withTableBorder>
+                <Table.Thead>
+                  <Table.Tr>
+                    <Table.Th>Tool</Table.Th>
+                    <Table.Th>Qty</Table.Th>
+                    <Table.Th>Location</Table.Th>
+                    <Table.Th>Required</Table.Th>
+                    <Table.Th></Table.Th>
+                  </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                  {tools.map((t, i) => (
+                    <Table.Tr key={t.localId}>
+                      <Table.Td>{t.name}</Table.Td>
+                      <Table.Td>{t.quantity}</Table.Td>
+                      <Table.Td>{t.location_hint || '—'}</Table.Td>
+                      <Table.Td>{t.is_required ? 'Required' : 'Optional'}</Table.Td>
+                      <Table.Td>
+                        <ActionIcon
+                          color="red"
+                          variant="subtle"
+                          onClick={() => removeTool(i)}
+                          aria-label="Remove tool"
+                        >
+                          <IconTrash size={16} />
+                        </ActionIcon>
+                      </Table.Td>
+                    </Table.Tr>
+                  ))}
+                </Table.Tbody>
+              </Table>
+            )}
+
+            <Paper p="sm" withBorder>
+              <Text size="sm" fw={500} mb="xs">
+                Add Tool
+              </Text>
+              <Group align="flex-end" gap="xs">
+                <TextInput
+                  label="Tool"
+                  value={newTool.name}
+                  onChange={(e) => setNewTool({ ...newTool, name: e.target.value })}
+                  placeholder="e.g. Torque wrench"
+                  style={{ flex: 2 }}
+                />
+                <NumberInput
+                  label="Qty"
+                  value={newTool.quantity}
+                  onChange={(v) => setNewTool({ ...newTool, quantity: Number(v) || 1 })}
+                  min={1}
+                  step={1}
+                  style={{ flex: 1 }}
+                />
+                <TextInput
+                  label="Location"
+                  value={newTool.location_hint}
+                  onChange={(e) => setNewTool({ ...newTool, location_hint: e.target.value })}
+                  placeholder="Tool crib, drawer 3"
+                  style={{ flex: 2 }}
+                />
+                <TextInput
+                  label="Notes"
+                  value={newTool.notes}
+                  onChange={(e) => setNewTool({ ...newTool, notes: e.target.value })}
+                  placeholder="Optional"
+                  style={{ flex: 2 }}
+                />
+                <Switch
+                  label="Required"
+                  checked={newTool.is_required}
+                  onChange={(e) => setNewTool({ ...newTool, is_required: e.currentTarget.checked })}
+                />
+                <Button
+                  leftSection={<IconPlus size={16} />}
+                  onClick={addTool}
+                  disabled={!newTool.name.trim()}
+                  variant="light"
+                >
+                  Add Tool
                 </Button>
               </Group>
             </Paper>

--- a/frontend/src/pages/WorkOrderPage.tsx
+++ b/frontend/src/pages/WorkOrderPage.tsx
@@ -35,6 +35,7 @@ import {
   IconRobot,
   IconScan,
   IconTag,
+  IconTool,
   IconUpload,
 } from '@tabler/icons-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -599,6 +600,8 @@ const WorkOrderPage: React.FC = () => {
   const lotoCompletions = workOrder.loto_completions ?? [];
   const completedLoto = lotoCompletions.filter((l) => l.is_completed).length;
   const totalLoto = lotoCompletions.length;
+  // Already ordered required-first by the serializer; older payloads omit it.
+  const tools = workOrder.tools ?? [];
 
   return (
     <WorkspacePage
@@ -671,6 +674,53 @@ const WorkOrderPage: React.FC = () => {
           size="md"
           mt="xs"
         />
+      </Card>
+
+      {/* op-67q5: what to grab, up front — directly above the electrical /
+          lockout cards, mirroring the printed work order's running order so
+          paper and screen read the same way. Reference only (no checkboxes):
+          nothing here is scanned back off the paper form. */}
+      <Card withBorder p="md" radius="md" mb="md" mt="md">
+        <Group mb="sm" gap="xs">
+          <IconTool size={18} />
+          <Title order={5}>Tools Required</Title>
+        </Group>
+        {tools.length > 0 ? (
+          <Stack gap="xs">
+            {tools.map((tool) => (
+              <Group key={tool.id} gap="xs" wrap="nowrap" align="flex-start">
+                <Text size="sm" fw={500} style={{ flex: 1, minWidth: 0 }}>
+                  {tool.name}
+                  {tool.quantity > 1 && (
+                    <Text span size="sm" c="dimmed">
+                      {' '}
+                      ×{tool.quantity}
+                    </Text>
+                  )}
+                  {tool.location_hint && (
+                    <Text size="xs" c="dimmed">
+                      {tool.location_hint}
+                    </Text>
+                  )}
+                  {tool.notes && (
+                    <Text size="xs" c="dimmed">
+                      {tool.notes}
+                    </Text>
+                  )}
+                </Text>
+                {tool.is_required && (
+                  <Badge color="orange" variant="light" size="sm">
+                    Required
+                  </Badge>
+                )}
+              </Group>
+            ))}
+          </Stack>
+        ) : (
+          <Text size="sm" c="dimmed">
+            No tools specified.
+          </Text>
+        )}
       </Card>
 
       {/* AC-1 Electrical info — present even when empty so the section is

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,7 +2,7 @@
  * API service for communicating with the Django backend
  */
 import axios from 'axios';
-import { ActiveMaintenanceRow, Asset, AssetCostRecoveryReport, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, InventoryItemMetrics, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LogUsageRequest, LogUsageResponse, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderLotoCompletion, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
+import { ActiveMaintenanceRow, Asset, AssetCostRecoveryReport, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, InventoryItemMetrics, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LogUsageRequest, LogUsageResponse, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, MaintenanceTool, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderLotoCompletion, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
 
 /**
  * Resolves the API base URL based on environment.
@@ -1279,6 +1279,23 @@ export const maintenanceAPI = {
 
   getDashboard: () =>
     api.get<MaintenanceDashboardData>('/inventory/maintenance/dashboard/'),
+};
+
+// Tools a PM task needs (gathered and returned, unlike materials, which are
+// consumed). Mirrors the material endpoints above; the work order carries a
+// read-only copy of this list for the up-front "Tools Required" panel.
+export const maintenanceToolAPI = {
+  list: (maintenanceItemId: string) =>
+    api.get<{ results: MaintenanceTool[] }>('/inventory/maintenance-tools/', { params: { maintenance_item: maintenanceItemId } }),
+
+  create: (data: Partial<MaintenanceTool>) =>
+    api.post<MaintenanceTool>('/inventory/maintenance-tools/', data),
+
+  update: (id: string, data: Partial<MaintenanceTool>) =>
+    api.patch<MaintenanceTool>(`/inventory/maintenance-tools/${id}/`, data),
+
+  delete: (id: string) =>
+    api.delete(`/inventory/maintenance-tools/${id}/`),
 };
 
 export interface MaintenanceDashboardScheduledRow {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -607,6 +607,35 @@ export interface MaintenanceMaterial {
   created_at: string;
 }
 
+/**
+ * A tool the maintainer must gather before starting a PM task — as opposed to
+ * a {@link MaintenanceMaterial}, which gets consumed. Field names are a pinned
+ * API contract (ScanTTY decodes the same payload); do not rename them.
+ */
+export interface MaintenanceTool {
+  id: string;
+  maintenance_item: string;
+  inventory_item: string | null;
+  inventory_item_detail: MaintenanceMaterialInventoryDetail | null;
+  name: string;
+  /** Whole units — the backend field is a PositiveIntegerField. */
+  quantity: number;
+  location_hint: string;
+  is_required: boolean;
+  notes: string;
+  created_at: string;
+}
+
+/**
+ * The trimmed tool shape a work order carries for display + print. The WO
+ * serializer deliberately omits the template-side keys (`maintenance_item`,
+ * `inventory_item*`, `created_at`) — this Pick keeps the two in step.
+ */
+export type WorkOrderTool = Pick<
+  MaintenanceTool,
+  'id' | 'name' | 'quantity' | 'location_hint' | 'is_required' | 'notes'
+>;
+
 export interface LowStockAlert {
   material_id: string;
   item_id: string;
@@ -637,6 +666,7 @@ export interface MaintenanceItem {
   days_overdue: number | null;
   next_due_at: string | null;
   materials: MaintenanceMaterial[];
+  tools?: MaintenanceTool[];
   tasks: MaintenanceTask[];
   created_at: string;
   updated_at: string;
@@ -849,6 +879,8 @@ export interface WorkOrder {
   material_usage: WorkOrderMaterialUsage[];
   loto_completions: WorkOrderLotoCompletion[];
   photos: WorkOrderPhoto[];
+  /** op-67q5: tools to gather, required first — reference only, no OMR box. */
+  tools?: WorkOrderTool[];
   submissions: WorkOrderSubmission[];
   electrical?: WorkOrderElectricalContext;
   loto?: WorkOrderLotoContext;


### PR DESCRIPTION
## Work order enhancement — PR 1 of 4: Tools Required list + LOTO up front

First of four PRs implementing the work-order/PM asks: **print a required-tools list and lockout/tagout info at the beginning of the work order**, across the printed PDF, the OMS web app, and (separate ScanTTY PR) the TUI.

### What this does
- Finishes the previously half-built `MaintenanceTool` model (it existed but had no serializer/API/PDF — only a Django admin inline).
- **PDF:** a new **"Tools Required"** table renders near the top of the sheet — after Asset Information, immediately before the Power & Lockout safety section — so tools + LOTO read as one job-prep block up front. Reference-only (no OMR checkbox), so the OMR template drift signature is unchanged.
- **Web:** a tool editor on the maintenance template (mirrors the existing materials editor) and a "Tools Required" card near the top of the work-order page.
- **Backend:** `MaintenanceToolSerializer` + `MaintenanceToolViewSet` (registered in the permission matrix), `tools` nested on the maintenance-item serializer, and a `tools` field on the work-order serializer. The list is built once in the shared `work_order_context` parity service so the serializer and PDF can't drift.

### Surfaces
serializer (read+write) · viewset + url · `api_permission_matrix.yaml` · PDF · web template form + WO display · `api.ts` + TS types · backend + vitest tests. No migration (model pre-existed).

### Verification (run by the implementing worker)
- Full backend suite on Postgres: **3650 passed / 4 skipped / 0 failed**; the 64 tests around the parity refactor re-run green.
- `bandit -r . -x tests,migrations -s B101,B105,B106,B308` → no issues.
- `black`/`isort`/`flake8` clean on touched files.
- Frontend (node24): `npm run lint` 0 errors; `npm run test:fast` 1195 passed.
- Independent codex completeness gate: all checklist surfaces covered, no contract violations, verdict COMPLETE.

### Reviewer note
This changes the PDF layout, so a WO printed before deploy and reprinted after gets a new region map (positions shift). The drift signature is content-based (task/material/LOTO ids) and unchanged, so scan-back is not weakened — normal for any layout change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
