### PR TITLE
feat(inventory): work-order manual / revision history / reference links at sign-off

### DIFF
--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -2346,6 +2346,7 @@ class WorkOrderSerializer(serializers.ModelSerializer):
     electrical = serializers.SerializerMethodField()
     loto = serializers.SerializerMethodField()
     validation = serializers.SerializerMethodField()
+    reference_documents = serializers.SerializerMethodField()
 
     class Meta:
         model = WorkOrder
@@ -2377,6 +2378,7 @@ class WorkOrderSerializer(serializers.ModelSerializer):
             "electrical",
             "loto",
             "validation",
+            "reference_documents",
             "created_at",
             "updated_at",
         ]
@@ -2396,6 +2398,7 @@ class WorkOrderSerializer(serializers.ModelSerializer):
             "electrical",
             "loto",
             "validation",
+            "reference_documents",
         ]
 
     def get_pending_review_count(self, obj):
@@ -2440,6 +2443,20 @@ class WorkOrderSerializer(serializers.ModelSerializer):
         if latest is None:
             return None
         return WorkOrderValidationSerializer(latest, context=self.context).data
+
+    def get_reference_documents(self, obj):
+        """Manual / revision history / reference links for the sign-off surface.
+
+        Read-only projection of the asset's existing document library — no new
+        link fields on the work order. Detail-only: the list view has no room
+        for it and would pay the prefetch for nothing.
+        """
+        from .services.work_order_context import build_reference_documents_context
+
+        return build_reference_documents_context(
+            obj.maintenance_item.asset,
+            request=self.context.get("request"),
+        )
 
 
 class WorkOrderListSerializer(serializers.ModelSerializer):

--- a/backend/inventory/services/work_order_context.py
+++ b/backend/inventory/services/work_order_context.py
@@ -28,6 +28,10 @@ the digital view shows the empty-state messages required by AC-1 / AC-2):
             "is_empty":              bool          # True iff is_required False
         },
         "tools": list[ToolDict]                    # required-first, then name
+        "reference_documents": {                   # asset doc library + quick links
+            "documents": list[DocumentDict],
+            "links":     list[{"label", "url"}],
+        }
     }
 """
 
@@ -37,6 +41,11 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from inventory.models import Asset, MaintenanceItem, MaintenanceTool, WorkOrder
+
+# A ``supersedes`` chain is linear in practice (each upload points at the one
+# version it replaced), but the FK is unconstrained — cap the walk so bad data
+# can never spin the renderer.
+MAX_REVISION_DEPTH = 20
 
 
 def _build_electrical_rows(asset: "Asset") -> list[list[str]]:
@@ -239,6 +248,141 @@ def build_electrical_context(asset: "Asset") -> dict[str, Any]:
     }
 
 
+def _absolute_url(url: str, request=None, base_url: str = "") -> str:
+    """Absolutize a media URL for whichever surface is rendering.
+
+    The API has a request to build against (mirroring
+    ``WorkOrderPhotoSerializer.image_url``); the printed form only knows the
+    deployment's ``base_url``. Storage backends that already hand back an
+    absolute URL (S3 and friends) are left alone by both paths —
+    ``build_absolute_uri`` returns a fully-qualified location unchanged.
+    """
+    if not url:
+        return ""
+    if request is not None:
+        return request.build_absolute_uri(url)
+    if base_url and url.startswith("/"):
+        return f"{base_url.rstrip('/')}{url}"
+    return url
+
+
+def _file_url(field_file, request=None, base_url: str = "") -> str | None:
+    """Absolute URL for a FileField, or None when there is no usable file.
+
+    A row can outlive its file (storage pruned, bad import); ``.url`` raises
+    for those, and neither the work-order page nor the printed form should
+    500 over a missing manual.
+    """
+    if not field_file:
+        return None
+    try:
+        url = field_file.url
+    except (ValueError, NotImplementedError):  # pragma: no cover — storage-dependent
+        return None
+    return _absolute_url(url, request=request, base_url=base_url) or None
+
+
+def _revision_chain(document, by_id: dict) -> list:
+    """Older versions behind ``document``, newest-first.
+
+    Walks ``supersedes`` through ``by_id`` — a map of the asset's documents
+    that the caller built from one prefetched queryset — so a chain of any
+    length still costs zero extra queries. A link that points outside the
+    asset (only reachable by editing around ``AssetDocumentSerializer``'s
+    same-asset check) ends the walk rather than firing a lazy fetch.
+    """
+    revisions: list = []
+    seen = {document.id}
+    prior_id = document.supersedes_id
+    while prior_id and len(revisions) < MAX_REVISION_DEPTH:
+        prior = by_id.get(prior_id)
+        if prior is None or prior.id in seen:
+            break
+        seen.add(prior.id)
+        revisions.append(prior)
+        prior_id = prior.supersedes_id
+    return revisions
+
+
+def _asset_links(asset: "Asset", *, request=None, base_url: str = "") -> list[dict[str, str]]:
+    """The asset's quick links that are actually set (blank ones are omitted)."""
+    links: list[dict[str, str]] = []
+
+    manual_url = _file_url(asset.manual_pdf, request=request, base_url=base_url)
+    if manual_url:
+        links.append({"label": "Manual (PDF)", "url": manual_url})
+    if asset.product_url:
+        links.append({"label": "Product / documentation page", "url": asset.product_url})
+    if asset.wiki_page_url:
+        links.append({"label": "Wiki", "url": asset.wiki_page_url})
+
+    return links
+
+
+def build_reference_documents_context(
+    asset: "Asset",
+    *,
+    request=None,
+    base_url: str = "",
+) -> dict[str, Any]:
+    """Docs a tech can reach while performing/signing the work order.
+
+    Reuses the per-asset document library (``AssetDocument``) rather than
+    inventing work-order link fields: "revision history" is that model's
+    ``supersedes`` chain, so uploading a new manual keeps the old one reachable
+    without anybody re-attaching it. Only ``is_current`` documents head the
+    list; superseded ones appear as each document's ``revisions``.
+
+    Keys are a pinned contract — ScanTTY decodes this payload — so do not
+    rename them. Reads ``asset.documents.all()`` unfiltered/unordered so the
+    ``maintenance_item__asset__documents`` prefetch is used instead of a query
+    per work order.
+    """
+    from inventory.models import AssetDocument
+
+    documents = list(asset.documents.all())
+    by_id = {doc.id: doc for doc in documents}
+
+    def sort_key(doc) -> tuple:
+        # The manual is what someone reaches for first; everything else falls
+        # back to a stable category/title order.
+        return (
+            doc.category != AssetDocument.Category.MANUAL,
+            doc.category or "",
+            doc.title.casefold(),
+            doc.title,
+        )
+
+    current = sorted((doc for doc in documents if doc.is_current), key=sort_key)
+
+    return {
+        "documents": [
+            {
+                "id": str(doc.id),
+                "category": doc.category,
+                "category_display": doc.get_category_display(),
+                "title": doc.title,
+                "version": doc.version,
+                "file_url": _file_url(doc.file, request=request, base_url=base_url),
+                "uploaded_at": doc.uploaded_at.isoformat() if doc.uploaded_at else None,
+                "revisions": [
+                    {
+                        "id": str(prior.id),
+                        "version": prior.version,
+                        "file_url": _file_url(prior.file, request=request, base_url=base_url),
+                        "uploaded_at": (
+                            prior.uploaded_at.isoformat() if prior.uploaded_at else None
+                        ),
+                    }
+                    for prior in _revision_chain(doc, by_id)
+                ],
+            }
+            for doc in current
+        ],
+        "links": _asset_links(asset, request=request, base_url=base_url),
+    }
+
+
 def build_work_order_context(work_order: "WorkOrder") -> dict[str, Any]:
     """Single source of truth for digital + PDF feature parity."""
     asset = work_order.maintenance_item.asset
