### PR TITLE
refactor(inventory): WorkOrder ⟂ MaintenanceItem — nullable item + direct asset link (op-svut, B1)

### DIFF
--- a/backend/inventory/admin.py
+++ b/backend/inventory/admin.py
@@ -2092,6 +2092,9 @@ class WorkOrderAdmin(admin.ModelAdmin):
     search_fields = [
         "maintenance_item__title",
         "maintenance_item__asset__name",
+        # Corrective work orders have no maintenance_item, so searching only
+        # through the template would make them unfindable by machine name.
+        "asset__name",
         "completed_by_name",
         "notes",
     ]

--- a/backend/inventory/migrations/0099_work_order_nullable_item_direct_asset.py
+++ b/backend/inventory/migrations/0099_work_order_nullable_item_direct_asset.py
@@ -1,0 +1,63 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def backfill_work_order_asset(apps, schema_editor):
+    """Populate the new direct asset FK from each WO's PM template.
+
+    Every pre-existing work order came from a ``MaintenanceItem``, so the
+    template's asset *is* the work order's asset. Done in one UPDATE...FROM-ish
+    subquery pass rather than row-by-row: this runs against production tables.
+    """
+    WorkOrder = apps.get_model("inventory", "WorkOrder")
+    MaintenanceItem = apps.get_model("inventory", "MaintenanceItem")
+
+    WorkOrder.objects.filter(asset__isnull=True, maintenance_item__isnull=False).update(
+        asset_id=models.Subquery(
+            MaintenanceItem.objects.filter(pk=models.OuterRef("maintenance_item_id")).values(
+                "asset_id"
+            )[:1]
+        )
+    )
+
+
+def unbackfill_work_order_asset(apps, schema_editor):
+    """No-op reverse: the column is dropped by the AddField reversal anyway."""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0098_drop_assetproblem_orphan_columns"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="workorder",
+            name="asset",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="The asset this work order is for",
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="work_orders",
+                to="inventory.asset",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="workorder",
+            name="maintenance_item",
+            field=models.ForeignKey(
+                blank=True,
+                help_text=(
+                    "The PM template this work order is for. Null for corrective work "
+                    "orders, which carry no template — read ``asset`` for the machine."
+                ),
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="work_orders",
+                to="inventory.maintenanceitem",
+            ),
+        ),
+        migrations.RunPython(backfill_work_order_asset, unbackfill_work_order_asset),
+    ]

--- a/backend/inventory/models/maintenance.py
+++ b/backend/inventory/models/maintenance.py
@@ -487,11 +487,33 @@ class WorkOrder(ElapsedTimerModel):
         COMPLETED = "completed", "Completed"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    # Optional: a *preventive* work order comes from a PM template, a
+    # *corrective* one comes from a reported problem and has no template at
+    # all. SET_NULL rather than CASCADE so deleting a retired PM template
+    # keeps the history of the work that was actually done under it.
     maintenance_item = models.ForeignKey(
         "MaintenanceItem",
-        on_delete=models.CASCADE,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
         related_name="work_orders",
-        help_text="The maintenance task this work order is for",
+        help_text=(
+            "The PM template this work order is for. Null for corrective work "
+            "orders, which carry no template — read ``asset`` for the machine."
+        ),
+    )
+    # The machine being worked on. Nullable in the schema (an FK can't be
+    # added non-null to an existing table), but populated on every row: when a
+    # ``maintenance_item`` is given and this is blank, ``save()`` derives it.
+    # Read this — never ``maintenance_item.asset`` — so corrective work orders
+    # are not silently dropped.
+    asset = models.ForeignKey(
+        "inventory.Asset",
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+        related_name="work_orders",
+        help_text="The asset this work order is for",
     )
     # Bundled sibling PMs on the same asset that were due around the
     # same time and got rolled into this work order via the auto-bundle
@@ -587,8 +609,40 @@ class WorkOrder(ElapsedTimerModel):
             models.Index(fields=["status", "-created_at"], name="wo_status_created_idx"),
         ]
 
+    def save(self, *args, **kwargs):
+        """Keep ``asset`` populated for every work order.
+
+        The column is nullable so the FK could be added to an existing table,
+        but the whole point of it is that downstream code can read
+        ``work_order.asset`` unconditionally. A preventive work order is
+        normally created with only ``maintenance_item=``, so derive the asset
+        from the template here rather than asking every caller to pass both.
+        """
+        if self.asset_id is None and self.maintenance_item_id:
+            self.asset_id = self.maintenance_item.asset_id
+            if "update_fields" in kwargs and kwargs["update_fields"] is not None:
+                kwargs["update_fields"] = list(kwargs["update_fields"]) + ["asset"]
+        super().save(*args, **kwargs)
+
+    @property
+    def display_title(self) -> str:
+        """What to call this work order on a screen, a report, or a form.
+
+        Preventive work orders are named by their PM template. Corrective ones
+        have no template, so they fall back to the reported problem and then to
+        the asset itself — a work order always has *something* to be called.
+        """
+        if self.maintenance_item_id:
+            return self.maintenance_item.title
+        problem = getattr(self, "asset_problem", None)
+        if problem is not None and problem.description:
+            return problem.description[:60]
+        if self.asset_id:
+            return self.asset.name
+        return self.short_id
+
     def __str__(self) -> str:
-        return f"WO-{str(self.id)[:8].upper()} — {self.maintenance_item.title} ({self.get_status_display()})"
+        return f"WO-{str(self.id)[:8].upper()} — {self.display_title} ({self.get_status_display()})"
 
     @property
     def is_overdue(self) -> bool:

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -2345,15 +2345,17 @@ def _pending_review_count(work_order) -> int:
 class WorkOrderSerializer(serializers.ModelSerializer):
     """Full serializer for a work order, including nested completions and photos."""
 
-    maintenance_item_title = serializers.CharField(source="maintenance_item.title", read_only=True)
-    asset_name = serializers.CharField(source="maintenance_item.asset.name", read_only=True)
-    asset_tag = serializers.CharField(source="maintenance_item.asset.asset_tag", read_only=True)
-    asset_id = serializers.UUIDField(source="maintenance_item.asset.id", read_only=True)
+    # Asset fields read the work order's own FK, not the PM template's: a
+    # corrective work order has no template and would otherwise lose its asset.
+    maintenance_item_title = serializers.SerializerMethodField()
+    asset_name = serializers.CharField(source="asset.name", read_only=True)
+    asset_tag = serializers.CharField(source="asset.asset_tag", read_only=True)
+    asset_id = serializers.UUIDField(source="asset.id", read_only=True)
     # The template's guess, carried alongside the stopwatch so the UI (and the
     # printed sign-off) can put actual next to estimate without a second fetch.
-    estimated_time_minutes = serializers.IntegerField(
-        source="maintenance_item.estimated_time_minutes", read_only=True
-    )
+    # Null for corrective work: nothing estimated it.
+    estimated_time_minutes = serializers.SerializerMethodField()
+    display_title = serializers.ReadOnlyField()
     assigned_to_name = serializers.SerializerMethodField()
     short_id = serializers.ReadOnlyField()
     is_overdue = serializers.ReadOnlyField()
@@ -2378,6 +2380,8 @@ class WorkOrderSerializer(serializers.ModelSerializer):
             "short_id",
             "maintenance_item",
             "maintenance_item_title",
+            "display_title",
+            "asset",
             "asset_name",
             "asset_tag",
             "asset_id",
@@ -2411,6 +2415,7 @@ class WorkOrderSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = [
             "short_id",
+            "display_title",
             "is_overdue",
             "created_at",
             "updated_at",
@@ -2430,6 +2435,33 @@ class WorkOrderSerializer(serializers.ModelSerializer):
             "validation",
             "reference_documents",
         ]
+
+    def validate(self, attrs):
+        """A work order is always *for* something — a PM template or an asset.
+
+        ``maintenance_item`` became nullable so corrective work orders can
+        exist; without this a POST that names neither would quietly create a
+        work order attached to nothing, which nothing downstream can render.
+        """
+        if self.instance is None:
+            item = attrs.get("maintenance_item")
+            asset = attrs.get("asset")
+            if item is None and asset is None:
+                raise serializers.ValidationError(
+                    "Provide either a maintenance_item (preventive) or an asset (corrective)."
+                )
+        return attrs
+
+    def get_maintenance_item_title(self, obj):
+        """The PM template's title, or None for corrective work.
+
+        Not ``display_title``: this key means "which template", and a caller
+        distinguishing preventive from corrective work reads it as such.
+        """
+        return obj.maintenance_item.title if obj.maintenance_item_id else None
+
+    def get_estimated_time_minutes(self, obj):
+        return obj.maintenance_item.estimated_time_minutes if obj.maintenance_item_id else None
 
     def get_pending_review_count(self, obj):
         return _pending_review_count(obj)
@@ -2471,12 +2503,12 @@ class WorkOrderSerializer(serializers.ModelSerializer):
     def get_electrical(self, obj):
         from .services.work_order_context import build_electrical_context
 
