### PR TITLE
feat(inventory): committee ledger charge on work-order completion (op-u2g5, B6)

### DIFF
--- a/backend/accounting/adapters.py
+++ b/backend/accounting/adapters.py
@@ -6,8 +6,9 @@ PO, recording a donation, …) and the double-entry engine in
 callers post money without hardcoding account codes or hand-writing balanced
 legs — they describe the business event, the adapter builds the entry.
 
-Phase 2 · Bead 1 ships the first one, :func:`post_supply_consumption`;
-Bead 5 adds :func:`post_po_receipt`.
+Phase 2 · Bead 1 ships the first one, :func:`post_supply_consumption` (reused
+unchanged by the Bead 6 work-order completion charge); Bead 5 adds
+:func:`post_po_receipt`.
 """
 
 from decimal import Decimal
@@ -72,10 +73,12 @@ def post_supply_consumption(
     Returns:
         The posted (or pre-existing, when idempotent) ``hordak.Transaction``.
 
-    This adapter is deliberately reusable by the later serialized-consume and
-    work-order material-usage charge paths, which will call it with the same
-    5100/1300 mapping. (No reversal helper yet — ``log_usage`` has no undo;
-    TODO: add one when a consumption-reversal flow lands.)
+    Two consumption routes share this one mapping: ``log_usage`` (Bead 1) and
+    :func:`inventory.services.work_order_ledger.charge_completed_work_order`
+    (Bead 6, the work-order completion charge). The serialized-consume path will
+    be the third. Undoing a charge is
+    :func:`accounting.services.reverse_entry` — append-only, never an edit; the
+    work-order path uses it when a completed job is reopened.
     """
     if not description:
         description = (

--- a/backend/inventory/services/work_order_ledger.py
+++ b/backend/inventory/services/work_order_ledger.py
@@ -1,0 +1,201 @@
+"""Committee ledger charge for a completed work order (op-u2g5, Phase 2 · B6).
+
+Finishing a job on a committee-owned machine spends the committee's money. This
+module is the one seam that says so in the books: when a work order transitions
+into ``completed`` it posts a **single aggregate** ``SIG_CHARGE`` for everything
+the job actually consumed::
+
+    DR 5100 Committee supplies expense   (dimensions: sig=committee, asset=asset)
+    CR 1300 Inventory — Supplies on hand
+
+It is the work-order half of the mapping ``log_usage`` has used since Phase 2 ·
+Bead 1 — the path :func:`accounting.adapters.post_supply_consumption` was
+explicitly reserved for — so the two consumption routes book identically and a
+committee statement reads as one story.
+
+Three decisions worth stating out loud
+--------------------------------------
+
+**The asset's committee is the cost centre; material lines are not filtered.**
+``committee = work_order.asset.owning_group``. A job on a space-owned machine
+posts nothing at all, and a job on a committee-owned one charges that committee
+for *everything it consumed* — shop stock, the committee's own stock, and
+out-of-pocket receipts alike. Filtering the basis down to lines whose inventory
+item happens to carry the same ``owning_group`` would drop exactly the case
+corrective work exists for: an ad-hoc, out-of-pocket line has no inventory item
+to own (see :attr:`WorkOrderMaterialUsage.stock_item`), so it would silently
+escape the charge.
+
+**One entry per job, not one per material line.** The basis is
+:attr:`WorkOrder.actual_material_cost` — ``quantity_used × unit_cost`` summed
+over the lines actually marked *used*. Lines with no recorded cost contribute
+nothing rather than blocking the post, so a partially-priced job still charges
+what is known. Vendor invoices are a separate, still-unwired flow
+(``SourceType.VENDOR_INVOICE``): the basis here is **in-house consumption only**.
+
+**Reopening reverses; re-completing re-posts.** A charge is keyed
+``wo_complete:<id>``, which makes re-saving a completed work order a no-op
+(the entry already exists). But a *reopened* job must not stay charged, so
+:func:`reverse_work_order_charge` posts an append-only ``REVERSAL`` — and a
+re-completion after that has to charge again, which the original key alone
+could never do. So a repeat cycle keys ``wo_complete:<id>:2``, ``:3``, … and
+the two entry points share one rule: **at most one un-reversed charge per work
+order at any time**. Nothing is ever edited or deleted; the balance simply walks
+back and forth.
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:  # pragma: no cover
+    from django.contrib.auth.models import Group
+
+    from hordak.models import Transaction
+
+    from ..models import WorkOrder
+
+logger = logging.getLogger(__name__)
+
+#: Prefix of every completion charge's idempotency key. The work-order UUID that
+#: follows is fixed-width, so ``startswith`` over the family cannot collide with
+#: another work order's keys.
+SOURCE_REF_PREFIX = "wo_complete:"
+
+#: Returned by :func:`charge_completed_work_order` when a committee-owned job had
+#: nothing to charge — the work-order analogue of ``log_usage``'s no-cost warning.
+NO_COST_WARNING = (
+    "committee-owned asset, but no material costs were recorded on this "
+    "work order — nothing posted to the ledger"
+)
+
+
+def _recorded_actor(actor):
+    """Only a real, logged-in user is recorded on an entry's provenance."""
+    return actor if actor is not None and getattr(actor, "is_authenticated", False) else None
+
+
+def _source_ref_base(work_order: "WorkOrder") -> str:
+    return f"{SOURCE_REF_PREFIX}{work_order.id}"
+
+
+def charge_committee(work_order: "WorkOrder") -> Optional["Group"]:
+    """The committee a completed ``work_order`` bills to, or ``None``.
+
+    The machine's owner pays: ``asset.owning_group`` via the :class:`OwnableModel`
+    mixin. A space-owned or user-owned asset has no committee and never touches
+    the ledger. Every work order carries an ``asset`` (``save()`` derives it from
+    the PM template when one is given), but the FK is nullable in the schema, so
+    read it defensively.
+    """
+    asset = work_order.asset if work_order.asset_id else None
+    if asset is None:
+        return None
+    return asset.owning_group if asset.owning_group_id else None
+
+
+def _charge_metas(work_order: "WorkOrder"):
+    """Every completion-charge ``EntryMeta`` for this work order, oldest first.
+
+    Annotated with ``is_reversed`` so the caller can find the live charge (and
+    the next free key) without a query per row.
+    """
+    from django.db.models import Exists, OuterRef
+
+    from accounting.models import EntryMeta, SourceType
+
+    reversals = EntryMeta.objects.filter(reverses_id=OuterRef("transaction_id"))
+    return (
+        EntryMeta.objects.filter(
+            source_type=SourceType.SIG_CHARGE,
+            source_ref__startswith=_source_ref_base(work_order),
+        )
+        .annotate(is_reversed=Exists(reversals))
+        .select_related("transaction")
+        .order_by("posted_at", "id")
+    )
+
+
+def active_charge(work_order: "WorkOrder") -> Optional["Transaction"]:
+    """The work order's live (posted, un-reversed) charge ``Transaction``, or ``None``."""
+    for meta in _charge_metas(work_order):
+        if not meta.is_reversed:
+            return meta.transaction
+    return None
+
+
+def charge_completed_work_order(
+    work_order: "WorkOrder", *, actor=None
+) -> tuple[Optional["Transaction"], Optional[str]]:
+    """Charge ``work_order``'s committee for what the job consumed.
+
+    Returns ``(transaction, warning)``. ``transaction`` is ``None`` when nothing
+    was posted; ``warning`` is set only in the case worth telling a human about —
+    a committee-owned job that finished with no priced materials, mirroring
+    ``log_usage``'s "committee recorded, but … nothing posted" response. A job on
+    a space-owned asset is the shop's default and warns about nothing.
+
+    Safe to call more than once: while a charge for this work order stands
+    un-reversed it is returned unchanged rather than re-posted, so re-saving a
+    completed work order never double-charges. After a reversal (see
+    :func:`reverse_work_order_charge`) the next call posts a fresh entry under the
+    next key in the family, which is what makes reopen → re-complete restore the
+    balance.
+    """
+    from accounting.adapters import post_supply_consumption
+
+    committee = charge_committee(work_order)
+    if committee is None:
+        return None, None
+
+    metas = list(_charge_metas(work_order))
+    for meta in metas:
+        if not meta.is_reversed:
+            return meta.transaction, None
+
+    amount = work_order.actual_material_cost or Decimal("0.00")
+    if amount <= 0:
+        logger.warning(
+            "Work order %s completed on committee-owned asset %s with no "
+            "material cost — nothing posted to the ledger.",
+            work_order.pk,
+            work_order.asset_id,
+        )
+        return None, NO_COST_WARNING
+
+    # First charge keeps the bare key; each later cycle appends its ordinal, so
+    # the family stays greppable and every entry keeps a stable idempotency key.
+    cycle = len(metas) + 1
+    base = _source_ref_base(work_order)
+    source_ref = base if cycle == 1 else f"{base}:{cycle}"
+
+    return (
+        post_supply_consumption(
+            committee=committee,
+            amount=amount,
+            source_ref=source_ref,
+            asset=work_order.asset,
+            created_by=_recorded_actor(actor),
+            description=f"Work order materials: {work_order.display_title}",
+        ),
+        None,
+    )
+
+
+def reverse_work_order_charge(work_order: "WorkOrder", *, actor=None) -> Optional["Transaction"]:
+    """Undo the charge when a completed work order is reopened.
+
+    Posts the append-only mirror of the live charge
+    (:func:`accounting.services.reverse_entry`) and returns it, or ``None`` when
+    this work order has no charge standing — a work order that was never charged,
+    or one already reversed. The original entry is never edited or deleted; the
+    committee's balance simply returns to where it was.
+    """
+    from accounting.services import reverse_entry
+
+    transaction = active_charge(work_order)
+    if transaction is None:
+        return None
+    return reverse_entry(transaction, created_by=_recorded_actor(actor))

--- a/backend/inventory/tests/test_work_order_committee_charge.py
+++ b/backend/inventory/tests/test_work_order_committee_charge.py
@@ -1,0 +1,420 @@
+"""Committee ledger charge on work-order completion (op-u2g5, Phase 2 · B6).
+
+The work-order half of charge-on-consume: finishing a job on a committee-owned
+asset posts one aggregate ``SIG_CHARGE`` for the materials it actually consumed,
+and reopening the job reverses it. Postgres/hordak required (``accounting.E001``).
+"""
+
+import io
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+from django.utils.crypto import get_random_string
+
+import pytest
+from hordak.models import Transaction
+from PIL import Image as PILImage
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounting.models import EntryMeta, LegDimension, SourceType
+from accounting.services import committee_balance, trial_balance
+from inventory.models import (
+    MaintenanceItem,
+    MaintenanceMaterial,
+    WorkOrder,
+    WorkOrderMaterialUsage,
+)
+from inventory.services.work_order_ledger import (
+    NO_COST_WARNING,
+    active_charge,
+    charge_committee,
+)
+from inventory.tests.factories import AssetFactory, InventoryItemFactory
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.fixture(autouse=True)
+def _isolated_media(settings, tmp_path):
+    """Keep uploaded receipts out of the tracked ``backend/media`` tree."""
+    settings.MEDIA_ROOT = str(tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def _chart_of_accounts(db):
+    """Guarantee the chart exists before a ledger test posts against it.
+
+    The chart is seeded by a *data migration*, and any ``transaction=True`` test
+    earlier in the session flushes it back out (its ``TransactionTestCase``
+    teardown truncates every table and ``post_migrate`` only restores
+    contenttypes/permissions). Re-seeding is idempotent by design — it is the
+    same call the migration and the management command make — and it rolls back
+    with the test, so this costs one no-op query and makes the module order-proof.
+    """
+    from accounting.chart import seed_chart_of_accounts
+
+    seed_chart_of_accounts()
+
+
+def _staff_client():
+    user = User.objects.create_user(
+        username=f"staff_{get_random_string(6)}",
+        email="staff@example.com",
+        password=get_random_string(24),
+        is_staff=True,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client, user
+
+
+def _committee(name="Woodshop SIG"):
+    return Group.objects.create(name=name)
+
+
+def _asset(committee=None):
+    """An asset owned by ``committee`` (a SIG), or by the space when omitted."""
+    if committee is None:
+        return AssetFactory()
+    return AssetFactory(
+        ownership_type="group",
+        owning_group=committee,
+    )
+
+
+def _corrective_wo(committee=None, asset=None):
+    """A corrective work order: an asset, no PM template, no materials."""
+    return WorkOrder.objects.create(maintenance_item=None, asset=asset or _asset(committee))
+
+
+def _preventive_wo(committee=None):
+    """A PM work order whose asset (and therefore committee) comes off the template."""
+    asset = _asset(committee)
+    item = MaintenanceItem.objects.create(asset=asset, title="Monthly PM")
+    material = MaintenanceMaterial.objects.create(
+        maintenance_item=item, name="Filter", quantity=Decimal("2.00")
+    )
+    wo = WorkOrder.objects.create(maintenance_item=item)
+    return wo, material
+
+
+def _line(wo, *, unit_cost, quantity="1.00", was_used=True, name="V-belt", **kwargs):
+    """One material line on ``wo`` — priced, used, and ad-hoc unless told otherwise."""
+    return WorkOrderMaterialUsage.objects.create(
+        work_order=wo,
+        material_name=name,
+        is_ad_hoc=kwargs.pop("is_ad_hoc", True),
+        quantity_planned=Decimal(quantity),
+        quantity_used=Decimal(quantity),
+        unit_cost=None if unit_cost is None else Decimal(unit_cost),
+        was_used=was_used,
+        **kwargs,
+    )
+
+
+def _acknowledge(client, wo):
+    """Clear the pre-finalization validation gate (a completion 412s without it)."""
+    resp = client.post(
+        reverse("workorder-validate-checklist", kwargs={"pk": wo.id}),
+        {
+            "electrical_acknowledged": True,
+            "loto_acknowledged": True,
+            "required_fields_acknowledged": True,
+        },
+        format="json",
+    )
+    assert resp.status_code == status.HTTP_201_CREATED
+
+
+def _set_status(client, wo, new_status):
+    return client.patch(
+        reverse("workorder-detail", kwargs={"pk": wo.id}),
+        {"status": new_status},
+        format="json",
+    )
+
+
+def _complete(client, wo, *, acknowledge=True):
+    if acknowledge:
+        _acknowledge(client, wo)
+    resp = _set_status(client, wo, WorkOrder.Status.COMPLETED)
+    assert resp.status_code == status.HTTP_200_OK, resp.data
+    return resp
+
+
+def _charges(wo):
+    """Every SIG_CHARGE ``EntryMeta`` posted for this work order, oldest first."""
+    return list(
+        EntryMeta.objects.filter(
+            source_type=SourceType.SIG_CHARGE,
+            source_ref__startswith=f"wo_complete:{wo.id}",
+        ).order_by("posted_at", "id")
+    )
+
+
+def _receipt_file(name="receipt.jpg"):
+    buf = io.BytesIO()
+    PILImage.new("RGB", (20, 30), color=(200, 200, 200)).save(buf, format="JPEG")
+    buf.seek(0)
+    return SimpleUploadedFile(name, buf.read(), content_type="image/jpeg")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Completing a job charges its committee
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.mark.integration
+class TestCompletionCharge:
+    def test_committee_owned_job_posts_one_balanced_sig_charge(self):
+        """DR 5100 (sig + asset dimensions) / CR 1300, keyed ``wo_complete:<id>``."""
+        client, user = _staff_client()
+        committee = _committee()
+        wo, _material = _preventive_wo(committee)
+        _line(wo, unit_cost="7.25", quantity="2.00")  # 14.50
+        _line(wo, unit_cost="3.00", quantity="1.00", name="Grease")  # 3.00
+
+        _complete(client, wo)
+
+        (meta,) = _charges(wo)
+        assert meta.source_ref == f"wo_complete:{wo.id}"
+        assert meta.created_by_id == user.id
+        txn = meta.transaction
+        assert txn.legs.count() == 2
+
+        debit_leg = txn.legs.get(debit__isnull=False)
+        credit_leg = txn.legs.get(credit__isnull=False)
+        assert debit_leg.account.code == "5100"
+        assert debit_leg.debit.amount == Decimal("17.50")
+        assert credit_leg.account.code == "1300"
+        assert credit_leg.credit.amount == Decimal("17.50")
+
+        # The committee is charged and the machine is attributed on the expense leg.
+        dim = LegDimension.objects.get(leg=debit_leg)
+        assert dim.sig_id == committee.id
+        assert dim.asset_id == wo.asset_id
+
+        assert committee_balance(committee) == Decimal("17.50")
+        assert trial_balance()["balanced"] is True
+
+    def test_corrective_job_with_ad_hoc_materials_charges(self):
+        """No PM template, ad-hoc lines only — including an out-of-pocket receipt."""
+        client, _user = _staff_client()
+        committee = _committee("Metal SIG")
+        wo = _corrective_wo(committee)
+        item = InventoryItemFactory(unit_cost=Decimal("7.25"), quantity_per_package=1)
+
+        stocked = client.post(
+            reverse("workorder-add-material", kwargs={"pk": wo.id}),
+            {"material_name": "V-belt", "quantity_used": "2", "inventory_item": str(item.id)},
+            format="json",
+        ).json()
+        receipted = client.post(
+            reverse("workorder-add-material", kwargs={"pk": wo.id}),
+            {
+                "material_name": "Misc supplies — Ace Hardware",
+                "unit_cost": "23.87",
+                "receipt_image": _receipt_file(),
+            },
+            format="multipart",
+        ).json()
+        for line in (stocked, receipted):
+            assert (
+                client.patch(
+                    reverse(
+                        "workorder-toggle-material",
+                        kwargs={"pk": wo.id, "material_id": line["id"]},
+                    ),
+                    {"was_used": True},
+                    format="json",
+                ).status_code
+                == status.HTTP_200_OK
+            )
+
+        _complete(client, wo)
+
+        # 2 × 7.25 (stock) + 23.87 (receipt) — the same total the WO reports.
+        wo.refresh_from_db()
+        assert wo.actual_material_cost == Decimal("38.37")
+        assert committee_balance(committee) == Decimal("38.37")
+        assert len(_charges(wo)) == 1
+
+    def test_basis_counts_only_used_and_priced_lines(self):
+        """Planned-but-unused and unpriced lines contribute nothing."""
+        client, _user = _staff_client()
+        committee = _committee("Textiles SIG")
+        wo = _corrective_wo(committee)
+        _line(wo, unit_cost="10.00", quantity="1.00")  # counted
+        _line(wo, unit_cost="99.00", was_used=False, name="Spare")  # never used
+        _line(wo, unit_cost=None, name="Shop rag")  # used, unpriced
+
+        _complete(client, wo)
+
+        assert committee_balance(committee) == Decimal("10.00")
+
+    def test_space_owned_job_posts_nothing(self):
+        """No committee owns the machine — the ledger is untouched, no warning."""
+        client, _user = _staff_client()
+        wo = _corrective_wo()  # space-owned asset
+        _line(wo, unit_cost="42.00")
+
+        resp = _complete(client, wo)
+
+        assert Transaction.objects.count() == 0
+        assert EntryMeta.objects.count() == 0
+        assert "warning" not in resp.data
+
+    def test_committee_owned_job_with_no_cost_warns_and_posts_nothing(self):
+        """The ``log_usage`` shape: committee on file, nothing priced → warning."""
+        client, _user = _staff_client()
+        committee = _committee("Ceramics SIG")
+        wo = _corrective_wo(committee)
+        _line(wo, unit_cost=None, name="Shop rag")
+
+        resp = _complete(client, wo)
+
+        assert Transaction.objects.count() == 0
+        assert resp.data["warning"] == NO_COST_WARNING
+        assert committee_balance(committee) == Decimal("0.00")
+
+    def test_editing_a_completed_job_does_not_charge_again(self):
+        """Only the transition into completed charges — later saves are no-ops."""
+        client, _user = _staff_client()
+        committee = _committee("Electronics SIG")
+        wo = _corrective_wo(committee)
+        _line(wo, unit_cost="12.00")
+
+        _complete(client, wo)
+        resp = client.patch(
+            reverse("workorder-detail", kwargs={"pk": wo.id}),
+            {"notes": "tightened the belt after all"},
+            format="json",
+        )
+
+        assert resp.status_code == status.HTTP_200_OK
+        assert len(_charges(wo)) == 1
+        assert committee_balance(committee) == Decimal("12.00")
+        assert "warning" not in resp.data
+
+    def test_a_never_completed_job_is_never_charged(self):
+        """Moving to in_progress is not a completion."""
+        client, _user = _staff_client()
+        committee = _committee("Print SIG")
+        wo = _corrective_wo(committee)
+        _line(wo, unit_cost="5.00")
+
+        assert (
+            _set_status(client, wo, WorkOrder.Status.IN_PROGRESS).status_code == status.HTTP_200_OK
+        )
+
+        assert Transaction.objects.count() == 0
+        assert committee_balance(committee) == Decimal("0.00")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Reopening gives the money back; re-completing takes it again
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.mark.integration
+class TestReopenAndRecomplete:
+    def test_reopening_posts_an_append_only_reversal(self):
+        client, user = _staff_client()
+        committee = _committee("Woodshop SIG")
+        wo = _corrective_wo(committee)
+        _line(wo, unit_cost="20.00")
+        _complete(client, wo)
+        charge = _charges(wo)[0].transaction
+
+        assert _set_status(client, wo, WorkOrder.Status.OPEN).status_code == status.HTTP_200_OK
+
+        reversal_meta = EntryMeta.objects.get(source_type=SourceType.REVERSAL)
+        assert reversal_meta.reverses_id == charge.id
+        assert reversal_meta.created_by_id == user.id
+        # Append-only: the original charge is still on the books, and the two
+        # entries net the committee back to zero.
+        assert EntryMeta.objects.filter(transaction=charge).exists()
+        assert committee_balance(committee) == Decimal("0.00")
+        assert trial_balance()["balanced"] is True
+        assert active_charge(wo) is None
+
+    def test_recompleting_restores_the_charge_exactly_once(self):
+        """The bead's verify loop: complete → reopen → complete, no double-charge."""
+        client, _user = _staff_client()
+        committee = _committee("Metal SIG")
+        wo = _corrective_wo(committee)
+        _line(wo, unit_cost="20.00")
+
+        _complete(client, wo)
+        assert committee_balance(committee) == Decimal("20.00")
+
+        _set_status(client, wo, WorkOrder.Status.OPEN)
+        assert committee_balance(committee) == Decimal("0.00")
+
+        # The acknowledgement from the first pass still stands, so this is a
+        # plain re-completion.
+        _complete(client, wo, acknowledge=False)
+        assert committee_balance(committee) == Decimal("20.00")
+
+        # Two charges and one reversal — never two live charges at once.
+        charges = _charges(wo)
+        assert [m.source_ref for m in charges] == [
+            f"wo_complete:{wo.id}",
+            f"wo_complete:{wo.id}:2",
+        ]
+        assert EntryMeta.objects.filter(source_type=SourceType.REVERSAL).count() == 1
+        assert active_charge(wo) == charges[1].transaction
+        assert trial_balance()["balanced"] is True
+
+    def test_recompleting_picks_up_a_corrected_cost(self):
+        """Reopen-to-fix-the-numbers is the point of the reversal: the new charge wins."""
+        client, _user = _staff_client()
+        committee = _committee("Auto SIG")
+        wo = _corrective_wo(committee)
+        line = _line(wo, unit_cost="20.00")
+
+        _complete(client, wo)
+        _set_status(client, wo, WorkOrder.Status.OPEN)
+
+        line.unit_cost = Decimal("32.50")
+        line.save(update_fields=["unit_cost"])
+        _complete(client, wo, acknowledge=False)
+
+        assert committee_balance(committee) == Decimal("32.50")
+
+    def test_reopening_an_uncharged_job_is_a_no_op(self):
+        """Nothing was ever posted, so there is nothing to reverse."""
+        client, _user = _staff_client()
+        wo = _corrective_wo()  # space-owned
+        _line(wo, unit_cost="9.00")
+        _complete(client, wo)
+
+        assert (
+            _set_status(client, wo, WorkOrder.Status.IN_PROGRESS).status_code == status.HTTP_200_OK
+        )
+
+        assert Transaction.objects.count() == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The service seam itself
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.mark.integration
+class TestChargeCommitteeResolution:
+    def test_reads_the_work_orders_own_asset(self):
+        """A preventive WO derives its asset from the template on save."""
+        committee = _committee("Woodshop SIG")
+        wo, _material = _preventive_wo(committee)
+        assert wo.asset_id is not None
+        assert charge_committee(wo) == committee
+
+    def test_space_and_user_owned_assets_have_no_committee(self):
+        owner = User.objects.create_user(username="owner", password=get_random_string(24))
+        assert charge_committee(_corrective_wo()) is None
+        user_owned = AssetFactory(ownership_type="user", owning_user=owner)
+        assert charge_committee(_corrective_wo(asset=user_owned)) is None

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -4452,6 +4452,47 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
             },
         )
 
+    def _sync_committee_ledger_charge(self, work_order, *, old_status) -> None:
+        """Keep the committee's ledger in step with this work order's status.
+
+        Completing a job on a committee-owned asset charges that committee for
+        what it consumed (DR 5100 / CR 1300, keyed ``wo_complete:<id>``);
+        reopening a charged job posts the append-only reversal that gives the
+        money back. Everything about *which* committee, *how much*, and how the
+        charge/reversal cycle stays idempotent lives in the service — see
+        :mod:`inventory.services.work_order_ledger`.
+
+        The ledger warning (committee-owned job, nothing priced to charge) is
+        stashed for :meth:`_with_ledger_warning` to surface on the response, the
+        way ``log_usage`` reports the same situation.
+        """
+        from .services.work_order_ledger import (
+            charge_completed_work_order,
+            reverse_work_order_charge,
+        )
+
+        became_completed = (
+            work_order.status == WorkOrder.Status.COMPLETED
+            and old_status != WorkOrder.Status.COMPLETED
+        )
+        left_completed = (
+            old_status == WorkOrder.Status.COMPLETED
+            and work_order.status != WorkOrder.Status.COMPLETED
+        )
+        if became_completed:
+            _txn, self._ledger_warning = charge_completed_work_order(
+                work_order, actor=self.request.user
+            )
+        elif left_completed:
+            reverse_work_order_charge(work_order, actor=self.request.user)
+
+    def _with_ledger_warning(self, response):
+        """Attach the pending committee-ledger warning, if this save raised one."""
+        warning = getattr(self, "_ledger_warning", None)
+        if warning and isinstance(response.data, dict):
+            response.data = {**response.data, "warning": warning}
+        return response
+
     def perform_update(self, serializer):
         old_status = serializer.instance.status
         work_order = serializer.save()
@@ -4460,6 +4501,9 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
         )
         self._finalize_timers(work_order)
         self._sync_maintenance_item_completion(work_order, actor=self.request.user)
