### PR TITLE
feat(inventory): AssetProblem → work order (internal + vendor) + auto-resolve (op-olai, B2)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -1158,6 +1158,15 @@ views:
       list:
         permission_classes:
         - IsAuthenticatedOrReadOnly
+      promote_to_standard_work_order:
+        permission_classes:
+        - IsAuthenticated
+      promote_to_third_party_work_order:
+        permission_classes:
+        - IsAuthenticated
+      resolve:
+        permission_classes:
+        - IsAuthenticated
       retrieve:
         permission_classes:
         - IsAuthenticatedOrReadOnly

--- a/backend/inventory/admin.py
+++ b/backend/inventory/admin.py
@@ -1742,11 +1742,22 @@ class AssetProblemAdmin(admin.ModelAdmin):
             },
         ),
         (
+            "Promotion",
+            {
+                "fields": (
+                    "work_order",
+                    "third_party_work_order",
+                ),
+                "classes": ("collapse",),
+            },
+        ),
+        (
             "Resolution",
             {
                 "fields": (
                     "resolution_notes",
                     "resolved_at",
+                    "resolved_by",
                 )
             },
         ),

--- a/backend/inventory/migrations/0100_asset_problem_work_order_links.py
+++ b/backend/inventory/migrations/0100_asset_problem_work_order_links.py
@@ -1,0 +1,31 @@
+"""Link an AssetProblem to the work order it was promoted to.
+
+Both FKs are nullable and ``SET_NULL``: a report exists before any work order
+does, and deleting the work order must not delete the report of the problem.
+Mirrors the pair ``LocationProblem`` has carried since the location-problem
+flow shipped.
+"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('inventory', '0099_work_order_nullable_item_direct_asset'),
+        ('maintenance_orders', '0005_thirdpartyworkorder_location'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='assetproblem',
+            name='third_party_work_order',
+            field=models.ForeignKey(blank=True, help_text='Third-party work order this problem was promoted to', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='asset_problems', to='maintenance_orders.thirdpartyworkorder'),
+        ),
+        migrations.AddField(
+            model_name='assetproblem',
+            name='work_order',
+            field=models.ForeignKey(blank=True, help_text='In-house corrective work order this problem was promoted to', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='asset_problems', to='inventory.workorder'),
+        ),
+    ]

--- a/backend/inventory/models/asset.py
+++ b/backend/inventory/models/asset.py
@@ -892,6 +892,22 @@ class AssetProblem(models.Model):
         default=Status.REPORTED,
         help_text="Current status of the problem report",
     )
+    work_order = models.ForeignKey(
+        "WorkOrder",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="asset_problems",
+        help_text="In-house corrective work order this problem was promoted to",
+    )
+    third_party_work_order = models.ForeignKey(
+        "maintenance_orders.ThirdPartyWorkOrder",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="asset_problems",
+        help_text="Third-party work order this problem was promoted to",
+    )
     resolution_notes = models.TextField(
         blank=True,
         help_text="Notes about how the problem was resolved",

--- a/backend/inventory/models/maintenance.py
+++ b/backend/inventory/models/maintenance.py
@@ -634,7 +634,10 @@ class WorkOrder(ElapsedTimerModel):
         """
         if self.maintenance_item_id:
             return self.maintenance_item.title
-        problem = getattr(self, "asset_problem", None)
+        # Reverse FK, so read it through ``.all()`` rather than ``.first()``:
+        # a caller that prefetched ``asset_problems`` pays no extra query.
+        # Only template-less (corrective) work orders ever reach this line.
+        problem = next(iter(self.asset_problems.all()), None)
         if problem is not None and problem.description:
             return problem.description[:60]
         if self.asset_id:

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -1596,6 +1596,8 @@ class AssetProblemSerializer(serializers.ModelSerializer):
         source="affected_parts",
         help_text="AssetPart ids the reporter flagged as needing replace/fix.",
     )
+    work_order_short_id = serializers.SerializerMethodField()
+    third_party_work_order_short_id = serializers.SerializerMethodField()
 
     class Meta:
         model = AssetProblem
@@ -1607,6 +1609,10 @@ class AssetProblemSerializer(serializers.ModelSerializer):
             "reported_by",
             "description",
             "status",
+            "work_order",
+            "work_order_short_id",
+            "third_party_work_order",
+            "third_party_work_order_short_id",
             "resolution_notes",
             "created_at",
             "updated_at",
@@ -1616,7 +1622,19 @@ class AssetProblemSerializer(serializers.ModelSerializer):
             "affected_parts",
             "part_ids",
         ]
-        read_only_fields = ["created_at", "updated_at", "resolved_at"]
+        read_only_fields = [
+            "created_at",
+            "updated_at",
+            "resolved_at",
+            "work_order",
+            "third_party_work_order",
+        ]
+
+    def get_work_order_short_id(self, obj):
+        return obj.work_order.short_id if obj.work_order_id else None
+
+    def get_third_party_work_order_short_id(self, obj):
+        return obj.third_party_work_order.short_id if obj.third_party_work_order_id else None
 
 
 class LocationProblemSerializer(serializers.ModelSerializer):

--- a/backend/inventory/services/problem_auto_resolve.py
+++ b/backend/inventory/services/problem_auto_resolve.py
@@ -5,16 +5,18 @@ promoted to a work order is *tracked by* that work order — nobody goes back to
 the report to close it by hand. So when the work order finishes, the reports it
 came from resolve with it.
 
-"Finishes" means two different things depending on where the work happened:
+"Finishes" has no single signal in this codebase, so every path that closes a
+work order calls :func:`resolve_problems_for_work_order`:
 