-        return build_electrical_context(obj.maintenance_item.asset)
+        return build_electrical_context(obj.asset)
 
     def get_loto(self, obj):
         from .services.work_order_context import build_loto_context
 
-        return build_loto_context(obj.maintenance_item.asset)
+        return build_loto_context(obj.asset)
 
     def get_validation(self, obj):
         latest = obj.validations.order_by("-validated_at").first()
@@ -2494,7 +2526,7 @@ class WorkOrderSerializer(serializers.ModelSerializer):
         from .services.work_order_context import build_reference_documents_context
 
         return build_reference_documents_context(
-            obj.maintenance_item.asset,
+            obj.asset,
             request=self.context.get("request"),
         )
 
@@ -2502,10 +2534,11 @@ class WorkOrderSerializer(serializers.ModelSerializer):
 class WorkOrderListSerializer(serializers.ModelSerializer):
     """Lightweight serializer for work order list views."""
 
-    maintenance_item_title = serializers.CharField(source="maintenance_item.title", read_only=True)
-    asset_name = serializers.CharField(source="maintenance_item.asset.name", read_only=True)
-    asset_tag = serializers.CharField(source="maintenance_item.asset.asset_tag", read_only=True)
-    asset_id = serializers.UUIDField(source="maintenance_item.asset.id", read_only=True)
+    maintenance_item_title = serializers.SerializerMethodField()
+    asset_name = serializers.CharField(source="asset.name", read_only=True)
+    asset_tag = serializers.CharField(source="asset.asset_tag", read_only=True)
+    asset_id = serializers.UUIDField(source="asset.id", read_only=True)
+    display_title = serializers.ReadOnlyField()
     short_id = serializers.ReadOnlyField()
     is_overdue = serializers.ReadOnlyField()
     task_completion_count = serializers.SerializerMethodField()
@@ -2520,6 +2553,8 @@ class WorkOrderListSerializer(serializers.ModelSerializer):
             "short_id",
             "maintenance_item",
             "maintenance_item_title",
+            "display_title",
+            "asset",
             "asset_name",
             "asset_tag",
             "asset_id",
@@ -2535,6 +2570,9 @@ class WorkOrderListSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
         ]
+
+    def get_maintenance_item_title(self, obj):
+        return obj.maintenance_item.title if obj.maintenance_item_id else None
 
     def get_task_completion_count(self, obj):
         return obj.task_completions.filter(is_completed=True).count()

--- a/backend/inventory/services/work_order_context.py
+++ b/backend/inventory/services/work_order_context.py
@@ -170,28 +170,37 @@ def build_loto_context(asset: "Asset") -> dict[str, Any]:
     }
 
 
-def sorted_maintenance_tools(maintenance_item: "MaintenanceItem") -> list["MaintenanceTool"]:
+def sorted_maintenance_tools(
+    maintenance_item: "MaintenanceItem | None",
+) -> list["MaintenanceTool"]:
     """A PM template's tools in display order: required first, then by name.
 
     Sorted in Python off ``.all()`` so a ``tools`` prefetch is used rather than
     a query per work order — an ``order_by()`` here would bypass that cache.
     Case-folded so ``Wrench`` and ``wrench`` sort together (a DB collation would
     do the same); the raw name breaks ties so the order is total.
+
+    Corrective work has no template, hence no tool list — ``None`` yields ``[]``.
     """
+    if maintenance_item is None:
+        return []
     return sorted(
         maintenance_item.tools.all(),
         key=lambda tool: (not tool.is_required, tool.name.casefold(), tool.name),
     )
 
 
-def build_tools_context(maintenance_item: "MaintenanceItem") -> list[dict[str, Any]]:
+def build_tools_context(maintenance_item: "MaintenanceItem | None") -> list[dict[str, Any]]:
     """The tool list both the WO detail page and the printed form render.
 
     Keys are a pinned contract — ScanTTY decodes this payload for the e-paper
     work order, so do not rename them. Only the primary maintenance item's
     tools: work orders that bundle ``additional_maintenance_items`` keep the
-    up-front list short and unambiguous.
+    up-front list short and unambiguous. Empty for a template-less (corrective)
+    work order.
     """