+        # Runs on both edges of the completed boundary (charge in, reverse out),
+        # so it sits outside the "just completed" block below.
+        self._sync_committee_ledger_charge(work_order, old_status=old_status)
         if (
             work_order.status == WorkOrder.Status.COMPLETED
             and old_status != WorkOrder.Status.COMPLETED
@@ -4487,13 +4531,13 @@ class WorkOrderViewSet(viewsets.ModelViewSet):
         gate = self._check_completion_gate(request)
         if gate is not None:
             return gate
-        return super().update(request, *args, **kwargs)
+        return self._with_ledger_warning(super().update(request, *args, **kwargs))
 
     def partial_update(self, request, *args, **kwargs):
         gate = self._check_completion_gate(request)
         if gate is not None:
             return gate
-        return super().partial_update(request, *args, **kwargs)
+        return self._with_ledger_warning(super().partial_update(request, *args, **kwargs))
 
     def _render_wo_pdf(self, work_order, base_url):
         """Shared work-order PDF renderer for :meth:`pdf` and :meth:`omr_pdf`.

--- a/docs/accounting.md
+++ b/docs/accounting.md
@@ -129,10 +129,12 @@ txn = post_supply_consumption(
 ```
 
 It wraps `accounting.services.post_entry` with the fixed **5100 / 1300** mapping
-and `source_type=SourceType.SIG_CHARGE`. It is deliberately reusable by the later
-serialized-consume and work-order material-usage charge paths, which share the
-same mapping. (No reversal helper yet — `log_usage` has no undo; a
-consumption-reversal flow is a future bead.)
+and `source_type=SourceType.SIG_CHARGE`. The [work-order completion
+charge](#committee-charge-on-work-order-completion-phase-2) reuses it unchanged;
+the serialized-consume path will be the third caller. Undoing a charge is
+`accounting.services.reverse_entry` — append-only, never an edit. `log_usage`
+itself still has no undo; the work-order path uses the reversal when a completed
+job is reopened.
 
 ### Snapshot + idempotency
 
@@ -367,5 +369,69 @@ an admin of SIG X cannot read SIG Y's statement. Otherwise **403**.
 
 Web committee-picker UI + ScanTTY consume-and-charge flow; the **web statement
 page** (a follow-on bead, mirroring the cost-recovery generator page); settlement /
-period-close; PO / vendor / donation / asset adapters; serialized-consume +
-work-order material-usage charge paths (they will reuse `post_supply_consumption`).
+period-close; PO / vendor / donation / asset adapters; the serialized-consume
+charge path (it will reuse `post_supply_consumption`).
+
+## Committee charge on work-order completion (Phase 2)
+
+The second consumption route into the same `SIG_CHARGE` mapping, and the one
+`post_supply_consumption` was explicitly reserved for. Finishing a job on a
+committee-owned machine spends that committee's money, so completing a work
+order posts **one aggregate entry** for everything the job consumed:
+
+```
+DR 5100 Committee supplies expense   (dimensions: sig = the committee, asset = the machine)
+CR 1300 Inventory — Supplies on hand
+```
+
+The seam is `inventory/services/work_order_ledger.py`, called from
+`WorkOrderViewSet.perform_update` on both edges of the completed boundary —
+charge on the way in, reverse on the way out.
+
+### Who pays, and for what
+
+- **The committee is the asset's owner** — `work_order.asset.owning_group` (the
+  `OwnableModel` mixin). A job on a space- or user-owned machine posts **nothing**.
+- **The basis is `WorkOrder.actual_material_cost`** — `quantity_used × unit_cost`
+  summed over the lines actually marked *used* (op-768w capture). Unused lines and
+  lines with no recorded cost contribute nothing, so a partially-priced job still
+  charges what is known.
+- **Material lines are not filtered by their own ownership.** The asset's committee
+  is the cost centre, so shop stock, the committee's own stock, and out-of-pocket
+  receipts are all charged alike. Filtering to lines whose inventory item carries
+  the same `owning_group` would silently drop every ad-hoc, out-of-pocket line —
+  which has no inventory item at all, and is exactly what corrective work orders
+  are made of.
+- **In-house consumption only.** Vendor invoices are a separate, still-unwired flow
+  (`SourceType.VENDOR_INVOICE`).
+
+### Reopen reverses; re-completing re-posts
+
+The first charge is keyed `source_ref=f"wo_complete:{work_order.id}"`, so re-saving
+an already-completed work order returns the existing entry instead of posting a
+second one. Reopening a charged job posts an append-only `REVERSAL`
+(`accounting.services.reverse_entry`) and the committee's balance returns to where
+it was — the original charge is never edited or deleted. A re-completion after
+that has to charge *again*, which the original key alone could never do, so each
+later cycle takes the next key in the family: `wo_complete:<id>:2`, `:3`, … The
+invariant both entry points maintain is **at most one un-reversed charge per work
+order at any time** (`work_order_ledger.active_charge`). Reopen-to-fix-the-numbers
+therefore works as expected: the corrected total is what gets charged.
+
+### The no-cost warning
+
+Mirroring `log_usage`: when the asset **is** committee-owned but the finished job
+carries no priced materials, nothing is posted and the update response carries a
+`warning`:
+
+> committee-owned asset, but no material costs were recorded on this work order —
+> nothing posted to the ledger
+
+A job on a space-owned asset is the shop's default and warns about nothing.
+
+### Out of scope (this bead)
+
+Vendor-invoice charges; the paper-form (OMR scan-to-complete) ingest path, which
+completes work orders outside `perform_update` and so does not yet charge — a
+scan-completed job that is later reopened via the API simply finds no charge to
+reverse, and a subsequent API re-completion charges normally.


### PR DESCRIPTION
B6 — the **final backend bead** of the corrective-work-order epic (bead **op-u2g5**, builds on B3's `WorkOrder.actual_material_cost`). Posts the committee `SIG_CHARGE` (charge-on-consume) to the hordak ledger when a work order completes — the WO-material path the accounting adapter was explicitly reserved for.

### Changes
- New `inventory/services/work_order_ledger.py` — the charge/reverse logic.
- In `WorkOrderViewSet.perform_update`'s "just transitioned to COMPLETED" block: post **one aggregate** `post_supply_consumption` (`DR 5100 Committee supplies expense / CR 1300 Inventory`) for committee-owned materials — `committee = wo.asset.owning_group` (skip if none), amount from the WO's actual material cost, `source_ref = "wo_complete:<id>"` (**idempotent** — re-completing won't double-post; skips when zero / non-committee).
- **Reopen:** if a charged WO leaves COMPLETED, its completion transaction is reversed via `reverse_entry()`; re-completing reposts safely.
- **No schema change** (posting logic only); `accounting/adapters.py` + `docs/accounting.md` updated.

### Tests
New `test_work_order_committee_charge.py` (+420) — committee-owned completion charges, non-committee / zero-cost no-ops, reopen→reversal, re-complete idempotency, and corrective-WO ad-hoc materials on a committee-owned asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