-* in-house — ``WorkOrder.status`` transitions to ``completed``
-  (``WorkOrderViewSet.perform_update``);
-* vendor — ``ThirdPartyWorkOrder`` reaches ``closed``
-  (``maintenance_orders.transitions.close_work_order``).
+* in-house, on screen — ``WorkOrderViewSet.perform_update``;
+* in-house, off a paper form — ``work_order_ingest._apply_pm_submission``
+  (emailed in) and ``omr_confirm_completion`` (reviewed scan);
+* vendor — ``maintenance_orders.transitions.close_work_order``, which is the
+  only completion signal that workflow has.
 
-Both call :func:`resolve_problems_for_work_order`. It duck-types on the two
-reverse accessors both models carry (``asset_problems`` / ``location_problems``)
-rather than branching on type, so the stamp is written identically either way.
+The function duck-types on the two reverse accessors both work-order models
+carry (``asset_problems`` / ``location_problems``) rather than branching on
+type, so the stamp is written identically whoever did the work.
 """
 
 from __future__ import annotations

--- a/backend/inventory/services/problem_auto_resolve.py
+++ b/backend/inventory/services/problem_auto_resolve.py
@@ -1,0 +1,68 @@
+"""Auto-resolve the problem reports a finished work order was promoted from.
+
+A reported problem (``AssetProblem`` / ``LocationProblem``) that has been
+promoted to a work order is *tracked by* that work order — nobody goes back to
+the report to close it by hand. So when the work order finishes, the reports it
+came from resolve with it.
+
+"Finishes" means two different things depending on where the work happened:
+
+* in-house — ``WorkOrder.status`` transitions to ``completed``
+  (``WorkOrderViewSet.perform_update``);
+* vendor — ``ThirdPartyWorkOrder`` reaches ``closed``
+  (``maintenance_orders.transitions.close_work_order``).
+
+Both call :func:`resolve_problems_for_work_order`. It duck-types on the two
+reverse accessors both models carry (``asset_problems`` / ``location_problems``)
+rather than branching on type, so the stamp is written identically either way.
+"""
+
+from __future__ import annotations
+
+from django.utils import timezone
+
+from membership.actor import SYSTEM_ACTOR, actor_display
+
+
+def resolve_problems_for_work_order(work_order, *, actor=None, notes: str = "") -> int:
+    """Resolve every open problem promoted to ``work_order``. Returns the count.
+
+    ``work_order`` is either an :class:`~inventory.models.WorkOrder` or a
+    :class:`~maintenance_orders.models.ThirdPartyWorkOrder` — both expose
+    ``asset_problems`` and ``location_problems``.
+
+    Already-resolved (or closed) reports are left alone, so a re-save of a
+    completed work order can't overwrite the original resolution stamp with a
+    later timestamp. ``notes`` (the work order's completion notes) is copied
+    into ``resolution_notes`` only when the report has none of its own.
+    """
+    from inventory.models import AssetProblem
+
+    # ``resolved_by`` is a free-text column; an actor-less call is a background
+    # completion, which the actor convention labels "System".
+    resolved_by = actor_display(actor, name=SYSTEM_ACTOR)
+    now = timezone.now()
+    open_statuses = (AssetProblem.Status.REPORTED, AssetProblem.Status.IN_PROGRESS)
+    count = 0
+
+    for manager in (work_order.asset_problems, work_order.location_problems):
+        for problem in manager.filter(status__in=open_statuses):
+            problem.status = problem.__class__.Status.RESOLVED
+            problem.resolved_at = now
+            problem.resolved_by = resolved_by
+            # Promotion seeds the work order's notes with the report text, so
+            # skip the copy when they still match — echoing the complaint back
+            # as its own resolution says nothing.
+            if notes and notes != problem.description and not problem.resolution_notes:
+                problem.resolution_notes = notes
+            problem.save(
+                update_fields=[
+                    "status",
+                    "resolved_at",
+                    "resolved_by",
+                    "resolution_notes",
+                    "updated_at",
+                ]
+            )
+            count += 1
+    return count

--- a/backend/inventory/services/problem_promotion.py
+++ b/backend/inventory/services/problem_promotion.py
@@ -1,0 +1,63 @@
+"""Carry a problem report's attachments onto the work order it was promoted to.
+
+Promotion has to carry the evidence forward: the photos (and, for locations, the
+scanned paper form) the reporter attached belong on the work order, because the
+work order is what the technician or the vendor actually looks at.
+
+Shared by ``AssetProblemViewSet`` and ``LocationProblemViewSet``. The two report
+types differ in where their files live — ``AssetProblem.photos`` is a related
+table, ``LocationProblem.photo``/``paper_form_attachment`` are single fields —
+but not in what copying one means, so the copy itself lives here once.
+"""
+
+from __future__ import annotations
+
+from django.core.files.base import ContentFile
+
+
+def _read(file_field) -> bytes:
+    """Read a FileField's bytes, leaving the underlying file closed."""
+    file_field.open("rb")
+    try:
+        return file_field.read()
+    finally:
+        file_field.close()
+
+
+def _extension(file_field, default: str = "bin") -> str:
+    """Extension of the stored file, so a copied PNG doesn't land named .jpg."""
+    name = file_field.name or ""
+    return name.rsplit(".", 1)[-1] if "." in name else default
+
+
+def copy_to_work_order_photo(file_field, work_order, *, caption: str, filename_hint: str):
+    """Copy one image onto ``work_order`` as a ``WorkOrderPhoto``."""
+    from inventory.models import WorkOrderPhoto
+
+    photo = WorkOrderPhoto(work_order=work_order, caption=caption)
+    photo.image.save(
+        f"{filename_hint}.{_extension(file_field, default='jpg')}",
+        ContentFile(_read(file_field)),
+        save=False,
+    )
+    photo.save()
+    return photo
+
+
+def copy_to_tpwo_attachment(file_field, tpwo, *, kind: str, caption: str, filename_hint: str, user):
+    """Copy one file onto ``tpwo`` as a ``ThirdPartyWorkOrderAttachment``."""
+    from maintenance_orders.models import ThirdPartyWorkOrderAttachment
+
+    attachment = ThirdPartyWorkOrderAttachment(
+        work_order=tpwo,
+        kind=kind,
+        caption=caption,
+        uploaded_by=user,
+    )
+    attachment.file.save(
+        f"{filename_hint}-{tpwo.short_id}.{_extension(file_field)}",
+        ContentFile(_read(file_field)),
+        save=False,
+    )
+    attachment.save()
+    return attachment

--- a/backend/inventory/services/work_order_ingest.py
+++ b/backend/inventory/services/work_order_ingest.py
@@ -44,6 +44,7 @@ from django.utils import timezone
 from pypdf import PdfReader
 
 from ..models import MaintenanceLog, WorkOrder, WorkOrderMaterialUsage, WorkOrderSubmission
+from .problem_auto_resolve import resolve_problems_for_work_order
 from .work_order_material_usage import apply_material_usage
 
 logger = logging.getLogger(__name__)
@@ -435,6 +436,9 @@ def _apply_pm_submission(submission: WorkOrderSubmission, pdf_bytes: bytes) -> W
     work_order.save()
 
     if wo_became_complete:
+        # Whatever problem report this work order was promoted from closes with
+        # it — a form mailed in completes the work just as the screen does.
+        resolve_problems_for_work_order(work_order, notes=work_order.notes or "")
         # Corrective work orders have no PM template to advance, and
         # ``MaintenanceLog.maintenance_item`` is non-nullable — there is no log
         # to write for them. The work order's own completion stamp is the record.
@@ -659,6 +663,8 @@ def omr_confirm_completion(
     # A WO started on-screen and closed off a scanned sheet must not be left
     # with a clock running — same finalize the digital completion path uses.
     finalize_work_order_timers(work_order, now=now)
+    # Same as the digital path: the report this work order came from closes too.
+    resolve_problems_for_work_order(work_order, actor=user, notes=work_order.notes or "")
     # No PM template on a corrective work order, and no MaintenanceLog either:
     # the log's ``maintenance_item`` is non-nullable, so there is nothing to
     # write. The elapsed time stays on the work order itself.

--- a/backend/inventory/tests/test_asset_problem_promote.py
+++ b/backend/inventory/tests/test_asset_problem_promote.py
@@ -1,0 +1,496 @@
+"""A reported asset problem becomes real, completable work (op-olai).
+
+Reporting a problem used to produce a report and nothing else: no work order,
+no way to close the loop except editing the report by hand. This is the promote
+path the sibling ``LocationProblem`` already had — in-house (a corrective
+``WorkOrder`` anchored straight to the asset, no PM template) or vendor (a
+``ThirdPartyWorkOrder``) — plus the auto-resolve that closes the report when
+either kind of work order finishes.
+
+Each test maps to one acceptance criterion on the bead: promote-standard,
+promote-third-party, resolve, the two auto-resolve hooks, and the dashboard
+feed no longer double-counting a promoted report.
+"""
+
+import io
+import uuid
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils.crypto import get_random_string
+
+import pytest
+from PIL import Image
+from rest_framework.test import APIClient
+
+from inventory.models import (
+    AssetProblem,
+    AssetProblemPhoto,
+    WorkOrder,
+    WorkOrderValidation,
+)
+from inventory.tests.factories import AssetFactory
+from maintenance_orders import transitions as t
+from maintenance_orders.models import ThirdPartyWorkOrder, ThirdPartyWorkOrderAttachment
+from vendors.models import Vendor
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_media(settings, tmp_path):
+    """Keep uploaded test images out of the tracked backend/media tree."""
+    settings.MEDIA_ROOT = str(tmp_path)
+
+
+@pytest.fixture
+def staff(db):
+    return User.objects.create_user(
+        username="ap-staff",
+        email="ap-staff@example.com",
+        password=get_random_string(24),
+        is_staff=True,
+    )
+
+
+@pytest.fixture
+def staff_client(staff):
+    client = APIClient()
+    client.force_authenticate(user=staff)
+    return client
+
+
+@pytest.fixture
+def asset(db):
+    return AssetFactory(asset_tag=f"AP-{uuid.uuid4().hex[:8].upper()}")
+
+
+@pytest.fixture
+def vendor(db):
+    return Vendor.objects.create(name="ACME Repair", vendor_kind=Vendor.KIND_HVAC)
+
+
+@pytest.fixture
+def problem(asset):
+    return AssetProblem.objects.create(
+        asset=asset,
+        description="Spindle screams above 8000 rpm",
+        reported_by="member1",
+    )
+
+
+def _png_bytes() -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (4, 4), color=(255, 0, 0)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _attach_photo(problem, caption="") -> AssetProblemPhoto:
+    photo = AssetProblemPhoto(problem=problem, caption=caption)
+    photo.image.save("report.png", ContentFile(_png_bytes()), save=True)
+    return photo
+
+
+def _complete_via_api(client, work_order, *, notes=None):
+    """Complete a work order the way the web app does, past the AC-3 gate."""
+    WorkOrderValidation.objects.create(
+        work_order=work_order,
+        electrical_acknowledged=True,
+        loto_acknowledged=True,
+        required_fields_acknowledged=True,
+    )
+    payload = {"status": WorkOrder.Status.COMPLETED}
+    if notes is not None:
+        payload["notes"] = notes
+    return client.patch(
+        f"/api/inventory/work-orders/{work_order.id}/",
+        payload,
+        format="json",
+    )
+
+
+def _ready_to_close(tpwo, *, user):
+    """Fast-forward a vendor WO to the last gate before closure.
+
+    The 7-step state machine is exercised in ``maintenance_orders`` tests; here
+    only the closure step matters, so jump to financial review and satisfy the
+    invoice + FSR requirement.
+    """
+    tpwo.status = ThirdPartyWorkOrder.STATUS_FINANCIAL_REVIEW
+    tpwo.actual_invoice_total = Decimal("250.00")
+    tpwo.variance_status = "auto_approved"
+    tpwo.save(update_fields=["status", "actual_invoice_total", "variance_status"])
+    for kind in (
+        ThirdPartyWorkOrderAttachment.KIND_INVOICE,
+        ThirdPartyWorkOrderAttachment.KIND_FSR,
+    ):
+        ThirdPartyWorkOrderAttachment.objects.create(
+            work_order=tpwo,
+            kind=kind,
+            file=SimpleUploadedFile(f"{kind}.pdf", b"%PDF", content_type="application/pdf"),
+            uploaded_by=user,
+        )
+
+
+class TestPromoteToStandardWorkOrder:
+    def test_creates_corrective_work_order_anchored_to_the_asset(
+        self, staff_client, staff, problem, asset
+    ):
+        _attach_photo(problem, caption="burn mark")
+
+        resp = staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-standard/",
+            {},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.content
+
+        problem.refresh_from_db()
+        wo = problem.work_order
+        assert wo is not None
+        # The point of the corrective shape: an asset, no PM template.
+        assert wo.maintenance_item_id is None
+        assert wo.asset_id == asset.id
+        assert wo.notes == problem.description
+        assert wo.assigned_to_id == staff.id
+        assert problem.status == AssetProblem.Status.IN_PROGRESS
+        # Reverse relation the auto-resolve hooks walk.
+        assert problem in wo.asset_problems.all()
+        # The reporter's photo came along.
+        assert wo.photos.count() == 1
+        assert wo.photos.get().caption == "burn mark"
+
+    def test_response_exposes_the_new_work_order(self, staff_client, problem):
+        resp = staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-standard/",
+            {},
+            format="json",
+        )
+        problem.refresh_from_db()
+        body = resp.json()
+        assert body["work_order"] == str(problem.work_order_id)
+        assert body["work_order_short_id"] == problem.work_order.short_id
+        assert body["third_party_work_order"] is None
+        assert body["third_party_work_order_short_id"] is None
+
+    def test_work_order_is_titled_by_the_reported_problem(self, staff_client, problem):
+        staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-standard/",
+            {},
+            format="json",
+        )
+        problem.refresh_from_db()
+        # No PM template to name it, so it falls back to the report.
+        assert problem.work_order.display_title == problem.description[:60]
+
+    def test_second_promotion_is_rejected(self, staff_client, problem):
+        first = staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-standard/",
+            {},
+            format="json",
+        )
+        assert first.status_code == 201, first.content
+
+        second = staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-standard/",
+            {},
+            format="json",
+        )
+        assert second.status_code == 400
+        assert WorkOrder.objects.filter(asset_problems=problem).count() == 1
+
+    def test_requires_authentication(self, problem):
+        resp = APIClient().post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-standard/",
+            {},
+            format="json",
+        )
+        assert resp.status_code in (401, 403)
+        problem.refresh_from_db()
+        assert problem.work_order_id is None
+
+    def test_materializes_loto_completion_rows(self, staff_client, problem, asset):
+        """A corrective WO prints and scans back like a generated one."""
+        from loto.models import AssetEnergySource
+
+        AssetEnergySource.objects.create(
+            asset=asset,
+            source_type=AssetEnergySource.SOURCE_ELECTRICAL,
+            magnitude="240V",
+            isolation_point="Panel B, breaker 12",
+        )
+        staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-standard/",
+            {},
+            format="json",
+        )
+        problem.refresh_from_db()
+        assert problem.work_order.loto_completions.count() == 1
+
+
+class TestPromoteToThirdPartyWorkOrder:
+    def test_creates_vendor_work_order_on_the_asset(
+        self, staff_client, staff, problem, asset, vendor
+    ):
+        _attach_photo(problem)
+
+        resp = staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-third-party/",
+            {"vendor": str(vendor.id), "title": "Spindle bearing replacement"},
+            format="json",
+        )
+        assert resp.status_code == 201, resp.content
+
+        problem.refresh_from_db()
+        tpwo = problem.third_party_work_order
+        assert tpwo is not None
+        assert tpwo.title == "Spindle bearing replacement"
+        assert tpwo.asset_id == asset.id
+        assert tpwo.location_id == asset.location_id
+        assert tpwo.vendor_id == vendor.id
+        assert tpwo.notes == problem.description
+        assert tpwo.opened_by_id == staff.id
+        assert problem.status == AssetProblem.Status.IN_PROGRESS
+        assert problem in tpwo.asset_problems.all()
+        # The reporter's photo came along as an attachment.
+        assert tpwo.attachments.filter(kind=ThirdPartyWorkOrderAttachment.KIND_PHOTO).count() == 1
+
+    def test_requires_vendor_and_title(self, staff_client, problem, vendor):
+        missing_both = staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-third-party/",
+            {},
+            format="json",
+        )
+        assert missing_both.status_code == 400
+
+        missing_title = staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-third-party/",
+            {"vendor": str(vendor.id)},
+            format="json",
+        )
+        assert missing_title.status_code == 400
+
+        problem.refresh_from_db()
+        assert problem.third_party_work_order_id is None
+        assert problem.status == AssetProblem.Status.REPORTED
+
+    def test_unknown_vendor_is_404(self, staff_client, problem):
+        resp = staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-third-party/",
+            {"vendor": str(uuid.uuid4()), "title": "x"},
+            format="json",
+        )
+        assert resp.status_code == 404
+
+    def test_second_promotion_is_rejected(self, staff_client, problem, vendor):
+        body = {"vendor": str(vendor.id), "title": "Spindle bearing replacement"}
+        first = staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-third-party/",
+            body,
+            format="json",
+        )
+        assert first.status_code == 201, first.content
+
+        second = staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-third-party/",
+            body,
+            format="json",
+        )
+        assert second.status_code == 400
+        assert ThirdPartyWorkOrder.objects.count() == 1
+
+
+class TestResolve:
+    def test_resolve_stamps_the_report(self, staff_client, staff, problem):
+        resp = staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/resolve/",
+            {"resolution_notes": "Replaced the bearing"},
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+
+        problem.refresh_from_db()
+        assert problem.status == AssetProblem.Status.RESOLVED
+        assert problem.resolution_notes == "Replaced the bearing"
+        assert problem.resolved_at is not None
+        assert problem.resolved_by == (staff.handle or staff.username)
+
+    def test_resolve_accepts_closed(self, staff_client, problem):
+        resp = staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/resolve/",
+            {"status": AssetProblem.Status.CLOSED},
+            format="json",
+        )
+        assert resp.status_code == 200, resp.content
+        problem.refresh_from_db()
+        assert problem.status == AssetProblem.Status.CLOSED
+
+    def test_resolve_rejects_other_statuses(self, staff_client, problem):
+        resp = staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/resolve/",
+            {"status": AssetProblem.Status.IN_PROGRESS},
+            format="json",
+        )
+        assert resp.status_code == 400
+        problem.refresh_from_db()
+        assert problem.status == AssetProblem.Status.REPORTED
+
+    def test_resolve_requires_authentication(self, problem):
+        resp = APIClient().post(
+            f"/api/inventory/asset-problems/{problem.id}/resolve/",
+            {},
+            format="json",
+        )
+        assert resp.status_code in (401, 403)
+
+
+class TestAutoResolveOnCompletion:
+    def test_report_to_work_order_to_resolved(self, staff_client, staff, asset):
+        """End to end: report → promote-standard → complete → RESOLVED."""
+        report = staff_client.post(
+            f"/api/inventory/assets/{asset.id}/report_problem/",
+            {"description": "Coolant pump leaking"},
+            format="multipart",
+        )
+        assert report.status_code == 201, report.content
+        problem = AssetProblem.objects.get(id=report.json()["id"])
+
+        promote = staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-standard/",
+            {},
+            format="json",
+        )
+        assert promote.status_code == 201, promote.content
+        problem.refresh_from_db()
+
+        done = _complete_via_api(staff_client, problem.work_order, notes="Swapped the pump")
+        assert done.status_code == 200, done.content
+
+        problem.refresh_from_db()
+        assert problem.status == AssetProblem.Status.RESOLVED
+        assert problem.resolved_at is not None
+        assert problem.resolved_by == (staff.handle or staff.username)
+        assert problem.resolution_notes == "Swapped the pump"
+
+    def test_completion_notes_echoing_the_report_are_not_copied(self, staff_client, problem):
+        """Promotion seeds the WO notes with the report text; don't echo it back."""
+        staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-standard/",
+            {},
+            format="json",
+        )
+        problem.refresh_from_db()
+
+        _complete_via_api(staff_client, problem.work_order)
+
+        problem.refresh_from_db()
+        assert problem.status == AssetProblem.Status.RESOLVED
+        assert problem.resolution_notes == ""
+
+    def test_already_resolved_report_keeps_its_original_stamp(self, staff_client, problem):
+        staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-standard/",
+            {},
+            format="json",
+        )
+        problem.refresh_from_db()
+        staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/resolve/",
+            {"resolution_notes": "Fixed on the spot"},
+            format="json",
+        )
+        problem.refresh_from_db()
+        stamped_at = problem.resolved_at
+
+        _complete_via_api(staff_client, problem.work_order, notes="Later paperwork")
+
+        problem.refresh_from_db()
+        assert problem.resolved_at == stamped_at
+        assert problem.resolution_notes == "Fixed on the spot"
+
+    def test_unpromoted_reports_are_untouched(self, staff_client, asset, problem):
+        """A WO on the same asset that this report was not promoted to."""
+        unrelated = WorkOrder.objects.create(maintenance_item=None, asset=asset)
+
+        _complete_via_api(staff_client, unrelated)
+
+        problem.refresh_from_db()
+        assert problem.status == AssetProblem.Status.REPORTED
+        assert problem.resolved_at is None
+
+    def test_vendor_closure_resolves_the_report(self, staff_client, staff, problem, vendor):
+        """End to end: promote-third-party → close_work_order → RESOLVED."""
+        promote = staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-third-party/",
+            {"vendor": str(vendor.id), "title": "Spindle bearing replacement"},
+            format="json",
+        )
+        assert promote.status_code == 201, promote.content
+        problem.refresh_from_db()
+        tpwo = problem.third_party_work_order
+
+        _ready_to_close(tpwo, user=staff)
+        t.close_work_order(tpwo, user=staff)
+
+        problem.refresh_from_db()
+        assert problem.status == AssetProblem.Status.RESOLVED
+        assert problem.resolved_at is not None
+        assert problem.resolved_by == (staff.handle or staff.username)
+
+    def test_vendor_closure_resolves_a_promoted_location_problem(self, staff, vendor):
+        """The same hook covers the location sibling, which had no closer either."""
+        from inventory.models import Location, LocationProblem
+
+        location = Location.objects.create(name="Bay 3")
+        tpwo = ThirdPartyWorkOrder.objects.create(
+            title="Leak", vendor=vendor, location=location, notes="fix the leak"
+        )
+        lp = LocationProblem.objects.create(
+            location=location,
+            description="Water on the floor",
+            third_party_work_order=tpwo,
+            status=LocationProblem.Status.IN_PROGRESS,
+        )
+
+        _ready_to_close(tpwo, user=staff)
+        t.close_work_order(tpwo, user=staff)
+
+        lp.refresh_from_db()
+        assert lp.status == LocationProblem.Status.RESOLVED
+        assert lp.resolved_at is not None
+
+
+class TestActiveMaintenanceFeed:
+    def test_promoted_problem_is_listed_as_its_work_order(self, staff_client, problem):
+        before = staff_client.get("/api/inventory/maintenance/active/")
+        assert before.status_code == 200, before.content
+        kinds = [row["kind"] for row in before.json()["results"]]
+        assert kinds.count("asset_problem") == 1
+
+        staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-standard/",
+            {},
+            format="json",
+        )
+
+        after = staff_client.get("/api/inventory/maintenance/active/")
+        rows = after.json()["results"]
+        # The raw report is gone; the work order it became took its place.
+        assert [row["kind"] for row in rows].count("asset_problem") == 0
+        work_orders = [row for row in rows if row["kind"] == "work_order"]
+        assert len(work_orders) == 1
+        assert work_orders[0]["title"] == problem.description[:60]
+
+    def test_vendor_promoted_problem_also_drops_out(self, staff_client, problem, vendor):
+        staff_client.post(
+            f"/api/inventory/asset-problems/{problem.id}/promote-third-party/",
+            {"vendor": str(vendor.id), "title": "Spindle bearing replacement"},
+            format="json",
+        )
+
+        resp = staff_client.get("/api/inventory/maintenance/active/")
+        assert [row["kind"] for row in resp.json()["results"]].count("asset_problem") == 0

