### PR TITLE
fix(inventory): Asset Cost Recovery — query all assets + filter by ownership (op-ilnl)

### DIFF
--- a/backend/inventory/tests/test_cost_recovery.py
+++ b/backend/inventory/tests/test_cost_recovery.py
@@ -3,8 +3,9 @@ Tests for the Asset Cost-Recovery report endpoint.
 
 Covers the cost walk (internal PM estimate vs vendor/manual actual, correct
 columns), period presets + custom range filtering, asset selection AND
-category expansion, an asset with no in-window services, the recoverable
-grand-total, and the CSV + PDF exports.
+category expansion, the all-assets + ownership (Space/Committee) filters, an
+asset with no in-window services, the recoverable grand-total, and the CSV +
+PDF exports.
 """
 
 import csv
@@ -12,12 +13,14 @@ import io
 from datetime import timedelta
 from decimal import Decimal
 
+from django.contrib.auth.models import Group
 from django.utils import timezone
 
 import pytest
 from rest_framework import status
 
 from inventory.models import (
+    Asset,
     MaintenanceItem,
     MaintenanceMaterial,
     MaintenanceRecord,
@@ -62,6 +65,12 @@ def _assets_by_id(response):
     return {block["asset_id"]: block for block in response.data["assets"]}
 
 
+def _error_details(response):
+    """Per-field details from the project's wrapped DRF error envelope
+    (``{"error": {"code", "message", "details": {...}}}``)."""
+    return response.data.get("error", {}).get("details", {})
+
+
 @pytest.mark.integration
 class TestCostRecoveryAccessAndParams:
     def test_requires_auth(self, api_client):
@@ -69,9 +78,39 @@ class TestCostRecoveryAccessAndParams:
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_requires_selection(self, authenticated_client):
+        """A bare request still 400s — all_assets=true is the explicit opt-in
+        for an unbounded run."""
         client, _ = authenticated_client
         response = client.get(URL, {"period": "past_month"})
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_empty_selection_params_still_rejected(self, authenticated_client):
+        """Blank/false values are not a selection."""
+        client, _ = authenticated_client
+        response = client.get(
+            URL,
+            {
+                "period": "past_month",
+                "asset_ids": "",
+                "category_ids": "",
+                "all_assets": "false",
+                "ownership_type": "",
+                "owning_group": "",
+            },
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_invalid_ownership_type_rejected(self, authenticated_client):
+        client, _ = authenticated_client
+        response = client.get(URL, {"ownership_type": "landlord", "period": "past_month"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "ownership_type" in _error_details(response)
+
+    def test_invalid_owning_group_rejected(self, authenticated_client):
+        client, _ = authenticated_client
+        response = client.get(URL, {"owning_group": "not-an-int", "period": "past_month"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "owning_group" in _error_details(response)
 
     def test_requires_period(self, authenticated_client):
         client, _ = authenticated_client
@@ -339,6 +378,188 @@ class TestCostRecoverySelection:
 
 
 @pytest.mark.integration
+class TestCostRecoveryAllAssetsAndOwnership:
+    """all_assets escape hatch + the Space/Committee ownership filters."""
+
+    def test_all_assets_returns_every_asset(self, authenticated_client):
+        client, _ = authenticated_client
+        a1 = AssetFactory(asset_tag="A-ALL1")
+        a2 = AssetFactory(asset_tag="A-ALL2")
+        a3 = AssetFactory(asset_tag="A-ALL3")
+
+        response = client.get(URL, {"all_assets": "true", "period": "past_month"})
+        assert response.status_code == status.HTTP_200_OK
+        ids = set(_assets_by_id(response))
+        assert {str(a1.id), str(a2.id), str(a3.id)} <= ids
+        assert response.data["all_assets"] is True
+        assert response.data["asset_count"] == len(ids)
+
+    def test_all_assets_accepts_1_as_true(self, authenticated_client):
+        client, _ = authenticated_client
+        asset = AssetFactory(asset_tag="A-ALL-1S")
+
+        response = client.get(URL, {"all_assets": "1", "period": "past_month"})
+        assert response.status_code == status.HTTP_200_OK
+        assert str(asset.id) in _assets_by_id(response)
+
+    def test_ownership_type_scopes_selection(self, authenticated_client):
+        """ownership_type alone = all assets with that ownership."""
+        client, _ = authenticated_client
+        sig = Group.objects.create(name="CR Robotics Committee")
+        space_asset = AssetFactory(asset_tag="A-OWN-SPACE")
+        group_asset = AssetFactory(
+            asset_tag="A-OWN-GROUP",
+            ownership_type=Asset.OwnershipType.GROUP,
+            owning_group=sig,
+        )
+
+        response = client.get(URL, {"ownership_type": "space", "period": "past_month"})
+        assert response.status_code == status.HTTP_200_OK
+        ids = set(_assets_by_id(response))
+        assert str(space_asset.id) in ids
+        assert str(group_asset.id) not in ids
+        assert response.data["ownership_type"] == "space"
+
+    def test_owning_group_scopes_to_that_committee(self, authenticated_client):
+        client, _ = authenticated_client
+        committee = Group.objects.create(name="CR Woodshop Committee")
+        other = Group.objects.create(name="CR Metal Committee")
+        mine = AssetFactory(
+            asset_tag="A-OG-MINE",
+            ownership_type=Asset.OwnershipType.GROUP,
+            owning_group=committee,
+        )
+        theirs = AssetFactory(
+            asset_tag="A-OG-THEIRS",
+            ownership_type=Asset.OwnershipType.GROUP,
+            owning_group=other,
+        )
+        space_asset = AssetFactory(asset_tag="A-OG-SPACE")
+
+        response = client.get(URL, {"owning_group": str(committee.id), "period": "past_month"})
+        assert response.status_code == status.HTTP_200_OK
+        ids = set(_assets_by_id(response))
+        assert ids == {str(mine.id)}
+        assert str(theirs.id) not in ids
+        assert str(space_asset.id) not in ids
+        assert response.data["owning_group"] == committee.id
+
+    def test_all_assets_plus_ownership_type_combine(self, authenticated_client):
+        client, _ = authenticated_client
+        sig = Group.objects.create(name="CR Combined Committee")
+        space_asset = AssetFactory(asset_tag="A-COMBO-SPACE")
+        group_asset = AssetFactory(
+            asset_tag="A-COMBO-GROUP",
+            ownership_type=Asset.OwnershipType.GROUP,
+            owning_group=sig,
+        )
+
+        response = client.get(
+            URL,
+            {"all_assets": "true", "ownership_type": "group", "period": "past_month"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        ids = set(_assets_by_id(response))
+        assert str(group_asset.id) in ids
+        assert str(space_asset.id) not in ids
+
+    def test_ownership_type_and_owning_group_combine(self, authenticated_client):
+        client, _ = authenticated_client
+        committee = Group.objects.create(name="CR Both-Filters Committee")
+        matching = AssetFactory(
+            asset_tag="A-BOTH-MATCH",
+            ownership_type=Asset.OwnershipType.GROUP,
+            owning_group=committee,
+        )
+        # Same committee, but owned by a user — excluded by ownership_type.
+        AssetFactory(
+            asset_tag="A-BOTH-USER",
+            ownership_type=Asset.OwnershipType.USER,
+            owning_group=committee,
+        )
+
+        response = client.get(
+            URL,
+            {
+                "ownership_type": "group",
+                "owning_group": str(committee.id),
+                "period": "past_month",
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert set(_assets_by_id(response)) == {str(matching.id)}
+
+    def test_ownership_filter_widens_past_explicit_asset_ids(self, authenticated_client):
+        """An ownership filter starts from every asset, so it is not narrowed
+        by a stray asset_ids list (the UI disables the pickers in that mode)."""
+        client, _ = authenticated_client
+        committee = Group.objects.create(name="CR Widening Committee")
+        picked = AssetFactory(
+            asset_tag="A-WIDE-PICKED",
+            ownership_type=Asset.OwnershipType.GROUP,
+            owning_group=committee,
+        )
+        sibling = AssetFactory(
+            asset_tag="A-WIDE-SIBLING",
+            ownership_type=Asset.OwnershipType.GROUP,
+            owning_group=committee,
+        )
+
+        response = client.get(
+            URL,
+            {
+                "asset_ids": str(picked.id),
+                "owning_group": str(committee.id),
+                "period": "past_month",
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert set(_assets_by_id(response)) == {str(picked.id), str(sibling.id)}
+
+    def test_costs_still_walk_under_ownership_selection(self, authenticated_client):
+        """The new selection feeds the same cost walk — vendor actual still
+        rolls into the recoverable grand total."""
+        client, _ = authenticated_client
+        committee = Group.objects.create(name="CR Billing Committee")
+        asset = AssetFactory(
+            asset_tag="A-OWN-COST",
+            ownership_type=Asset.OwnershipType.GROUP,
+            owning_group=committee,
+        )
+        _closed_vendor_link(asset, allocated_cost=Decimal("175.00"), closed_days_ago=3)
+
+        response = client.get(URL, {"owning_group": str(committee.id), "period": "past_month"})
+        assert response.status_code == status.HTTP_200_OK
+        assert Decimal(response.data["grand_total_actual"]) == Decimal("175.00")
+        assert response.data["service_count"] == 1
+
+    def test_unknown_owning_group_returns_no_assets(self, authenticated_client):
+        client, _ = authenticated_client
+        AssetFactory(asset_tag="A-OG-NONE")
+
+        response = client.get(URL, {"owning_group": "99999999", "period": "past_month"})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["assets"] == []
+        assert response.data["asset_count"] == 0
+
+    def test_explicit_selection_unaffected_by_new_params(self, authenticated_client):
+        """Without all_assets/ownership params the base set is still the
+        id + category union (regression guard on the default path)."""
+        client, _ = authenticated_client
+        picked = AssetFactory(asset_tag="A-DEFAULT-IN")
+        other = AssetFactory(asset_tag="A-DEFAULT-OUT")
+
+        response = client.get(URL, {"asset_ids": str(picked.id), "period": "past_month"})
+        assert response.status_code == status.HTTP_200_OK
+        ids = set(_assets_by_id(response))
+        assert ids == {str(picked.id)}
+        assert str(other.id) not in ids
+        assert response.data["all_assets"] is False
+        assert response.data["ownership_type"] is None
+        assert response.data["owning_group"] is None
+
+
+@pytest.mark.integration
 class TestCostRecoveryExports:
     def test_csv_export(self, authenticated_client):
         client, _ = authenticated_client
@@ -407,6 +628,83 @@ class TestCostRecoveryExports:
         assert "Cost-Recovery" in text
         assert "Amount to recover" in text
         assert "A-PDF" in text
+
+    def test_csv_honors_ownership_selection(self, authenticated_client):
+        """CSV flows through the same selection — the committee's asset is in,
+        the space-owned one is out."""
+        client, _ = authenticated_client
+        committee = Group.objects.create(name="CR CSV Committee")
+        owned = AssetFactory(
+            asset_tag="A-CSV-OWNED",
+            ownership_type=Asset.OwnershipType.GROUP,
+            owning_group=committee,
+        )
+        _closed_vendor_link(owned, allocated_cost=Decimal("42.00"), closed_days_ago=4)
+        AssetFactory(asset_tag="A-CSV-SPACE")
+
+        response = client.get(
+            URL,
+            {"owning_group": str(committee.id), "period": "past_month", "format": "csv"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        reader = csv.DictReader(io.StringIO(response.content.decode("utf-8")))
+        tags = {row["asset_tag"] for row in reader}
+        assert tags == {"A-CSV-OWNED"}
+
+    def test_csv_all_assets(self, authenticated_client):
+        client, _ = authenticated_client
+        a1 = AssetFactory(asset_tag="A-CSVALL1")
+        a2 = AssetFactory(asset_tag="A-CSVALL2")
+
+        response = client.get(URL, {"all_assets": "true", "period": "past_month", "format": "csv"})
+        assert response.status_code == status.HTTP_200_OK
+        reader = csv.DictReader(io.StringIO(response.content.decode("utf-8")))
+        tags = {row["asset_tag"] for row in reader}
+        assert {a1.asset_tag, a2.asset_tag} <= tags
+
+    def test_pdf_honors_ownership_selection(self, authenticated_client):
+        client, _ = authenticated_client
+        committee = Group.objects.create(name="CR PDF Committee")
+        owned = AssetFactory(
+            name="Committee Lathe",
+            asset_tag="A-PDF-OWNED",
+            ownership_type=Asset.OwnershipType.GROUP,
+            owning_group=committee,
+        )
+        _closed_vendor_link(owned, allocated_cost=Decimal("99.00"), closed_days_ago=4)
+        AssetFactory(name="Space Router", asset_tag="A-PDF-SPACE")
+
+        response = client.get(
+            URL,
+            {"owning_group": str(committee.id), "period": "past_month", "format": "pdf"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response["Content-Type"] == "application/pdf"
+
+        from pypdf import PdfReader
+
+        text = "".join(
+            page.extract_text() or "" for page in PdfReader(io.BytesIO(response.content)).pages
+        )
+        assert "A-PDF-OWNED" in text
+        assert "A-PDF-SPACE" not in text
+        # The header summarizes the ownership scope for the landlord.
+        assert "CR PDF Committee" in text
+
+    def test_pdf_all_assets_header(self, authenticated_client):
+        client, _ = authenticated_client
+        AssetFactory(asset_tag="A-PDFALL")
+
+        response = client.get(URL, {"all_assets": "true", "period": "past_month", "format": "pdf"})
+        assert response.status_code == status.HTTP_200_OK
+
+        from pypdf import PdfReader
+
+        text = "".join(
+            page.extract_text() or "" for page in PdfReader(io.BytesIO(response.content)).pages
+        )
+        assert "All assets" in text
+        assert "A-PDFALL" in text
 
     def test_unknown_format_404s_in_negotiation(self, authenticated_client):
         """``format`` is DRF's reserved content-negotiation param; an

