### PR TITLE
feat(web): promote asset problem → work order + resolve (op-ybpn, W1)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import AnalyticsDashboardPage from './pages/AnalyticsDashboardPage';
 import AssetCostRecoveryPage from './pages/AssetCostRecoveryPage';
 import AssetDetailPage from './pages/AssetDetailPage';
 import AssetFormPage from './pages/AssetFormPage';
+import AssetProblemDetailPage from './pages/AssetProblemDetailPage';
 import MaintenanceItemFormPage from './pages/MaintenanceItemFormPage';
 import AssetReportPage from './pages/AssetReportPage';
 import AssetScanPage from './pages/AssetScanPage';
@@ -362,6 +363,7 @@ function AppContent() {
           <Route path="/maintenance/dashboard" element={<WorkspaceLayout><MaintenanceDashboard /></WorkspaceLayout>} />
           <Route path="/maintenance/work-orders/:id" element={<WorkspaceLayout><WorkOrderPage /></WorkspaceLayout>} />
           <Route path="/maintenance/third-party/:id" element={<WorkspaceLayout><ThirdPartyWorkOrderPage /></WorkspaceLayout>} />
+          <Route path="/maintenance/asset-problems/:id" element={<WorkspaceLayout><AssetProblemDetailPage /></WorkspaceLayout>} />
           <Route path="/maintenance/location-problems" element={<WorkspaceLayout><LocationProblemsListPage /></WorkspaceLayout>} />
           <Route path="/maintenance/location-problems/:id" element={<WorkspaceLayout><LocationProblemDetailPage /></WorkspaceLayout>} />
           <Route path="/facilities/checklist" element={<WorkspaceLayout><FacilitiesChecklistsPage /></WorkspaceLayout>} />

--- a/frontend/src/__tests__/pages/AssetDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/AssetDetailPage.test.tsx
@@ -7,9 +7,10 @@ import userEvent from '@testing-library/user-event';
 import { AxiosError } from 'axios';
 import { MemoryRouter } from 'react-router-dom';
 import AssetDetailPage from '../../pages/AssetDetailPage';
-import {
+import api, {
   AssetLOTORequirements,
   assetPartsAPI,
+  assetProblemsAPI,
   assetsAPI,
   lotoAPI,
   maintenanceAPI,
@@ -27,6 +28,8 @@ vi.mock('react-router-dom', async () => ({
 
 const mockAssetsAPI = assetsAPI as jest.Mocked<typeof assetsAPI>;
 const mockAssetPartsAPI = assetPartsAPI as jest.Mocked<typeof assetPartsAPI>;
+const mockAssetProblemsAPI = assetProblemsAPI as jest.Mocked<typeof assetProblemsAPI>;
+const mockApi = api as jest.Mocked<typeof api>;
 const mockMaintenanceAPI = maintenanceAPI as jest.Mocked<typeof maintenanceAPI>;
 const mockWorkOrderAPI = workOrderAPI as jest.Mocked<typeof workOrderAPI>;
 const mockLotoAPI = lotoAPI as jest.Mocked<typeof lotoAPI>;
@@ -1051,6 +1054,173 @@ describe('AssetDetailPage', () => {
 
       expect(await screen.findByText(/components flagged/i)).toBeInTheDocument();
       expect(screen.getByText(/flagged belt/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('promote problem to work order (op-ybpn)', () => {
+    const renderDetail = () =>
+      render(
+        <MantineProvider>
+          <MemoryRouter>
+            <AssetDetailPage />
+          </MemoryRouter>
+        </MantineProvider>,
+      );
+
+    /** Serve one problem, with any promote/resolve fields the test needs. */
+    const serveProblem = (overrides: Partial<AssetProblem> = {}) => {
+      mockAssetsAPI.getAssetProblems.mockResolvedValue({
+        data: [{ ...mockProblems[0], ...overrides }],
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      } as any);
+    };
+
+    beforeEach(() => {
+      localStorage.setItem('token', 'fake-token');
+      mockApi.get.mockResolvedValue({
+        data: { results: [{ id: 'vendor-1', name: 'Acme Repairs' }] },
+      } as any);
+    });
+
+    afterEach(() => {
+      localStorage.removeItem('token');
+    });
+
+    it('creates an in-house work order and shows the WO link without a reload', async () => {
+      serveProblem();
+      mockAssetProblemsAPI.promoteStandard.mockResolvedValue({
+        data: {
+          ...mockProblems[0],
+          status: 'in_progress',
+          work_order: 'wo-1',
+          work_order_short_id: 'WO-ABCD1234',
+        },
+      } as any);
+
+      renderDetail();
+
+      await screen.findByText('Test problem');
+      fireEvent.click(screen.getByRole('button', { name: /create work order/i }));
+
+      await waitFor(() => {
+        expect(mockAssetProblemsAPI.promoteStandard).toHaveBeenCalledWith('1');
+      });
+
+      // The row is patched from the response — no second problems fetch.
+      const link = await screen.findByRole('link', { name: 'WO-ABCD1234' });
+      expect(link).toHaveAttribute('href', '/maintenance/work-orders/wo-1');
+      expect(mockAssetsAPI.getAssetProblems).toHaveBeenCalledTimes(1);
+      // A promoted report can't be promoted again.
+      expect(
+        screen.queryByRole('button', { name: /create work order/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /send to vendor/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('sends a problem to a vendor from the inline form', async () => {
+      serveProblem();
+      mockAssetProblemsAPI.promoteThirdParty.mockResolvedValue({
+        data: {
+          ...mockProblems[0],
+          status: 'in_progress',
+          third_party_work_order: 'tp-1',
+          third_party_work_order_short_id: 'TPWO-99887766',
+        },
+      } as any);
+
+      renderDetail();
+
+      await screen.findByText('Test problem');
+      fireEvent.click(screen.getByRole('button', { name: /send to vendor/i }));
+
+      // Vendors load lazily when the form opens.
+      const vendorSelect = await screen.findByLabelText(/^vendor:$/i);
+      await waitFor(() => {
+        expect(within(vendorSelect as HTMLSelectElement).getByText('Acme Repairs')).toBeInTheDocument();
+      });
+      fireEvent.change(vendorSelect, { target: { value: 'vendor-1' } });
+      fireEvent.change(screen.getByLabelText(/^title:$/i), {
+        target: { value: 'Replace spindle bearing' },
+      });
+      fireEvent.change(screen.getByLabelText(/^work type:$/i), {
+        target: { value: 'major_repair' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /open vendor work order/i }));
+
+      await waitFor(() => {
+        expect(mockAssetProblemsAPI.promoteThirdParty).toHaveBeenCalledWith('1', {
+          vendor: 'vendor-1',
+          title: 'Replace spindle bearing',
+          work_type: 'major_repair',
+        });
+      });
+
+      const link = await screen.findByRole('link', { name: 'TPWO-99887766' });
+      expect(link).toHaveAttribute('href', '/maintenance/third-party/tp-1');
+      // Form closes once the vendor work order exists.
+      expect(screen.queryByTestId('vendor-form-1')).not.toBeInTheDocument();
+    });
+
+    it('shows the promoted work order instead of promote actions on an already-promoted report', async () => {
+      serveProblem({
+        status: 'in_progress',
+        work_order: 'wo-7',
+        work_order_short_id: 'WO-77777777',
+      });
+
+      renderDetail();
+
+      expect(await screen.findByRole('link', { name: 'WO-77777777' })).toHaveAttribute(
+        'href',
+        '/maintenance/work-orders/wo-7',
+      );
+      expect(
+        screen.queryByRole('button', { name: /create work order/i }),
+      ).not.toBeInTheDocument();
+      // Resolving by hand stays available on a promoted report.
+      expect(
+        screen.getByRole('button', { name: /resolve problem/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('keeps the report intact and re-enables the action when promotion fails', async () => {
+      serveProblem();
+      mockAssetProblemsAPI.promoteStandard.mockRejectedValue(sessionExpiredError());
+
+      renderDetail();
+
+      await screen.findByText('Test problem');
+      fireEvent.click(screen.getByRole('button', { name: /create work order/i }));
+
+      await waitFor(() => {
+        expect(mockAssetProblemsAPI.promoteStandard).toHaveBeenCalledTimes(1);
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /create work order/i }),
+        ).not.toBeDisabled();
+      });
+      expect(screen.getByText('Test problem')).toBeInTheDocument();
+    });
+
+    it('hides the promote actions when logged out', async () => {
+      localStorage.removeItem('token');
+      serveProblem();
+
+      renderDetail();
+
+      await screen.findByText('Test problem');
+      expect(
+        screen.queryByRole('button', { name: /create work order/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /send to vendor/i }),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/__tests__/pages/AssetProblemDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/AssetProblemDetailPage.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Tests for AssetProblemDetailPage (op-ybpn).
+ *
+ * The asset-side twin of LocationProblemDetailPage: promote to an in-house
+ * work order, promote to a vendor work order, resolve. Every mutation patches
+ * the visible problem from its response — no follow-up GET, no flip back to
+ * "Loading problem…".
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import AssetProblemDetailPage from '../../pages/AssetProblemDetailPage';
+import api, { assetProblemsAPI } from '../../services/api';
+import { AssetProblem } from '../../types';
+import { networkError } from '../helpers/offline';
+
+vi.mock('../../services/api', () => {
+  const apiMock = { get: jest.fn() };
+  return {
+    __esModule: true,
+    default: apiMock,
+    assetProblemsAPI: {
+      get: jest.fn(),
+      promoteStandard: jest.fn(),
+      promoteThirdParty: jest.fn(),
+      resolve: jest.fn(),
+    },
+  };
+});
+
+const mockApi = api as jest.Mocked<typeof api>;
+const mockAP = assetProblemsAPI as jest.Mocked<typeof assetProblemsAPI>;
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={['/maintenance/asset-problems/ap-1']}>
+        <Routes>
+          <Route
+            path="/maintenance/asset-problems/:id"
+            element={<AssetProblemDetailPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+const buildProblem = (overrides: Partial<AssetProblem> = {}): AssetProblem => ({
+  id: 'ap-1',
+  asset: 'asset-1',
+  asset_name: 'Bandsaw',
+  asset_tag: 'TAG001',
+  reported_by: 'alice',
+  description: 'Blade guide is loose',
+  status: 'reported',
+  work_order: null,
+  work_order_short_id: null,
+  third_party_work_order: null,
+  third_party_work_order_short_id: null,
+  resolution_notes: '',
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  resolved_at: null,
+  resolved_by: '',
+  photos: [],
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+  localStorage.setItem('token', 'fake-token');
+  mockApi.get.mockResolvedValue({
+    data: { results: [{ id: 'vendor-1', name: 'Acme Repairs' }] },
+  } as any);
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('AssetProblemDetailPage promote/resolve (op-ybpn)', () => {
+  test('promotes to an in-house work order and links to it — no follow-up GET', async () => {
+    mockAP.get.mockResolvedValue({ data: buildProblem() } as any);
+    mockAP.promoteStandard.mockResolvedValue({
+      data: buildProblem({
+        status: 'in_progress',
+        work_order: 'wo-1',
+        work_order_short_id: 'WO-ABCD1234',
+      }),
+    } as any);
+
+    renderPage();
+
+    await screen.findByText('Blade guide is loose');
+    // No MaintenanceItem picker on this side — the WO anchors to the asset.
+    expect(screen.queryByLabelText(/maintenance item/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /create work order/i }));
+
+    await waitFor(() => {
+      expect(mockAP.promoteStandard).toHaveBeenCalledWith('ap-1');
+    });
+
+    const link = await screen.findByRole('link', { name: 'WO-ABCD1234' });
+    expect(link).toHaveAttribute('href', '/maintenance/work-orders/wo-1');
+    expect(mockAP.get).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/loading problem/i)).not.toBeInTheDocument();
+    // Promote actions retire once the report has real work attached.
+    expect(
+      screen.queryByRole('button', { name: /create work order/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('promotes to a vendor work order with the picked vendor, title and work type', async () => {
+    mockAP.get.mockResolvedValue({ data: buildProblem() } as any);
+    mockAP.promoteThirdParty.mockResolvedValue({
+      data: buildProblem({
+        status: 'in_progress',
+        third_party_work_order: 'tp-1',
+        third_party_work_order_short_id: 'TPWO-99887766',
+      }),
+    } as any);
+
+    renderPage();
+
+    await screen.findByText('Blade guide is loose');
+
+    const vendorSelect = await screen.findByLabelText(/^vendor$/i);
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Acme Repairs' })).toBeInTheDocument();
+    });
+    fireEvent.change(vendorSelect, { target: { value: 'vendor-1' } });
+    fireEvent.change(screen.getByLabelText(/^title$/i), {
+      target: { value: 'Rebuild blade guide' },
+    });
+    fireEvent.change(screen.getByLabelText(/^work type$/i), {
+      target: { value: 'major_repair' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /open vendor work order/i }));
+
+    await waitFor(() => {
+      expect(mockAP.promoteThirdParty).toHaveBeenCalledWith('ap-1', {
+        vendor: 'vendor-1',
+        title: 'Rebuild blade guide',
+        work_type: 'major_repair',
+      });
+    });
+
+    const link = await screen.findByRole('link', { name: 'TPWO-99887766' });
+    expect(link).toHaveAttribute('href', '/maintenance/third-party/tp-1');
+  });
+
+  test('resolve patches the problem from the response and disables both actions in flight', async () => {
+    mockAP.get.mockResolvedValue({ data: buildProblem() } as any);
+    let resolveResolve: (value: any) => void = () => undefined;
+    mockAP.resolve.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveResolve = resolve;
+        }) as any,
+    );
+
+    renderPage();
+
+    await screen.findByText('Blade guide is loose');
+
+    fireEvent.change(screen.getByLabelText(/resolution notes/i), {
+      target: { value: 'Tightened the guide' },
+    });
+    const markResolved = screen.getByRole('button', { name: /mark resolved/i });
+    const markClosed = screen.getByRole('button', { name: /mark closed/i });
+    fireEvent.click(markResolved);
+
+    await waitFor(() => expect(markResolved).toBeDisabled());
+    // The sibling action is locked too so transitions can't race.
+    expect(markClosed).toBeDisabled();
+    // Duplicate clicks while pending are ignored.
+    fireEvent.click(markResolved);
+    expect(mockAP.resolve).toHaveBeenCalledTimes(1);
+    expect(mockAP.resolve).toHaveBeenCalledWith('ap-1', {
+      status: 'resolved',
+      resolution_notes: 'Tightened the guide',
+    });
+
+    resolveResolve({
+      data: buildProblem({
+        status: 'resolved',
+        resolved_at: '2026-05-02T00:00:00Z',
+        resolved_by: 'alice',
+        resolution_notes: 'Tightened the guide',
+      }),
+    });
+
+    // Resolved: the resolve panel retires and the notes are shown back.
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: /mark resolved/i }),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('Tightened the guide')).toBeInTheDocument();
+    expect(screen.queryByText(/loading problem/i)).not.toBeInTheDocument();
+  });
+
+  test('hides the mutation actions when logged out', async () => {
+    localStorage.removeItem('token');
+    mockAP.get.mockResolvedValue({ data: buildProblem() } as any);
+
+    renderPage();
+
+    await screen.findByText('Blade guide is loose');
+    expect(
+      screen.queryByRole('button', { name: /create work order/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /mark resolved/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders an actionable error state when the load fails offline', async () => {
+    mockAP.get.mockRejectedValue(networkError());
+
+    renderPage();
+
+    expect(
+      await screen.findByRole('link', { name: /back to maintenance/i }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/failed to load/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/loading problem/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/MaintenanceDashboardPage.test.tsx
+++ b/frontend/src/__tests__/pages/MaintenanceDashboardPage.test.tsx
@@ -135,6 +135,67 @@ describe('MaintenanceDashboardPage', () => {
     expect(screen.getByText('$5,000.00')).toBeInTheDocument();
   });
 
+  test('links an un-promoted asset problem to its own detail page (op-ybpn)', async () => {
+    mockMaintenanceAPI.getDashboard.mockResolvedValue({ data: emptyDashboard() } as any);
+    mockActiveMaintenanceAPI.list.mockResolvedValue({
+      data: {
+        count: 1,
+        results: [
+          {
+            kind: 'asset_problem',
+            id: 'ap-1',
+            short_id: 'AP123456',
+            title: 'Blade guide is loose',
+            status: 'reported',
+            status_display: 'Reported',
+            asset_id: 'asset-1',
+            asset_name: 'Bandsaw',
+            location_id: null,
+            location_name: null,
+            severity: null,
+            due_date: null,
+            opened_at: new Date().toISOString(),
+          },
+        ],
+      },
+    } as any);
+
+    renderPage();
+
+    const link = await screen.findByRole('link', { name: 'AP123456' });
+    expect(link).toHaveAttribute('href', '/maintenance/asset-problems/ap-1');
+  });
+
+  test('a promoted asset problem surfaces as its work order row (op-ybpn)', async () => {
+    // B2 drops promoted reports from the active feed and the corrective work
+    // order carries the report's text as its title — so the unscheduled table's
+    // Work Order column lights up with a WO the user can open.
+    mockMaintenanceAPI.getDashboard.mockResolvedValue({
+      data: {
+        ...emptyDashboard(),
+        unscheduled: [
+          {
+            workorder_id: 'wo-9',
+            short_id: 'WO-99999999',
+            asset_id: 'asset-1',
+            asset_name: 'Bandsaw',
+            problem: 'Blade guide is loose',
+            opened_at: new Date().toISOString(),
+            status: 'open',
+          },
+        ],
+      },
+    } as any);
+
+    renderPage();
+
+    const link = await screen.findByRole('link', { name: 'WO-99999999' });
+    expect(link).toHaveAttribute('href', '/maintenance/work-orders/wo-9');
+    expect(screen.getByText('Blade guide is loose')).toBeInTheDocument();
+    // The report itself is no longer double-listed in the active feed.
+    expect(screen.queryByTestId('active-row-asset_problem')).not.toBeInTheDocument();
+  });
+
   test('shows error alert when the dashboard API fails', async () => {
     mockMaintenanceAPI.getDashboard.mockRejectedValue({
       response: { data: { detail: 'Server exploded' } },

--- a/frontend/src/pages/AssetDetailPage.tsx
+++ b/frontend/src/pages/AssetDetailPage.tsx
@@ -4,7 +4,7 @@
  */
 import { Badge, Button, Group, Paper, Text } from '@mantine/core';
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import AssetForgeKeyAccessCard from '../components/AssetForgeKeyAccessCard';
 import AssetReservationsAndOOSSection from '../components/AssetReservationsAndOOSSection';
 import AssetDocumentsSection from '../components/assets/AssetDocumentsSection';
@@ -12,9 +12,10 @@ import AssetMetersSection from '../components/assets/AssetMetersSection';
 import MaintenanceHistorySection from '../components/assets/MaintenanceHistorySection';
 import AssetSerializedComponentsSection from '../components/inventory/AssetSerializedComponentsSection';
 import WorkspacePage from '../components/landing/WorkspacePage';
-import {
+import api, {
   AssetLOTORequirements,
   assetPartsAPI,
+  assetProblemsAPI,
   assetsAPI,
   lotoAPI,
   maintenanceAPI,
@@ -25,6 +26,19 @@ import { Asset, AssetPart, AssetProblem, MaintenanceItem, WorkOrder } from '../t
 import { formatDateOnly } from '../utils/dates';
 import { showError } from '../utils/dialogs';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+interface VendorOption {
+  id: string;
+  name: string;
+}
+
+/** Work types a vendor work order can be opened as (ThirdPartyWorkOrder). */
+const VENDOR_WORK_TYPES: Array<{ value: string; label: string }> = [
+  { value: 'standard', label: 'Standard' },
+  { value: 'major_repair', label: 'Major Repair' },
+  { value: 'buildout', label: 'Buildout' },
+  { value: 'building_emergency', label: 'Building Emergency' },
+];
 
 const AssetDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -58,6 +72,14 @@ const AssetDetailPage: React.FC = () => {
   // a replacement; non-serialized parts stay one-click.
   const [serialModalPart, setSerialModalPart] = useState<AssetPart | null>(null);
   const [replacementSerial, setReplacementSerial] = useState<string>('');
+  // Promote-to-work-order state. `vendorFormProblemId` is the problem whose
+  // "Send to Vendor" form is expanded; vendors load lazily the first time one
+  // is opened so the page keeps its existing request budget on mount.
+  const [vendorFormProblemId, setVendorFormProblemId] = useState<string | null>(null);
+  const [vendors, setVendors] = useState<VendorOption[]>([]);
+  const [vendorId, setVendorId] = useState<string>('');
+  const [vendorTitle, setVendorTitle] = useState<string>('');
+  const [vendorWorkType, setVendorWorkType] = useState<string>('standard');
 
   const loadAssetDetails = useCallback(async () => {
     if (!id) return;
@@ -368,6 +390,82 @@ const AssetDetailPage: React.FC = () => {
     } catch (err: any) {
       showError(extractErrorMessage(err, 'Failed to resolve problem'));
       console.error('Error resolving problem:', err);
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  // Patch one problem in place from a mutation response instead of reloading
+  // the whole asset — see docs/REACTIVE_MUTATIONS.md. Falls back to a partial
+  // merge so a thin mock body can't blank out the row.
+  const applyProblemUpdate = (problemId: string, data: unknown) => {
+    if (!data || typeof data !== 'object') return;
+    setProblems((existing) =>
+      existing.map((p) =>
+        p.id === problemId ? { ...p, ...(data as Partial<AssetProblem>) } : p,
+      ),
+    );
+  };
+
+  const handlePromoteStandard = async (problemId: string) => {
+    if (actionLoading) return;
+    try {
+      setActionLoading(`promote-${problemId}`);
+      const resp = await assetProblemsAPI.promoteStandard(problemId);
+      applyProblemUpdate(problemId, resp?.data);
+    } catch (err: any) {
+      showError(extractErrorMessage(err, 'Failed to create work order'));
+      console.error('Error promoting problem:', err);
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const openVendorForm = async (problem: AssetProblem) => {
+    setVendorFormProblemId(problem.id);
+    setVendorId('');
+    // Seed the scope line from the report; a vendor WO is a purchase, so the
+    // title is editable rather than the raw complaint.
+    setVendorTitle(problem.description.slice(0, 80));
+    setVendorWorkType('standard');
+    if (vendors.length > 0) return;
+    try {
+      const resp = await api.get<{ results: VendorOption[] } | VendorOption[]>(
+        '/vendors/vendors/',
+      );
+      const body = resp?.data;
+      setVendors(Array.isArray(body) ? body : body?.results ?? []);
+    } catch (err) {
+      // Non-fatal: the picker just stays empty and the user can cancel out.
+      console.warn('Vendors unavailable', err);
+    }
+  };
+
+  const closeVendorForm = () => {
+    setVendorFormProblemId(null);
+    setVendorId('');
+    setVendorTitle('');
+    setVendorWorkType('standard');
+  };
+
+  const handlePromoteThirdParty = async (problemId: string) => {
+    if (!vendorId || !vendorTitle.trim()) {
+      showError('Vendor and title are required.');
+      return;
+    }
+    if (actionLoading) return;
+    try {
+      setActionLoading(`promote-tp-${problemId}`);
+      const resp = await assetProblemsAPI.promoteThirdParty(problemId, {
+        vendor: vendorId,
+        title: vendorTitle.trim(),
+        work_type: vendorWorkType,
+      });
+      applyProblemUpdate(problemId, resp?.data);
+      closeVendorForm();
+    } catch (err: any) {
+      showError(extractErrorMessage(err, 'Failed to send to vendor'));
+      console.error('Error promoting problem to vendor:', err);
     } finally {
       setActionLoading(null);
     }
@@ -894,6 +992,25 @@ const AssetDetailPage: React.FC = () => {
                       </p>
                     )}
 
+                    {(problem.work_order_short_id || problem.third_party_work_order_short_id) && (
+                      <p
+                        className="problem-promoted-to"
+                        data-testid={`problem-promoted-${problem.id}`}
+                      >
+                        <strong>Promoted to:</strong>{' '}
+                        {problem.work_order_short_id && (
+                          <Link to={`/maintenance/work-orders/${problem.work_order}`}>
+                            {problem.work_order_short_id}
+                          </Link>
+                        )}
+                        {problem.third_party_work_order_short_id && (
+                          <Link to={`/maintenance/third-party/${problem.third_party_work_order}`}>
+                            {problem.third_party_work_order_short_id}
+                          </Link>
+                        )}
+                      </p>
+                    )}
+
                     {problem.photos && problem.photos.length > 0 && (
                       <div className="problem-photos">
                         <strong>Photos:</strong>
@@ -983,7 +1100,31 @@ const AssetDetailPage: React.FC = () => {
                       </div>
                     ) : (
                       isLoggedIn && problem.status !== 'resolved' && problem.status !== 'closed' && (
-                        <div style={{ marginTop: '0.5rem' }}>
+                        <div style={{ marginTop: '0.5rem', display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                          {/* An already-promoted report has real work attached;
+                              promoting twice is a 400 from the API. */}
+                          {!problem.work_order && !problem.third_party_work_order && (
+                            <>
+                              <button
+                                className="action-button"
+                                onClick={() => handlePromoteStandard(problem.id)}
+                                disabled={!!actionLoading}
+                                style={{ padding: '0.5rem 1rem', fontSize: '0.9rem' }}
+                              >
+                                {actionLoading === `promote-${problem.id}`
+                                  ? 'Creating...'
+                                  : 'Create Work Order'}
+                              </button>
+                              <button
+                                className="action-button"
+                                onClick={() => openVendorForm(problem)}
+                                disabled={!!actionLoading}
+                                style={{ padding: '0.5rem 1rem', fontSize: '0.9rem' }}
+                              >
+                                Send to Vendor
+                              </button>
+                            </>
+                          )}
                           <button
                             className="action-button"
                             onClick={() => startResolving(problem.id)}
@@ -994,6 +1135,89 @@ const AssetDetailPage: React.FC = () => {
                           </button>
                         </div>
                       )
+                    )}
+
+                    {/* Send-to-Vendor form: a vendor work order is a purchase,
+                        so it needs a picked vendor and a written scope line. */}
+                    {isLoggedIn && vendorFormProblemId === problem.id && (
+                      <div
+                        className="vendor-promote-form"
+                        data-testid={`vendor-form-${problem.id}`}
+                        style={{ marginTop: '1rem', padding: '1rem', border: '1px solid #ddd', borderRadius: '4px', backgroundColor: '#f9f9f9' }}
+                      >
+                        <h4>Send to Vendor</h4>
+                        <div style={{ marginBottom: '0.5rem' }}>
+                          <label htmlFor={`vendor-${problem.id}`} style={{ display: 'block', marginBottom: '0.25rem' }}>
+                            Vendor:
+                          </label>
+                          <select
+                            id={`vendor-${problem.id}`}
+                            value={vendorId}
+                            onChange={(e) => setVendorId(e.target.value)}
+                            style={{ width: '100%', padding: '0.5rem' }}
+                          >
+                            <option value="">Select…</option>
+                            {vendors.map((vendor) => (
+                              <option key={vendor.id} value={vendor.id}>
+                                {vendor.name}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div style={{ marginBottom: '0.5rem' }}>
+                          <label htmlFor={`vendor-title-${problem.id}`} style={{ display: 'block', marginBottom: '0.25rem' }}>
+                            Title:
+                          </label>
+                          <input
+                            id={`vendor-title-${problem.id}`}
+                            type="text"
+                            value={vendorTitle}
+                            onChange={(e) => setVendorTitle(e.target.value)}
+                            placeholder="Short summary of the work"
+                            style={{ width: '100%', padding: '0.5rem' }}
+                          />
+                        </div>
+                        <div style={{ marginBottom: '0.5rem' }}>
+                          <label htmlFor={`vendor-work-type-${problem.id}`} style={{ display: 'block', marginBottom: '0.25rem' }}>
+                            Work Type:
+                          </label>
+                          <select
+                            id={`vendor-work-type-${problem.id}`}
+                            value={vendorWorkType}
+                            onChange={(e) => setVendorWorkType(e.target.value)}
+                            style={{ width: '100%', padding: '0.5rem' }}
+                          >
+                            {VENDOR_WORK_TYPES.map((wt) => (
+                              <option key={wt.value} value={wt.value}>
+                                {wt.label}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div style={{ display: 'flex', gap: '0.5rem' }}>
+                          <button
+                            className="action-button"
+                            onClick={() => handlePromoteThirdParty(problem.id)}
+                            disabled={
+                              !vendorId
+                              || !vendorTitle.trim()
+                              || actionLoading === `promote-tp-${problem.id}`
+                            }
+                          >
+                            {actionLoading === `promote-tp-${problem.id}`
+                              ? 'Sending...'
+                              : 'Open Vendor Work Order'}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={closeVendorForm}
+                            disabled={actionLoading === `promote-tp-${problem.id}`}
+                            style={{ padding: '0.5rem 1rem', background: '#ccc', border: 'none', borderRadius: '4px', cursor: 'pointer' }}
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
                     )}
                   </div>
                 </div>

--- a/frontend/src/pages/AssetProblemDetailPage.tsx
+++ b/frontend/src/pages/AssetProblemDetailPage.tsx
@@ -1,0 +1,397 @@
+/**
+ * Asset Problem Detail Page (op-ybpn).
+ *
+ * The asset-side twin of LocationProblemDetailPage: one reported problem with
+ * its photos, flagged components, and the promote-to-work-order / resolve
+ * actions. Mutations patch the visible problem from the response rather than
+ * re-fetching — see docs/REACTIVE_MUTATIONS.md.
+ *
+ * Unlike the location sibling there is no MaintenanceItem picker: a corrective
+ * work order anchors straight to the problem's asset.
+ */
+import { Button, Paper, Text } from '@mantine/core';
+import React, { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import WorkspacePage from '../components/landing/WorkspacePage';
+import api, { assetProblemsAPI } from '../services/api';
+import { AssetProblem } from '../types';
+import { showError, showSuccess } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+interface VendorOption {
+  id: string;
+  name: string;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  reported: 'Reported',
+  in_progress: 'In Progress',
+  resolved: 'Resolved',
+  closed: 'Closed',
+};
+
+const WORK_TYPES: Array<{ value: string; label: string }> = [
+  { value: 'standard', label: 'Standard' },
+  { value: 'major_repair', label: 'Major Repair' },
+  { value: 'buildout', label: 'Buildout' },
+  { value: 'building_emergency', label: 'Building Emergency' },
+];
+
+const AssetProblemDetailPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [problem, setProblem] = useState<AssetProblem | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [pendingAction, setPendingAction] =
+    useState<'promote-standard' | 'promote-tp' | 'resolve' | null>(null);
+
+  const [vendors, setVendors] = useState<VendorOption[]>([]);
+  const [tpVendor, setTpVendor] = useState<string>('');
+  const [tpTitle, setTpTitle] = useState<string>('');
+  const [tpWorkType, setTpWorkType] = useState<string>('standard');
+
+  const [resolutionNotes, setResolutionNotes] = useState<string>('');
+
+  useEffect(() => {
+    setIsLoggedIn(Boolean(localStorage.getItem('token')));
+  }, []);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    const load = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const resp = await assetProblemsAPI.get(id);
+        if (!cancelled) setProblem(resp?.data ?? null);
+      } catch (err: any) {
+        if (!cancelled) setError(extractErrorMessage(err, 'Failed to load'));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const resp = await api.get<{ results: VendorOption[] } | VendorOption[]>(
+          '/vendors/vendors/',
+        );
+        if (cancelled) return;
+        const body = resp?.data;
+        setVendors(Array.isArray(body) ? body : body?.results ?? []);
+      } catch {
+        // Non-fatal: the picker stays empty and the in-house path still works.
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoggedIn]);
+
+  // Patch the visible problem from a mutation response. Partial merge keeps a
+  // thin mock body from blanking the panel; production returns the full object.
+  const applyProblemUpdate = (data: unknown) => {
+    if (!data || typeof data !== 'object') return;
+    setProblem((prev) =>
+      prev ? ({ ...prev, ...(data as Partial<AssetProblem>) }) : (data as AssetProblem),
+    );
+  };
+
+  const handlePromoteStandard = async () => {
+    if (!id || pendingAction) return;
+    try {
+      setPendingAction('promote-standard');
+      const resp = await assetProblemsAPI.promoteStandard(id);
+      applyProblemUpdate(resp?.data);
+      showSuccess('Work order opened.');
+    } catch (err: any) {
+      showError(extractErrorMessage(err, 'Failed to promote.'));
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const handlePromoteThirdParty = async () => {
+    if (!id) return;
+    if (!tpVendor || !tpTitle.trim()) {
+      showError('Vendor and title are required.');
+      return;
+    }
+    if (pendingAction) return;
+    try {
+      setPendingAction('promote-tp');
+      const resp = await assetProblemsAPI.promoteThirdParty(id, {
+        vendor: tpVendor,
+        title: tpTitle.trim(),
+        work_type: tpWorkType,
+      });
+      applyProblemUpdate(resp?.data);
+      showSuccess('Vendor work order opened.');
+    } catch (err: any) {
+      showError(extractErrorMessage(err, 'Failed to promote.'));
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const handleResolve = async (status: 'resolved' | 'closed') => {
+    if (!id || pendingAction) return;
+    try {
+      setPendingAction('resolve');
+      const resp = await assetProblemsAPI.resolve(id, {
+        status,
+        resolution_notes: resolutionNotes.trim() || undefined,
+      });
+      applyProblemUpdate(resp?.data);
+      showSuccess(`Problem marked ${status}.`);
+    } catch (err: any) {
+      showError(extractErrorMessage(err, 'Failed to resolve.'));
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <WorkspacePage
+        testId="asset-problem-detail-page"
+        hero={{
+          eyebrow: 'Maintenance · Asset problem',
+          title: 'Asset problem',
+          description: 'Loading…',
+        }}
+      >
+        <Paper withBorder p="md">
+          <Text c="dimmed">Loading problem…</Text>
+        </Paper>
+      </WorkspacePage>
+    );
+  }
+
+  if (error || !problem) {
+    return (
+      <WorkspacePage
+        testId="asset-problem-detail-page"
+        hero={{
+          eyebrow: 'Maintenance · Asset problem',
+          title: 'Asset problem',
+          description: error || 'Not found.',
+          action: (
+            <Button component={Link} to="/maintenance" variant="default">
+              Back to maintenance
+            </Button>
+          ),
+        }}
+      >
+        <Paper withBorder p="md" radius="md" bg="red.0" c="red.9">
+          <Text>{error || 'Problem not found.'}</Text>
+        </Paper>
+      </WorkspacePage>
+    );
+  }
+
+  const isPromoted =
+    Boolean(problem.work_order) || Boolean(problem.third_party_work_order);
+  const isResolved = problem.status === 'resolved' || problem.status === 'closed';
+
+  return (
+    <WorkspacePage
+      testId="asset-problem-detail-page"
+      hero={{
+        eyebrow: `Maintenance · ${problem.asset_name}`,
+        title: 'Asset problem',
+        description: STATUS_LABELS[problem.status] || problem.status,
+        action: (
+          <Button component={Link} to={`/assets/${problem.asset}`} variant="default">
+            Open asset
+          </Button>
+        ),
+      }}
+    >
+      <div className="page asset-problem-detail-page">
+        <div className="header-actions" style={{ marginBottom: '1rem' }}>
+          <span className={`status-badge ${problem.status}`}>
+            {STATUS_LABELS[problem.status] || problem.status}
+          </span>
+        </div>
+
+        <section className="detail-section">
+          <h2>Description</h2>
+          <p>{problem.description}</p>
+          {problem.reported_by && (
+            <p className="muted">
+              Reported by {problem.reported_by} on{' '}
+              {new Date(problem.created_at).toLocaleString()}
+            </p>
+          )}
+        </section>
+
+        {problem.affected_parts && problem.affected_parts.length > 0 && (
+          <section className="detail-section">
+            <h2>Components Flagged</h2>
+            <ul>
+              {problem.affected_parts.map((part) => (
+                <li key={part.id}>
+                  {part.part_name}
+                  {part.quantity_needed ? ` (qty ${part.quantity_needed})` : ''}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {problem.photos && problem.photos.length > 0 && (
+          <section className="detail-section">
+            <h2>Photos</h2>
+            {problem.photos.map((photo) => (
+              <p key={photo.id}>
+                <a href={photo.image_url || '#'} target="_blank" rel="noreferrer">
+                  {photo.caption || 'Reporter photo'}
+                </a>
+              </p>
+            ))}
+          </section>
+        )}
+
+        {(problem.work_order_short_id || problem.third_party_work_order_short_id) && (
+          <section className="detail-section">
+            <h2>Promoted To</h2>
+            {problem.work_order_short_id && (
+              <p>
+                Work Order:{' '}
+                <Link to={`/maintenance/work-orders/${problem.work_order}`}>
+                  {problem.work_order_short_id}
+                </Link>
+              </p>
+            )}
+            {problem.third_party_work_order_short_id && (
+              <p>
+                Vendor Work Order:{' '}
+                <Link to={`/maintenance/third-party/${problem.third_party_work_order}`}>
+                  {problem.third_party_work_order_short_id}
+                </Link>
+              </p>
+            )}
+          </section>
+        )}
+
+        {problem.resolution_notes && (
+          <section className="detail-section">
+            <h2>Resolution</h2>
+            <p>{problem.resolution_notes}</p>
+          </section>
+        )}
+
+        {isLoggedIn && !isPromoted && !isResolved && (
+          <>
+            <section className="detail-section">
+              <h2>Create Work Order</h2>
+              <p className="muted">
+                Opens an in-house corrective work order against {problem.asset_name}.
+              </p>
+              <button
+                type="button"
+                className="btn-primary"
+                onClick={handlePromoteStandard}
+                disabled={pendingAction !== null}
+              >
+                {pendingAction === 'promote-standard' ? 'Creating…' : 'Create Work Order'}
+              </button>
+            </section>
+
+            <section className="detail-section">
+              <h2>Send to Vendor</h2>
+              <label htmlFor="ap-vendor">Vendor</label>
+              <select
+                id="ap-vendor"
+                value={tpVendor}
+                onChange={(e) => setTpVendor(e.target.value)}
+              >
+                <option value="">Select…</option>
+                {vendors.map((v) => (
+                  <option key={v.id} value={v.id}>
+                    {v.name}
+                  </option>
+                ))}
+              </select>
+              <label htmlFor="ap-title">Title</label>
+              <input
+                id="ap-title"
+                type="text"
+                value={tpTitle}
+                onChange={(e) => setTpTitle(e.target.value)}
+                placeholder="Short summary of the work"
+              />
+              <label htmlFor="ap-worktype">Work Type</label>
+              <select
+                id="ap-worktype"
+                value={tpWorkType}
+                onChange={(e) => setTpWorkType(e.target.value)}
+              >
+                {WORK_TYPES.map((wt) => (
+                  <option key={wt.value} value={wt.value}>
+                    {wt.label}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                className="btn-primary"
+                onClick={handlePromoteThirdParty}
+                disabled={!tpVendor || !tpTitle.trim() || pendingAction !== null}
+              >
+                {pendingAction === 'promote-tp' ? 'Sending…' : 'Open Vendor Work Order'}
+              </button>
+            </section>
+          </>
+        )}
+
+        {isLoggedIn && !isResolved && (
+          <section className="detail-section">
+            <h2>Resolve</h2>
+            <label htmlFor="ap-notes">Resolution notes</label>
+            <textarea
+              id="ap-notes"
+              rows={3}
+              value={resolutionNotes}
+              onChange={(e) => setResolutionNotes(e.target.value)}
+            />
+            <div className="modal-actions">
+              <button
+                type="button"
+                className="btn-secondary"
+                onClick={() => handleResolve('resolved')}
+                disabled={pendingAction !== null}
+                aria-busy={pendingAction === 'resolve' ? 'true' : undefined}
+              >
+                Mark Resolved
+              </button>
+              <button
+                type="button"
+                className="btn-secondary"
+                onClick={() => handleResolve('closed')}
+                disabled={pendingAction !== null}
+                aria-busy={pendingAction === 'resolve' ? 'true' : undefined}
+              >
+                Mark Closed
+              </button>
+            </div>
+          </section>
+        )}
+      </div>
+    </WorkspacePage>
+  );
+};
+
+export default AssetProblemDetailPage;

--- a/frontend/src/pages/LocationProblemDetailPage.tsx
+++ b/frontend/src/pages/LocationProblemDetailPage.tsx
@@ -271,7 +271,7 @@ const LocationProblemDetailPage: React.FC = () => {
             <p>
               Third-Party Work Order:{' '}
               <Link
-                to={`/maintenance/third-party-work-orders/${problem.third_party_work_order}`}
+                to={`/maintenance/third-party/${problem.third_party_work_order}`}
               >
                 {problem.third_party_work_order_short_id}
               </Link>

--- a/frontend/src/pages/MaintenanceDashboardPage.tsx
+++ b/frontend/src/pages/MaintenanceDashboardPage.tsx
@@ -66,7 +66,9 @@ const SEVERITY_COLORS: Record<string, string> = {
 const detailLinkFor = (row: ActiveMaintenanceRow): string => {
   if (row.kind === 'work_order') return `/maintenance/work-orders/${row.id}`;
   if (row.kind === 'location_problem') return `/maintenance/location-problems/${row.id}`;
-  return `/assets/${row.asset_id ?? ''}`;
+  // Asset problems get their own detail page (op-ybpn) so the promote/resolve
+  // actions are one click from this feed instead of buried in the asset page.
+  return `/maintenance/asset-problems/${row.id}`;
 };
 
 const MaintenanceDashboardPage: React.FC = () => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1135,6 +1135,29 @@ export const assetProblemsAPI = {
       { headers: { 'Content-Type': 'multipart/form-data' } },
     );
   },
+
+  // Promote a report to real work. Unlike the LocationProblem sibling there is
+  // no MaintenanceItem picker — a corrective work order anchors straight to the
+  // problem's asset. All three actions return the full updated AssetProblem so
+  // the caller can patch its row without a follow-up GET.
+  promoteStandard: (id: string) =>
+    api.post<AssetProblem>(`/inventory/asset-problems/${id}/promote-standard/`, {}),
+
+  promoteThirdParty: (id: string, payload: {
+    vendor: string;
+    title: string;
+    work_type?: string;
+  }) =>
+    api.post<AssetProblem>(
+      `/inventory/asset-problems/${id}/promote-third-party/`,
+      payload,
+    ),
+
+  resolve: (id: string, payload: {
+    status?: 'resolved' | 'closed';
+    resolution_notes?: string;
+  }) =>
+    api.post<AssetProblem>(`/inventory/asset-problems/${id}/resolve/`, payload),
 };
 
 // Asset Document Library API (per-asset manuals / CAD / wiring / cut-ready files)

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -527,6 +527,12 @@ export interface AssetProblem {
   reported_by: string;
   description: string;
   status: AssetProblemStatus;
+  // Set once the report is promoted to real work: an in-house corrective
+  // WorkOrder or a vendor ThirdPartyWorkOrder (never both from one promote).
+  work_order?: string | null;
+  work_order_short_id?: string | null;
+  third_party_work_order?: string | null;
+  third_party_work_order_short_id?: string | null;
   resolution_notes: string;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
Web half of the corrective-work-order epic (`wo-corrective-epic`). Surfaces the promote/resolve endpoints that **B2 / op-olai (#946)** added, so a reported asset problem becomes real work without leaving the UI.

## Scope (per bead op-ybpn)

**Types** — `AssetProblem` gains `work_order`, `work_order_short_id`, `third_party_work_order`, `third_party_work_order_short_id`. Optional rather than required, matching the partial fixtures this interface already carries (`affected_parts?`).

**API client** — `assetProblemsAPI.promoteStandard(id)`, `.promoteThirdParty(id, {vendor, title, work_type})`, `.resolve(id, {status, resolution_notes})`. Unlike the LocationProblem sibling, `promoteStandard` takes **no MaintenanceItem** — a corrective WO anchors straight to the problem's asset.

**AssetDetailPage** (Problem History) — an open, un-promoted report gets **Create Work Order** and **Send to Vendor** (inline vendor picker + title + work type; vendors load lazily when the form opens, so the page's on-mount request budget is unchanged). Once promoted the row shows `Promoted to: WO-xxxx` / `TPWO-xxxx` linking to the work order and the promote actions retire — a second promote is a 400 from the API. Mutations patch the row in place per `docs/REACTIVE_MUTATIONS.md`; the existing Resolve flow is untouched.

**AssetProblemDetailPage** (the bead's *optional parity* item — included) — mirrors `LocationProblemDetailPage`, on route `/maintenance/asset-problems/:id`. The maintenance dashboard's `asset_problem` rows now link there instead of at the whole asset page, so promote/resolve is one click from the feed.

**Maintenance dashboard** — no structural change was needed for the "Work Order column": B2 already drops promoted reports from `maintenance/active` and `WorkOrder.display_title` falls back to the report text, so a promoted problem surfaces in *Unscheduled / Open Problems* as its WO. Locked in with a regression test rather than new UI.

**Drive-by fix** — `LocationProblemDetailPage` linked third-party work orders at `/maintenance/third-party-work-orders/:id`; the real route is `/maintenance/third-party/:id`. Dead link, same class as the ones added here.

## Tests

12 new component tests: 5 promote cases on `AssetDetailPage` (in-house promote + WO link, vendor promote from the inline form, promoted-state hides the actions, failure re-enables the action, logged-out hides them), 5 on `AssetProblemDetailPage` (both promote paths, resolve in-flight locking, logged-out, offline error state), 2 on `MaintenanceDashboardPage` (un-promoted problem links to its detail page; a promoted one surfaces as its WO row).

## Verification

- `npm run lint` — 0 errors (26 pre-existing repo-wide warnings).
- `npm run test:fast` — 158 files / 1253 tests, all green.
- `npm run build` — green.
- `tsc -b` — 73 errors on this branch and 73 on `origin/main`; no new type errors.
- **Live drive** against a dev stack (Postgres + `runserver`): report problem → `promote-standard` (201, `work_order_short_id: WO-7C6E7290`) → WO detail → validate → complete → problem auto-resolves (`status: resolved`, `resolved_by: ybpn`). Also exercised `promote-third-party` (201, `TPWO-B6210F84`) and confirmed both dashboard feeds: an un-promoted report appears as `kind=asset_problem` with the problem id my link uses, a promoted one as its `work_order` row carrying the report text.

### Note for the epic owner (not addressed here)

`maintenance/active` unions WorkOrders + un-promoted problems, but **not** ThirdPartyWorkOrders — so a report promoted to a vendor leaves the active feed with nothing replacing it. It stays visible (with its TPWO link) on the asset page and its own detail page. Backend feed behavior from B2, outside this bead's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)