+    if maintenance_item is None:
+        return []
     return [
         {
             "id": str(tool.id),
@@ -385,7 +394,7 @@ def build_reference_documents_context(
 
 def build_work_order_context(work_order: "WorkOrder") -> dict[str, Any]:
     """Single source of truth for digital + PDF feature parity."""
-    asset = work_order.maintenance_item.asset
+    asset = work_order.asset
     return {
         "electrical": build_electrical_context(asset),
         "loto": build_loto_context(asset),

--- a/backend/inventory/services/work_order_ingest.py
+++ b/backend/inventory/services/work_order_ingest.py
@@ -435,17 +435,21 @@ def _apply_pm_submission(submission: WorkOrderSubmission, pdf_bytes: bytes) -> W
     work_order.save()
 
     if wo_became_complete:
+        # Corrective work orders have no PM template to advance, and
+        # ``MaintenanceLog.maintenance_item`` is non-nullable — there is no log
+        # to write for them. The work order's own completion stamp is the record.
         item = work_order.maintenance_item
-        item.last_completed_at = now
-        item.save(update_fields=["last_completed_at"])
-        MaintenanceLog.objects.create(
-            maintenance_item=item,
-            completed_by=None,
-            notes=(
-                f"Completed via emailed paper work order "
-                f"(submission {submission.id}, WO {work_order.short_id})."
-            ),
-        )
+        if item is not None:
+            item.last_completed_at = now
+            item.save(update_fields=["last_completed_at"])
+            MaintenanceLog.objects.create(
+                maintenance_item=item,
+                completed_by=None,
+                notes=(
+                    f"Completed via emailed paper work order "
+                    f"(submission {submission.id}, WO {work_order.short_id})."
+                ),
+            )
 
     # Apply auto-confidence CV detections inline; queue the rest.
     cv_notes_to_append: list[str] = []
@@ -655,18 +659,22 @@ def omr_confirm_completion(
     # A WO started on-screen and closed off a scanned sheet must not be left
     # with a clock running — same finalize the digital completion path uses.
     finalize_work_order_timers(work_order, now=now)
+    # No PM template on a corrective work order, and no MaintenanceLog either:
+    # the log's ``maintenance_item`` is non-nullable, so there is nothing to
+    # write. The elapsed time stays on the work order itself.
     item = work_order.maintenance_item
-    item.last_completed_at = now
-    item.save(update_fields=["last_completed_at"])
-    log = MaintenanceLog.objects.create(
-        maintenance_item=item,
-        completed_by=user if (user and getattr(user, "is_authenticated", False)) else None,
-        notes=(
-            f"Completed via reviewed scan "
-            f"(submission {submission.id}, WO {work_order.short_id})."
-        ),
-    )
-    apply_elapsed_to_log(log, work_order)
+    if item is not None:
+        item.last_completed_at = now
+        item.save(update_fields=["last_completed_at"])
+        log = MaintenanceLog.objects.create(
+            maintenance_item=item,
+            completed_by=user if (user and getattr(user, "is_authenticated", False)) else None,
+            notes=(
+                f"Completed via reviewed scan "
+                f"(submission {submission.id}, WO {work_order.short_id})."
+            ),
+        )
+        apply_elapsed_to_log(log, work_order)
     return True
 
 

--- a/backend/inventory/services/work_order_loto.py
+++ b/backend/inventory/services/work_order_loto.py
@@ -58,8 +58,9 @@ def create_loto_completions(work_order: "WorkOrder") -> "list[WorkOrderLotoCompl
     """
     from inventory.models import WorkOrderLotoCompletion
 
-    item = work_order.maintenance_item
-    asset = getattr(item, "asset", None) if item is not None else None
+    # Straight off the work order: a corrective WO has no PM template but is
+    # every bit as capable of needing the machine locked out.
+    asset = work_order.asset
     if asset is None:
         return []
 

--- a/backend/inventory/services/work_order_omr.py
+++ b/backend/inventory/services/work_order_omr.py
@@ -62,7 +62,10 @@ def dynamic_target_ids(work_order: "WorkOrder") -> list[str]:
     material_usage = list(work_order.material_usage.all())
     if material_usage:
         ids += [f"material_{mu.id}" for mu in material_usage]
-    else:
+    elif work_order.maintenance_item_id:
+        # Legacy fallback only: a work order with no usage rows borrows its PM
+        # template's material spec. Corrective work orders have no template,
+        # so they simply print no material boxes.
         ids += [f"materialspec_{mat.id}" for mat in work_order.maintenance_item.materials.all()]
 
     ids += [f"loto_{lc.id}" for lc in work_order.loto_completions.all()]

--- a/backend/inventory/services/work_order_reports.py
+++ b/backend/inventory/services/work_order_reports.py
@@ -1,0 +1,83 @@
+"""Asset → work-order traversal shared by the maintenance and asset reports.
+
+Every report that costs or counts maintenance walks *assets*, not work orders,
+so each one used to reach the work through ``asset.maintenance_items →
+work_orders``. That path only finds **preventive** work: a corrective work
+order has no ``MaintenanceItem`` at all and would be silently omitted from the
+cost total, the days-in-maintenance span, and the supplies list.
+
+This module is the one place that knows how to reach *all* of an asset's work
+orders. Use the two functions as a pair: :func:`prefetch_asset_work_orders`
+attaches both halves of the traversal to an ``Asset`` queryset, and
+:func:`iter_asset_work_orders` walks them without double-counting the overlap.
+"""
+
+from typing import TYPE_CHECKING, Iterator, Optional
+
+from django.db.models import Prefetch, QuerySet
+
+if TYPE_CHECKING:  # pragma: no cover — typing only
+    from inventory.models import MaintenanceItem, WorkOrder
+
+#: Where :func:`prefetch_asset_work_orders` parks the direct-FK half.
+DIRECT_WORK_ORDERS_ATTR = "_direct_work_orders"
+
+
+def prefetch_asset_work_orders(
+    asset_queryset: QuerySet,
+    work_order_queryset: QuerySet,
+) -> QuerySet:
+    """Attach both halves of the asset → work-order traversal in one call.
+
+    ``work_order_queryset`` is applied to *both* halves, so any window/status
+    filter a report needs holds on preventive and corrective work alike.
+    Bundled as one call rather than two exported ``Prefetch`` objects because
+    applying only one half is exactly the bug this module exists to prevent.
+    """
+    return asset_queryset.prefetch_related(
+        Prefetch("maintenance_items__work_orders", queryset=work_order_queryset),
+        Prefetch(
+            "work_orders",
+            # ``maintenance_item`` is read for every row yielded from this half;
+            # without this it is a query per corrective work order.
+            queryset=work_order_queryset.select_related("maintenance_item"),
+            to_attr=DIRECT_WORK_ORDERS_ATTR,
+        ),
+    )
+
+
+def iter_asset_work_orders(
+    asset,
+) -> Iterator[tuple["WorkOrder", Optional["MaintenanceItem"]]]:
+    """Yield ``(work_order, maintenance_item_or_None)`` for one asset, once each.
+
+    Preventive work orders reach the asset through their template and are
+    yielded with it; corrective ones have no template and are yielded with
+    ``None``. A preventive work order sits in both halves of the traversal —
+    it has a template *and* a direct asset FK — so ids already seen are
+    skipped, and a report that sums costs cannot double-count.
+
+    Requires :func:`prefetch_asset_work_orders` on the asset queryset; without
+    it the direct half is missing and corrective work would be dropped again,
+    so that is an error rather than a quiet under-count.
+    """
+    direct = getattr(asset, DIRECT_WORK_ORDERS_ATTR, None)
+    if direct is None:
+        raise AttributeError(
+            "iter_asset_work_orders() needs the asset queryset prepared by "
+            "prefetch_asset_work_orders(); "
+            f"Asset {asset.pk} has no {DIRECT_WORK_ORDERS_ATTR!r}."
+        )
+
+    seen: set = set()
+    for maintenance_item in asset.maintenance_items.all():
+        for work_order in maintenance_item.work_orders.all():
+            if work_order.id in seen:
+                continue
+            seen.add(work_order.id)
+            yield work_order, maintenance_item
+    for work_order in direct:
+        if work_order.id in seen:
+            continue
+        seen.add(work_order.id)
+        yield work_order, work_order.maintenance_item

--- a/backend/inventory/tests/test_work_order_corrective_foundation.py
+++ b/backend/inventory/tests/test_work_order_corrective_foundation.py
@@ -12,12 +12,12 @@ silently omitted the row, so these tests are the regression net for the whole
 refactor. The preventive path is asserted alongside where the two must agree.
 """
 
-from datetime import date, timedelta
+import importlib
+from datetime import timedelta
 from decimal import Decimal
 
+from django.apps import apps
 from django.contrib.auth import get_user_model
-from django.db import connection
-from django.db.migrations.executor import MigrationExecutor
 from django.utils import timezone
 
 import pytest
@@ -443,36 +443,48 @@ class TestReports:
 # ─────────────────────────────────────────────────────────────────────────────
 # Data migration
 # ─────────────────────────────────────────────────────────────────────────────
-START = [("inventory", "0098_drop_assetproblem_orphan_columns")]
-END = [("inventory", "0099_work_order_nullable_item_direct_asset")]
+class TestMigrationBackfill:
+    """The 0099 backfill, run against the live registry.
 
+    Deliberately *not* driven through ``MigrationExecutor``: rewinding the graph
+    needs ``transaction=True``, and that marker's post-test flush deletes
+    migration-seeded rows (the accounting chart of accounts) for every test that
+    runs after it in the same session. The backfill query is the part worth
+    testing, and calling it directly exercises exactly that.
+    """
 
-def _migrate(targets):
-    executor = MigrationExecutor(connection)
-    executor.migrate(targets)
-    executor.loader.build_graph()
-    return executor
+    @staticmethod
+    def _backfill():
+        migration = importlib.import_module(
+            "inventory.migrations.0099_work_order_nullable_item_direct_asset"
+        )
+        migration.backfill_work_order_asset(apps, None)
 
+    def test_a_pre_migration_row_ends_up_on_its_templates_asset(self):
+        wo = _preventive_wo()
+        expected_asset_id = wo.asset_id
+        # The pre-migration state: the column exists but was never populated.
+        WorkOrder.objects.filter(pk=wo.pk).update(asset=None)
 
-@pytest.mark.django_db(transaction=True)
-def test_migration_backfills_asset_from_the_template():
-    """Rows written before the FK existed must come out pointing at their asset."""
-    executor = _migrate(START)
-    old_apps = executor.loader.project_state(START).apps
-    try:
-        Asset = old_apps.get_model("inventory", "Asset")
-        MaintenanceItemModel = old_apps.get_model("inventory", "MaintenanceItem")
-        WorkOrderModel = old_apps.get_model("inventory", "WorkOrder")
+        self._backfill()
 
-        asset = Asset.objects.create(name="Legacy Mill", status="active")
-        item = MaintenanceItemModel.objects.create(asset=asset, title="Legacy PM", interval_days=30)
-        wo = WorkOrderModel.objects.create(maintenance_item=item, due_date=date.today())
+        assert WorkOrder.objects.get(pk=wo.pk).asset_id == expected_asset_id
 
-        _migrate(END)
+    def test_an_already_populated_row_is_left_alone(self):
+        """Idempotent: re-running must not reassign a work order's asset."""
+        other_asset = AssetFactory()
+        wo = _preventive_wo()
+        WorkOrder.objects.filter(pk=wo.pk).update(asset=other_asset)
 
-        migrated = WorkOrder.objects.get(pk=wo.pk)
-        assert migrated.asset_id == asset.id
-        assert migrated.maintenance_item_id == item.id
-    finally:
-        # Always leave the graph at HEAD, even if an assertion above blew up.
-        _migrate(END)
+        self._backfill()
+
+        assert WorkOrder.objects.get(pk=wo.pk).asset_id == other_asset.id
+
+    def test_a_template_less_row_is_skipped(self):
+        """Nothing to derive from — and no crash trying."""
+        wo = _corrective_wo()
+        WorkOrder.objects.filter(pk=wo.pk).update(asset=None)
+
+        self._backfill()
+
+        assert WorkOrder.objects.get(pk=wo.pk).asset_id is None

--- a/backend/inventory/tests/test_work_order_corrective_foundation.py
+++ b/backend/inventory/tests/test_work_order_corrective_foundation.py
@@ -1,0 +1,478 @@
+"""A work order without a PM template still works everywhere (op-svut).
+
+``WorkOrder.maintenance_item`` became nullable so a *corrective* work order —
+one raised from a reported problem rather than generated from a preventive
+schedule — can exist. Nothing in this file creates one through a product
+feature (there is no promote-a-problem action yet); each test builds the shape
+directly, ``WorkOrder(maintenance_item=None, asset=…)``, and drives it through
+a surface that used to reach the asset via ``maintenance_item.asset``.
+
+Every one of those surfaces would previously have raised ``AttributeError`` or
+silently omitted the row, so these tests are the regression net for the whole
+refactor. The preventive path is asserted alongside where the two must agree.
+"""
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.utils import timezone
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from inventory.models import (
+    MaintenanceItem,
+    MaintenanceMaterial,
+    WorkOrder,
+    WorkOrderMaterialUsage,
+)
+from inventory.serializers import WorkOrderListSerializer, WorkOrderSerializer
+from inventory.services.work_order_context import build_work_order_context
+from inventory.services.work_order_loto import create_loto_completions
+from inventory.services.work_order_omr import dynamic_target_ids
+from inventory.tests.factories import AssetFactory
+from inventory.utils.work_order_pdf import generate_work_order_omr_pdf, generate_work_order_pdf
+
+pytestmark = pytest.mark.django_db
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+def _corrective_wo(asset=None, **kwargs):
+    """The shape this whole bead exists for: an asset, no PM template."""
+    asset = asset or AssetFactory()
+    return WorkOrder.objects.create(maintenance_item=None, asset=asset, **kwargs)
+
+
+def _preventive_wo(asset=None, *, interval_days=30, title="Monthly inspection", **kwargs):
+    """The classic shape: created with only ``maintenance_item=``, as callers do."""
+    asset = asset or AssetFactory()
+    item = MaintenanceItem.objects.create(
+        asset=asset,
+        title=title,
+        description="Standard monthly checklist",
+        interval_days=interval_days,
+        estimated_time_minutes=45,
+    )
+    return WorkOrder.objects.create(maintenance_item=item, **kwargs)
+
+
+def _staff_client():
+    user = get_user_model().objects.create_user(
+        username="wo_corrective_staff",
+        email="staff@example.com",
+        password="pw-not-secret-test",  # noqa: S106 — test fixture
+        is_staff=True,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client, user
+
+
+def _used_material(work_order, *, cost_per_unit="4.00", quantity="3"):
+    """A consumed material so the cost/supplies reports have something to report.
+
+    ``MaintenanceMaterial`` hangs off a ``MaintenanceItem``, so the spec lives on
+    a template with no work orders of its own — it must not add cost rows of its
+    own to the reports under test.
+    """
+    spec_item = MaintenanceItem.objects.create(
+        asset=work_order.asset,
+        title="Material spec (no work orders)",
+        interval_days=None,
+    )
+    material = MaintenanceMaterial.objects.create(
+        maintenance_item=spec_item,
+        name="Filter cartridge",
+        quantity=Decimal(quantity),
+        unit="ea",
+        estimated_cost_per_unit=Decimal(cost_per_unit),
+    )
+    return WorkOrderMaterialUsage.objects.create(
+        work_order=work_order,
+        material=material,
+        material_name=material.name,
+        quantity_planned=Decimal(quantity),
+        quantity_used=Decimal(quantity),
+        unit="ea",
+        was_used=True,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Model: the asset invariant
+# ─────────────────────────────────────────────────────────────────────────────
+class TestAssetInvariant:
+    def test_save_backfills_asset_from_the_template(self):
+        """Every existing caller passes only ``maintenance_item=`` — still fine."""
+        wo = _preventive_wo()
+        assert wo.asset_id == wo.maintenance_item.asset_id
+
+    def test_backfill_survives_a_reload(self):
+        wo = _preventive_wo()
+        assert WorkOrder.objects.get(pk=wo.pk).asset_id == wo.maintenance_item.asset_id
+
+    def test_backfill_applies_on_a_partial_save(self):
+        """``update_fields`` must not pin the write to a column set without asset."""
+        wo = _preventive_wo()
+        expected_asset_id = wo.maintenance_item.asset_id
+        WorkOrder.objects.filter(pk=wo.pk).update(asset=None)
+
+        stale = WorkOrder.objects.get(pk=wo.pk)
+        stale.status = WorkOrder.Status.IN_PROGRESS
+        stale.save(update_fields=["status"])
+
+        assert WorkOrder.objects.get(pk=wo.pk).asset_id == expected_asset_id
+
+    def test_explicit_asset_is_not_overwritten(self):
+        asset = AssetFactory()
+        wo = _corrective_wo(asset)
+        assert wo.asset_id == asset.id
+        assert wo.maintenance_item_id is None
+
+    def test_deleting_the_template_keeps_the_work_order_and_its_asset(self):
+        """SET_NULL, not CASCADE: retiring a PM template must not erase history."""
+        wo = _preventive_wo()
+        asset_id = wo.asset_id
+        wo.maintenance_item.delete()
+
+        wo.refresh_from_db()
+        assert wo.maintenance_item_id is None
+        assert wo.asset_id == asset_id
+
+
+class TestDisplayTitle:
+    def test_preventive_uses_the_template_title(self):
+        wo = _preventive_wo(title="Quarterly belt change")
+        assert wo.display_title == "Quarterly belt change"
+
+    def test_corrective_falls_back_to_the_asset_name(self):
+        asset = AssetFactory(name="Bridgeport Mill")
+        assert _corrective_wo(asset).display_title == "Bridgeport Mill"
+
+    def test_str_uses_display_title(self):
+        """``__str__`` used to dereference the template unconditionally."""
+        asset = AssetFactory(name="Bridgeport Mill")
+        assert "Bridgeport Mill" in str(_corrective_wo(asset))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Serializers
+# ─────────────────────────────────────────────────────────────────────────────
+class TestSerializers:
+    def test_detail_reads_the_asset_off_the_work_order(self):
+        asset = AssetFactory(name="Laser Cutter", asset_tag="LC-1")
+        data = WorkOrderSerializer(_corrective_wo(asset)).data
+
+        assert data["asset_name"] == "Laser Cutter"
+        assert data["asset_tag"] == "LC-1"
+        assert data["asset_id"] == str(asset.id)
+
+    def test_detail_nulls_the_template_derived_keys(self):
+        """Keys stay present — a client reading them must not KeyError."""
+        data = WorkOrderSerializer(_corrective_wo()).data
+
+        assert data["maintenance_item"] is None
+        assert data["maintenance_item_title"] is None
+        assert data["estimated_time_minutes"] is None
+        assert data["tools"] == []
+
+    def test_detail_still_renders_asset_derived_blocks(self):
+        data = WorkOrderSerializer(_corrective_wo()).data
+
+        assert data["electrical"] is not None
+        assert data["loto"] is not None
+        assert data["reference_documents"]["documents"] == []
+
+    def test_detail_keeps_the_preventive_values(self):
+        wo = _preventive_wo(title="Quarterly belt change")
+        data = WorkOrderSerializer(wo).data
+
+        assert data["maintenance_item_title"] == "Quarterly belt change"
+        assert data["estimated_time_minutes"] == 45
+        assert data["asset_name"] == wo.asset.name
+
+    def test_display_title_is_exposed_on_both_serializers(self):
+        asset = AssetFactory(name="Bridgeport Mill")
+        wo = _corrective_wo(asset)
+
+        assert WorkOrderSerializer(wo).data["display_title"] == "Bridgeport Mill"
+        assert WorkOrderListSerializer(wo).data["display_title"] == "Bridgeport Mill"
+
+    def test_list_reads_the_asset_off_the_work_order(self):
+        asset = AssetFactory(name="Laser Cutter", asset_tag="LC-1")
+        data = WorkOrderListSerializer(_corrective_wo(asset)).data
+
+        assert data["asset_name"] == "Laser Cutter"
+        assert data["asset_tag"] == "LC-1"
+        assert data["asset_id"] == str(asset.id)
+        assert data["maintenance_item_title"] is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# API surface
+# ─────────────────────────────────────────────────────────────────────────────
+class TestWorkOrderApi:
+    def test_detail_endpoint_renders_a_corrective_work_order(self):
+        client, _ = _staff_client()
+        wo = _corrective_wo()
+
+        response = client.get(f"/api/inventory/work-orders/{wo.id}/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["asset_id"] == str(wo.asset_id)
+
+    def test_list_endpoint_renders_a_corrective_work_order(self):
+        client, _ = _staff_client()
+        wo = _corrective_wo()
+
+        response = client.get("/api/inventory/work-orders/")
+
+        ids = [row["id"] for row in response.data["results"]]
+        assert str(wo.id) in ids
+
+    def test_asset_filter_returns_both_kinds(self):
+        """A bare ``maintenance_item__asset_id=`` inner-joins corrective WOs away."""
+        client, _ = _staff_client()
+        asset = AssetFactory()
+        preventive = _preventive_wo(asset)
+        corrective = _corrective_wo(asset)
+
+        response = client.get(f"/api/inventory/work-orders/?asset={asset.id}")
+
+        ids = {row["id"] for row in response.data["results"]}
+        assert ids == {str(preventive.id), str(corrective.id)}
+
+    def test_create_without_a_template_or_asset_is_rejected(self):
+        """Nullable FK must not become a way to make a work order about nothing."""
+        client, _ = _staff_client()
+
+        response = client.post("/api/inventory/work-orders/", {}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_create_with_only_an_asset_is_accepted(self):
+        client, _ = _staff_client()
+        asset = AssetFactory()
+
+        response = client.post(
+            "/api/inventory/work-orders/", {"asset": str(asset.id)}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["asset_id"] == str(asset.id)
+        assert response.data["maintenance_item"] is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Printed form + OMR + LOTO
+# ─────────────────────────────────────────────────────────────────────────────
+class TestPrintedSurfaces:
+    def test_pdf_renders_without_a_template(self):
+        pdf = generate_work_order_pdf(_corrective_wo(), base_url="http://testserver")
+        assert pdf.startswith(b"%PDF")
+
+    def test_pdf_renders_with_material_usage_but_no_template(self):
+        """The materials block used to fall back to ``item.materials``."""
+        wo = _corrective_wo()
+        _used_material(wo)
+
+        assert generate_work_order_pdf(wo).startswith(b"%PDF")
+
+    def test_omr_form_and_template_map_build(self):
+        pdf, template_map = generate_work_order_omr_pdf(_corrective_wo())
+
+        assert pdf.startswith(b"%PDF")
+        assert template_map["regions"]
+
+    def test_omr_target_ids_skip_the_absent_material_spec(self):
+        """``materialspec_`` is a template fallback; there is no template here."""
+        assert dynamic_target_ids(_corrective_wo()) == []
+
+    def test_loto_rows_materialize_for_a_corrective_work_order(self):
+        from loto.models import AssetEnergySource
+
+        asset = AssetFactory()
+        AssetEnergySource.objects.create(
+            asset=asset,
+            source_type=AssetEnergySource.SOURCE_ELECTRICAL,
+            isolation_point="Wall disconnect",
+        )
+        wo = _corrective_wo(asset)
+
+        rows = create_loto_completions(wo)
+
+        assert len(rows) == 1
+        assert wo.loto_completions.count() == 1
+
+    def test_parity_context_reads_the_work_order_asset(self):
+        asset = AssetFactory(name="Bridgeport Mill")
+        context = build_work_order_context(_corrective_wo(asset))
+
+        assert context["tools"] == []
+        assert context["loto"] is not None
+        assert context["reference_documents"]["documents"] == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Reports — every one of these walked asset → maintenance_items → work_orders
+# ─────────────────────────────────────────────────────────────────────────────
+class TestReports:
+    def _completed_corrective(self, *, days_ago=2, cost_per_unit="4.00", quantity="3"):
+        wo = _corrective_wo(
+            status=WorkOrder.Status.COMPLETED,
+            completed_at=timezone.now() - timedelta(days=days_ago),
+        )
+        _used_material(wo, cost_per_unit=cost_per_unit, quantity=quantity)
+        return wo
+
+    def test_dashboard_lists_it_as_unscheduled_open_work(self):
+        client, _ = _staff_client()
+        asset = AssetFactory(name="Bridgeport Mill")
+        wo = _corrective_wo(asset)
+
+        response = client.get("/api/inventory/maintenance/dashboard/")
+
+        rows = {row["workorder_id"]: row for row in response.data["unscheduled"]}
+        assert str(wo.id) in rows
+        assert rows[str(wo.id)]["asset_name"] == "Bridgeport Mill"
+        assert rows[str(wo.id)]["problem"] == "Bridgeport Mill"
+
+    def test_dashboard_costs_it_from_used_materials(self):
+        client, _ = _staff_client()
+        wo = self._completed_corrective()
+
+        response = client.get("/api/inventory/maintenance/dashboard/")
+
+        by_asset = {row["asset_id"]: row for row in response.data["costs"]["by_asset"]}
+        assert Decimal(by_asset[str(wo.asset_id)]["total_cost"]) == Decimal("12.00")
+
+    def test_dashboard_does_not_double_count_preventive_work(self):
+        """A preventive WO sits in both halves of the union — count it once."""
+        client, _ = _staff_client()
+        asset = AssetFactory()
+        item = MaintenanceItem.objects.create(
+            asset=asset, title="Monthly", interval_days=30, estimated_cost=Decimal("25.00")
+        )
+        WorkOrder.objects.create(
+            maintenance_item=item,
+            status=WorkOrder.Status.COMPLETED,
+            completed_at=timezone.now() - timedelta(days=1),
+        )
+
+        response = client.get("/api/inventory/maintenance/dashboard/")
+
+        by_asset = {row["asset_id"]: row for row in response.data["costs"]["by_asset"]}
+        assert Decimal(by_asset[str(asset.id)]["total_cost"]) == Decimal("25.00")
+
+    def test_active_report_lists_it(self):
+        client, _ = _staff_client()
+        asset = AssetFactory(name="Bridgeport Mill")
+        wo = _corrective_wo(asset)
+
+        response = client.get("/api/inventory/maintenance/active/")
+
+        rows = {row["id"]: row for row in response.data["results"] if row["kind"] == "work_order"}
+        assert rows[str(wo.id)]["title"] == "Bridgeport Mill"
+        assert rows[str(wo.id)]["asset_name"] == "Bridgeport Mill"
+
+    def test_tco_counts_its_cost_and_maintenance_days(self):
+        # Closed the same day it was opened, so its one-day span lands inside
+        # the window (the span runs created_at → completed_at, not backwards).
+        client, _ = _staff_client()
+        wo = self._completed_corrective(days_ago=0)
+
+        response = client.get("/api/inventory/reports/assets/tco/")
+
+        rows = {row["asset_id"]: row for row in response.data}
+        assert Decimal(rows[str(wo.asset_id)]["unscheduled_maintenance_cost"]) == Decimal("12.00")
+        assert rows[str(wo.asset_id)]["maintenance_days_last_90"] == 1
+
+    def test_tco_does_not_double_count_preventive_work(self):
+        client, _ = _staff_client()
+        asset = AssetFactory()
+        item = MaintenanceItem.objects.create(
+            asset=asset, title="Monthly", interval_days=30, estimated_cost=Decimal("25.00")
+        )
+        WorkOrder.objects.create(
+            maintenance_item=item,
+            status=WorkOrder.Status.COMPLETED,
+            completed_at=timezone.now() - timedelta(days=1),
+        )
+
+        response = client.get("/api/inventory/reports/assets/tco/")
+
+        rows = {row["asset_id"]: row for row in response.data}
+        assert Decimal(rows[str(asset.id)]["scheduled_maintenance_cost"]) == Decimal("25.00")
+
+    def test_supplies_used_lists_its_consumables(self):
+        client, _ = _staff_client()
+        wo = self._completed_corrective()
+
+        response = client.get("/api/inventory/reports/assets/supplies_used/?period=past_month")
+
+        consumables = [
+            row
+            for row in response.data
+            if row["source"] == "consumable" and row.get("work_order_id") == str(wo.id)
+        ]
+        assert len(consumables) == 1
+        assert consumables[0]["item_name"] == "Filter cartridge"
+
+    def test_cost_recovery_includes_it_as_an_internal_service(self):
+        client, _ = _staff_client()
+        wo = self._completed_corrective()
+
+        response = client.get(
+            "/api/inventory/reports/assets/cost_recovery/",
+            {"asset_ids": str(wo.asset_id), "period": "past_month"},
+        )
+
+        blocks = {b["asset_id"]: b for b in response.data["assets"]}
+        services = [s for s in blocks[str(wo.asset_id)]["services"] if s["source"] == "pm"]
+        assert len(services) == 1
+        assert services[0]["description"] == wo.asset.name
+        assert Decimal(services[0]["estimated_cost"]) == Decimal("12.00")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Data migration
+# ─────────────────────────────────────────────────────────────────────────────
+START = [("inventory", "0098_drop_assetproblem_orphan_columns")]
+END = [("inventory", "0099_work_order_nullable_item_direct_asset")]
+
+
+def _migrate(targets):
+    executor = MigrationExecutor(connection)
+    executor.migrate(targets)
+    executor.loader.build_graph()
+    return executor
+
+
+@pytest.mark.django_db(transaction=True)
+def test_migration_backfills_asset_from_the_template():
+    """Rows written before the FK existed must come out pointing at their asset."""
+    executor = _migrate(START)
+    old_apps = executor.loader.project_state(START).apps
+    try:
+        Asset = old_apps.get_model("inventory", "Asset")
+        MaintenanceItemModel = old_apps.get_model("inventory", "MaintenanceItem")
+        WorkOrderModel = old_apps.get_model("inventory", "WorkOrder")
+
+        asset = Asset.objects.create(name="Legacy Mill", status="active")
+        item = MaintenanceItemModel.objects.create(asset=asset, title="Legacy PM", interval_days=30)
+        wo = WorkOrderModel.objects.create(maintenance_item=item, due_date=date.today())
+
+        _migrate(END)
+
+        migrated = WorkOrder.objects.get(pk=wo.pk)
+        assert migrated.asset_id == asset.id
+        assert migrated.maintenance_item_id == item.id
+    finally:
+        # Always leave the graph at HEAD, even if an assertion above blew up.
+        _migrate(END)

--- a/backend/inventory/tests/test_work_order_ingest.py
+++ b/backend/inventory/tests/test_work_order_ingest.py
@@ -314,9 +314,11 @@ class TestApplySubmission:
     def test_unknown_work_order_id_marks_failed(self):
         wo = _make_work_order(num_tasks=1)
         pdf_bytes = generate_work_order_pdf(wo, base_url="http://example.com")
-        # Delete the WO so the id in the PDF no longer resolves.
+        # Delete the WO so the id in the PDF no longer resolves. Deleting the
+        # maintenance item no longer does it: that FK is SET_NULL now (op-svut),
+        # so the work order outlives its PM template.
         wo_id = wo.id
-        wo.maintenance_item.delete()  # cascades
+        wo.delete()
 
         submission = WorkOrderSubmission()
         submission.attachment.save("wo.pdf", ContentFile(pdf_bytes), save=False)

--- a/backend/inventory/utils/work_order_pdf.py
+++ b/backend/inventory/utils/work_order_pdf.py
@@ -489,8 +489,11 @@ def generate_work_order_pdf(
         fontName="Helvetica-Bold",
     )
 
+    # ``item`` is None for a corrective work order — every template-derived
+    # block below is guarded. The asset always exists, and comes off the work
+    # order directly rather than through the template.
     item = work_order.maintenance_item
-    asset = item.asset
+    asset = work_order.asset
 
     # ── Header row: title + QR code ──────────────────────────────────────────
     digital_url = f"{base_url}/maintenance/work-orders/{work_order.id}"
@@ -506,7 +509,7 @@ def generate_work_order_pdf(
             qr_image,
         ],
         [
-            Paragraph(item.title, subheading_style),
+            Paragraph(work_order.display_title, subheading_style),
             Paragraph(
                 "<font size='7' color='#666666'>Scan to open digital version</font>",
                 small_style,
@@ -798,19 +801,21 @@ def generate_work_order_pdf(
         story.append(Spacer(1, 8))
 
     # ── Task description ──────────────────────────────────────────────────────
-    if item.description:
+    if item and item.description:
         story.append(Paragraph("Task Description", subheading_style))
         story.append(Paragraph(item.description, normal_style))
         story.append(Spacer(1, 4))
 
     # ── Estimated time/cost ───────────────────────────────────────────────────
+    # All three come off the PM template; corrective work has no estimate.
     meta_parts = []
-    if item.estimated_time_minutes:
-        meta_parts.append(f"Est. Time: {item.estimated_time_minutes} min")
-    if item.estimated_cost:
-        meta_parts.append(f"Est. Cost: ${item.estimated_cost:.2f}")
-    if item.interval_days:
-        meta_parts.append(f"Interval: every {item.interval_days} days")
+    if item:
+        if item.estimated_time_minutes:
+            meta_parts.append(f"Est. Time: {item.estimated_time_minutes} min")
+        if item.estimated_cost:
+            meta_parts.append(f"Est. Cost: ${item.estimated_cost:.2f}")
+        if item.interval_days:
+            meta_parts.append(f"Interval: every {item.interval_days} days")
     if meta_parts:
         story.append(Paragraph("  |  ".join(meta_parts), small_style))
         story.append(Spacer(1, 4))
@@ -827,11 +832,13 @@ def generate_work_order_pdf(
             (f"material_{mu.id}", mu.material_name, mu.quantity_planned, mu.unit, "")
             for mu in material_usage_rows
         ]
-    else:
+    elif item:
         material_checklist = [
             (f"materialspec_{mat.id}", mat.name, mat.quantity, mat.unit, mat.notes or "")
             for mat in item.materials.all()
         ]
+    else:
+        material_checklist = []
 
     if material_checklist:
         story.append(Paragraph("Materials Required", subheading_style))
@@ -938,7 +945,7 @@ def generate_work_order_pdf(
         story.append(task_table)
         story.append(Paragraph("✱ = Required step", small_style))
         story.append(Spacer(1, 8))
-    elif item.instructions:
+    elif item and item.instructions:
         # Fall back to instructions text if no structured tasks
         story.append(Paragraph("Instructions", subheading_style))
         story.append(Paragraph(item.instructions, normal_style))

--- a/backend/inventory/utils/work_order_pdf.py
+++ b/backend/inventory/utils/work_order_pdf.py
@@ -509,7 +509,10 @@ def generate_work_order_pdf(
             qr_image,
         ],
         [
-            Paragraph(work_order.display_title, subheading_style),
+            # Operator-entered (a PM title, an asset name, or a problem
+            # description) and headed for a reportlab Paragraph, which parses a
+            # mini-XML dialect — escape it like every other such string here.
+            Paragraph(escape(work_order.display_title, quote=False), subheading_style),
             Paragraph(
                 "<font size='7' color='#666666'>Scan to open digital version</font>",
                 small_style,

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -5989,9 +5989,9 @@ class AssetReportViewSet(viewsets.ViewSet):
                 }
             )
 
-        # Consumable usage: materials marked used on a completed PM work order.
-        # Reuse tco's asset -> maintenance_items -> work_orders -> material_usage
-        # prefetch traversal to avoid N+1.
+        # Consumable usage: materials marked used on a completed internal work
+        # order, preventive or corrective. Same prefetch traversal tco uses, so
+        # this stays a fixed number of queries.
         assets = prefetch_asset_work_orders(
             Asset.objects.all(),
             WorkOrder.objects.prefetch_related("material_usage__material"),

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -3039,6 +3039,7 @@ class LocationProblemViewSet(viewsets.ReadOnlyModelViewSet):
         with transaction.atomic():
             wo = WorkOrder.objects.create(
                 maintenance_item=mi,
+                asset=mi.asset,
                 notes=problem.description,
                 assigned_to=request.user if request.user.is_authenticated else None,
             )
@@ -3983,6 +3984,11 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
             "maintenance_item__asset__location",
             "maintenance_item__asset__manufacturer",
             "maintenance_item__asset__category",
+            # The work order's own asset — the one every serializer field and
+            # context builder reads, and the only one a corrective WO has.
+            "asset__location",
+            "asset__manufacturer",
+            "asset__category",
             "assigned_to",
         )
         .prefetch_related(
@@ -4007,6 +4013,7 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
             # then walked in Python off this cache, so a deep supersedes chain
             # costs nothing extra.
             "maintenance_item__asset__documents",
+            "asset__documents",
         )
         .all()
     )
@@ -4028,7 +4035,10 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(maintenance_item_id=maintenance_item)
         asset = self.request.query_params.get("asset")
         if asset:
-            queryset = queryset.filter(maintenance_item__asset_id=asset)
+            # Both sides of the union: a bare ``maintenance_item__asset_id=``
+            # is an INNER JOIN through the (now nullable) template, which would
+            # silently drop every corrective work order on this asset.
+            queryset = queryset.filter(Q(maintenance_item__asset_id=asset) | Q(asset_id=asset))
         wo_status = self.request.query_params.get("status")
         if wo_status:
             queryset = queryset.filter(status=wo_status)
@@ -4281,7 +4291,10 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
             actor=self.request.user,
             work_order=work_order,
             metadata={
-                "maintenance_item_id": str(work_order.maintenance_item_id),
+                "maintenance_item_id": (
+                    str(work_order.maintenance_item_id) if work_order.maintenance_item_id else None
+                ),
+                "asset_id": str(work_order.asset_id) if work_order.asset_id else None,
                 "due_date": work_order.due_date.isoformat() if work_order.due_date else None,
             },
         )
@@ -5205,6 +5218,7 @@ class MaintenanceItemViewSet(viewsets.ModelViewSet):
             )
             wo = WorkOrder.objects.create(
                 maintenance_item=item,
+                asset=item.asset,
                 due_date=due_date,
                 notes=request.data.get("notes", ""),
             )
@@ -5269,6 +5283,7 @@ class MaintenanceItemViewSet(viewsets.ModelViewSet):
                 due_date = next_due.date() if next_due else now.date()
                 wo = WorkOrder.objects.create(
                     maintenance_item=item,
+                    asset=item.asset,
                     due_date=due_date,
                 )
                 for task in item.tasks.order_by("order", "title"):
@@ -5313,7 +5328,10 @@ class MaintenanceDashboardViewSet(viewsets.ViewSet):
         filter on completed_at; the by_asset rollup uses the trailing 90 days
         and reports days_in_maintenance_90d the same way TCO does.
         """
-        from django.db.models import Prefetch
+        from .services.work_order_reports import (
+            iter_asset_work_orders,
+            prefetch_asset_work_orders,
+        )
 
         now = timezone.now()
         today = now.date()
@@ -5362,21 +5380,26 @@ class MaintenanceDashboardViewSet(viewsets.ViewSet):
             WorkOrder.Status.IN_PROGRESS,
             WorkOrder.Status.BLOCKED,
         ]
+        # "Unscheduled" = open work that isn't on a recurring interval: a
+        # one-off PM (template with no ``interval_days``) or a corrective work
+        # order, which has no template at all. The template-less arm is spelled
+        # out rather than left to join promotion — this must not depend on how
+        # the ORM chooses to join a nullable FK.
         unscheduled_qs = (
-            WorkOrder.objects.filter(
-                status__in=open_statuses,
-                maintenance_item__interval_days__isnull=True,
+            WorkOrder.objects.filter(status__in=open_statuses)
+            .filter(
+                Q(maintenance_item__isnull=True) | Q(maintenance_item__interval_days__isnull=True)
             )
-            .select_related("maintenance_item__asset")
+            .select_related("maintenance_item", "asset")
             .order_by("created_at")
         )
         unscheduled = [
             {
                 "workorder_id": str(wo.id),
                 "short_id": wo.short_id,
-                "asset_id": str(wo.maintenance_item.asset_id),
-                "asset_name": wo.maintenance_item.asset.name,
-                "problem": wo.maintenance_item.title,
+                "asset_id": str(wo.asset_id) if wo.asset_id else None,
+                "asset_name": wo.asset.name if wo.asset_id else "",
+                "problem": wo.display_title,
                 "opened_at": wo.created_at.isoformat(),
                 "status": wo.status,
             }
@@ -5403,7 +5426,9 @@ class MaintenanceDashboardViewSet(viewsets.ViewSet):
 
         for wo in completed_qs:
             mi = wo.maintenance_item
-            if mi.interval_days is not None:
+            # No template means no estimate to draw on: cost such a work order
+            # from the materials actually used, same as a one-off PM.
+            if mi is not None and mi.interval_days is not None:
                 cost = mi.estimated_cost or Decimal("0.00")
             else:
                 cost = Decimal("0.00")
@@ -5418,41 +5443,37 @@ class MaintenanceDashboardViewSet(viewsets.ViewSet):
                 if completed_date >= start:
                     per_period[key] += cost
 
-        assets = Asset.objects.all().prefetch_related(
-            Prefetch(
-                "maintenance_items__work_orders",
-                queryset=WorkOrder.objects.prefetch_related("material_usage__material"),
-            )
+        assets = prefetch_asset_work_orders(
+            Asset.objects.all(),
+            WorkOrder.objects.prefetch_related("material_usage__material"),
         )
         by_asset = []
         for asset in assets:
             days_set: set = set()
             total_cost = Decimal("0.00")
-            for mi in asset.maintenance_items.all():
-                for wo in mi.work_orders.all():
-                    wo_start = wo.created_at.date()
-                    wo_end = wo.completed_at.date() if wo.completed_at else today
-                    span_start = max(wo_start, window_start_date)
-                    span_end = min(wo_end, today)
-                    if span_start <= span_end:
-                        d = span_start
-                        while d <= span_end:
-                            days_set.add(d)
-                            d += timedelta(days=1)
-                    if (
-                        wo.status == WorkOrder.Status.COMPLETED
-                        and wo.completed_at is not None
-                        and window_start_date <= wo.completed_at.date() <= today
-                    ):
-                        if mi.interval_days is not None:
-                            total_cost += mi.estimated_cost or Decimal("0.00")
-                        else:
-                            for usage in wo.material_usage.all():
-                                if usage.was_used and usage.material is not None:
-                                    total_cost += (
-                                        usage.quantity_planned
-                                        * usage.material.estimated_cost_per_unit
-                                    )
+            for wo, mi in iter_asset_work_orders(asset):
+                wo_start = wo.created_at.date()
+                wo_end = wo.completed_at.date() if wo.completed_at else today
+                span_start = max(wo_start, window_start_date)
+                span_end = min(wo_end, today)
+                if span_start <= span_end:
+                    d = span_start
+                    while d <= span_end:
+                        days_set.add(d)
+                        d += timedelta(days=1)
+                if (
+                    wo.status == WorkOrder.Status.COMPLETED
+                    and wo.completed_at is not None
+                    and window_start_date <= wo.completed_at.date() <= today
+                ):
+                    if mi is not None and mi.interval_days is not None:
+                        total_cost += mi.estimated_cost or Decimal("0.00")
+                    else:
+                        for usage in wo.material_usage.all():
+                            if usage.was_used and usage.material is not None:
+                                total_cost += (
+                                    usage.quantity_planned * usage.material.estimated_cost_per_unit
+                                )
             if asset.status == Asset.Status.MAINTENANCE:
                 days_set.add(today)
             if not days_set and total_cost == 0:
@@ -5508,7 +5529,7 @@ class MaintenanceDashboardViewSet(viewsets.ViewSet):
 
         for wo in (
             WorkOrder.objects.filter(status__in=open_wo_statuses)
-            .select_related("maintenance_item__asset")
+            .select_related("maintenance_item", "asset")
             .order_by("-created_at")
         ):
             rows.append(
@@ -5516,11 +5537,11 @@ class MaintenanceDashboardViewSet(viewsets.ViewSet):
                     "kind": "work_order",
                     "id": str(wo.id),
                     "short_id": wo.short_id,
-                    "title": wo.maintenance_item.title,
+                    "title": wo.display_title,
                     "status": wo.status,
                     "status_display": wo.get_status_display(),
-                    "asset_id": str(wo.maintenance_item.asset_id),
-                    "asset_name": wo.maintenance_item.asset.name,
+                    "asset_id": str(wo.asset_id) if wo.asset_id else None,
+                    "asset_name": wo.asset.name if wo.asset_id else "",
                     "location_id": None,
                     "location_name": None,
                     "severity": None,
@@ -5788,6 +5809,10 @@ class AssetReportViewSet(viewsets.ViewSet):
         from maintenance_orders.models import ThirdPartyWorkOrder, ThirdPartyWorkOrderAsset
 
         from .serializers import AssetTcoReportSerializer
+        from .services.work_order_reports import (
+            iter_asset_work_orders,
+            prefetch_asset_work_orders,
+        )
 
         today = timezone.now().date()
         window_start = today - timedelta(days=90)
@@ -5798,11 +5823,10 @@ class AssetReportViewSet(viewsets.ViewSet):
             work_order__closed_at__date__lte=today,
         )
 
-        assets = Asset.objects.all().prefetch_related(
-            Prefetch(
-                "maintenance_items__work_orders",
-                queryset=WorkOrder.objects.prefetch_related("material_usage__material"),
-            ),
+        assets = prefetch_asset_work_orders(
+            Asset.objects.all(),
+            WorkOrder.objects.prefetch_related("material_usage__material"),
+        ).prefetch_related(
             Prefetch(
                 "third_party_work_order_links",
                 queryset=vendor_link_qs,
@@ -5816,32 +5840,32 @@ class AssetReportViewSet(viewsets.ViewSet):
             scheduled = Decimal("0.00")
             unscheduled = Decimal("0.00")
 
-            for mi in asset.maintenance_items.all():
-                for wo in mi.work_orders.all():
-                    wo_start = wo.created_at.date()
-                    wo_end = wo.completed_at.date() if wo.completed_at else today
-                    span_start = max(wo_start, window_start)
-                    span_end = min(wo_end, today)
-                    if span_start <= span_end:
-                        d = span_start
-                        while d <= span_end:
-                            days_set.add(d)
-                            d += timedelta(days=1)
+            for wo, mi in iter_asset_work_orders(asset):
+                wo_start = wo.created_at.date()
+                wo_end = wo.completed_at.date() if wo.completed_at else today
+                span_start = max(wo_start, window_start)
+                span_end = min(wo_end, today)
+                if span_start <= span_end:
+                    d = span_start
+                    while d <= span_end:
+                        days_set.add(d)
+                        d += timedelta(days=1)
 
-                    if (
-                        wo.status == WorkOrder.Status.COMPLETED
-                        and wo.completed_at is not None
-                        and window_start <= wo.completed_at.date() <= today
-                    ):
-                        if mi.interval_days is not None:
-                            scheduled += mi.estimated_cost or Decimal("0.00")
-                        else:
-                            for usage in wo.material_usage.all():
-                                if usage.was_used and usage.material is not None:
-                                    unscheduled += (
-                                        usage.quantity_planned
-                                        * usage.material.estimated_cost_per_unit
-                                    )
+                if (
+                    wo.status == WorkOrder.Status.COMPLETED
+                    and wo.completed_at is not None
+                    and window_start <= wo.completed_at.date() <= today
+                ):
+                    # Corrective work has no template estimate, so it costs
+                    # like a one-off PM: the materials it actually consumed.
+                    if mi is not None and mi.interval_days is not None:
+                        scheduled += mi.estimated_cost or Decimal("0.00")
+                    else:
+                        for usage in wo.material_usage.all():
+                            if usage.was_used and usage.material is not None:
+                                unscheduled += (
+                                    usage.quantity_planned * usage.material.estimated_cost_per_unit
+                                )
 
             vendor = Decimal("0.00")
             for link in getattr(asset, "_tco_vendor_links", []):
@@ -5929,7 +5953,10 @@ class AssetReportViewSet(viewsets.ViewSet):
         Query params ``start_date``/``end_date`` (``YYYY-MM-DD``) default to the
         last 30 days. Rows are sorted by ``asset_name`` then ``used_at``.
         """
-        from django.db.models import Prefetch
+        from .services.work_order_reports import (
+            iter_asset_work_orders,
+            prefetch_asset_work_orders,
+        )
 
         start_date, end_date = self._supplies_window(request)
 
@@ -5965,43 +5992,40 @@ class AssetReportViewSet(viewsets.ViewSet):
         # Consumable usage: materials marked used on a completed PM work order.
         # Reuse tco's asset -> maintenance_items -> work_orders -> material_usage
         # prefetch traversal to avoid N+1.
-        assets = Asset.objects.all().prefetch_related(
-            Prefetch(
-                "maintenance_items__work_orders",
-                queryset=WorkOrder.objects.prefetch_related("material_usage__material"),
-            ),
+        assets = prefetch_asset_work_orders(
+            Asset.objects.all(),
+            WorkOrder.objects.prefetch_related("material_usage__material"),
         )
         for asset in assets:
-            for mi in asset.maintenance_items.all():
-                for wo in mi.work_orders.all():
-                    if wo.status != WorkOrder.Status.COMPLETED or wo.completed_at is None:
+            for wo, _mi in iter_asset_work_orders(asset):
+                if wo.status != WorkOrder.Status.COMPLETED or wo.completed_at is None:
+                    continue
+                completed_date = wo.completed_at.date()
+                if not (start_date <= completed_date <= end_date):
+                    continue
+                for usage in wo.material_usage.all():
+                    if not usage.was_used:
                         continue
-                    completed_date = wo.completed_at.date()
-                    if not (start_date <= completed_date <= end_date):
-                        continue
-                    for usage in wo.material_usage.all():
-                        if not usage.was_used:
-                            continue
-                        estimated_cost = None
-                        if usage.material is not None:
-                            estimated_cost = str(
-                                (
-                                    usage.quantity_planned * usage.material.estimated_cost_per_unit
-                                ).quantize(Decimal("0.01"))
-                            )
-                        rows.append(
-                            {
-                                "asset_id": str(asset.id),
-                                "asset_name": asset.name,
-                                "source": "consumable",
-                                "item_name": usage.material_name,
-                                "quantity": str(usage.quantity_planned),
-                                "unit": usage.unit,
-                                "used_at": wo.completed_at,
-                                "work_order_id": str(wo.id),
-                                "estimated_cost": estimated_cost,
-                            }
+                    estimated_cost = None
+                    if usage.material is not None:
+                        estimated_cost = str(
+                            (
+                                usage.quantity_planned * usage.material.estimated_cost_per_unit
+                            ).quantize(Decimal("0.01"))
                         )
+                    rows.append(
+                        {
+                            "asset_id": str(asset.id),
+                            "asset_name": asset.name,
+                            "source": "consumable",
+                            "item_name": usage.material_name,
+                            "quantity": str(usage.quantity_planned),
+                            "unit": usage.unit,
+                            "used_at": wo.completed_at,
+                            "work_order_id": str(wo.id),
+                            "estimated_cost": estimated_cost,
+                        }
+                    )
 
         # Sort on the aware datetimes, then serialize used_at to ISO-8601.
         rows.sort(key=lambda r: (r["asset_name"], r["used_at"]))
@@ -6113,8 +6137,11 @@ class AssetReportViewSet(viewsets.ViewSet):
         one-off task contributes the sum of its used materials
         (``quantity_planned * material.estimated_cost_per_unit``). Internal PM
         has no actual-cost source, so this feeds the Estimated column only.
+
+        A corrective work order has no template to estimate from
+        (``maintenance_item is None``), so it costs like a one-off: materials.
         """
-        if maintenance_item.interval_days is not None:
+        if maintenance_item is not None and maintenance_item.interval_days is not None:
             return maintenance_item.estimated_cost or Decimal("0.00")
         total = Decimal("0.00")
         for usage in work_order.material_usage.all():
@@ -6216,6 +6243,10 @@ class AssetReportViewSet(viewsets.ViewSet):
         from maintenance_orders.models import ThirdPartyWorkOrder, ThirdPartyWorkOrderAsset
 
         from .serializers import AssetCostRecoveryReportSerializer
+        from .services.work_order_reports import (
+            iter_asset_work_orders,
+            prefetch_asset_work_orders,
+        )
 
         asset_ids, category_ids = self._cost_recovery_selection(request)
         start_date, end_date, period_label = self._cost_recovery_window(request)
@@ -6254,10 +6285,11 @@ class AssetReportViewSet(viewsets.ViewSet):
         )
 
         assets = (
-            Asset.objects.filter(id__in=selected_ids)
-            .select_related("category")
+            prefetch_asset_work_orders(
+                Asset.objects.filter(id__in=selected_ids).select_related("category"),
+                pm_wo_qs,
+            )
             .prefetch_related(
-                Prefetch("maintenance_items__work_orders", queryset=pm_wo_qs),
                 Prefetch(
                     "third_party_work_order_links",
                     queryset=vendor_link_qs,
@@ -6275,18 +6307,18 @@ class AssetReportViewSet(viewsets.ViewSet):
 
         for asset in assets:
             services = []
-            # Internal PM — estimated only (no actual-cost source).
-            for mi in asset.maintenance_items.all():
-                for wo in mi.work_orders.all():
-                    services.append(
-                        {
-                            "date": wo.completed_at.date(),
-                            "source": "pm",
-                            "description": mi.title,
-                            "estimated_cost": self._pm_estimated_cost(mi, wo),
-                            "actual_cost": None,
-                        }
-                    )
+            # Internal work — estimated only (no actual-cost source). Covers
+            # both preventive (from a template) and corrective work orders.
+            for wo, mi in iter_asset_work_orders(asset):
+                services.append(
+                    {
+                        "date": wo.completed_at.date(),
+                        "source": "pm",
+                        "description": wo.display_title,
+                        "estimated_cost": self._pm_estimated_cost(mi, wo),
+                        "actual_cost": None,
+                    }
+                )
             # Vendor — actual = per-asset allocated_cost (the recoverable spend).
             for link in getattr(asset, "_cr_vendor_links", []):
                 wo = link.work_order

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -5941,10 +5941,10 @@ class AssetReportViewSet(viewsets.ViewSet):
           windowed by the event timestamp ``at``. Extra keys: ``serial_number``,
           ``action``, ``action_display``, ``actor``.
         - ``source == "consumable"`` — a bulk maintenance material actually used
-          while closing a preventive-maintenance work order. Sourced from
-          ``WorkOrderMaterialUsage`` rows with ``was_used=True``, reached via
-          ``asset -> maintenance_items -> work_orders -> material_usage`` and
-          windowed by the work order's ``completed_at`` date (the same field
+          while closing an internal work order, preventive or corrective.
+          Sourced from ``WorkOrderMaterialUsage`` rows with ``was_used=True``,
+          reached via ``iter_asset_work_orders`` (both the PM-template path and
+          the direct asset FK) and windowed by the ``completed_at`` date (the same field
           ``tco`` uses). Extra keys: ``quantity`` (planned qty), ``unit``,
           ``work_order_id``, ``estimated_cost`` (``quantity`` ×
           ``material.estimated_cost_per_unit``; null if the material was


### PR DESCRIPTION
## B1 — WorkOrder ⟂ MaintenanceItem (foundation)

First PR of the corrective-work-order epic (bead **op-svut**). Behavior-preserving refactor that decouples `WorkOrder` from a required `MaintenanceItem`, so a later "corrective" work order (generated from a reported `AssetProblem`) can carry its asset directly instead of hanging off a recurring PM item.

### Changes
- `WorkOrder.maintenance_item` → **nullable** (`CASCADE`→`SET_NULL`); new direct **`WorkOrder.asset`** FK (`PROTECT`), backfilled by migration `0099` and kept populated by `WorkOrder.save()` (so every existing creation path is untouched and `wo.asset` is always present).
- Added `WorkOrder.display_title`.
- Repointed every asset read from `maintenance_item.asset` → `wo.asset`: both WO serializers (with `maintenance_item_title`/`estimated_time_minutes` now null-safe method fields), `work_order_context` / `pdf` / `loto` / `omr` / `ingest` (the ingest path skips the `MaintenanceLog` write — its `maintenance_item` is non-nullable), the `?asset=` filter (Q-union rather than a silently-dropping INNER JOIN), audit metadata, admin search, and the 3 PM creation paths now pass `asset=` explicitly.
- New `inventory/services/work_order_reports.py` owns the dedup'd PM + corrective `asset → WO` traversal, wired into the dashboard `by_asset` / `active` / `tco` / `supplies_used` / `cost_recovery` reports (all of which previously walked `asset.maintenance_items → work_orders` and would have silently omitted corrective WOs).

### Scope call-out
A nullable FK turned `POST /work-orders/` with no `maintenance_item` from a 400 into a WO attached to nothing, so `asset` is now a writable serializer field and `validate()` requires exactly one of `maintenance_item`/`asset`. Deliberately left alone: the analytics forecast `last_wo_at` (a repair isn't a PM completion).

### Tests / verification
- 34 new tests (`test_work_order_corrective_foundation.py`) exercising template-less WOs through serializers, PDF, OMR, LOTO, and every report.
- Backend (inventory + analytics + `test_permission_matrix`) **1284 passed / 4 skipped / 0 failed** (Postgres); frontend 1233 tests passed + lint 0 errors (untouched); `black`/`isort`/`flake8`/`bandit` clean; `makemigrations --check` no changes.

Foundation only — no `AssetProblem` FK, promote actions, or materials/cost work (those land in B2/B3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