--- a/backend/inventory/utils/cost_recovery_pdf.py
+++ b/backend/inventory/utils/cost_recovery_pdf.py
@@ -44,6 +44,13 @@ _PERIOD_LABELS = {
     "past_year": "Past year",
 }
 
+# Asset.OwnershipType values, for the selection summary in the header.
+_OWNERSHIP_LABELS = {
+    "user": "User",
+    "group": "Group (SIG / committee)",
+    "space": "Space",
+}
+
 
 def _money(value: Optional[Decimal]) -> str:
     """Render a Decimal as ``$X.XX``; blank for a missing (null) value."""
@@ -127,13 +134,21 @@ def generate_cost_recovery_pdf(report: dict) -> bytes:
     selection_bits = []
     asset_ids = report.get("asset_ids") or []
     category_ids = report.get("category_ids") or []
+    if report.get("all_assets"):
+        selection_bits.append("All assets")
     if asset_ids:
         selection_bits.append(f"{len(asset_ids)} asset(s) selected")
     if category_ids:
         selection_bits.append(f"{len(category_ids)} category(ies) selected")
+    ownership_type = report.get("ownership_type")
+    if ownership_type:
+        selection_bits.append(f"Ownership: {_OWNERSHIP_LABELS.get(ownership_type, ownership_type)}")
+    owning_group = report.get("owning_group")
+    if owning_group is not None:
+        selection_bits.append(f"Owning group: {report.get('owning_group_name') or owning_group}")
     selection_bits.append(f"{report.get('asset_count', 0)} asset(s) in statement")
     selection_bits.append(f"{report.get('service_count', 0)} service line(s)")