@@ -246,4 +390,5 @@ def build_work_order_context(work_order: "WorkOrder") -> dict[str, Any]:
         "electrical": build_electrical_context(asset),
         "loto": build_loto_context(asset),
         "tools": build_tools_context(work_order.maintenance_item),
+        "reference_documents": build_reference_documents_context(asset),
     }

--- a/backend/inventory/tests/test_work_order_parity.py
+++ b/backend/inventory/tests/test_work_order_parity.py
@@ -486,7 +486,7 @@ def test_pdf_and_serializer_share_the_same_context_builder():
     wo = _build_wo(asset=asset)
 
     ctx = build_work_order_context(wo)
-    assert set(ctx.keys()) == {"electrical", "loto", "tools"}
+    assert set(ctx.keys()) == {"electrical", "loto", "tools", "reference_documents"}
 
     # Re-derive the PDF row set through its public helper and confirm every
     # asset-level row from the shared electrical context appears.

--- a/backend/inventory/tests/test_work_order_reference_documents.py
+++ b/backend/inventory/tests/test_work_order_reference_documents.py
@@ -1,0 +1,341 @@
+"""Tests for the work order's "Documentation & References" surface (op-pzae).
+
+Whoever performs and signs a work order needs the manual — and needs to know
+which revision is current — without leaving the job. Rather than new link
+fields on the work order, this reuses the per-asset document library:
+``AssetDocument`` already carries ``version`` / ``is_current`` / ``supersedes``,
+so "revision history" is that chain and a freshly uploaded manual is reachable
+the moment it lands.
+
+Covers the pinned ``WorkOrderSerializer.reference_documents`` contract (ScanTTY
+decodes these exact keys), the prefetch that keeps a deep chain from becoming an
+N+1, the printed block above the sign-off, and the invariant that a
+reference-only section leaves the OMR targets alone.
+"""
+
+from __future__ import annotations
+
+import io
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+import pytest
+from pypdf import PdfReader
+
+from inventory.models import AssetDocument
+from inventory.serializers import WorkOrderSerializer
+from inventory.services.work_order_context import (
+    MAX_REVISION_DEPTH,
+    build_reference_documents_context,
+)
+from inventory.services.work_order_omr import compute_template_version, dynamic_target_ids
+from inventory.tests.test_work_order_ingest import _make_work_order
+from inventory.utils.work_order_pdf import generate_work_order_pdf
+from inventory.views import WorkOrderViewSet
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def _isolated_media(settings, tmp_path):
+    """Keep uploaded test files out of the tracked backend/media tree."""
+    settings.MEDIA_ROOT = str(tmp_path)
+
+
+def _make_file(name="manual.pdf") -> SimpleUploadedFile:
+    return SimpleUploadedFile(name, b"%PDF-1.4 fake", content_type="application/pdf")
+
+
+def _make_document(asset, **kwargs) -> AssetDocument:
+    kwargs.setdefault("title", "Operator manual")
+    kwargs.setdefault("category", AssetDocument.Category.MANUAL)
+    kwargs.setdefault("file", _make_file())
+    return AssetDocument.objects.create(asset=asset, **kwargs)
+
+
+def _supersede(asset, older: AssetDocument, **kwargs) -> AssetDocument:
+    """Upload a newer version of ``older``, exactly as the viewset does."""
+    newer = _make_document(
+        asset,
+        title=kwargs.pop("title", older.title),
+        category=kwargs.pop("category", older.category),
+        version=older.version + 1,
+        supersedes=older,
+        **kwargs,
+    )
+    older.is_current = False
+    older.save(update_fields=["is_current"])
+    return newer
+
+
+def _pdf_text(pdf_bytes: bytes) -> str:
+    reader = PdfReader(io.BytesIO(pdf_bytes))
+    return "\n".join(page.extract_text() or "" for page in reader.pages)
+
+
+def _serialize(work_order, request=None) -> dict:
+    return WorkOrderSerializer(work_order, context={"request": request}).data["reference_documents"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Serializer — pinned shape
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestReferenceDocumentsShape:
+    def test_exposes_the_pinned_keys(self, rf):
+        wo = _make_work_order(num_tasks=1)
+        _make_document(wo.maintenance_item.asset, title="Bandsaw manual")
+
+        payload = _serialize(wo, rf.get("/api/inventory/work-orders/"))
+
+        assert set(payload) == {"documents", "links"}
+        assert set(payload["documents"][0]) == {
+            "id",
+            "category",
+            "category_display",
+            "title",
+            "version",
+            "file_url",
+            "uploaded_at",
+            "revisions",
+        }
+
+    def test_only_current_documents_head_the_list(self, rf):
+        """A superseded row is history, not something to hand a tech."""
+        wo = _make_work_order(num_tasks=1)
+        asset = wo.maintenance_item.asset
+        v1 = _make_document(asset, title="Bandsaw manual")
+        _supersede(asset, v1)
+
+        payload = _serialize(wo, rf.get("/api/inventory/work-orders/"))
+
+        assert [doc["version"] for doc in payload["documents"]] == [2]
+
+    def test_revisions_are_the_supersedes_chain_newest_first(self, rf):
+        wo = _make_work_order(num_tasks=1)
+        asset = wo.maintenance_item.asset
+        v1 = _make_document(asset, title="Bandsaw manual")
+        v2 = _supersede(asset, v1)
+        _supersede(asset, v2)
+
+        payload = _serialize(wo, rf.get("/api/inventory/work-orders/"))
+
+        (manual,) = payload["documents"]
+        assert manual["version"] == 3
+        assert [rev["version"] for rev in manual["revisions"]] == [2, 1]
+        assert set(manual["revisions"][0]) == {"id", "version", "file_url", "uploaded_at"}
+        assert manual["revisions"][0]["file_url"].endswith(".pdf")
+
+    def test_manual_sorts_first_then_category_and_title(self, rf):
+        wo = _make_work_order(num_tasks=1)
+        asset = wo.maintenance_item.asset
+        _make_document(asset, title="Zeta wiring", category=AssetDocument.Category.WIRING_DIAGRAM)
+        _make_document(
+            asset, title="Alpha cut sheet", category=AssetDocument.Category.CUT_SHEET_SPEC
+        )
+        _make_document(asset, title="Operator manual")
+
+        payload = _serialize(wo, rf.get("/api/inventory/work-orders/"))
+
+        assert [doc["title"] for doc in payload["documents"]] == [
+            "Operator manual",
+            "Alpha cut sheet",
+            "Zeta wiring",
+        ]
+
+    def test_file_urls_are_absolute_against_the_request(self, rf):
+        wo = _make_work_order(num_tasks=1)
+        _make_document(wo.maintenance_item.asset)
+
+        payload = _serialize(wo, rf.get("/api/inventory/work-orders/"))
+
+        assert payload["documents"][0]["file_url"].startswith("http://testserver/")
+
+    def test_a_document_without_a_file_reads_back_null(self, rf):
+        """A row can outlive its file — the page must not 500 over it."""
+        wo = _make_work_order(num_tasks=1)
+        _make_document(wo.maintenance_item.asset, file="")
+
+        payload = _serialize(wo, rf.get("/api/inventory/work-orders/"))
+
+        assert payload["documents"][0]["file_url"] is None
+
+
+class TestReferenceDocumentsLinks:
+    def test_only_the_links_that_are_set_are_listed(self, rf):
+        wo = _make_work_order(num_tasks=1)
+        asset = wo.maintenance_item.asset
+        asset.product_url = "https://example.com/bandsaw"
+        asset.wiki_page_url = ""
+        asset.manual_pdf = _make_file("legacy-manual.pdf")
+        asset.save(update_fields=["product_url", "wiki_page_url", "manual_pdf"])
+
+        payload = _serialize(wo, rf.get("/api/inventory/work-orders/"))
+
+        assert payload["documents"] == []
+        assert [link["label"] for link in payload["links"]] == [
+            "Manual (PDF)",
+            "Product / documentation page",
+        ]
+        assert payload["links"][0]["url"].startswith("http://testserver/")
+        assert payload["links"][1]["url"] == "https://example.com/bandsaw"
+
+    def test_all_three_quick_links_when_all_are_set(self, rf):
+        wo = _make_work_order(num_tasks=1)
+        asset = wo.maintenance_item.asset
+        asset.product_url = "https://example.com/bandsaw"
+        asset.wiki_page_url = "https://wiki.example.com/bandsaw"
+        asset.manual_pdf = _make_file("legacy-manual.pdf")
+        asset.save(update_fields=["product_url", "wiki_page_url", "manual_pdf"])
+
+        payload = _serialize(wo, rf.get("/api/inventory/work-orders/"))
+
+        assert [link["label"] for link in payload["links"]] == [
+            "Manual (PDF)",
+            "Product / documentation page",
+            "Wiki",
+        ]
+
+    def test_asset_with_nothing_returns_the_empty_shape(self, rf):
+        wo = _make_work_order(num_tasks=1)
+
+        payload = _serialize(wo, rf.get("/api/inventory/work-orders/"))
+
+        assert payload == {"documents": [], "links": []}
+
+
+class TestReferenceDocumentsRobustness:
+    def test_a_supersedes_cycle_terminates(self):
+        """Bad data (only reachable around the serializer's guard) must not spin."""
+        wo = _make_work_order(num_tasks=1)
+        asset = wo.maintenance_item.asset
+        v1 = _make_document(asset, title="Looping manual")
+        v2 = _supersede(asset, v1)
+        v1.supersedes = v2
+        v1.save(update_fields=["supersedes"])
+
+        (manual,) = build_reference_documents_context(asset)["documents"]
+
+        assert [rev["version"] for rev in manual["revisions"]] == [1]
+
+    def test_a_long_chain_is_capped(self):
+        wo = _make_work_order(num_tasks=1)
+        asset = wo.maintenance_item.asset
+        doc = _make_document(asset, title="Much-revised manual")
+        for _ in range(MAX_REVISION_DEPTH + 3):
+            doc = _supersede(asset, doc)
+
+        (manual,) = build_reference_documents_context(asset)["documents"]
+
+        assert len(manual["revisions"]) == MAX_REVISION_DEPTH
+
+    def test_a_link_to_another_assets_document_does_not_leak(self):
+        wo = _make_work_order(num_tasks=1)
+        other = _make_work_order(num_tasks=1).maintenance_item.asset
+        stray = _make_document(other, title="Someone else's manual")
+        _make_document(wo.maintenance_item.asset, title="Our manual", supersedes=stray)
+
+        (manual,) = build_reference_documents_context(wo.maintenance_item.asset)["documents"]
+
+        assert manual["revisions"] == []
+
+    def test_the_pdf_builder_absolutizes_against_base_url(self):
+        wo = _make_work_order(num_tasks=1)
+        _make_document(wo.maintenance_item.asset)
+
+        payload = build_reference_documents_context(
+            wo.maintenance_item.asset, base_url="https://oms.example.org"
+        )
+
+        assert payload["documents"][0]["file_url"].startswith("https://oms.example.org/")
+
+
+class TestReferenceDocumentsQueryCount:
+    def test_the_prefetch_absorbs_a_deep_revision_chain(self, rf):
+        """Chain depth must not add queries — the walk runs off one prefetch."""
+
+        def documented_work_order(revisions: int):
+            wo = _make_work_order(num_tasks=1)
+            asset = wo.maintenance_item.asset
+            doc = _make_document(asset, title="Bandsaw manual")
+            for _ in range(revisions):
+                doc = _supersede(asset, doc)
+            return wo
+
+        shallow = documented_work_order(0)
+        deep = documented_work_order(5)
+
+        request = rf.get("/api/inventory/work-orders/")
+
+        def render(work_order):
+            with CaptureQueriesContext(connection) as captured:
+                instance = WorkOrderViewSet.queryset.get(id=work_order.id)
+                payload = WorkOrderSerializer(instance, context={"request": request}).data[
+                    "reference_documents"
+                ]
+            return len(captured), payload
+
+        shallow_queries, shallow_payload = render(shallow)
+        deep_queries, deep_payload = render(deep)
+
+        assert deep_queries == shallow_queries
+        assert shallow_payload["documents"][0]["revisions"] == []
+        assert len(deep_payload["documents"][0]["revisions"]) == 5
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Printed form — the block above the sign-off
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestWorkOrderPdfReferences:
+    def test_documents_print_above_the_sign_off(self):
+        wo = _make_work_order(num_tasks=1)
+        asset = wo.maintenance_item.asset
+        v1 = _make_document(asset, title="Bandsaw manual")
+        _supersede(asset, v1)
+        asset.wiki_page_url = "https://wiki.example.com/bandsaw"
+        asset.save(update_fields=["wiki_page_url"])
+
+        text = _pdf_text(generate_work_order_pdf(wo, base_url="https://oms.example.org"))
+
+        assert "Documentation & References" in text
+        assert "Bandsaw manual" in text
+        assert "Manual / Documentation" in text
+        assert "rev 2" in text
+        assert "supersedes rev 1" in text
+        assert "https://wiki.example.com/bandsaw" in text
+        assert "https://oms.example.org/" in text
+        assert text.index("Documentation & References") < text.index("Work Order Sign-Off")
+
+    def test_an_asset_without_documents_prints_the_empty_state(self):
+        wo = _make_work_order(num_tasks=1)
+
+        text = _pdf_text(generate_work_order_pdf(wo, base_url="https://oms.example.org"))
+
+        assert "No linked documents." in text
+
+    def test_xml_metacharacters_in_a_title_do_not_break_the_pdf(self):
+        wo = _make_work_order(num_tasks=1)
+        _make_document(wo.maintenance_item.asset, title="Manual <b>v2</b> & addendum")
+
+        text = _pdf_text(generate_work_order_pdf(wo, base_url="https://oms.example.org"))
+
+        assert "Manual <b>v2</b> & addendum" in text
+
+    def test_references_add_no_omr_marks_and_no_drift(self):
+        """Reference-only: a sheet printed before the docs landed still scans."""
+        wo = _make_work_order(num_tasks=2)
+        before_version = compute_template_version(wo)
+        before_targets = set(dynamic_target_ids(wo))
+
+        asset = wo.maintenance_item.asset
+        _make_document(asset, title="Bandsaw manual")
+        asset.wiki_page_url = "https://wiki.example.com/bandsaw"
+        asset.save(update_fields=["wiki_page_url"])
+
+        assert compute_template_version(wo) == before_version
+        assert set(dynamic_target_ids(wo)) == before_targets

--- a/backend/inventory/utils/work_order_pdf.py
+++ b/backend/inventory/utils/work_order_pdf.py
@@ -920,6 +920,45 @@ def generate_work_order_pdf(
 
     story.append(HRFlowable(width="100%", thickness=1, color=colors.black))
 
+    # ── Documentation & references ────────────────────────────────────────────
+    # Printed immediately above the sign-off block: whoever performs and signs
+    # the job should be able to reach the manual — and know which revision is
+    # current — without hunting for it. Text only (it's paper), sourced from the
+    # same builder the digital work order reads so the two cannot drift.
+    # Reference only: no AcroCheckbox, so the OMR target ids are untouched.
+    from inventory.services.work_order_context import build_reference_documents_context
+
+    references = build_reference_documents_context(asset, base_url=base_url)
+    story.append(Paragraph("Documentation &amp; References", subheading_style))
+    if references["documents"] or references["links"]:
+        # NB: not ``doc`` — that name is the SimpleDocTemplate being built.
+        for reference in references["documents"]:
+            # Titles are operator-entered and land in a reportlab Paragraph,
+            # which parses a mini-XML dialect — escape via ``html.escape``, not
+            # ``xml.sax.saxutils.escape`` (bandit B406).
+            line = (
+                f"<b>{escape(reference['title'], quote=False)}</b> — "
+                f"{escape(reference['category_display'], quote=False)} "
+                f"(rev {reference['version']})"
+            )
+            if reference["revisions"]:
+                prior = ", ".join(f"rev {rev['version']}" for rev in reference["revisions"])
+                line += f" <font color='#666666'>(supersedes {prior})</font>"
+            story.append(Paragraph(line, small_style))
+            if reference["file_url"]:
+                story.append(Paragraph(escape(reference["file_url"], quote=False), small_style))
+        for link in references["links"]:
+            story.append(
+                Paragraph(
+                    f"<b>{escape(link['label'], quote=False)}:</b> "
+                    f"{escape(link['url'], quote=False)}",
+                    small_style,
+                )
+            )
+    else:
+        story.append(Paragraph("No linked documents.", small_style))
+    story.append(Spacer(1, 6))
+
     # ── Sign-off section ──────────────────────────────────────────────────────
     story.append(Paragraph("Work Order Sign-Off", subheading_style))
 

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -4002,6 +4002,11 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
             # op-o6rs: feed the pending-review badge (pending_review_count) from
             # a single prefetch instead of a per-row submissions query (N+1).
             "submissions",
+            # op-pzae: feed WorkOrderSerializer.reference_documents. One query
+            # for the asset's whole document library — the revision chains are
+            # then walked in Python off this cache, so a deep supersedes chain
+            # costs nothing extra.
+            "maintenance_item__asset__documents",
         )
         .all()
     )

