### PR TITLE
feat(web): work-order actual materials & cost UI (op-xl80, W2)

### DIFF
--- a/frontend/src/__tests__/pages/WorkOrderPage.test.tsx
+++ b/frontend/src/__tests__/pages/WorkOrderPage.test.tsx
@@ -250,13 +250,16 @@ describe('WorkOrderPage material usage → inventory decrement (op-uh8z)', () =>
     fireEvent.click(checkbox);
 
     // Checking the box records the material as used AND carries the quantity,
-    // which the backend decrements from the linked inventory item.
+    // which the backend decrements from the linked inventory item. The trailing
+    // unit cost (op-768w) is undefined here — nobody typed a price, and an
+    // omitted one leaves whatever the line already recorded alone.
     await waitFor(() => {
       expect(mockWorkOrderAPI.toggleMaterial).toHaveBeenCalledWith(
         'wo-1',
         'mu-1',
         true,
         '2.00',
+        undefined,
       );
     });
   });
@@ -282,8 +285,6 @@ describe('WorkOrderPage material usage → inventory decrement (op-uh8z)', () =>
     expect(await screen.findByText(/3 from stock/i)).toBeInTheDocument();
     expect(screen.getByText(/usage logged/i)).toBeInTheDocument();
     // The quantity input is locked away once the decrement is applied.
-    expect(
-      screen.queryByRole('spinbutton', { name: /qty used/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/qty used/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/pages/WorkOrderPageMaterials.test.tsx
+++ b/frontend/src/__tests__/pages/WorkOrderPageMaterials.test.tsx
@@ -1,0 +1,526 @@
+/**
+ * Work-order actual materials & cost (op-xl80, web half of op-768w).
+ *
+ * The thing that was impossible before this slice: recording what a job
+ * actually consumed or cost. A *corrective* work order has no PM template to
+ * copy material rows from, so the add-material form is its only path to a
+ * material at all — and any work order can now record something bought
+ * mid-job, priced, with the receipt attached.
+ *
+ * Also covers the ordering-side view (op-bu80): the PO lines bought for this
+ * job, which is what tells a tech the part is still in transit.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import WorkOrderPage from '../../pages/WorkOrderPage';
+import { inventoryAPI, maintenanceAPI, workOrderAPI } from '../../services/api';
+import { WorkOrder, WorkOrderMaterialUsage, WorkOrderPurchaseLine } from '../../types';
+
+vi.mock('../../services/api');
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useParams: () => ({ id: 'wo-1' }),
+  useNavigate: () => jest.fn(),
+}));
+
+const mockWorkOrderAPI = workOrderAPI as jest.Mocked<typeof workOrderAPI>;
+const mockInventoryAPI = inventoryAPI as jest.Mocked<typeof inventoryAPI>;
+const mockMaintenanceAPI = maintenanceAPI as jest.Mocked<typeof maintenanceAPI>;
+
+const okResponse = <T,>(data: T) =>
+  ({ data, status: 200, statusText: 'OK', headers: {}, config: {} as never }) as never;
+
+// `env="test"` keeps Mantine's dropdowns out of their transition, which never
+// completes in jsdom and would leave the Select's options display:none.
+const renderPage = () =>
+  render(
+    <MantineProvider env="test">
+      <MemoryRouter>
+        <WorkOrderPage />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+const buildMaterial = (
+  overrides: Partial<WorkOrderMaterialUsage> = {},
+): WorkOrderMaterialUsage => ({
+  id: 'mu-1',
+  work_order: 'wo-1',
+  material: 'm-1',
+  material_name: 'Air filter',
+  quantity_planned: '2.00',
+  quantity_used: '2.00',
+  unit: 'ea',
+  was_used: false,
+  applied_quantity: null,
+  stock_applied: false,
+  is_ad_hoc: false,
+  inventory_item: null,
+  inventory_item_name: null,
+  purchase_order_item: null,
+  unit_cost: null,
+  actual_cost: null,
+  receipt_url: null,
+  created_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const buildPurchaseLine = (
+  overrides: Partial<WorkOrderPurchaseLine> = {},
+): WorkOrderPurchaseLine => ({
+  id: 'poi-1',
+  purchase_order_id: 'po-1',
+  po_number: 'PO-2026-0007',
+  po_status: 'ordered',
+  supplier_name: 'Grainger',
+  name: 'Drive belt A45',
+  item_type: 'inventory',
+  quantity_ordered: 4,
+  quantity_received: 0,
+  quantity_pending: 4,
+  is_fully_received: false,
+  unit_cost: '11.25',
+  expected_delivery_date: '2026-02-10',
+  expected_shipment_date: null,
+  ...overrides,
+});
+
+const buildWorkOrder = (overrides: Partial<WorkOrder> = {}): WorkOrder =>
+  ({
+    id: 'wo-1',
+    short_id: 'wo-001',
+    maintenance_item: null,
+    maintenance_item_title: null,
+    asset_name: 'Bandsaw',
+    asset_tag: 'TAG001',
+    asset_id: 'a-1',
+    status: 'in_progress',
+    due_date: null,
+    assigned_to: null,
+    assigned_to_name: 'Alice',
+    completed_by_name: null,
+    completed_at: null,
+    notes: '',
+    loto_completion_note: '',
+    is_overdue: false,
+    task_completions: [],
+    material_usage: [],
+    actual_material_cost: '0.00',
+    loto_completions: [],
+    photos: [],
+    submissions: [],
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }) as unknown as WorkOrder;
+
+const materialsCard = async () =>
+  (await screen.findByText('Materials')).closest('.mantine-Card-root') as HTMLElement;
+
+/** Open the add-material form and wait for it to be on screen. */
+const openAddMaterial = async () => {
+  fireEvent.click(await screen.findByRole('button', { name: /add material/i }));
+  await screen.findByRole('radio', { name: /out-of-pocket receipt/i });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockWorkOrderAPI.addMaterial.mockResolvedValue(okResponse(buildMaterial({ id: 'mu-new' })));
+  mockWorkOrderAPI.removeMaterial.mockResolvedValue(okResponse(undefined));
+  mockWorkOrderAPI.toggleMaterial.mockResolvedValue(okResponse(buildMaterial()));
+  mockInventoryAPI.listItems.mockResolvedValue(okResponse({ results: [] }));
+});
+
+describe('WorkOrderPage — adding a material (op-xl80)', () => {
+  it('offers the add form on a corrective work order with no materials at all', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(okResponse(buildWorkOrder()));
+
+    renderPage();
+
+    const card = await materialsCard();
+    expect(within(card).getByText(/no materials recorded/i)).toBeInTheDocument();
+    expect(within(card).getByRole('button', { name: /add material/i })).toBeInTheDocument();
+  });
+
+  it('posts an ad-hoc line with the quantity, unit and price typed in', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(okResponse(buildWorkOrder()));
+
+    renderPage();
+    await openAddMaterial();
+
+    fireEvent.change(screen.getByLabelText(/material name/i), { target: { value: 'Coupling' } });
+    fireEvent.change(screen.getByLabelText('Quantity'), { target: { value: '3' } });
+    fireEvent.change(screen.getByLabelText('Unit'), { target: { value: 'ea' } });
+    fireEvent.change(screen.getByLabelText('Unit cost'), { target: { value: '4.25' } });
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }));
+
+    await waitFor(() => expect(mockWorkOrderAPI.addMaterial).toHaveBeenCalled());
+    const [workOrderId, payload] = mockWorkOrderAPI.addMaterial.mock.calls[0];
+    expect(workOrderId).toBe('wo-1');
+    expect(payload).toEqual({
+      material_name: 'Coupling',
+      quantity_used: 3,
+      unit: 'ea',
+      unit_cost: 4.25,
+    });
+    // No receipt attached -> a plain JSON body, not multipart.
+    expect(payload).not.toBeInstanceOf(FormData);
+    // The page reloads so the new line appears with its actual cost.
+    expect(mockWorkOrderAPI.getWorkOrder).toHaveBeenCalledTimes(2);
+  });
+
+  it('defaults the unit cost from the inventory item that was picked', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(okResponse(buildWorkOrder()));
+    mockInventoryAPI.listItems.mockResolvedValue(
+      okResponse({ results: [{ id: 'item-1', name: 'Bearing 6203', unit_cost: '7.50' }] }),
+    );
+
+    renderPage();
+    await openAddMaterial();
+
+    fireEvent.change(screen.getByLabelText(/material name/i), { target: { value: 'Bearing' } });
+    // The picker is searched server-side (debounced), so wait for the options.
+    await waitFor(() => expect(mockInventoryAPI.listItems).toHaveBeenCalled());
+    fireEvent.click(screen.getByPlaceholderText('Search inventory…'));
+    fireEvent.click(await screen.findByRole('option', { name: 'Bearing 6203' }));
+
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }));
+
+    await waitFor(() => expect(mockWorkOrderAPI.addMaterial).toHaveBeenCalled());
+    const [, payload] = mockWorkOrderAPI.addMaterial.mock.calls[0];
+    // Linking stock is what lets marking the line used decrement it, and the
+    // item's current price seeds the cost so the tech types one only when the
+    // real one differs.
+    expect(payload).toMatchObject({ inventory_item: 'item-1', unit_cost: '7.50' });
+  });
+
+  it('records an out-of-pocket receipt as a priced line with the image attached', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(okResponse(buildWorkOrder()));
+
+    renderPage();
+    await openAddMaterial();
+
+    fireEvent.click(screen.getByRole('radio', { name: /out-of-pocket receipt/i }));
+    fireEvent.change(screen.getByLabelText('Bought where'), {
+      target: { value: 'Ace Hardware' },
+    });
+    fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '18.40' } });
+
+    const attach = screen.getByRole('button', { name: /attach receipt/i });
+    const fileInput = attach.parentElement?.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: { files: [new File(['bytes'], 'receipt.jpg', { type: 'image/jpeg' })] },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }));
+
+    await waitFor(() => expect(mockWorkOrderAPI.addMaterial).toHaveBeenCalled());
+    const [, body] = mockWorkOrderAPI.addMaterial.mock.calls[0];
+    // A receipt rides along, so the body goes up multipart like a WO photo.
+    expect(body).toBeInstanceOf(FormData);
+    const formData = body as FormData;
+    expect(formData.get('material_name')).toBe('Misc supplies — Ace Hardware');
+    expect(Number(formData.get('unit_cost'))).toBe(18.4);
+    expect(Number(formData.get('quantity_used'))).toBe(1);
+    expect((formData.get('receipt_image') as File).name).toBe('receipt.jpg');
+    // An out-of-pocket buy moves no stock — it is money spent, not inventory.
+    expect(formData.get('inventory_item')).toBeNull();
+  });
+});
+
+describe('WorkOrderPage — per-line cost and removal (op-xl80)', () => {
+  it('sends an edited unit cost for a line that no checkbox click will carry', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(
+        buildWorkOrder({
+          material_usage: [
+            buildMaterial({ is_ad_hoc: true, was_used: true, material: null }),
+          ],
+        }),
+      ),
+    );
+
+    renderPage();
+
+    const cost = await screen.findByLabelText('Unit cost for Air filter');
+    fireEvent.change(cost, { target: { value: '3.25' } });
+    fireEvent.blur(cost);
+
+    // `was_used` rides along unchanged — the toggle is the only write path for
+    // the price, and an already-used line still has to be able to record one.
+    await waitFor(() =>
+      expect(mockWorkOrderAPI.toggleMaterial).toHaveBeenCalledWith(
+        'wo-1',
+        'mu-1',
+        true,
+        undefined,
+        3.25,
+      ),
+    );
+  });
+
+  it('carries a freshly typed price when the line is checked off as used', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(buildWorkOrder({ material_usage: [buildMaterial({ is_ad_hoc: true })] })),
+    );
+
+    renderPage();
+
+    fireEvent.change(await screen.findByLabelText('Unit cost for Air filter'), {
+      target: { value: '5' },
+    });
+    fireEvent.click(screen.getByRole('checkbox', { name: /air filter/i }));
+
+    await waitFor(() =>
+      expect(mockWorkOrderAPI.toggleMaterial).toHaveBeenCalledWith(
+        'wo-1',
+        'mu-1',
+        true,
+        '2.00',
+        5,
+      ),
+    );
+  });
+
+  it('locks the price away once the stock decrement is applied', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(
+        buildWorkOrder({
+          material_usage: [
+            buildMaterial({
+              is_ad_hoc: true,
+              was_used: true,
+              applied_quantity: 2,
+              stock_applied: true,
+              unit_cost: '4.00',
+              actual_cost: '8.00',
+            }),
+          ],
+        }),
+      ),
+    );
+
+    renderPage();
+
+    const card = await materialsCard();
+    expect(within(card).getByText(/2 from stock/i)).toBeInTheDocument();
+    // Both editable fields are gone: changing either after stock moved would
+    // desync the reversal from the spend it backs.
+    expect(screen.queryByLabelText('Unit cost for Air filter')).not.toBeInTheDocument();
+    expect(within(card).getByText(/\$8\.00/)).toBeInTheDocument();
+    // Removing it would strand the units taken out of inventory.
+    expect(within(card).getByRole('button', { name: /remove air filter/i })).toBeDisabled();
+  });
+
+  it('removes an ad-hoc line and leaves template lines alone', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(
+        buildWorkOrder({
+          material_usage: [
+            buildMaterial({ id: 'mu-tpl', material_name: 'Air filter' }),
+            buildMaterial({
+              id: 'mu-adhoc',
+              material: null,
+              is_ad_hoc: true,
+              material_name: 'Zip ties',
+            }),
+          ],
+        }),
+      ),
+    );
+
+    renderPage();
+
+    const card = await materialsCard();
+    // A template row is the frozen copy of what the job was supposed to be —
+    // it prints on the sign-off sheet, so it is never removable.
+    expect(within(card).queryByRole('button', { name: /remove air filter/i })).toBeNull();
+
+    fireEvent.click(within(card).getByRole('button', { name: /remove zip ties/i }));
+
+    await waitFor(() =>
+      expect(mockWorkOrderAPI.removeMaterial).toHaveBeenCalledWith('wo-1', 'mu-adhoc'),
+    );
+    expect(mockWorkOrderAPI.getWorkOrder).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows a PO-sourced line as owned by its purchase order', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(
+        buildWorkOrder({
+          material_usage: [
+            buildMaterial({
+              id: 'mu-po',
+              material: null,
+              is_ad_hoc: true,
+              purchase_order_item: 'poi-1',
+              material_name: 'Drive belt A45',
+              was_used: true,
+              quantity_used: '4.00',
+              unit_cost: '11.25',
+              actual_cost: '45.00',
+            }),
+          ],
+        }),
+      ),
+    );
+
+    renderPage();
+
+    const card = await materialsCard();
+    expect(within(card).getByText('from PO')).toBeInTheDocument();
+    // The PO owns the quantity and the price — a later receipt re-writes both,
+    // so the job page reports them rather than offering edits or a delete.
+    expect(screen.queryByLabelText('Unit cost for Drive belt A45')).not.toBeInTheDocument();
+    expect(within(card).queryByRole('button', { name: /remove drive belt/i })).toBeNull();
+    expect(within(card).getByText(/\$45\.00/)).toBeInTheDocument();
+  });
+
+  it('links the receipt backing an out-of-pocket line', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(
+        buildWorkOrder({
+          material_usage: [
+            buildMaterial({
+              material: null,
+              is_ad_hoc: true,
+              material_name: 'Misc supplies — Ace Hardware',
+              unit_cost: '18.40',
+              actual_cost: '18.40',
+              receipt_url: 'http://api.test/media/receipt.jpg',
+            }),
+          ],
+        }),
+      ),
+    );
+
+    renderPage();
+
+    const card = await materialsCard();
+    expect(within(card).getByRole('link', { name: 'Receipt' })).toHaveAttribute(
+      'href',
+      'http://api.test/media/receipt.jpg',
+    );
+  });
+});
+
+describe('WorkOrderPage — actual vs estimated material cost (op-xl80)', () => {
+  it('measures the actual against the PM template estimate', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(
+        buildWorkOrder({
+          maintenance_item: 'mi-1',
+          actual_material_cost: '25.00',
+          material_usage: [
+            buildMaterial({ quantity_planned: '2.00', unit_cost: '12.50', actual_cost: '25.00', was_used: true }),
+          ],
+        }),
+      ),
+    );
+    mockMaintenanceAPI.getItem.mockResolvedValue(
+      okResponse({ id: 'mi-1', materials: [{ id: 'm-1', estimated_cost_per_unit: '10.00' }] }),
+    );
+
+    renderPage();
+
+    const card = await materialsCard();
+    expect(await within(card).findByTestId('wo-actual-material-cost')).toHaveTextContent('$25.00');
+    // 2 planned × $10.00 estimated = $20.00, so the job ran $5.00 over.
+    const estimated = within(card).getByTestId('wo-estimated-material-cost');
+    expect(estimated).toHaveTextContent('$20.00');
+    expect(estimated).toHaveTextContent('$5.00 over');
+  });
+
+  it('shows the actual alone on a corrective job, which nothing estimated', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(
+        buildWorkOrder({
+          actual_material_cost: '18.40',
+          material_usage: [
+            buildMaterial({
+              material: null,
+              is_ad_hoc: true,
+              was_used: true,
+              unit_cost: '18.40',
+              actual_cost: '18.40',
+            }),
+          ],
+        }),
+      ),
+    );
+
+    renderPage();
+
+    const card = await materialsCard();
+    expect(within(card).getByTestId('wo-actual-material-cost')).toHaveTextContent('$18.40');
+    expect(within(card).getByText(/no estimate for this job/i)).toBeInTheDocument();
+    // No template, so nothing is fetched to compare against.
+    expect(mockMaintenanceAPI.getItem).not.toHaveBeenCalled();
+  });
+
+  it('falls back to summing the used lines when the payload has no server total', async () => {
+    const legacy = buildWorkOrder({
+      material_usage: [
+        buildMaterial({ was_used: true, actual_cost: '6.00' }),
+        // Planned but not used: it cost nothing, so it counts for nothing.
+        buildMaterial({ id: 'mu-2', was_used: false, actual_cost: '99.00' }),
+      ],
+    });
+    delete (legacy as Partial<WorkOrder>).actual_material_cost;
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(okResponse(legacy));
+
+    renderPage();
+
+    const card = await materialsCard();
+    expect(within(card).getByTestId('wo-actual-material-cost')).toHaveTextContent('$6.00');
+  });
+});
+
+describe('WorkOrderPage — ordered for this work order (op-bu80)', () => {
+  it('shows what is still in transit and what has landed', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(
+      okResponse(
+        buildWorkOrder({
+          purchase_order_lines: [
+            buildPurchaseLine(),
+            buildPurchaseLine({
+              id: 'poi-2',
+              name: 'Filter cartridge',
+              quantity_received: 2,
+              quantity_pending: 0,
+              is_fully_received: true,
+              po_status: 'received',
+            }),
+          ],
+        }),
+      ),
+    );
+
+    renderPage();
+
+    const card = (await screen.findByText('Ordered for this work order')).closest(
+      '.mantine-Card-root',
+    ) as HTMLElement;
+    expect(within(card).getByText('Drive belt A45')).toBeInTheDocument();
+    // The point of the section: the part is bought but has not shown up yet.
+    expect(within(card).getByText('4 on order')).toBeInTheDocument();
+    expect(within(card).getByText('received')).toBeInTheDocument();
+    expect(within(card).getAllByRole('link', { name: 'PO-2026-0007' })[0]).toHaveAttribute(
+      'href',
+      '/purchasing/orders/po-1',
+    );
+  });
+
+  it('leaves the section out when nothing was ordered for the job', async () => {
+    mockWorkOrderAPI.getWorkOrder.mockResolvedValue(okResponse(buildWorkOrder()));
+
+    renderPage();
+
+    await materialsCard();
+    expect(screen.queryByText('Ordered for this work order')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/WorkOrderPage.tsx
+++ b/frontend/src/pages/WorkOrderPage.tsx
@@ -8,15 +8,18 @@ import {
   Card,
   Checkbox,
   Container,
+  Divider,
   FileButton,
   Group,
   Image,
   Loader,
   Modal,
   NumberInput,
+  SegmentedControl,
   Select,
   Stack,
   Text,
+  TextInput,
   Textarea,
   Title,
   Tooltip,
@@ -35,18 +38,27 @@ import {
   IconPhoto,
   IconPlayerPause,
   IconPlayerPlay,
+  IconPlus,
+  IconReceipt,
   IconRobot,
   IconScan,
+  IconShoppingCart,
   IconStopwatch,
   IconTag,
   IconTool,
+  IconTrash,
   IconUpload,
 } from '@tabler/icons-react';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import WorkspacePage from '../components/landing/WorkspacePage';
-import { workOrderAPI } from '../services/api';
-import { WorkOrder, WorkOrderStatus } from '../types';
+import { inventoryAPI, maintenanceAPI, workOrderAPI } from '../services/api';
+import {
+  WorkOrder,
+  WorkOrderAdHocMaterialInput,
+  WorkOrderMaterialUsage,
+  WorkOrderStatus,
+} from '../types';
 import { formatDateOnly } from '../utils/dates';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
 
@@ -87,6 +99,44 @@ export const formatElapsedSummary = (
 ): string => {
   const minutes = Math.round(Math.max(0, totalSeconds || 0) / 60);
   return estimateMinutes ? `${minutes}m / est ${estimateMinutes}m` : `${minutes}m on job`;
+};
+
+// ── Material cost (op-768w) ─────────────────────────────────────────────────
+// A line's real spend is `quantity_used × unit_cost`, and the *work order's*
+// actual is the server-owned sum of that over the lines actually used. The
+// estimate it gets measured against lives on the PM template
+// (`MaintenanceMaterial.estimated_cost_per_unit`), so a corrective work order —
+// which has no template — has an actual and nothing to compare it against,
+// exactly like the stopwatch has no `estimated_time_minutes`.
+
+/** `$12.50`, or an em dash when nothing was priced. */
+export const formatMoney = (value: string | number | null | undefined): string => {
+  if (value === null || value === undefined || value === '') return '—';
+  const num = Number(value);
+  return Number.isFinite(num) ? `$${num.toFixed(2)}` : '—';
+};
+
+/** The number a Decimal-as-string field carries, or 0 when it carries nothing. */
+const toNumber = (value: string | number | null | undefined): number => {
+  const num = Number(value ?? 0);
+  return Number.isFinite(num) ? num : 0;
+};
+
+/**
+ * What the used lines actually cost, for a payload without the server total.
+ *
+ * Mirrors `WorkOrder.actual_material_cost`: planned-but-unused costs nothing,
+ * and an unpriced used line contributes 0 rather than voiding the total.
+ */
+const sumActualMaterialCost = (lines: WorkOrderMaterialUsage[]): number =>
+  lines.reduce((total, mu) => (mu.was_used ? total + toNumber(mu.actual_cost) : total), 0);
+
+/** True when two money/quantity drafts mean the same thing (`''`/null = unset). */
+const sameAmount = (a: string | number | null | undefined, b: string | number | null | undefined) => {
+  const left = a === '' || a === null || a === undefined ? null : Number(a);
+  const right = b === '' || b === null || b === undefined ? null : Number(b);
+  if (left === null || right === null) return left === right;
+  return Math.abs(left - right) < 1e-9;
 };
 
 /**
@@ -411,6 +461,33 @@ const WorkOrderPage: React.FC = () => {
   // Per-row "quantity used" edits, keyed by material-usage id. Seeded from the
   // row's quantity_used and sent when the material is checked off as used.
   const [materialQty, setMaterialQty] = useState<Record<string, number | string>>({});
+  // op-768w: the same idea for the real price paid per unit. Both drafts ride
+  // the toggle and commit on blur, so an already-checked line can still be
+  // priced — the backend freezes both once the stock decrement lands.
+  const [materialCost, setMaterialCost] = useState<Record<string, number | string>>({});
+  const [removingMaterial, setRemovingMaterial] = useState<string | null>(null);
+  // op-768w: the add-material form. `receipt` mode is the out-of-pocket buy —
+  // a line that records a spend and moves no stock.
+  const [addMaterialOpen, setAddMaterialOpen] = useState(false);
+  const [addMode, setAddMode] = useState<'material' | 'receipt'>('material');
+  const [newMaterialName, setNewMaterialName] = useState('');
+  const [newMaterialQty, setNewMaterialQty] = useState<number | string>(1);
+  const [newMaterialUnit, setNewMaterialUnit] = useState('');
+  const [newMaterialCost, setNewMaterialCost] = useState<number | string>('');
+  const [newMaterialItem, setNewMaterialItem] = useState<string | null>(null);
+  const [newReceiptWhere, setNewReceiptWhere] = useState('');
+  const [newReceiptFile, setNewReceiptFile] = useState<File | null>(null);
+  const [savingMaterial, setSavingMaterial] = useState(false);
+  // Stock picker for an ad-hoc line: searched server-side, since a shop's item
+  // list is far longer than a dropdown should ever hold.
+  const [itemSearch, setItemSearch] = useState('');
+  const [itemOptions, setItemOptions] = useState<{ value: string; label: string }[]>([]);
+  const [itemCosts, setItemCosts] = useState<Record<string, string | null>>({});
+  const resetReceiptRef = useRef<() => void>(null);
+  // Estimated cost per unit from the PM template, keyed by MaintenanceMaterial
+  // id — the only thing the "actual vs estimated" comparison can be measured
+  // against, and it does not ride the work-order payload.
+  const [estimatedUnitCosts, setEstimatedUnitCosts] = useState<Record<string, string>>({});
   const [uploadingPhoto, setUploadingPhoto] = useState(false);
   // Which step's evidence photo is currently uploading (null = none).
   const [uploadingStepPhoto, setUploadingStepPhoto] = useState<string | null>(null);
@@ -461,6 +538,65 @@ const WorkOrderPage: React.FC = () => {
   useEffect(() => {
     loadWorkOrder();
   }, [loadWorkOrder]);
+
+  // op-768w: pull the PM template's per-unit estimates so the materials total
+  // can say actual *against* estimate. One fetch per template; a corrective
+  // work order has none, and a failure just drops the comparison — the actual
+  // spend stands on its own.
+  const maintenanceItemId = workOrder?.maintenance_item ?? null;
+  useEffect(() => {
+    if (!maintenanceItemId) {
+      setEstimatedUnitCosts({});
+      return undefined;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await maintenanceAPI.getItem(maintenanceItemId);
+        if (cancelled) return;
+        const costs: Record<string, string> = {};
+        (res?.data?.materials ?? []).forEach((mat) => {
+          costs[mat.id] = mat.estimated_cost_per_unit;
+        });
+        setEstimatedUnitCosts(costs);
+      } catch {
+        // No estimate to compare against; the actual is still worth showing.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [maintenanceItemId]);
+
+  // Stock picker options for the add-material form. Searched server-side and
+  // only while the form is open, so the page itself never pays for it.
+  useEffect(() => {
+    if (!addMaterialOpen) return undefined;
+    let cancelled = false;
+    const handle = setTimeout(async () => {
+      try {
+        const res = await inventoryAPI.listItems({
+          search: itemSearch || undefined,
+          page_size: 25,
+        });
+        if (cancelled) return;
+        const items = res?.data?.results ?? [];
+        setItemOptions(items.map((item) => ({ value: item.id, label: item.name })));
+        setItemCosts(
+          items.reduce<Record<string, string | null>>((acc, item) => {
+            acc[item.id] = item.unit_cost;
+            return acc;
+          }, {}),
+        );
+      } catch {
+        // Picking stock is optional — an ad-hoc line works without it.
+      }
+    }, 250);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [addMaterialOpen, itemSearch]);
 
   const handleStatusChange = async (newStatus: string | null) => {
     if (!workOrder || !newStatus) return;
@@ -704,12 +840,29 @@ const WorkOrderPage: React.FC = () => {
   const handleToggleMaterial = async (
     materialUsageId: string,
     wasUsed: boolean,
-    quantityUsed?: number | string
+    quantityUsed?: number | string,
+    unitCost?: number | string | null
   ) => {
     if (!workOrder) return;
     setTogglingMaterial(materialUsageId);
     try {
-      await workOrderAPI.toggleMaterial(workOrder.id, materialUsageId, wasUsed, quantityUsed);
+      await workOrderAPI.toggleMaterial(
+        workOrder.id,
+        materialUsageId,
+        wasUsed,
+        quantityUsed,
+        unitCost
+      );
+      // The server now holds what the drafts were proposing — drop them so the
+      // row reads from the payload again (a PO re-mirror can move either one).
+      setMaterialQty((prev) => {
+        const { [materialUsageId]: _dropped, ...rest } = prev;
+        return rest;
+      });
+      setMaterialCost((prev) => {
+        const { [materialUsageId]: _dropped, ...rest } = prev;
+        return rest;
+      });
       await loadWorkOrder();
     } catch {
       notifications.show({
@@ -719,6 +872,118 @@ const WorkOrderPage: React.FC = () => {
       });
     } finally {
       setTogglingMaterial(null);
+    }
+  };
+
+  /**
+   * Send a quantity/cost edit that no checkbox click is going to carry.
+   *
+   * The toggle is the only write endpoint for these two fields, so an
+   * already-marked line (an out-of-pocket buy is marked used and moves no
+   * stock) would otherwise have no way to record what it cost. Sends the
+   * line's current `was_used` unchanged; a no-op edit sends nothing.
+   */
+  const handleCommitMaterialEdits = async (mu: WorkOrderMaterialUsage) => {
+    const qtyDraft = materialQty[mu.id];
+    const costDraft = materialCost[mu.id];
+    const qtyChanged = qtyDraft !== undefined && !sameAmount(qtyDraft, mu.quantity_used);
+    const costChanged = costDraft !== undefined && !sameAmount(costDraft, mu.unit_cost);
+    if (!qtyChanged && !costChanged) return;
+    await handleToggleMaterial(
+      mu.id,
+      mu.was_used,
+      qtyChanged ? qtyDraft : undefined,
+      // '' is a real answer — "I don't know what this cost" clears the price.
+      costChanged ? (costDraft === '' ? null : costDraft) : undefined
+    );
+  };
+
+  const handleRemoveMaterial = async (mu: WorkOrderMaterialUsage) => {
+    if (!workOrder) return;
+    setRemovingMaterial(mu.id);
+    try {
+      await workOrderAPI.removeMaterial(workOrder.id, mu.id);
+      await loadWorkOrder();
+      notifications.show({
+        title: 'Material removed',
+        message: `${mu.material_name} removed from this work order.`,
+        color: 'green',
+        icon: <IconCheck size={16} />,
+      });
+    } catch (err: unknown) {
+      notifications.show({
+        title: 'Error',
+        message: extractErrorMessage(err, 'Failed to remove material.'),
+        color: 'red',
+      });
+    } finally {
+      setRemovingMaterial(null);
+    }
+  };
+
+  const resetAddMaterialForm = () => {
+    setAddMode('material');
+    setNewMaterialName('');
+    setNewMaterialQty(1);
+    setNewMaterialUnit('');
+    setNewMaterialCost('');
+    setNewMaterialItem(null);
+    setNewReceiptWhere('');
+    setNewReceiptFile(null);
+    setItemSearch('');
+    resetReceiptRef.current?.();
+  };
+
+  /** The line an out-of-pocket receipt becomes: one unit, priced at the total. */
+  const receiptMaterialName = newReceiptWhere.trim()
+    ? `Misc supplies — ${newReceiptWhere.trim()}`
+    : 'Misc supplies';
+
+  const handleAddMaterial = async () => {
+    if (!workOrder) return;
+    const isReceipt = addMode === 'receipt';
+    const materialName = isReceipt ? receiptMaterialName : newMaterialName.trim();
+    if (!materialName) return;
+
+    const payload: WorkOrderAdHocMaterialInput = {
+      material_name: materialName,
+      quantity_used: isReceipt ? 1 : (newMaterialQty === '' ? 1 : newMaterialQty),
+    };
+    if (!isReceipt && newMaterialUnit.trim()) payload.unit = newMaterialUnit.trim();
+    if (newMaterialCost !== '' && newMaterialCost !== null) payload.unit_cost = newMaterialCost;
+    // A receipt buy is out of pocket by definition — it moves no stock.
+    if (!isReceipt && newMaterialItem) payload.inventory_item = newMaterialItem;
+
+    setSavingMaterial(true);
+    try {
+      if (newReceiptFile) {
+        // Multipart only when a receipt rides along, mirroring the photo client.
+        const formData = new FormData();
+        Object.entries(payload).forEach(([key, value]) => {
+          if (value !== undefined && value !== null) formData.append(key, String(value));
+        });
+        formData.append('receipt_image', newReceiptFile);
+        await workOrderAPI.addMaterial(workOrder.id, formData);
+      } else {
+        await workOrderAPI.addMaterial(workOrder.id, payload);
+      }
+      setAddMaterialOpen(false);
+      resetAddMaterialForm();
+      await loadWorkOrder();
+      notifications.show({
+        title: 'Material added',
+        message: `${materialName} added to this work order.`,
+        color: 'green',
+        icon: <IconCheck size={16} />,
+      });
+    } catch (err: unknown) {
+      notifications.show({
+        title: 'Error',
+        message: extractErrorMessage(err, 'Failed to add material.'),
+        color: 'red',
+      });
+    } finally {
+      setSavingMaterial(false);
     }
   };
 
@@ -843,6 +1108,27 @@ const WorkOrderPage: React.FC = () => {
       setUploadingStepPhoto(null);
     }
   };
+
+  // op-768w: actual against estimate, the pair the materials card exists to
+  // produce. The actual is the server's; the estimate is the template's
+  // per-unit price applied to the quantities *this* work order planned, so a
+  // later edit to the template does not rewrite what this job estimated.
+  const materialCosts = useMemo(() => {
+    const lines = workOrder?.material_usage ?? [];
+    const actual =
+      workOrder?.actual_material_cost != null
+        ? toNumber(workOrder.actual_material_cost)
+        : sumActualMaterialCost(lines);
+    let estimated = 0;
+    let hasEstimate = false;
+    lines.forEach((mu) => {
+      const perUnit = mu.material ? estimatedUnitCosts[mu.material] : undefined;
+      if (perUnit === undefined) return;
+      hasEstimate = true;
+      estimated += toNumber(mu.quantity_planned) * toNumber(perUnit);
+    });
+    return { actual, estimated, hasEstimate };
+  }, [workOrder, estimatedUnitCosts]);
 
   if (loading) {
     return (
@@ -1563,80 +1849,288 @@ const WorkOrderPage: React.FC = () => {
       )}
 
       {/* Materials */}
-      {workOrder.material_usage.length > 0 && (
-        <Card withBorder p="md" radius="md" mb="md">
-          <Group mb="sm" gap="xs">
+      <Card withBorder p="md" radius="md" mb="md">
+        <Group mb="sm" justify="space-between">
+          <Group gap="xs">
             <IconTag size={18} />
             <Title order={5}>Materials</Title>
+            {workOrder.material_usage.length > 0 && (
+              <Badge color="gray" size="sm">{workOrder.material_usage.length}</Badge>
+            )}
+          </Group>
+          <Button
+            size="sm"
+            variant="light"
+            leftSection={<IconPlus size={16} />}
+            onClick={() => {
+              resetAddMaterialForm();
+              setAddMaterialOpen(true);
+            }}
+          >
+            Add material
+          </Button>
+        </Group>
+
+        {workOrder.material_usage.length === 0 ? (
+          <Text size="sm" c="dimmed" ta="center" py="sm">
+            No materials recorded. Add what you used or bought to do this job.
+          </Text>
+        ) : (
+          <Stack gap="xs">
+            {workOrder.material_usage.map((mu) => {
+              // A PO-sourced line mirrors its purchase order (op-bu80): the PO
+              // owns its quantity and price, and a later receipt re-writes
+              // both, so the job page shows them rather than offering edits.
+              const fromPurchaseOrder = Boolean(mu.purchase_order_item);
+              const busy = togglingMaterial === mu.id || removingMaterial === mu.id;
+              return (
+                <Box
+                  key={mu.id}
+                  p="sm"
+                  style={{
+                    borderRadius: 8,
+                    backgroundColor: mu.was_used ? '#f0fff4' : '#f8f9fa',
+                    border: `1px solid ${mu.was_used ? '#69db7c' : '#dee2e6'}`,
+                    opacity: busy ? 0.6 : 1,
+                  }}
+                >
+                  <Group gap="md" wrap="nowrap" justify="space-between" align="flex-start">
+                    <Checkbox
+                      checked={mu.was_used}
+                      onChange={(e) => {
+                        const checked = e.currentTarget.checked;
+                        handleToggleMaterial(
+                          mu.id,
+                          checked,
+                          checked ? (materialQty[mu.id] ?? mu.quantity_used) : undefined,
+                          checked ? materialCost[mu.id] : undefined
+                        );
+                      }}
+                      disabled={busy}
+                      size="lg"
+                      label={
+                        <Box>
+                          <Group gap={6}>
+                            <Text
+                              fw={mu.was_used ? 400 : 600}
+                              size="md"
+                              td={mu.was_used ? 'line-through' : 'none'}
+                              c={mu.was_used ? 'dimmed' : 'inherit'}
+                            >
+                              {mu.material_name}
+                            </Text>
+                            {mu.is_ad_hoc && !fromPurchaseOrder && (
+                              <Badge size="xs" variant="light" color="blue">added</Badge>
+                            )}
+                            {fromPurchaseOrder && (
+                              <Badge size="xs" variant="light" color="grape">from PO</Badge>
+                            )}
+                          </Group>
+                          <Text size="xs" c="dimmed">
+                            Planned: {mu.quantity_planned}
+                            {mu.unit ? ` ${mu.unit}` : ''}
+                            {mu.inventory_item_name ? ` · stock: ${mu.inventory_item_name}` : ''}
+                          </Text>
+                          <Group gap={8}>
+                            <Text size="xs" c={mu.actual_cost ? 'inherit' : 'dimmed'}>
+                              Cost: {formatMoney(mu.actual_cost)}
+                              {mu.unit_cost ? ` (${formatMoney(mu.unit_cost)}/unit)` : ''}
+                            </Text>
+                            {mu.receipt_url && (
+                              <Anchor
+                                size="xs"
+                                href={mu.receipt_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                Receipt
+                              </Anchor>
+                            )}
+                          </Group>
+                        </Box>
+                      }
+                    />
+                    <Group gap="xs" wrap="nowrap" align="flex-start">
+                      {mu.stock_applied ? (
+                        <Stack gap={0} align="flex-end">
+                          <Text
+                            size="xs"
+                            c="teal.7"
+                            fw={600}
+                            style={{ whiteSpace: 'nowrap' }}
+                          >
+                            −{mu.applied_quantity} from stock
+                          </Text>
+                          <Text size="xs" c="dimmed">
+                            usage logged
+                          </Text>
+                        </Stack>
+                      ) : fromPurchaseOrder ? (
+                        <Stack gap={0} align="flex-end">
+                          <Text size="xs" fw={600} style={{ whiteSpace: 'nowrap' }}>
+                            {mu.quantity_used} received
+                          </Text>
+                          <Text size="xs" c="dimmed">
+                            priced by the PO
+                          </Text>
+                        </Stack>
+                      ) : (
+                        <>
+                          {/* flexShrink 0 on both: the row is `nowrap`, and a
+                              shrunk NumberInput lays its stepper controls over
+                              whatever sits next to it — which put the remove
+                              button out of reach. */}
+                          <NumberInput
+                            size="xs"
+                            label="Qty used"
+                            value={materialQty[mu.id] ?? Number(mu.quantity_used)}
+                            onChange={(v) => setMaterialQty((prev) => ({ ...prev, [mu.id]: v }))}
+                            onBlur={() => handleCommitMaterialEdits(mu)}
+                            min={0}
+                            step={1}
+                            disabled={busy}
+                            style={{ width: 110, flexShrink: 0 }}
+                          />
+                          <NumberInput
+                            size="xs"
+                            label="Unit cost"
+                            aria-label={`Unit cost for ${mu.material_name}`}
+                            value={materialCost[mu.id] ?? (mu.unit_cost ?? '')}
+                            onChange={(v) => setMaterialCost((prev) => ({ ...prev, [mu.id]: v }))}
+                            onBlur={() => handleCommitMaterialEdits(mu)}
+                            min={0}
+                            prefix="$"
+                            decimalScale={2}
+                            // Stepping a price by ±1 is never what anyone wants,
+                            // and the controls are what did the overlapping.
+                            hideControls
+                            disabled={busy}
+                            style={{ width: 110, flexShrink: 0 }}
+                          />
+                        </>
+                      )}
+                      {mu.is_ad_hoc && !fromPurchaseOrder && (
+                        <Tooltip
+                          label={
+                            mu.stock_applied
+                              ? 'Un-mark it as used first to restore the stock'
+                              : 'Remove this line'
+                          }
+                        >
+                          {/* A disabled ActionIcon swallows pointer events, so
+                              the tooltip needs a wrapper to hang off. */}
+                          <Box style={{ flexShrink: 0 }}>
+                            <ActionIcon
+                              variant="subtle"
+                              color="red"
+                              mt={20}
+                              aria-label={`Remove ${mu.material_name}`}
+                              disabled={busy || mu.stock_applied}
+                              onClick={() => handleRemoveMaterial(mu)}
+                            >
+                              <IconTrash size={16} />
+                            </ActionIcon>
+                          </Box>
+                        </Tooltip>
+                      )}
+                    </Group>
+                  </Group>
+                </Box>
+              );
+            })}
+          </Stack>
+        )}
+
+        {workOrder.material_usage.length > 0 && (
+          <>
+            <Divider my="sm" />
+            <Group justify="space-between" align="flex-end">
+              <Box>
+                <Text size="xs" c="dimmed">Actual material cost</Text>
+                <Text fw={700} size="lg" data-testid="wo-actual-material-cost">
+                  {formatMoney(materialCosts.actual)}
+                </Text>
+              </Box>
+              <Box ta="right">
+                {materialCosts.hasEstimate ? (
+                  <>
+                    <Text size="xs" c="dimmed">Estimated</Text>
+                    <Text size="sm" data-testid="wo-estimated-material-cost">
+                      {formatMoney(materialCosts.estimated)}
+                      {' · '}
+                      <Text
+                        span
+                        fw={600}
+                        c={materialCosts.actual > materialCosts.estimated ? 'red.7' : 'teal.7'}
+                      >
+                        {materialCosts.actual > materialCosts.estimated
+                          ? `${formatMoney(materialCosts.actual - materialCosts.estimated)} over`
+                          : `${formatMoney(materialCosts.estimated - materialCosts.actual)} under`}
+                      </Text>
+                    </Text>
+                  </>
+                ) : (
+                  <Text size="xs" c="dimmed">No estimate for this job</Text>
+                )}
+              </Box>
+            </Group>
+          </>
+        )}
+      </Card>
+
+      {/* Ordered for this work order (op-bu80) */}
+      {workOrder.purchase_order_lines && workOrder.purchase_order_lines.length > 0 && (
+        <Card withBorder p="md" radius="md" mb="md">
+          <Group mb="sm" gap="xs">
+            <IconShoppingCart size={18} />
+            <Title order={5}>Ordered for this work order</Title>
+            <Badge color="gray" size="sm">{workOrder.purchase_order_lines.length}</Badge>
           </Group>
           <Stack gap="xs">
-            {workOrder.material_usage.map((mu) => (
+            {workOrder.purchase_order_lines.map((line) => (
               <Box
-                key={mu.id}
+                key={line.id}
                 p="sm"
                 style={{
                   borderRadius: 8,
-                  backgroundColor: mu.was_used ? '#f0fff4' : '#f8f9fa',
-                  border: `1px solid ${mu.was_used ? '#69db7c' : '#dee2e6'}`,
-                  opacity: togglingMaterial === mu.id ? 0.6 : 1,
+                  backgroundColor: '#f8f9fa',
+                  border: '1px solid #dee2e6',
                 }}
               >
-                <Group gap="md" wrap="nowrap" justify="space-between" align="flex-start">
-                  <Checkbox
-                    checked={mu.was_used}
-                    onChange={(e) => {
-                      const checked = e.currentTarget.checked;
-                      handleToggleMaterial(
-                        mu.id,
-                        checked,
-                        checked ? (materialQty[mu.id] ?? mu.quantity_used) : undefined
-                      );
-                    }}
-                    disabled={togglingMaterial === mu.id}
-                    size="lg"
-                    label={
-                      <Box>
-                        <Text
-                          fw={mu.was_used ? 400 : 600}
-                          size="md"
-                          td={mu.was_used ? 'line-through' : 'none'}
-                          c={mu.was_used ? 'dimmed' : 'inherit'}
-                        >
-                          {mu.material_name}
-                        </Text>
-                        <Text size="xs" c="dimmed">
-                          Planned: {mu.quantity_planned}
-                          {mu.unit ? ` ${mu.unit}` : ''}
-                        </Text>
-                      </Box>
-                    }
-                  />
-                  {mu.stock_applied ? (
-                    <Stack gap={0} align="flex-end">
-                      <Text
+                <Group justify="space-between" wrap="nowrap" align="flex-start" gap="sm">
+                  <Box style={{ flex: 1, minWidth: 0 }}>
+                    <Group gap="xs">
+                      <Text fw={600} size="sm">{line.name}</Text>
+                      <Badge
                         size="xs"
-                        c="teal.7"
-                        fw={600}
-                        style={{ whiteSpace: 'nowrap' }}
+                        variant="light"
+                        color={line.is_fully_received ? 'green' : 'yellow'}
                       >
-                        −{mu.applied_quantity} from stock
-                      </Text>
+                        {line.is_fully_received
+                          ? 'received'
+                          : `${line.quantity_pending} on order`}
+                      </Badge>
+                    </Group>
+                    <Text size="xs" c="dimmed">
+                      <Anchor
+                        component={Link}
+                        to={`/purchasing/orders/${line.purchase_order_id}`}
+                        size="xs"
+                      >
+                        {line.po_number}
+                      </Anchor>
+                      {line.supplier_name ? ` · ${line.supplier_name}` : ''}
+                      {` · ${line.quantity_received}/${line.quantity_ordered} received`}
+                    </Text>
+                    {!line.is_fully_received && line.expected_delivery_date && (
                       <Text size="xs" c="dimmed">
-                        usage logged
+                        Expected {formatDateOnly(line.expected_delivery_date)}
                       </Text>
-                    </Stack>
-                  ) : (
-                    <NumberInput
-                      size="xs"
-                      label="Qty used"
-                      value={materialQty[mu.id] ?? Number(mu.quantity_used)}
-                      onChange={(v) => setMaterialQty((prev) => ({ ...prev, [mu.id]: v }))}
-                      min={0}
-                      step={1}
-                      disabled={togglingMaterial === mu.id}
-                      style={{ maxWidth: 110 }}
-                    />
-                  )}
+                    )}
+                  </Box>
+                  <Text size="sm" fw={600} style={{ whiteSpace: 'nowrap' }}>
+                    {formatMoney(line.unit_cost)}/unit
+                  </Text>
                 </Group>
               </Box>
             ))}
@@ -1911,6 +2405,144 @@ const WorkOrderPage: React.FC = () => {
               disabled={!ackElectrical || !ackLoto || !ackRequired}
             >
               Confirm
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+
+      {/* op-768w: record a material used or bought to do this job */}
+      <Modal
+        opened={addMaterialOpen}
+        onClose={() => setAddMaterialOpen(false)}
+        title="Add material"
+        centered
+      >
+        <Stack gap="sm">
+          <SegmentedControl
+            value={addMode}
+            onChange={(value) => setAddMode(value as 'material' | 'receipt')}
+            data={[
+              { value: 'material', label: 'Material used' },
+              { value: 'receipt', label: 'Out-of-pocket receipt' },
+            ]}
+            fullWidth
+          />
+
+          {addMode === 'material' ? (
+            <>
+              <TextInput
+                label="Material name"
+                placeholder="What did you use?"
+                value={newMaterialName}
+                onChange={(e) => setNewMaterialName(e.currentTarget.value)}
+                required
+              />
+              <Select
+                label="Inventory item"
+                description="Link it to draw the material from stock when you mark it used. Leave empty for something bought just for this job."
+                placeholder="Search inventory…"
+                data={itemOptions}
+                value={newMaterialItem}
+                searchable
+                clearable
+                nothingFoundMessage="No matching items"
+                searchValue={itemSearch}
+                onSearchChange={setItemSearch}
+                // The server already matched the query (on sku and description
+                // too), so re-filtering the results by label would hide hits.
+                filter={({ options }) => options}
+                onChange={(value) => {
+                  setNewMaterialItem(value);
+                  // Seed the price from what the item costs today — a default,
+                  // not a lock: the tech overrides it when the real one differs.
+                  const seeded = value ? itemCosts[value] : null;
+                  if (seeded != null && newMaterialCost === '') setNewMaterialCost(seeded);
+                }}
+              />
+              <Group grow>
+                <NumberInput
+                  label="Quantity"
+                  value={newMaterialQty}
+                  onChange={setNewMaterialQty}
+                  min={0}
+                  step={1}
+                />
+                <TextInput
+                  label="Unit"
+                  placeholder="ea, ft, qt…"
+                  value={newMaterialUnit}
+                  onChange={(e) => setNewMaterialUnit(e.currentTarget.value)}
+                />
+              </Group>
+              <NumberInput
+                label="Unit cost"
+                description="Real price paid per unit. Leave empty if nobody prices it."
+                value={newMaterialCost}
+                onChange={setNewMaterialCost}
+                min={0}
+                prefix="$"
+                decimalScale={2}
+              />
+            </>
+          ) : (
+            <>
+              <TextInput
+                label="Bought where"
+                placeholder="Hardware store"
+                value={newReceiptWhere}
+                onChange={(e) => setNewReceiptWhere(e.currentTarget.value)}
+              />
+              <NumberInput
+                label="Amount"
+                description="What the receipt totals. Recorded as one line at this price."
+                value={newMaterialCost}
+                onChange={setNewMaterialCost}
+                min={0}
+                prefix="$"
+                decimalScale={2}
+              />
+              <Text size="xs" c="dimmed">
+                Records as “{receiptMaterialName}”. Moves no stock — it is money
+                spent, not something drawn from inventory.
+              </Text>
+            </>
+          )}
+
+          <Group gap="xs">
+            <FileButton
+              resetRef={resetReceiptRef}
+              onChange={setNewReceiptFile}
+              accept="image/*"
+            >
+              {(props) => (
+                <Button
+                  {...props}
+                  size="sm"
+                  variant="light"
+                  leftSection={<IconReceipt size={16} />}
+                >
+                  {newReceiptFile ? 'Change receipt' : 'Attach receipt'}
+                </Button>
+              )}
+            </FileButton>
+            {newReceiptFile && (
+              <Text size="xs" c="dimmed" truncate>
+                {newReceiptFile.name}
+              </Text>
+            )}
+          </Group>
+
+          <Group justify="flex-end" gap="xs">
+            <Button variant="default" onClick={() => setAddMaterialOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              leftSection={<IconPlus size={16} />}
+              onClick={handleAddMaterial}
+              loading={savingMaterial}
+              disabled={addMode === 'material' && !newMaterialName.trim()}
+            >
+              Add
             </Button>
           </Group>
         </Stack>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,7 +2,7 @@
  * API service for communicating with the Django backend
  */
 import axios from 'axios';
-import { ActiveMaintenanceRow, Asset, AssetCostRecoveryReport, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, InventoryItemMetrics, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LogUsageRequest, LogUsageResponse, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, MaintenanceTool, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderLotoCompletion, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
+import { ActiveMaintenanceRow, Asset, AssetCostRecoveryReport, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, InventoryItemMetrics, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LogUsageRequest, LogUsageResponse, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, MaintenanceTool, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderAdHocMaterialInput, WorkOrderLotoCompletion, WorkOrderMaterialUsage, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
 
 /**
  * Resolves the API base URL based on environment.
@@ -1442,18 +1442,43 @@ export const workOrderAPI = {
       { action }
     ),
 
+  // `quantityUsed` and `unitCost` are only honoured before the stock decrement
+  // is applied — the backend freezes both once stock has moved, so the recorded
+  // spend can never drift from the decrement it backs (op-768w). Omit a value
+  // to leave it alone; pass `null` for unitCost to clear a recorded price.
   toggleMaterial: (
     workOrderId: string,
     materialUsageId: string,
     wasUsed: boolean,
-    quantityUsed?: number | string
-  ) =>
-    api.patch(
+    quantityUsed?: number | string,
+    unitCost?: number | string | null
+  ) => {
+    const body: Record<string, unknown> = { was_used: wasUsed };
+    if (quantityUsed !== undefined) body.quantity_used = quantityUsed;
+    if (unitCost !== undefined) body.unit_cost = unitCost;
+    return api.patch<WorkOrderMaterialUsage>(
       `/inventory/work-orders/${workOrderId}/materials/${materialUsageId}/toggle/`,
-      quantityUsed === undefined
-        ? { was_used: wasUsed }
-        : { was_used: wasUsed, quantity_used: quantityUsed }
+      body
+    );
+  },
+
+  // op-768w: add an ad-hoc material line — the only way a *corrective* work
+  // order (no PM template to copy rows from) records a material at all, and the
+  // way any work order records something bought mid-job. Pass FormData when a
+  // receipt image rides along, mirroring `addPhoto`.
+  addMaterial: (workOrderId: string, data: WorkOrderAdHocMaterialInput | FormData) =>
+    api.post<WorkOrderMaterialUsage>(
+      `/inventory/work-orders/${workOrderId}/materials/`,
+      data,
+      data instanceof FormData
+        ? { headers: { 'Content-Type': 'multipart/form-data' } }
+        : undefined
     ),
+
+  // Only ad-hoc lines with no stock applied can go: the backend 400s on a
+  // template row and on a line still holding a decrement (un-toggle it first).
+  removeMaterial: (workOrderId: string, materialUsageId: string) =>
+    api.delete(`/inventory/work-orders/${workOrderId}/materials/${materialUsageId}/`),
 
   addPhoto: (workOrderId: string, formData: FormData) =>
     api.post<WorkOrderPhoto>(`/inventory/work-orders/${workOrderId}/add_photo/`, formData, {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -760,7 +760,62 @@ export interface WorkOrderMaterialUsage {
   applied_quantity: number | null;
   /** True when a stock decrement is currently applied for this usage. */
   stock_applied: boolean;
+  /**
+   * op-768w: added *during* the job rather than copied from the PM template.
+   * Only ad-hoc lines can be removed — a template line is the frozen copy of
+   * what the job was supposed to be, and it prints on the sign-off sheet.
+   */
+  is_ad_hoc?: boolean;
+  /** Direct stock link of an ad-hoc line (null for an out-of-pocket buy). */
+  inventory_item?: string | null;
+  /** Name of whichever item this line draws from, either kind of row. */
+  inventory_item_name?: string | null;
+  /** op-bu80: set only by the receipt bridge — this line mirrors a PO line. */
+  purchase_order_item?: string | null;
+  /** Real price paid per unit; null when nobody priced the line. */
+  unit_cost?: string | null;
+  /** `quantity_used × unit_cost`; null when no cost was recorded. */
+  actual_cost?: string | null;
+  /** Proof-of-purchase photo backing an out-of-pocket buy. */
+  receipt_url?: string | null;
   created_at: string;
+}
+
+/**
+ * Body of `workOrderAPI.addMaterial` (op-768w). `unit_cost` defaults from the
+ * linked item's current cost when an item is given and no price is supplied —
+ * a default, not a lock. Omit `inventory_item` for an out-of-pocket buy: the
+ * line then records the spend and moves no stock.
+ */
+export interface WorkOrderAdHocMaterialInput {
+  material_name: string;
+  quantity_used?: number | string;
+  unit?: string;
+  unit_cost?: number | string | null;
+  inventory_item?: string | null;
+}
+
+/**
+ * op-bu80: a purchase-order line bought to complete this work order — the
+ * *ordering* view of the material, which is what says "the part you are
+ * waiting on is still in transit". Received lines also show up as material
+ * rows, posted by the receipt bridge.
+ */
+export interface WorkOrderPurchaseLine {
+  id: string;
+  purchase_order_id: string;
+  po_number: string;
+  po_status: string;
+  supplier_name: string | null;
+  name: string;
+  item_type: string;
+  quantity_ordered: number;
+  quantity_received: number;
+  quantity_pending: number;
+  is_fully_received: boolean;
+  unit_cost: string;
+  expected_delivery_date: string | null;
+  expected_shipment_date: string | null;
 }
 
 export interface WorkOrderLotoCompletion {
@@ -965,6 +1020,13 @@ export interface WorkOrder {
   is_overdue: boolean;
   task_completions: WorkOrderTaskCompletion[];
   material_usage: WorkOrderMaterialUsage[];
+  /**
+   * op-768w: real money spent on materials — the sum of `actual_cost` over the
+   * lines actually used. Server-owned; the page never accumulates into it.
+   */
+  actual_material_cost?: string | null;
+  /** op-bu80: PO lines ordered for this job, on order *and* received. */
+  purchase_order_lines?: WorkOrderPurchaseLine[];
   loto_completions: WorkOrderLotoCompletion[];
   photos: WorkOrderPhoto[];
   /** op-67q5: tools to gather, required first — reference only, no OMR box. */


### PR DESCRIPTION
Web half of **op-768w (B3)**, consuming the **op-bu80 (B4)** purchase surface. Bead **op-xl80**, `wo-corrective-epic`.

Recording what a job actually consumed or cost was impossible from the app: the materials card was a read-only checklist of template-derived rows, so a *corrective* work order — which has no PM template to copy rows from — could not record a material at all.

## `WorkOrderPage` materials card

- **Add material** — a form for an ad-hoc line (name, quantity, unit, real unit cost, optional inventory-item picker). The picker is searched server-side and seeds the price from the item's current cost — a default, not a lock. POSTs `add_material`. The card now renders even with zero lines, since that is the corrective work order's only path to a material.
- **Out-of-pocket receipt** — the same form in receipt mode: where it was bought and what the receipt totals, filed as `Misc supplies — <where>` with the image attached. Goes up multipart, mirroring `addPhoto`.
- **Cost on the line** — `unit_cost` is editable beside the quantity, both frozen once the stock decrement lands (the backend's rule). Edits ride the toggle *and* commit on blur, so an already-marked line — an out-of-pocket buy is marked used and moves no stock — can still be priced. Each line shows its `actual_cost` and links its receipt.
- **Remove** — ad-hoc lines only, disabled while a decrement is applied. A PO-sourced line (op-bu80) shows what it cost but offers neither edit nor delete: its purchase order owns those, and a later receipt re-writes them.
- **Actual vs estimated** — the server's `actual_material_cost` measured against the PM template's `estimated_cost_per_unit` applied to the quantities *this* work order planned. A corrective job has no template, so it shows the actual alone — like the stopwatch with no `estimated_time_minutes`.
- **Ordered for this work order** — the WO's live PO lines, on order and received, so a tech can see the part they are waiting on is still in transit.

## Types / API

- `WorkOrderMaterialUsage` gains `unit_cost`, `actual_cost`, `receipt_url`, `is_ad_hoc`, `inventory_item`/`inventory_item_name`, `purchase_order_item`; new `WorkOrderPurchaseLine` and `WorkOrderAdHocMaterialInput`; `WorkOrder` gains `actual_material_cost` and `purchase_order_lines`.
- `workOrderAPI`: `addMaterial` (JSON body, or `FormData` when a receipt rides along), `removeMaterial`, and `toggleMaterial` extended with `unitCost` — omit it to leave the price alone, pass `null` to clear one. The existing toggle test moves to the 5-argument call.

## Verification

- 15 new component tests in `WorkOrderPageMaterials.test.tsx` (add ad-hoc line, item-seeded price, receipt multipart, blur-commit price, price frozen once applied, template/PO lines not removable, actual-vs-estimated, PO section).
- `npm run lint` — 0 errors. Full `vitest run` — **158 files / 1256 tests green**. Production `vite build` succeeds.
- Driven in a real browser against a live backend: add material with a stock link and seeded price, out-of-pocket receipt upload, `$33.40` page total matching the server's `actual_material_cost`, stock-linked line's remove correctly disabled, receipt line removed and the total dropping to `$15.00`. That drive is what caught the row's number-input steppers laying themselves over the remove button — fixed with `flexShrink: 0` and `hideControls` on the price field.

No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)