-    story.append(Paragraph("; ".join(selection_bits), small_style))
+    story.append(_para("; ".join(selection_bits), small_style))
     story.append(HRFlowable(width="100%", thickness=1, color=colors.black))
     story.append(Spacer(1, 4))
 

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -6036,13 +6036,25 @@ class AssetReportViewSet(viewsets.ViewSet):
 
     @staticmethod
     def _cost_recovery_selection(request):
-        """Parse and validate the asset/category selection for cost_recovery.
+        """Parse and validate the asset selection for cost_recovery.
 
-        ``asset_ids`` (Asset UUIDs) and ``category_ids`` (integer Category PKs)
-        are each accepted as repeated params and/or comma-joined lists. At
-        least one asset or category must be supplied. Returns
-        ``(asset_ids, category_ids)`` as validated lists (UUID strings / ints).
-        Raises DRF ValidationError on malformed ids or an empty selection.
+        Selection params (all optional individually, but at least one is
+        required):
+
+        * ``asset_ids`` — Asset UUIDs, repeated and/or comma-joined.
+        * ``category_ids`` — integer Category PKs, repeated and/or comma-joined.
+        * ``all_assets`` — ``"true"``/``"1"`` to run across every asset.
+        * ``ownership_type`` — one of ``Asset.OwnershipType.values``
+          (user/group/space).
+        * ``owning_group`` — integer ``auth.Group`` PK (the SIG/committee).
+
+        Requiring at least one keeps a bare request from silently running an
+        unbounded statement; ``all_assets=true`` is the explicit escape hatch.
+
+        Returns a dict with keys ``asset_ids`` (UUID strings), ``category_ids``
+        (ints), ``all_assets`` (bool), ``ownership_type`` (str or None) and
+        ``owning_group`` (int or None). Raises DRF ValidationError on malformed
+        values or an empty selection.
         """
         import uuid
 
@@ -6055,9 +6067,37 @@ class AssetReportViewSet(viewsets.ViewSet):
         raw_asset_ids = _collect("asset_ids")
         raw_category_ids = _collect("category_ids")
 
-        if not raw_asset_ids and not raw_category_ids:
+        all_assets = (request.query_params.get("all_assets") or "").strip().lower() in {
+            "true",
+            "1",
+        }
+
+        ownership_type = (request.query_params.get("ownership_type") or "").strip() or None
+        if ownership_type is not None and ownership_type not in Asset.OwnershipType.values:
+            allowed = ", ".join(Asset.OwnershipType.values)
+            raise serializers.ValidationError({"ownership_type": f"Must be one of {allowed}."})
+
+        raw_owning_group = (request.query_params.get("owning_group") or "").strip() or None
+        owning_group = None
+        if raw_owning_group is not None:
+            try:
+                owning_group = int(raw_owning_group)
+            except (ValueError, TypeError):
+                raise serializers.ValidationError(
+                    {"owning_group": f"Invalid group id: {raw_owning_group!r}."}
+                )
+
+        if not (
+            raw_asset_ids
+            or raw_category_ids
+            or all_assets
+            or ownership_type is not None
+            or owning_group is not None
+        ):
             raise serializers.ValidationError(
-                "Select at least one asset (asset_ids) or category (category_ids)."
+                "Select at least one asset (asset_ids), category (category_ids), or "
+                "ownership filter (ownership_type / owning_group) — or pass "
+                "all_assets=true to run the statement across every asset."
             )
 
         asset_ids = []
@@ -6076,7 +6116,46 @@ class AssetReportViewSet(viewsets.ViewSet):
                     {"category_ids": f"Invalid category id: {value!r}."}
                 )
 
-        return asset_ids, category_ids
+        return {
+            "asset_ids": asset_ids,
+            "category_ids": category_ids,
+            "all_assets": all_assets,
+            "ownership_type": ownership_type,
+            "owning_group": owning_group,
+        }
+
+    @staticmethod
+    def _cost_recovery_asset_queryset(selection):
+        """Resolve the selected assets for cost_recovery from a parsed selection.
+
+        ``all_assets`` or either ownership filter widens the base set to every
+        asset (an ownership filter alone therefore means "all assets with that
+        ownership"); otherwise the base set is the explicit ``asset_ids`` UNION
+        the ``category_ids`` expansion, de-duped. The ownership filters are then
+        applied on top of whichever base set was chosen.
+        """
+        if (
+            selection["all_assets"]
+            or selection["ownership_type"] is not None
+            or selection["owning_group"] is not None
+        ):
+            queryset = Asset.objects.all()
+        else:
+            selected_ids = set(selection["asset_ids"])
+            if selection["category_ids"]:
+                selected_ids.update(
+                    str(pk)
+                    for pk in Asset.objects.filter(
+                        category_id__in=selection["category_ids"]
+                    ).values_list("id", flat=True)
+                )
+            queryset = Asset.objects.filter(id__in=selected_ids)
+
+        if selection["ownership_type"] is not None:
+            queryset = queryset.filter(ownership_type=selection["ownership_type"])
+        if selection["owning_group"] is not None:
+            queryset = queryset.filter(owning_group_id=selection["owning_group"])
+        return queryset
 
     @staticmethod
     def _cost_recovery_window(request):
@@ -6226,7 +6305,10 @@ class AssetReportViewSet(viewsets.ViewSet):
         - Selection (>=1 required): ``asset_ids`` (Asset UUIDs) and/or
           ``category_ids`` (integer Category PKs); each repeatable and/or
           comma-joined. Categories expand to ``category.assets`` and the union
-          is de-duped.
+          is de-duped. ``all_assets=true`` runs across every asset;
+          ``ownership_type`` (user/group/space) and ``owning_group`` (auth.Group
+          PK — the SIG/committee) scope by asset ownership and likewise widen
+          the base set to every asset before filtering.
         - Period (one of): ``period`` in {past_week, past_month, past_year}
           (trailing window ending today) OR ``start_date`` & ``end_date``
           (YYYY-MM-DD).
@@ -6248,7 +6330,9 @@ class AssetReportViewSet(viewsets.ViewSet):
             prefetch_asset_work_orders,
         )
 
-        asset_ids, category_ids = self._cost_recovery_selection(request)
+        selection = self._cost_recovery_selection(request)
+        asset_ids = selection["asset_ids"]
+        category_ids = selection["category_ids"]
         start_date, end_date, period_label = self._cost_recovery_window(request)
 
         # ``format`` is DRF's reserved content-negotiation query param; the
@@ -6256,15 +6340,8 @@ class AssetReportViewSet(viewsets.ViewSet):
         # cleanly (an unknown format 404s in negotiation before we get here).
         fmt = request.accepted_renderer.format
 
-        # Resolve the selected asset set: explicit ids UNION category expansion.
-        selected_ids = set(asset_ids)
-        if category_ids:
-            selected_ids.update(
-                str(pk)
-                for pk in Asset.objects.filter(category_id__in=category_ids).values_list(
-                    "id", flat=True
-                )
-            )
+        # Resolve the selected asset set (ids/categories/all + ownership).
+        selected_qs = self._cost_recovery_asset_queryset(selection)
 
         # Window-scoped prefetch querysets — one pass per source, no N+1.
         pm_wo_qs = WorkOrder.objects.filter(
@@ -6286,7 +6363,7 @@ class AssetReportViewSet(viewsets.ViewSet):
 
         assets = (
             prefetch_asset_work_orders(
-                Asset.objects.filter(id__in=selected_ids).select_related("category"),
+                selected_qs.select_related("category"),
                 pm_wo_qs,
             )
             .prefetch_related(
@@ -6378,7 +6455,17 @@ class AssetReportViewSet(viewsets.ViewSet):
             return self._cost_recovery_csv(asset_blocks)
 
         if fmt == "pdf":
+            from django.contrib.auth.models import Group
+
             from .utils.cost_recovery_pdf import generate_cost_recovery_pdf
+
+            owning_group_name = None
+            if selection["owning_group"] is not None:
+                owning_group_name = (
+                    Group.objects.filter(pk=selection["owning_group"])
+                    .values_list("name", flat=True)
+                    .first()
+                )
 
             report = {
                 "period": period_label,
@@ -6387,6 +6474,10 @@ class AssetReportViewSet(viewsets.ViewSet):
                 "generated_at": timezone.now(),
                 "asset_ids": asset_ids,
                 "category_ids": category_ids,
+                "all_assets": selection["all_assets"],
+                "ownership_type": selection["ownership_type"],
+                "owning_group": selection["owning_group"],
+                "owning_group_name": owning_group_name,
                 "asset_count": len(asset_blocks),
                 "service_count": service_count,
                 "grand_total_estimated": grand_estimated,
@@ -6405,6 +6496,9 @@ class AssetReportViewSet(viewsets.ViewSet):
             "end_date": end_date.isoformat(),
             "asset_ids": asset_ids,
             "category_ids": category_ids,
+            "all_assets": selection["all_assets"],
+            "ownership_type": selection["ownership_type"],
+            "owning_group": selection["owning_group"],
             "asset_count": len(asset_blocks),
             "service_count": service_count,
             "grand_total_estimated": f"{grand_estimated:.2f}",

--- a/frontend/src/__tests__/pages/AssetCostRecoveryPage.test.tsx
+++ b/frontend/src/__tests__/pages/AssetCostRecoveryPage.test.tsx
@@ -1,16 +1,19 @@
 /**
- * Tests for AssetCostRecoveryPage — the cost-recovery report generator (op-wjmm).
+ * Tests for AssetCostRecoveryPage — the cost-recovery report generator
+ * (op-wjmm; all-assets + ownership filters op-ilnl).
  *
  * Covers: options load on mount; asset select + default preset build the right
  * params and render per-asset line items + grand total; the custom date range
- * sends start_date/end_date instead of a period; CSV/PDF buttons hit the
- * format= endpoint and trigger a download; empty-state; and error surfacing.
+ * sends start_date/end_date instead of a period; the All-assets toggle and the
+ * ownership-type / owning-group (committee) selects drive the params and stand
+ * in as a selection on their own; CSV/PDF buttons hit the format= endpoint and
+ * trigger a download; empty-state; and error surfacing.
  */
 import { MantineProvider } from '@mantine/core';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import AssetCostRecoveryPage from '../../pages/AssetCostRecoveryPage';
-import { assetsAPI, inventoryAPI, reportsAPI } from '../../services/api';
+import { assetsAPI, inventoryAPI, reportsAPI, sigAPI } from '../../services/api';
 import { networkError } from '../helpers/offline';
 
 vi.mock('../../services/api');
@@ -18,6 +21,7 @@ vi.mock('../../services/api');
 const mockAssetsAPI = assetsAPI as jest.Mocked<typeof assetsAPI>;
 const mockInventoryAPI = inventoryAPI as jest.Mocked<typeof inventoryAPI>;
 const mockReportsAPI = reportsAPI as jest.Mocked<typeof reportsAPI>;
+const mockSigAPI = sigAPI as jest.Mocked<typeof sigAPI>;
 
 const okResponse = <T,>(data: T) =>
   ({ data, status: 200, statusText: 'OK', headers: {}, config: {} as never }) as never;
@@ -28,6 +32,11 @@ const ASSETS = [
 ];
 
 const CATEGORIES = [{ id: 3, name: 'Fabrication' }];
+
+const SIGS = [
+  { id: 11, name: 'Woodshop Committee' },
+  { id: 12, name: 'Electronics Committee' },
+];
 
 const SAMPLE_REPORT = {
   period: 'past_month',
@@ -86,6 +95,7 @@ beforeEach(() => {
     okResponse({ count: ASSETS.length, next: null, previous: null, results: ASSETS }),
   );
   mockInventoryAPI.listCategories.mockResolvedValue(okResponse({ results: CATEGORIES }));
+  mockSigAPI.listMySIGs.mockResolvedValue(okResponse({ results: SIGS }));
   mockReportsAPI.getAssetCostRecovery.mockResolvedValue(okResponse(SAMPLE_REPORT));
   mockReportsAPI.downloadAssetCostRecovery.mockResolvedValue(okResponse(new Blob(['x'])));
 });
@@ -98,12 +108,24 @@ const selectLaserCutter = async () => {
   fireEvent.click(await screen.findByRole('option', { name: /Laser Cutter/i }));
 };
 
+// Pick an option from one of the ownership <Select>s. Mantine renders both a
+// visible and a hidden input per Select, so target the testid (which lands on
+// the visible one) rather than the shared label.
+const pickFromSelect = async (testId: string, option: RegExp) => {
+  const input = screen.getByTestId(testId);
+  await waitFor(() => expect(input).not.toBeDisabled());
+  fireEvent.click(input);
+  fireEvent.click(await screen.findByRole('option', { name: option }));
+};
+
+const allAssetsToggle = () => screen.getByTestId('cost-recovery-all-assets');
+
 describe('AssetCostRecoveryPage', () => {
-  it('loads asset + category pickers and shows the initial prompt', async () => {
+  it('loads asset + category + committee pickers and shows the initial prompt', async () => {
     renderPage();
 
     expect(
-      await screen.findByText(/choose one or more assets or categories and a period/i),
+      await screen.findByText(/choose assets or categories .* plus a period/i),
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Generate' })).toBeInTheDocument();
 
@@ -111,6 +133,8 @@ describe('AssetCostRecoveryPage', () => {
       expect(mockAssetsAPI.listAssets).toHaveBeenCalledWith({ page_size: 500 });
     });
     expect(mockInventoryAPI.listCategories).toHaveBeenCalled();
+    // Committees come from the same source as the asset ownership editor.
+    expect(mockSigAPI.listMySIGs).toHaveBeenCalled();
   });
 
   it('generates with the default preset and renders per-asset line items + grand total', async () => {
@@ -228,5 +252,83 @@ describe('AssetCostRecoveryPage', () => {
     // Enable once loaded + a selection is made.
     await selectLaserCutter();
     await waitFor(() => expect(generate).not.toBeDisabled());
+  });
+
+  it('All assets is a selection on its own and sends all_assets=true', async () => {
+    renderPage();
+    const generate = screen.getByRole('button', { name: 'Generate' });
+    expect(generate).toBeDisabled();
+
+    fireEvent.click(allAssetsToggle());
+    await waitFor(() => expect(generate).not.toBeDisabled());
+    fireEvent.click(generate);
+
+    await waitFor(() => expect(mockReportsAPI.getAssetCostRecovery).toHaveBeenCalled());
+    const params = mockReportsAPI.getAssetCostRecovery.mock.calls[0][0];
+    expect(params.all_assets).toBe(true);
+    expect(params.period).toBe('past_month');
+    // The pickers are ignored in this mode, so no stale ids ride along.
+    expect(params.asset_ids).toEqual([]);
+    expect(params.category_ids).toEqual([]);
+  });
+
+  it('All assets disables the asset + category pickers', async () => {
+    renderPage();
+    const assetInput = screen.getByPlaceholderText('Search assets');
+    await waitFor(() => expect(assetInput).not.toBeDisabled());
+
+    fireEvent.click(allAssetsToggle());
+
+    await waitFor(() => expect(assetInput).toBeDisabled());
+    expect(screen.getByPlaceholderText('Search categories')).toBeDisabled();
+  });
+
+  it('an ownership type alone enables Generate and sends ownership_type', async () => {
+    renderPage();
+    const generate = screen.getByRole('button', { name: 'Generate' });
+    expect(generate).toBeDisabled();
+
+    await pickFromSelect('cost-recovery-ownership-type', /^Space$/);
+    await waitFor(() => expect(generate).not.toBeDisabled());
+    fireEvent.click(generate);
+
+    await waitFor(() => expect(mockReportsAPI.getAssetCostRecovery).toHaveBeenCalled());
+    const params = mockReportsAPI.getAssetCostRecovery.mock.calls[0][0];
+    expect(params.ownership_type).toBe('space');
+    expect(params.all_assets).toBeUndefined();
+  });
+
+  it('picking a committee sends owning_group and combines with All assets', async () => {
+    renderPage();
+
+    fireEvent.click(allAssetsToggle());
+    await pickFromSelect('cost-recovery-owning-group', /Woodshop Committee/i);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => expect(mockReportsAPI.getAssetCostRecovery).toHaveBeenCalled());
+    const params = mockReportsAPI.getAssetCostRecovery.mock.calls[0][0];
+    expect(params.all_assets).toBe(true);
+    expect(params.owning_group).toBe(11);
+  });
+
+  it('carries the ownership scope into the CSV export', async () => {
+    Object.defineProperty(window.URL, 'createObjectURL', {
+      value: vi.fn(() => 'blob:mock'),
+      writable: true,
+    });
+    Object.defineProperty(window.URL, 'revokeObjectURL', { value: vi.fn(), writable: true });
+
+    renderPage();
+    await pickFromSelect('cost-recovery-owning-group', /Electronics Committee/i);
+
+    fireEvent.click(screen.getByRole('button', { name: /export csv/i }));
+
+    await waitFor(() => {
+      expect(mockReportsAPI.downloadAssetCostRecovery).toHaveBeenCalledWith(
+        expect.objectContaining({ owning_group: 12, period: 'past_month' }),
+        'csv',
+      );
+    });
   });
 });

--- a/frontend/src/__tests__/services/api.test.ts
+++ b/frontend/src/__tests__/services/api.test.ts
@@ -1017,6 +1017,70 @@ describe('API Service', () => {
       expect(decoded).toContain('start_date=2026-01-01');
       expect(decoded).toContain('end_date=2026-03-31');
     });
+
+    test('getAssetCostRecovery sends all_assets + the ownership filters', async () => {
+      mock.onGet('/inventory/reports/assets/cost_recovery/').reply((config) => {
+        expect(config.params).toEqual({
+          all_assets: 'true',
+          ownership_type: 'group',
+          owning_group: '7',
+          period: 'past_year',
+        });
+        return [
+          200,
+          {
+            period: 'past_year',
+            start_date: '2025-07-23',
+            end_date: '2026-07-23',
+            asset_ids: [],
+            category_ids: [],
+            all_assets: true,
+            ownership_type: 'group',
+            owning_group: 7,
+            asset_count: 2,
+            service_count: 0,
+            grand_total_estimated: '0.00',
+            grand_total_actual: '0.00',
+            assets: [],
+          },
+        ];
+      });
+
+      const response = await reportsAPI.getAssetCostRecovery({
+        all_assets: true,
+        ownership_type: 'group',
+        owning_group: 7,
+        period: 'past_year',
+      });
+
+      expect(response.data.owning_group).toBe(7);
+    });
+
+    test('getAssetCostRecovery omits all_assets when false and keeps ownership_type', async () => {
+      mock.onGet('/inventory/reports/assets/cost_recovery/').reply((config) => {
+        expect(config.params).toEqual({ ownership_type: 'space', period: 'past_month' });
+        return [200, { assets: [] }];
+      });
+
+      await reportsAPI.getAssetCostRecovery({
+        all_assets: false,
+        ownership_type: 'space',
+        period: 'past_month',
+      });
+    });
+
+    test('the ownership filters ride along on the CSV/PDF download URL', () => {
+      const decoded = decodeURIComponent(
+        reportsAPI.getAssetCostRecoveryUrl(
+          { all_assets: true, owning_group: 12, period: 'past_month' },
+          'csv',
+        ),
+      );
+
+      expect(decoded).toContain('all_assets=true');
+      expect(decoded).toContain('owning_group=12');
+      expect(decoded).toContain('format=csv');
+    });
   });
 
   describe('resolveApiBaseUrl (deployment-configurable API base URL)', () => {

--- a/frontend/src/pages/AssetCostRecoveryPage.tsx
+++ b/frontend/src/pages/AssetCostRecoveryPage.tsx
@@ -1,26 +1,35 @@
 /**
  * Asset Cost-Recovery Report generator.
  *
- * Pick one or more assets and/or asset categories plus a reporting period,
- * then Generate a per-asset service statement with Estimated (internal) and
- * Actual (vendor-invoice / recorded) columns. The Actual total is the amount
+ * Pick assets and/or asset categories — or switch on "All assets" and/or an
+ * ownership scope (Space / a Committee) — plus a reporting period, then
+ * Generate a per-asset service statement with Estimated (internal) and Actual
+ * (vendor-invoice / recorded) columns. The Actual total is the amount
  * recoverable from the landlord. CSV and the landlord-ready PDF are produced
  * server-side and downloaded as blobs.
  *
  * Consumes reports/assets/cost_recovery/ (PR1, backend) — see
  * inventory/views.py AssetReportViewSet.cost_recovery.
  */
-import { Alert, Button, Group, Loader, MultiSelect, Paper, SegmentedControl, Stack, Table, Text, Title } from '@mantine/core';
+import { Alert, Button, Group, Loader, MultiSelect, Paper, SegmentedControl, Select, Stack, Switch, Table, Text, Title } from '@mantine/core';
 import { DatePickerInput, DatesRangeValue } from '@mantine/dates';
 import { IconAlertTriangle, IconDownload } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { assetsAPI, CostRecoveryParams, CostRecoveryPeriod, inventoryAPI, reportsAPI } from '../services/api';
-import { Asset, AssetCostRecoveryReport, Category } from '../types';
+import { assetsAPI, CostRecoveryOwnershipType, CostRecoveryParams, CostRecoveryPeriod, inventoryAPI, reportsAPI, sigAPI } from '../services/api';
+import { Asset, AssetCostRecoveryReport, Category, SIG } from '../types';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 type PeriodMode = CostRecoveryPeriod | 'custom';
+
+// "" = Any (no ownership_type param sent).
+const OWNERSHIP_OPTIONS: Array<{ label: string; value: string }> = [
+  { label: 'Any', value: '' },
+  { label: 'User', value: 'user' },
+  { label: 'Group (SIG / committee)', value: 'group' },
+  { label: 'Space', value: 'space' },
+];
 
 const PERIOD_OPTIONS: Array<{ label: string; value: PeriodMode }> = [
   { label: 'Past week', value: 'past_week' },
@@ -60,10 +69,14 @@ const getDefaultDateRange = (): DatesRangeValue => [
 const AssetCostRecoveryPage: React.FC = () => {
   const [assets, setAssets] = useState<Asset[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
+  const [sigs, setSigs] = useState<SIG[]>([]);
   const [loadingOptions, setLoadingOptions] = useState(true);
 
   const [selectedAssetIds, setSelectedAssetIds] = useState<string[]>([]);
   const [selectedCategoryIds, setSelectedCategoryIds] = useState<string[]>([]);
+  const [allAssets, setAllAssets] = useState(false);
+  const [ownershipType, setOwnershipType] = useState<string>('');
+  const [owningGroup, setOwningGroup] = useState<string>('');
   const [periodMode, setPeriodMode] = useState<PeriodMode>('past_month');
   const [dateRange, setDateRange] = useState<DatesRangeValue>(getDefaultDateRange);
 
@@ -72,16 +85,22 @@ const AssetCostRecoveryPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [exporting, setExporting] = useState<'csv' | 'pdf' | null>(null);
 
-  // Load the asset + category pickers once. Guard the responses so an
-  // undefined payload (e.g. a fully mocked API in tests) can't throw.
+  // Load the asset + category + committee pickers once. Guard the responses so
+  // an undefined payload (e.g. a fully mocked API in tests) can't throw. The
+  // committee list reuses the same source as the asset ownership editor.
   useEffect(() => {
     let cancelled = false;
     setLoadingOptions(true);
-    Promise.all([assetsAPI.listAssets({ page_size: 500 }), inventoryAPI.listCategories()])
-      .then(([assetRes, catRes]) => {
+    Promise.all([
+      assetsAPI.listAssets({ page_size: 500 }),
+      inventoryAPI.listCategories(),
+      sigAPI.listMySIGs(),
+    ])
+      .then(([assetRes, catRes, sigRes]) => {
         if (cancelled) return;
         setAssets(assetRes?.data?.results ?? []);
         setCategories(catRes?.data?.results ?? []);
+        setSigs(sigRes?.data?.results ?? []);
       })
       .catch((err) => {
         if (cancelled) return;
@@ -109,17 +128,42 @@ const AssetCostRecoveryPage: React.FC = () => {
     [categories],
   );
 
-  const hasSelection = selectedAssetIds.length > 0 || selectedCategoryIds.length > 0;
+  const sigOptions = useMemo(
+    () => sigs.map((sig) => ({ value: String(sig.id), label: sig.name })),
+    [sigs],
+  );
+
+  // An ownership filter or the All-assets toggle is itself a selection — the
+  // backend reads either as "every asset (then scoped)", so the asset/category
+  // pickers become optional and are disabled while All assets is on.
+  const scopeIsAll = allAssets || ownershipType !== '' || owningGroup !== '';
+  const pickersDisabled = loadingOptions || allAssets;
+  const hasSelection =
+    scopeIsAll || selectedAssetIds.length > 0 || selectedCategoryIds.length > 0;
   const periodComplete = periodMode !== 'custom' || Boolean(dateRange[0] && dateRange[1]);
   const canRun = hasSelection && periodComplete;
+
+  const selectionHint =
+    'Select at least one asset or category, switch on All assets, or pick an ownership scope — plus a complete period.';
 
   // Assemble the request params, or null if the selection/window is incomplete.
   const buildParams = useCallback((): CostRecoveryParams | null => {
     if (!hasSelection) return null;
     const base: CostRecoveryParams = {
-      asset_ids: selectedAssetIds,
-      category_ids: selectedCategoryIds.map(Number),
+      // All assets ignores the pickers (the backend widens the base set), so
+      // don't send a stale id list alongside it.
+      asset_ids: allAssets ? [] : selectedAssetIds,
+      category_ids: allAssets ? [] : selectedCategoryIds.map(Number),
     };
+    if (allAssets) {
+      base.all_assets = true;
+    }
+    if (ownershipType !== '') {
+      base.ownership_type = ownershipType as CostRecoveryOwnershipType;
+    }
+    if (owningGroup !== '') {
+      base.owning_group = Number(owningGroup);
+    }
     if (periodMode === 'custom') {
       if (!dateRange[0] || !dateRange[1]) return null;
       return {
@@ -129,12 +173,21 @@ const AssetCostRecoveryPage: React.FC = () => {
       };
     }
     return { ...base, period: periodMode };
-  }, [hasSelection, selectedAssetIds, selectedCategoryIds, periodMode, dateRange]);
+  }, [
+    hasSelection,
+    selectedAssetIds,
+    selectedCategoryIds,
+    allAssets,
+    ownershipType,
+    owningGroup,
+    periodMode,
+    dateRange,
+  ]);
 
   const handleGenerate = async () => {
     const params = buildParams();
     if (!params) {
-      setError('Select at least one asset or category and a complete period.');
+      setError(selectionHint);
       return;
     }
     try {
@@ -153,7 +206,7 @@ const AssetCostRecoveryPage: React.FC = () => {
   const handleExport = async (format: 'csv' | 'pdf') => {
     const params = buildParams();
     if (!params) {
-      setError('Select at least one asset or category and a complete period.');
+      setError(selectionHint);
       return;
     }
     try {
@@ -181,13 +234,22 @@ const AssetCostRecoveryPage: React.FC = () => {
     <Stack gap="md" p="md">
       <Title order={2}>Asset Cost-Recovery Report</Title>
       <Text size="sm" c="dimmed">
-        Build a per-asset service statement billed to the landlord. The Actual
-        (vendor-invoice / recorded) total is the recoverable amount; estimates
-        for internal preventive maintenance are shown as context only.
+        Build a per-asset service statement billed to the landlord. Scope it to
+        specific assets or categories, to every asset, or to an ownership group
+        (Space-owned, or one committee&apos;s assets). The Actual (vendor-invoice /
+        recorded) total is the recoverable amount; estimates for internal
+        preventive maintenance are shown as context only.
       </Text>
 
       <Paper withBorder p="md">
         <Stack gap="md">
+          <Switch
+            label="All assets"
+            description="Run the statement across every asset — the asset and category pickers are then ignored."
+            checked={allAssets}
+            onChange={(e) => setAllAssets(e.currentTarget.checked)}
+            data-testid="cost-recovery-all-assets"
+          />
           <MultiSelect
             label="Assets"
             placeholder="Search assets"
@@ -196,7 +258,7 @@ const AssetCostRecoveryPage: React.FC = () => {
             onChange={setSelectedAssetIds}
             searchable
             clearable
-            disabled={loadingOptions}
+            disabled={pickersDisabled}
             data-testid="cost-recovery-assets"
           />
           <MultiSelect
@@ -208,9 +270,33 @@ const AssetCostRecoveryPage: React.FC = () => {
             onChange={setSelectedCategoryIds}
             searchable
             clearable
-            disabled={loadingOptions}
+            disabled={pickersDisabled}
             data-testid="cost-recovery-categories"
           />
+
+          <Group grow align="flex-start">
+            <Select
+              label="Ownership type"
+              description="Scopes to assets with that ownership."
+              placeholder="Any"
+              data={OWNERSHIP_OPTIONS}
+              value={ownershipType}
+              onChange={(value) => setOwnershipType(value ?? '')}
+              data-testid="cost-recovery-ownership-type"
+            />
+            <Select
+              label="Owning group (Committee / SIG)"
+              description="Scopes to that committee's assets."
+              placeholder="Any"
+              data={sigOptions}
+              value={owningGroup === '' ? null : owningGroup}
+              onChange={(value) => setOwningGroup(value ?? '')}
+              searchable
+              clearable
+              disabled={loadingOptions}
+              data-testid="cost-recovery-owning-group"
+            />
+          </Group>
 
           <div>
             <Text size="sm" fw={500} mb={4}>
@@ -276,7 +362,8 @@ const AssetCostRecoveryPage: React.FC = () => {
         </Group>
       ) : report === null ? (
         <Text c="dimmed">
-          Choose one or more assets or categories and a period, then Generate the statement.
+          Choose assets or categories — or switch on All assets, or pick an ownership
+          scope — plus a period, then Generate the statement.
         </Text>
       ) : report.assets.length === 0 ? (
         <Paper withBorder p="md">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2139,11 +2139,20 @@ type DateRangeParams = { start_date?: string; end_date?: string };
 
 export type CostRecoveryPeriod = 'past_week' | 'past_month' | 'past_year';
 
+// Asset ownership scope for the cost-recovery report (Asset.OwnershipType).
+export type CostRecoveryOwnershipType = 'user' | 'group' | 'space';
+
 // Selection + window for the asset cost-recovery report. Supply at least one
-// of asset_ids / category_ids, and exactly one of period OR start_date+end_date.
+// selection param (asset_ids / category_ids / all_assets / ownership_type /
+// owning_group), and exactly one of period OR start_date+end_date. Note that
+// all_assets or either ownership filter widens the base set to every asset,
+// so they are not narrowed by asset_ids/category_ids.
 export interface CostRecoveryParams {
   asset_ids?: string[];
   category_ids?: number[];
+  all_assets?: boolean;
+  ownership_type?: CostRecoveryOwnershipType;
+  owning_group?: number; // auth.Group PK — the owning SIG / committee
   period?: CostRecoveryPeriod;
   start_date?: string; // YYYY-MM-DD
   end_date?: string; // YYYY-MM-DD
@@ -2164,6 +2173,15 @@ const buildCostRecoveryQuery = (
   }
   if (params.category_ids && params.category_ids.length > 0) {
     query.category_ids = params.category_ids.join(',');
+  }
+  if (params.all_assets) {
+    query.all_assets = 'true';
+  }
+  if (params.ownership_type) {
+    query.ownership_type = params.ownership_type;
+  }
+  if (params.owning_group != null) {
+    query.owning_group = String(params.owning_group);
   }
   if (params.period) {
     query.period = params.period;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1387,6 +1387,11 @@ export interface AssetCostRecoveryReport {
   end_date: string;
   asset_ids: string[];
   category_ids: number[];
+  // Ownership/all-assets selection echo. Optional so a cached response from
+  // before these filters shipped still type-checks.
+  all_assets?: boolean;
+  ownership_type?: 'user' | 'group' | 'space' | null;
+  owning_group?: number | null;
   asset_count: number;
   service_count: number;
   grand_total_estimated: string;


### PR DESCRIPTION
Fixes the Asset Cost Recovery report so it can be run across **all assets**, and adds **ownership filtering** (Space / Committee / …).

### Bug — couldn't query all assets
`_cost_recovery_selection` required ≥1 `asset_ids`/`category_ids`, so there was no way to run the statement across every asset — it just 400'd. Added an explicit **`all_assets`** path.

### Feature — filter by ownership
New params `ownership_type` (user/group/space) and `owning_group` (the SIG / **committee**). Any of `all_assets` / `ownership_type` / `owning_group` widens the base to all assets, then filters; the existing `asset_ids ∪ category` union is unchanged, and a bare request still 400s. JSON, CSV, and PDF all flow through one `_cost_recovery_asset_queryset` and echo the new params (the PDF resolves the committee name).

Frontend (`AssetCostRecoveryPage`): an **All-assets** toggle (disables the asset/category pickers), an **Ownership type** select, and an **Owning group (Committee/SIG)** select fed by the same source as the asset ownership editor (`sigAPI.listMySIGs()`). Any of the three counts as a selection.

### Tests / verification
- `test_cost_recovery.py`: **37 passed** (was 20) — covers `all_assets`, `ownership_type=space/group`, `owning_group`, combinations, the bare-request 400, and CSV/PDF parity.
- Full backend suite (Postgres) **3780 passed / 4 skipped**; `check_permission_matrix` OK (883 endpoints, no matrix change); vitest **1241 passed**; eslint 0 errors; black/isort/flake8 clean.
- Driven end-to-end vs a seeded Postgres DB across **9 modes** — JSON == CSV == PDF asset sets and the expected recoverable totals in every one.

Scope: `cost_recovery` only; permissions unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