--- a/backend/inventory/tests/test_asset_problem_promote.py
+++ b/backend/inventory/tests/test_asset_problem_promote.py
@@ -441,6 +441,53 @@ class TestAutoResolveOnCompletion:
         assert problem.resolved_at is not None
         assert problem.resolved_by == (staff.handle or staff.username)
 
+    def test_scanned_paper_completion_resolves_the_report(self, staff, asset):
+        """The paper path completes work orders too, so it must close reports.
+
+        A scanned sheet can only close a work order that has required tasks, so
+        this is the PM shape — the one a promoted LocationProblem rides on.
+        """
+        from inventory.models import (
+            MaintenanceItem,
+            MaintenanceTask,
+            WorkOrderSubmission,
+            WorkOrderTaskCompletion,
+        )
+        from inventory.services.work_order_ingest import omr_confirm_completion
+
+        item = MaintenanceItem.objects.create(
+            asset=asset, title="Monthly inspection", interval_days=30
+        )
+        wo = WorkOrder.objects.create(maintenance_item=item)
+        task = MaintenanceTask.objects.create(
+            maintenance_item=item, title="Check the belt", order=1, is_required=True
+        )
+        WorkOrderTaskCompletion.objects.create(
+            work_order=wo,
+            task=task,
+            task_title=task.title,
+            task_order=task.order,
+            is_required=True,
+            is_completed=True,
+        )
+        problem = AssetProblem.objects.create(
+            asset=asset,
+            description="Belt squeals",
+            work_order=wo,
+            status=AssetProblem.Status.IN_PROGRESS,
+        )
+        submission = WorkOrderSubmission.objects.create(
+            kind=WorkOrderSubmission.Kind.PM_COMPLETION,
+            work_order=wo,
+            status=WorkOrderSubmission.Status.PENDING_REVIEW,
+        )
+
+        assert omr_confirm_completion(wo, submission, user=staff) is True
+
+        problem.refresh_from_db()
+        assert problem.status == AssetProblem.Status.RESOLVED
+        assert problem.resolved_by == (staff.handle or staff.username)
+
     def test_vendor_closure_resolves_a_promoted_location_problem(self, staff, vendor):
         """The same hook covers the location sibling, which had no closer either."""
         from inventory.models import Location, LocationProblem

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -111,6 +111,7 @@ from .serializers import (
     WorkOrderTaskCompletionSerializer,
     WorkOrderValidationSerializer,
 )