--- a/frontend/src/__tests__/pages/WorkOrderPageReferences.test.tsx
+++ b/frontend/src/__tests__/pages/WorkOrderPageReferences.test.tsx
@@ -1,0 +1,231 @@
+/**
+ * "Documentation & References" panel on the work-order detail page (op-pzae).
+ *
+ * Whoever performs and signs the work order needs the manual — and needs to
+ * know which revision is current — without leaving the job, so the panel sits
+ * with the sign-off / completion CTA at the bottom of the page. The rows come
+ * from the asset's existing document library: `revisions` is that library's
+ * supersedes chain, collapsed until someone asks for the history.
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import WorkOrderPage from '../../pages/WorkOrderPage';
+import { workOrderAPI } from '../../services/api';
+import { ReferenceDocument, ReferenceDocuments, WorkOrder } from '../../types';
+
+vi.mock('../../services/api');
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useParams: () => ({ id: 'wo-1' }),
+  useNavigate: () => jest.fn(),
+}));
+
+const mockWorkOrderAPI = workOrderAPI as jest.Mocked<typeof workOrderAPI>;
+
+const okResponse = <T,>(data: T) =>
+  ({ data, status: 200, statusText: 'OK', headers: {}, config: {} as never }) as never;
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <WorkOrderPage />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+const buildWorkOrder = (reference_documents?: ReferenceDocuments): WorkOrder =>
+  ({
+    id: 'wo-1',
+    short_id: 'wo-001',
+    maintenance_item: 'mi-1',
+    maintenance_item_title: 'Quarterly belt inspection',
+    asset_name: 'Bandsaw',
+    asset_tag: 'TAG001',
+    asset_id: 'a-1',
+    status: 'open',
+    due_date: null,
+    assigned_to: null,
+    assigned_to_name: 'Alice',
+    completed_by_name: '',
+    completed_at: null,
+    notes: '',
+    loto_completion_note: '',
+    is_overdue: false,
+    task_completions: [],
+    material_usage: [],
+    loto_completions: [],
+    photos: [],
+    submissions: [],
+    reference_documents,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  }) as WorkOrder;
+
+const document_ = (overrides: Partial<ReferenceDocument> = {}): ReferenceDocument => ({
+  id: 'doc-1',
+  category: 'manual',
+  category_display: 'Manual / Documentation',
+  title: 'Bandsaw operator manual',
+  version: 3,
+  file_url: 'http://testserver/media/assets/documents/manual-v3.pdf',
+  uploaded_at: '2026-05-02T10:00:00Z',
+  revisions: [],
+  ...overrides,
+});
+
+const panel = () =>
+  (screen.getByText('Documentation & References').closest('.mantine-Card-root') ??
+    undefined) as HTMLElement;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('WorkOrderPage — Documentation & References (op-pzae)', () => {
+  it('lists each current document with its category, revision and link', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(
+        buildWorkOrder({
+          documents: [
+            document_(),
+            document_({
+              id: 'doc-2',
+              category: 'wiring_diagram',
+              category_display: 'Wiring Diagram',
+              title: 'Motor wiring',
+              version: 1,
+              file_url: 'http://testserver/media/assets/documents/wiring.pdf',
+            }),
+          ],
+          links: [],
+        }),
+      ),
+    );
+
+    renderPage();
+    await screen.findByText('Documentation & References');
+
+    const card = panel();
+    expect(within(card).getByText('Manual / Documentation')).toBeInTheDocument();
+    expect(within(card).getByText('rev 3')).toBeInTheDocument();
+    expect(within(card).getByText('Motor wiring')).toBeInTheDocument();
+    const manualLink = within(card).getByRole('link', { name: 'Bandsaw operator manual' });
+    expect(manualLink).toHaveAttribute(
+      'href',
+      'http://testserver/media/assets/documents/manual-v3.pdf',
+    );
+    expect(manualLink).toHaveAttribute('target', '_blank');
+  });
+
+  it('keeps the revision history collapsed until it is asked for', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(
+        buildWorkOrder({
+          documents: [
+            document_({
+              revisions: [
+                {
+                  id: 'rev-2',
+                  version: 2,
+                  file_url: 'http://testserver/media/assets/documents/manual-v2.pdf',
+                  uploaded_at: '2026-02-01T10:00:00Z',
+                },
+                {
+                  id: 'rev-1',
+                  version: 1,
+                  file_url: 'http://testserver/media/assets/documents/manual-v1.pdf',
+                  uploaded_at: '2025-06-01T10:00:00Z',
+                },
+              ],
+            }),
+          ],
+          links: [],
+        }),
+      ),
+    );
+
+    renderPage();
+    await screen.findByText('Documentation & References');
+
+    const card = panel();
+    expect(within(card).queryByText(/rev 2/)).not.toBeInTheDocument();
+
+    await userEvent.click(within(card).getByText('Revision history (2)'));
+
+    expect(within(card).getByText(/rev 2/)).toBeInTheDocument();
+    expect(within(card).getByText(/rev 1/)).toBeInTheDocument();
+    expect(within(card).getAllByRole('link', { name: 'Open' })).toHaveLength(2);
+    expect(within(card).getByText('Hide revision history')).toBeInTheDocument();
+  });
+
+  it('offers no revision history for a document that has never been superseded', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(buildWorkOrder({ documents: [document_()], links: [] })),
+    );
+
+    renderPage();
+    await screen.findByText('Documentation & References');
+
+    expect(within(panel()).queryByText(/Revision history/)).not.toBeInTheDocument();
+  });
+
+  it('renders the asset quick links as external links', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(
+        buildWorkOrder({
+          documents: [],
+          links: [
+            { label: 'Manual (PDF)', url: 'http://testserver/media/assets/manuals/legacy.pdf' },
+            { label: 'Wiki', url: 'https://wiki.example.com/bandsaw' },
+          ],
+        }),
+      ),
+    );
+
+    renderPage();
+    await screen.findByText('Documentation & References');
+
+    const wiki = within(panel()).getByRole('link', { name: 'Wiki' });
+    expect(wiki).toHaveAttribute('href', 'https://wiki.example.com/bandsaw');
+    expect(wiki).toHaveAttribute('target', '_blank');
+  });
+
+  it('accounts for itself when the asset has no documents or links', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(buildWorkOrder({ documents: [], links: [] })),
+    );
+
+    renderPage();
+    await screen.findByText('Documentation & References');
+
+    expect(within(panel()).getByText('No linked documents.')).toBeInTheDocument();
+  });
+
+  it('renders on an older payload that omits the reference_documents key', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(okResponse(buildWorkOrder(undefined)));
+
+    renderPage();
+
+    expect(await screen.findByText('No linked documents.')).toBeInTheDocument();
+  });
+
+  it('sits at the bottom of the page, with the sign-off CTA', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(buildWorkOrder({ documents: [document_()], links: [] })),
+    );
+
+    renderPage();
+
+    const heading = await screen.findByText('Documentation & References');
+    const loto = screen.getByText('Lockout / Tagout');
+    const backButton = screen.getByRole('button', { name: 'Back to Dashboard' });
+    expect(loto.compareDocumentPosition(heading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(
+      heading.compareDocumentPosition(backButton) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/WorkOrderPage.tsx
+++ b/frontend/src/pages/WorkOrderPage.tsx
@@ -1,6 +1,7 @@
 import {
   ActionIcon,
   Alert,
+  Anchor,
   Badge,
   Box,
   Button,
@@ -284,6 +285,8 @@ const WorkOrderPage: React.FC = () => {
   const [lotoNote, setLotoNote] = useState('');
   const [savingLotoNote, setSavingLotoNote] = useState(false);
   const resetPhotoRef = useRef<() => void>(null);
+  // op-pzae: which reference document has its revision history expanded.
+  const [openRevisions, setOpenRevisions] = useState<Record<string, boolean>>({});
 
   // AC-3: validation prompt state.
   const [validationOpen, setValidationOpen] = useState(false);
@@ -707,6 +710,9 @@ const WorkOrderPage: React.FC = () => {
   const totalLoto = lotoCompletions.length;
   // Already ordered required-first by the serializer; older payloads omit it.
   const tools = workOrder.tools ?? [];
+  // op-pzae: detail-only, and absent from payloads printed before it shipped.
+  const referenceDocuments = workOrder.reference_documents?.documents ?? [];
+  const referenceLinks = workOrder.reference_documents?.links ?? [];
 
   return (
     <WorkspacePage
@@ -1515,6 +1521,110 @@ const WorkOrderPage: React.FC = () => {
               </Box>
             ))}
           </Group>
+        )}
+      </Card>
+
+      {/* op-pzae: manual / revision history / reference links, at the point of
+          sign-off — whoever performs and signs the job should be able to reach
+          the docs without hunting for them. Reuses the asset's document library
+          (the work order stores no links of its own), and mirrors the block the
+          printed form puts above its sign-off box: both read one builder. */}
+      <Card withBorder p="md" radius="md" mb="md">
+        <Group mb="sm" gap="xs">
+          <IconFileText size={18} />
+          <Title order={5}>Documentation &amp; References</Title>
+        </Group>
+        {referenceDocuments.length > 0 || referenceLinks.length > 0 ? (
+          <Stack gap="sm">
+            {referenceDocuments.map((doc) => (
+              <Box key={doc.id}>
+                <Group gap="xs" wrap="nowrap" align="center">
+                  <Box style={{ flex: 1, minWidth: 0 }}>
+                    {doc.file_url ? (
+                      <Anchor
+                        href={doc.file_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        size="sm"
+                        fw={500}
+                      >
+                        {doc.title}
+                      </Anchor>
+                    ) : (
+                      <Text size="sm" fw={500}>
+                        {doc.title}
+                      </Text>
+                    )}
+                  </Box>
+                  <Badge color="gray" variant="light" size="sm">
+                    {doc.category_display}
+                  </Badge>
+                  <Badge color="blue" variant="light" size="sm">
+                    rev {doc.version}
+                  </Badge>
+                </Group>
+                {doc.revisions.length > 0 && (
+                  <Box mt={4}>
+                    <UnstyledButton
+                      onClick={() =>
+                        setOpenRevisions((prev) => ({ ...prev, [doc.id]: !prev[doc.id] }))
+                      }
+                    >
+                      <Text size="xs" c="dimmed" td="underline">
+                        {openRevisions[doc.id]
+                          ? 'Hide revision history'
+                          : `Revision history (${doc.revisions.length})`}
+                      </Text>
+                    </UnstyledButton>
+                    {openRevisions[doc.id] && (
+                      <Stack gap={2} mt={4} pl="sm">
+                        {doc.revisions.map((rev) => (
+                          <Text key={rev.id} size="xs" c="dimmed">
+                            rev {rev.version}
+                            {rev.uploaded_at
+                              ? ` · ${new Date(rev.uploaded_at).toLocaleDateString()}`
+                              : ''}
+                            {rev.file_url && (
+                              <>
+                                {' · '}
+                                <Anchor
+                                  href={rev.file_url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  size="xs"
+                                >
+                                  Open
+                                </Anchor>
+                              </>
+                            )}
+                          </Text>
+                        ))}
+                      </Stack>
+                    )}
+                  </Box>
+                )}
+              </Box>
+            ))}
+            {referenceLinks.length > 0 && (
+              <Stack gap={2}>
+                {referenceLinks.map((link) => (
+                  <Anchor
+                    key={link.label}
+                    href={link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    size="sm"
+                  >
+                    {link.label}
+                  </Anchor>
+                ))}
+              </Stack>
+            )}
+          </Stack>
+        ) : (
+          <Text size="sm" c="dimmed">
+            No linked documents.
+          </Text>
         )}
       </Card>
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -874,6 +874,45 @@ export interface WorkOrderLotoContext {
   is_empty: boolean;
 }
 
+/**
+ * op-pzae: an older version of a reference document, from the backend's walk
+ * of the `AssetDocument.supersedes` chain (newest-first).
+ */
+export interface ReferenceDocumentRevision {
+  id: string;
+  version: number;
+  /** Absolute URL, or null when the row outlived its file. */
+  file_url: string | null;
+  uploaded_at: string | null;
+}
+
+/** A current document in the asset's library, with its revision history. */
+export interface ReferenceDocument {
+  id: string;
+  category: string;
+  category_display: string;
+  title: string;
+  version: number;
+  file_url: string | null;
+  uploaded_at: string | null;
+  revisions: ReferenceDocumentRevision[];
+}
+
+export interface ReferenceLink {
+  label: string;
+  url: string;
+}
+
+/**
+ * Docs a tech can reach while performing/signing the work order — the asset's
+ * current documents (manual first) plus its quick links. Read-only projection
+ * of the existing document library; the work order stores no links of its own.
+ */
+export interface ReferenceDocuments {
+  documents: ReferenceDocument[];
+  links: ReferenceLink[];
+}
+
 export interface WorkOrderValidationRecord {
   id: string;
   work_order: string;
@@ -915,6 +954,8 @@ export interface WorkOrder {
   electrical?: WorkOrderElectricalContext;
   loto?: WorkOrderLotoContext;
   validation?: WorkOrderValidationRecord | null;
+  /** op-pzae: manual / revision history / reference links, shown at sign-off. */
+  reference_documents?: ReferenceDocuments;
   task_completion_count?: number;
   task_total_count?: number;
   // op-o6rs: number of submissions still awaiting human review (drives the


### PR DESCRIPTION
## Work order enhancement — PR 3 of 4: manual / revision history / reference links at sign-off

Third of four work-order PRs. Puts the **manual, its revision history, and reference links** right by the **sign-off** section — reusing the existing per-asset document library rather than adding new fields.

### What this does
- **Backend:** a read-only `reference_documents` field on the work-order detail serializer, built by a shared `build_reference_documents_context()` service (so serializer + PDF + web can't drift). Shape: `documents[]` (the asset's current docs — manual first — each with `version`, `file_url`, and a `revisions[]` chain walked from `AssetDocument.supersedes`, newest-first) and `links[]` (the asset's manual PDF / product / wiki URLs). The revision chain is walked in Python off a `maintenance_item__asset__documents` prefetch — **0 extra queries**, depth-capped with a cycle guard.
- **PDF:** a "Documentation & References" block directly above "Work Order Sign-Off" (text/links — it's paper; escaped for reportlab). Reference-only → **OMR target-ids and drift signature unchanged.**
- **Web:** a "Documentation & References" card by the completion CTA, with a collapsed revision history per document and a "No linked documents." empty state.

No migration, no new model, no permission change (pure read-surface over existing asset documents).

### Surfaces
serializer (read) + prefetch · PDF sign-off block · web card · TS types · backend + vitest tests. Docs stay managed where they already live (the asset page).

### Notable fix
Caught and fixed a latent bug: `doc` is the `SimpleDocTemplate` in `generate_work_order_pdf`, and a `for doc in …` loop would have shadowed it and broken **every** PDF render.

### Verification (implementing worker)
- Full backend suite on Postgres: **3695 passed / 4 skipped / 0 failed** (the known accounting xdist flake did not appear); 18 new tests. `check_permission_matrix --write` → no diff.
- `bandit` 0 issues; black/isort/flake8 clean on changed files.
- Frontend (node24): `npm run lint` 0 errors; `npm run test:fast` 156 files / 1215 tests (7 new); `npm run build` clean.

> ScanTTY parity PR follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
