### PR TITLE
fix(inventory): drop orphan is_urgent column breaking asset problem reports (BACKEND-12)

### DIFF
--- a/backend/inventory/migrations/0098_drop_assetproblem_orphan_columns.py
+++ b/backend/inventory/migrations/0098_drop_assetproblem_orphan_columns.py
@@ -1,0 +1,44 @@
+"""Drop three orphan columns on inventory_assetproblem (Sentry BACKEND-12).
+
+Production's ``inventory_assetproblem`` table carried three columns that exist
+in neither the ``AssetProblem`` model nor any migration — an out-of-band schema
+change (an abandoned "logistics escalation" experiment):
+
+    * ``is_urgent``               boolean NOT NULL, no default
+    * ``escalated_to_logistics``  boolean, default false
+    * ``mitigation_notes``        text, default ''
+
+Because ``is_urgent`` is NOT NULL with no default and the code never sets it,
+every ``AssetProblem`` INSERT (``AssetViewSet.report_problem``) failed with a
+NotNullViolation. This reconciles the schema to the code by dropping all three.
+
+Guarded with ``IF EXISTS`` / ``IF NOT EXISTS`` so it is a no-op on databases
+that never had the columns (fresh dev/CI). RunSQL only: the model never declared
+these fields, so Django's migration state is already correct and unaffected.
+"""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0097_work_order_elapsed_timer"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=[
+                "ALTER TABLE inventory_assetproblem DROP COLUMN IF EXISTS is_urgent;",
+                "ALTER TABLE inventory_assetproblem DROP COLUMN IF EXISTS escalated_to_logistics;",
+                "ALTER TABLE inventory_assetproblem DROP COLUMN IF EXISTS mitigation_notes;",
+            ],
+            # Reverse re-adds the columns defensively — is_urgent comes back with
+            # a default so a rollback cannot reintroduce the BACKEND-12 crash.
+            reverse_sql=[
+                "ALTER TABLE inventory_assetproblem ADD COLUMN IF NOT EXISTS is_urgent boolean NOT NULL DEFAULT false;",
+                "ALTER TABLE inventory_assetproblem ADD COLUMN IF NOT EXISTS escalated_to_logistics boolean DEFAULT false;",
+                "ALTER TABLE inventory_assetproblem ADD COLUMN IF NOT EXISTS mitigation_notes text DEFAULT '';",
+            ],
+        ),
+    ]

--- a/backend/inventory/tests/test_asset_problem_orphan_columns.py
+++ b/backend/inventory/tests/test_asset_problem_orphan_columns.py
@@ -1,0 +1,37 @@
+"""Regression for Sentry BACKEND-12.
+
+Reporting an asset problem with only a description must succeed. Production's
+``inventory_assetproblem`` table had an orphan ``is_urgent`` column (NOT NULL,
+no default) that made every ``report_problem`` INSERT fail with a
+NotNullViolation; migration 0098 drops it. This guards the minimal-create path
+against future regressions.
+"""
+
+from django.contrib.auth import get_user_model
+
+import pytest
+from rest_framework.test import APIClient
+
+from inventory.models import AssetProblem
+from inventory.tests.factories import AssetFactory
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def test_report_asset_problem_with_only_description_succeeds():
+    asset = AssetFactory(name="Roof AHU")
+    user = User.objects.create_user(username="reporter", email="r@x.test", password="x")
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    resp = client.post(
+        f"/api/inventory/assets/{asset.id}/report_problem/",
+        data={"description": "Leaking from Roof pan"},
+        format="json",
+    )
+
+    assert resp.status_code == 201, resp.content
+    problem = AssetProblem.objects.get(id=resp.data["id"])
+    assert problem.description == "Leaking from Roof pan"
+    assert problem.asset_id == asset.id


### PR DESCRIPTION
## Fix: asset problem reporting 500s on prod (Sentry BACKEND-12)

### Symptom
Reporting a problem on an asset returns a server error. Sentry **BACKEND-12**: `NotNullViolation — null value in column "is_urgent" of relation "inventory_assetproblem"`, at `AssetViewSet.report_problem`.

### Root cause — schema drift
`is_urgent` **exists in neither the `AssetProblem` model nor any migration** (git pickaxe confirms it was never committed to the backend). Yet production's `inventory_assetproblem` table has it — along with two siblings — added **out-of-band** (manual `ALTER` / a since-deleted local migration):

| Column | Prod state | Breaks inserts? |
|--------|-----------|-----------------|
| `is_urgent` | NOT NULL, **no default** | **yes** |
| `escalated_to_logistics` | nullable, default `false` | no |
| `mitigation_notes` | nullable, default `''` | no |

`report_problem` inserts only `asset`/`reported_by`/`description`, so `is_urgent` gets no value → NOT NULL violation on every report. (They look like an abandoned "logistics escalation" experiment; prod's applied migrations otherwise match the repo.)

### Fix
Migration `0098` drops all three columns to reconcile the schema to the code (Ian's call: drop rather than keep/adopt). Guarded with `DROP COLUMN IF EXISTS`, so it's a **no-op on databases that never had them** (fresh dev/CI) and a clean drop on prod. RunSQL only — the model never declared these fields, so Django's migration state is untouched (`makemigrations --check` stays clean). Reverse re-adds them defensively (with a default on `is_urgent`, so a rollback can't reintroduce the crash). Plus a regression test posting the exact failing payload.

### Notes
- Diagnosis was read-only against prod; this PR is the only change, applied through the normal deploy (no prod hotfix). Takes effect on prod once merged + deployed (prod is currently a few migrations behind).
- CI exercises the migration + the report_problem path on a clean schema; the prod-specific `DROP` can't be reproduced in CI (the test DB never had the columns), but the SQL is a straightforward guarded drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