+from .services.problem_auto_resolve import resolve_problems_for_work_order
 
 
 class SupplierViewSet(viewsets.ModelViewSet):
@@ -2651,11 +2652,14 @@ class AssetProblemViewSet(viewsets.ReadOnlyModelViewSet):
     """API endpoint for asset problem reports.
 
     Read-only here; problems are created via Asset.report_problem. This viewset
-    exposes detail GET plus the upload-photo action so reporters can attach
-    images to a freshly-created problem report.
+    exposes detail GET, the upload-photo action so reporters can attach images
+    to a freshly-created problem report, and the promote/resolve actions that
+    turn a report into real work and close it out.
     """
 
-    queryset = AssetProblem.objects.select_related("asset", "part").prefetch_related("photos")
+    queryset = AssetProblem.objects.select_related(
+        "asset", "part", "work_order", "third_party_work_order"
+    ).prefetch_related("photos")
     serializer_class = AssetProblemSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
 
@@ -2721,6 +2725,164 @@ class AssetProblemViewSet(viewsets.ReadOnlyModelViewSet):
         uploaded_by = user if (user and user.is_authenticated) else None
         serializer.save(problem=problem, uploaded_by=uploaded_by)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="promote-standard",
+        permission_classes=[IsAuthenticated],
+    )
+    def promote_to_standard_work_order(self, request, pk=None):
+        """Promote this AssetProblem to an in-house corrective WorkOrder.
+
+        No MaintenanceItem picker, unlike the LocationProblem sibling: a
+        corrective work order anchors directly to the problem's asset
+        (``maintenance_item=None``), which is exactly what the nullable-item
+        foundation exists for. The reporter's description becomes the work
+        order's notes and their photos are copied onto it.
+        """
+        from .services.problem_promotion import copy_to_work_order_photo
+        from .services.work_order_loto import create_loto_completions
+
+        problem = self.get_object()
+        if problem.work_order_id:
+            return Response(
+                {"error": "Already promoted to a standard work order."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        user = request.user if request.user.is_authenticated else None
+        with transaction.atomic():
+            wo = WorkOrder.objects.create(
+                maintenance_item=None,
+                asset=problem.asset,
+                notes=problem.description,
+                assigned_to=user,
+            )
+            # Materialize the per-energy-source LOTO rows so a corrective WO
+            # prints and scans back exactly like a generated PM one.
+            create_loto_completions(wo)
+            problem.work_order = wo
+            problem.status = AssetProblem.Status.IN_PROGRESS
+            problem.save(update_fields=["work_order", "status", "updated_at"])
+            for photo in problem.photos.all():
+                if not photo.image:
+                    continue
+                copy_to_work_order_photo(
+                    photo.image,
+                    wo,
+                    caption=photo.caption or f"From AssetProblem {problem.id}",
+                    filename_hint=f"asset-problem-{problem.id}",
+                )
+
+        serializer = AssetProblemSerializer(problem, context={"request": request})
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="promote-third-party",
+        permission_classes=[IsAuthenticated],
+    )
+    def promote_to_third_party_work_order(self, request, pk=None):
+        """Promote this AssetProblem to a vendor ThirdPartyWorkOrder.
+
+        Required: ``vendor`` (uuid) and ``title`` — a vendor WO is a purchase,
+        so it needs a human-written scope line rather than the raw report text.
+        The description rides along in ``notes``, the asset (and its location)
+        are pre-filled, and the reporter's photos are copied to attachments.
+        """
+        from maintenance_orders.models import ThirdPartyWorkOrder, ThirdPartyWorkOrderAttachment
+        from vendors.models import Vendor
+
+        from .services.problem_promotion import copy_to_tpwo_attachment
+
+        problem = self.get_object()
+        if problem.third_party_work_order_id:
+            return Response(
+                {"error": "Already promoted to a third-party work order."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        vendor_id = request.data.get("vendor")
+        title = (request.data.get("title") or "").strip()
+        if not vendor_id or not title:
+            return Response(
+                {"error": "vendor and title are required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            vendor = Vendor.objects.get(id=vendor_id)
+        except (Vendor.DoesNotExist, DjangoValidationError, ValueError):
+            # DjangoValidationError covers a malformed uuid, which would
+            # otherwise 500 out of the queryset rather than 404.
+            return Response(
+                {"error": "Vendor not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        work_type = request.data.get("work_type") or ThirdPartyWorkOrder.WORK_TYPE_STANDARD
+        user = request.user if request.user.is_authenticated else None
+
+        with transaction.atomic():
+            tpwo = ThirdPartyWorkOrder.objects.create(
+                title=title,
+                asset=problem.asset,
+                location=problem.asset.location,
+                vendor=vendor,
+                work_type=work_type,
+                notes=problem.description,
+                opened_by=user,
+            )
+            problem.third_party_work_order = tpwo
+            problem.status = AssetProblem.Status.IN_PROGRESS
+            problem.save(update_fields=["third_party_work_order", "status", "updated_at"])
+            for photo in problem.photos.all():
+                if not photo.image:
+                    continue
+                copy_to_tpwo_attachment(
+                    photo.image,
+                    tpwo,
+                    kind=ThirdPartyWorkOrderAttachment.KIND_PHOTO,
+                    caption=photo.caption or f"Reporter photo from AssetProblem {problem.id}",
+                    filename_hint="asset-problem-photo",
+                    user=user,
+                )
+
+        serializer = AssetProblemSerializer(problem, context={"request": request})
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=["post"], permission_classes=[IsAuthenticated])
+    def resolve(self, request, pk=None):
+        """Mark this asset problem resolved or closed.
+
+        Same stamp as ``AssetViewSet.resolve_problem``, reachable from the
+        problem itself so web and ScanTTY don't need the asset in hand.
+        """
+        problem = self.get_object()
+        new_status = request.data.get("status", AssetProblem.Status.RESOLVED)
+        if new_status not in (AssetProblem.Status.RESOLVED, AssetProblem.Status.CLOSED):
+            return Response(
+                {
+                    "error": (
+                        f"status must be '{AssetProblem.Status.RESOLVED}' or "
+                        f"'{AssetProblem.Status.CLOSED}'"
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        problem.status = new_status
+        problem.resolution_notes = request.data.get(
+            "resolution_notes", problem.resolution_notes or ""
+        )
+        if not problem.resolved_at:
+            problem.resolved_at = timezone.now()
+            problem.resolved_by = actor_display(request.user)
+        problem.save()
+
+        serializer = AssetProblemSerializer(problem, context={"request": request})
+        return Response(serializer.data)
 
 
 class AssetDocumentViewSet(viewsets.ModelViewSet):
@@ -3169,50 +3331,29 @@ class LocationProblemViewSet(viewsets.ReadOnlyModelViewSet):
     @staticmethod
     def _copy_attachments_to_work_order(problem, work_order):
         """Copy a problem's photo to a PM WorkOrder via WorkOrderPhoto."""
-        from .models import WorkOrderPhoto
+        from .services.problem_promotion import copy_to_work_order_photo
 
         if problem.photo:
-            wop = WorkOrderPhoto(
-                work_order=work_order,
+            copy_to_work_order_photo(
+                problem.photo,
+                work_order,
                 caption=f"From LocationProblem {problem.id}",
+                filename_hint=f"location-problem-{problem.id}",
             )
-            problem.photo.open("rb")
-            try:
-                from django.core.files.base import ContentFile
-
-                wop.image.save(
-                    f"location-problem-{problem.id}.jpg",
-                    ContentFile(problem.photo.read()),
-                    save=False,
-                )
-            finally:
-                problem.photo.close()
-            wop.save()
 
     @staticmethod
     def _copy_to_tpwo_attachment(file_field, tpwo, *, kind, caption, filename_hint, user):
-        from django.core.files.base import ContentFile
+        """Copy one of a problem's files to a TPWO attachment."""
+        from .services.problem_promotion import copy_to_tpwo_attachment
 
-        from maintenance_orders.models import ThirdPartyWorkOrderAttachment
-
-        file_field.open("rb")
-        try:
-            data = file_field.read()
-        finally:
-            file_field.close()
-        attachment = ThirdPartyWorkOrderAttachment(
-            work_order=tpwo,
+        copy_to_tpwo_attachment(
+            file_field,
+            tpwo,
             kind=kind,
             caption=caption,
-            uploaded_by=user,
+            filename_hint=filename_hint,
+            user=user,
         )
-        ext = file_field.name.rsplit(".", 1)[-1] if "." in file_field.name else "bin"
-        attachment.file.save(
-            f"{filename_hint}-{tpwo.short_id}.{ext}",
-            ContentFile(data),
-            save=False,
-        )
-        attachment.save()
 
 
 class AssetPartViewSet(viewsets.ModelViewSet):
@@ -4311,6 +4452,13 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
             work_order.status == WorkOrder.Status.COMPLETED
             and old_status != WorkOrder.Status.COMPLETED
         ):
+            # A problem promoted to this work order is tracked by it — finishing
+            # the work is what resolves the report.
+            resolve_problems_for_work_order(
+                work_order,
+                actor=self.request.user,
+                notes=work_order.notes or "",
+            )
             record_maintenance_audit_event(
                 action=MaintenanceAuditEvent.Action.WO_COMPLETE,
                 actor=self.request.user,
@@ -5530,6 +5678,8 @@ class MaintenanceDashboardViewSet(viewsets.ViewSet):
         for wo in (
             WorkOrder.objects.filter(status__in=open_wo_statuses)
             .select_related("maintenance_item", "asset")
+            # display_title falls back to the promoted report on a corrective WO
+            .prefetch_related("asset_problems")
             .order_by("-created_at")
         ):
             rows.append(
@@ -5550,9 +5700,14 @@ class MaintenanceDashboardViewSet(viewsets.ViewSet):
                 }
             )
 
-        # AssetProblem has no FK to WorkOrder, so we surface every open report.
+        # A promoted problem is already in this feed as its work order, so only
+        # un-promoted reports appear here (same rule as LocationProblem below).
         for ap in (
-            AssetProblem.objects.filter(status__in=open_problem_statuses)
+            AssetProblem.objects.filter(
+                status__in=open_problem_statuses,
+                work_order__isnull=True,
+                third_party_work_order__isnull=True,
+            )
             .select_related("asset")
             .order_by("-created_at")
         ):

--- a/backend/maintenance_orders/transitions.py
+++ b/backend/maintenance_orders/transitions.py
@@ -24,6 +24,7 @@ from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import transaction
 from django.utils import timezone
 
+from inventory.services.problem_auto_resolve import resolve_problems_for_work_order
 from membership.utils import is_logistics_member, is_sig_admin
 
 from .models import (
@@ -592,6 +593,9 @@ def close_work_order(wo: ThirdPartyWorkOrder, *, user) -> ThirdPartyWorkOrder:
             "warranty_recovery": wo.warranty_recovery,
         },
     )
+    # A problem report promoted to this vendor WO is tracked by it, and a
+    # closed WO is the only completion signal the vendor workflow has.
+    resolve_problems_for_work_order(wo, actor=user, notes=wo.notes or "")
     if wo.warranty_recovery:
         _create_warranty_recovery_task(wo, user=user)
     _emit_closure_notifications(wo)


### PR DESCRIPTION
Second PR of the corrective-work-order epic (bead **op-olai**, builds on B1 #944). A reported `AssetProblem` can now be promoted into a real, completable work order — in-house **or** third-party vendor — and completing that work order **auto-resolves the problem**. Mirrors the existing `LocationProblem` promote pattern.

### Changes
- **Model** (migration `0100`): `AssetProblem.work_order` + `AssetProblem.third_party_work_order` FKs (`related_name="asset_problems"`).
- **Actions on `AssetProblemViewSet`**: `promote-standard` (creates a corrective WO — `maintenance_item=None`, `asset=problem.asset`), `promote-third-party` (creates a `ThirdPartyWorkOrder` with `asset=problem.asset`), and `resolve` (parity with the Asset viewset).
- **Auto-resolve**: completing the WO resolves the linked problem — via `perform_update`, **both** paper-form completion paths (emailed form + reviewed scan), and `ThirdPartyWorkOrder.close_work_order` (which now also closes promoted `LocationProblem`s).
- Promoted problems drop out of the active-maintenance feed; the serializer exposes both WO short-ids; **permission matrix regenerated**.
- New service seams: `problem_auto_resolve.py` (one resolve seam, duck-typed over both WO models) and `problem_promotion.py` (attachment copy, de-duplicated with `LocationProblemViewSet`).

### Notes
- Reconciled a spec inconsistency: the WO↔problem link is the **reverse FK on `AssetProblem`** (not a field on `WorkOrder`); `WorkOrder.display_title` now reads that accessor (B1 left a defensive getattr for exactly this).
- **Beyond-spec (completeness):** also hooked the two paper-form completion paths — without them a paper-completed WO would leave its report open forever.

### Tests / verification
- **23 new tests** (`test_asset_problem_promote.py`) — both promote paths, resolve, auto-resolve on digital + paper + vendor completion, dashboard filtering.
- inventory + maintenance_orders + permission-matrix on Postgres: **1285 passed / 4 skipped**. The **2 failures in `test_log_usage_charge.py` are a pre-existing accounting chart-flush test-isolation flake** (triggered by `facilities` `transaction=True`; this branch touches none of that code and adds no such test) — those 6 accounting tests + all 23 new pass on an isolated `--create-db` run (85 passed). CI Backend Tests confirms independently.
- black/isort/flake8/bandit clean; `makemigrations --check` no changes; migration conflict detection empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
