### PR TITLE
fix(deploy): rebuild nginx on deploy so the Let's Encrypt fix (#934) actually ships

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -119,6 +119,16 @@ echo "📝 Using GIT_HASH=$GIT_HASH for build..."
 export GIT_HASH
 $COMPOSE build --no-cache frontend
 $COMPOSE build --no-cache backend
+# nginx bakes in certbot + the Let's Encrypt entrypoint
+# (nginx/docker-entrypoint.d/10-letsencrypt.sh) and the server template.
+# Historically it was NOT rebuilt here — only `restart`ed below — so changes to
+# nginx/Dockerfile, the entrypoint, or the template never reached prod. That is
+# why the #934 cert-lineage fix (stop pinning live/<domain>-00NN; follow the
+# live lineage via /etc/letsencrypt/nginx symlinks) stayed undeployed and TLS
+# certs kept needing manual resets every deploy. Build it so the `up -d` below
+# recreates the container from the freshly-built image. nginx is a locally-built
+# compose service (build: context: ./nginx), same mechanism as the two above.
+$COMPOSE build --no-cache nginx
 
 # Start only the database + redis so we can run migrations against the target DB
 # BEFORE the backend container starts serving traffic. This prevents the class of


### PR DESCRIPTION
## Fix: nginx (and the Let's Encrypt fix) never actually deploys — deploy.sh doesn't rebuild nginx

### Why the certs keep needing manual resets
The Let's Encrypt lineage fix (#934, already merged) makes nginx follow the live cert lineage via `/etc/letsencrypt/nginx/*` symlinks instead of a hardcoded `live/<domain>-00NN` path. But it has **never been live on prod — and structurally can't be**, because **`deploy.sh` only rebuilds `frontend` and `backend`; `nginx` is only `restart`ed, never rebuilt.**

Verified on prod (read-only probes only):
- Running `openmakersuite-nginx-1` still has the **old entrypoint** — 0 occurrences of the new `resolve_live_dir` logic — and the **old hardcoded config**: `ssl_certificate …/live/dms.openmakersuite.net-0032/…`.
- The artifacts #934 creates are all absent: no `/etc/letsencrypt/nginx/` symlink dir, no `/etc/letsencrypt/bootstrap/`, empty `renewal-hooks/deploy/` (dated Nov 2025).
- The lineage has kept forking (now `-0033`, ~34 lineages).

So every deploy/renewal keeps stranding nginx on a pinned lineage → the hand-resets. Any change to `nginx/Dockerfile`, `nginx/docker-entrypoint.d/*`, or the template has the same fate: it silently never ships.

### Fix
`deploy.sh` now also `build`s `nginx` alongside frontend/backend, so the existing `up -d` recreates the nginx container from the freshly-built image (with #934's entrypoint). nginx is a locally-built compose service (`build: context: ./nginx`) — same mechanism already used for the other two services. One line + a comment; no behavior change for anything else.

### #934's own logic verified out-of-band
CI never boots the nginx container (that's the blind spot the original `-0001` pin slipped through), so I smoke-tested the merged entrypoint locally:
- `sh -n` clean; the template renders and references the stable symlink.
- `resolve_live_dir` correctly **picks the highest valid CA-issued lineage** and **skips the self-signed bootstrap**, falling back to bootstrap only when no real cert exists.

So once this deploys, nginx follows the live `-0033` lineage and stops needing resets, and `--cert-name` keeps certbot renewing a single lineage in place instead of forking.

### Deploying
Because this changes `deploy.sh` itself, the first deploy that includes it should `git pull` **before** running `./deploy.sh` (a running invocation executes the pre-pull script). After that, a normal deploy rebuilds nginx and #934 goes live. Verify with (read-only): `docker compose -f docker-compose.prod.yml exec nginx readlink -f /etc/letsencrypt/nginx/fullchain.pem` — it should resolve into the current live lineage. (The ~33 old forked lineages are harmless clutter that can be cleaned up separately.)

> CI does not boot nginx, so this path isn't exercised by CI — verified out-of-band above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
