### PR TITLE
feat(web): WorkOrderPage attachments section (op-rjsv)

### DIFF
--- a/frontend/src/__tests__/pages/WorkOrderPageAttachments.test.tsx
+++ b/frontend/src/__tests__/pages/WorkOrderPageAttachments.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * Attachments section on the work-order detail page (op-rjsv, op-7pjj backend).
+ *
+ * The internal work order's general file list — a receipt, datasheet, or
+ * nameplate photo hung off the whole job. Every authenticated volunteer can
+ * read the list; only staff / SIG-admin can upload or delete, the server rule
+ * (`IsAuthenticatedOrStaffSigAdminWrite`) the page mirrors with `isStaff`.
+ * Covers list, upload, delete, and the staff gate.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import WorkOrderPage from '../../pages/WorkOrderPage';
+import { workOrderAPI } from '../../services/api';
+import { WorkOrder, WorkOrderAttachment } from '../../types';
+
+vi.mock('../../services/api');
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useParams: () => ({ id: 'wo-1' }),
+  useNavigate: () => jest.fn(),
+}));
+
+const mockWorkOrderAPI = workOrderAPI as jest.Mocked<typeof workOrderAPI>;
+
+const okResponse = <T,>(data: T) =>
+  ({ data, status: 200, statusText: 'OK', headers: {}, config: {} as never }) as never;
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <WorkOrderPage />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+// A corrective work order with no PM template — maintenance_item null keeps the
+// estimate fetch (maintenanceAPI) out of this test entirely.
+const buildWorkOrder = (): WorkOrder =>
+  ({
+    id: 'wo-1',
+    short_id: 'wo-001',
+    maintenance_item: null,
+    maintenance_item_title: '',
+    asset_name: 'Bandsaw',
+    asset_tag: 'TAG001',
+    asset_id: 'a-1',
+    status: 'open',
+    due_date: null,
+    assigned_to: null,
+    assigned_to_name: null,
+    completed_by_name: null,
+    completed_at: null,
+    notes: '',
+    loto_completion_note: '',
+    is_overdue: false,
+    task_completions: [],
+    material_usage: [],
+    loto_completions: [],
+    photos: [],
+    submissions: [],
+    tools: [],
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  }) as unknown as WorkOrder;
+
+const buildAttachment = (
+  overrides: Partial<WorkOrderAttachment> = {},
+): WorkOrderAttachment => ({
+  id: 'att-1',
+  work_order: 'wo-1',
+  file: '/media/work_orders/attachments/2026/07/receipt.pdf',
+  file_url: 'http://api.test/media/work_orders/attachments/2026/07/receipt.pdf',
+  file_name: 'receipt.pdf',
+  kind: 'document',
+  kind_display: 'Document',
+  description: 'Supplier receipt',
+  uploaded_by: 7,
+  uploaded_by_name: 'Alice Tech',
+  uploaded_at: '2026-07-20T12:00:00Z',
+  ...overrides,
+});
+
+const listResponse = (results: WorkOrderAttachment[]) =>
+  okResponse({ count: results.length, next: null, previous: null, results });
+
+const attachmentsCard = async () =>
+  (await screen.findByText('Attachments')).closest('.mantine-Card-root') as HTMLElement;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+  mockWorkOrderAPI.getWorkOrder.mockResolvedValue(okResponse(buildWorkOrder()));
+  mockWorkOrderAPI.listAttachments.mockResolvedValue(listResponse([]));
+  mockWorkOrderAPI.uploadAttachment.mockResolvedValue(
+    okResponse(buildAttachment({ id: 'att-new' })),
+  );
+  mockWorkOrderAPI.deleteAttachment.mockResolvedValue(okResponse({}));
+});
+
+describe('WorkOrderPage — attachments (op-rjsv)', () => {
+  it('lists the work order attachments with a download link and metadata', async () => {
+    mockWorkOrderAPI.listAttachments.mockResolvedValue(listResponse([buildAttachment()]));
+
+    renderPage();
+
+    const card = await attachmentsCard();
+    const link = await within(card).findByRole('link', { name: 'receipt.pdf' });
+    expect(link).toHaveAttribute(
+      'href',
+      'http://api.test/media/work_orders/attachments/2026/07/receipt.pdf',
+    );
+    expect(within(card).getByText('Document')).toBeInTheDocument();
+    expect(within(card).getByText('Supplier receipt')).toBeInTheDocument();
+    expect(within(card).getByText(/Uploaded by Alice Tech/)).toBeInTheDocument();
+    // The list is fetched for this work order via the top-level route.
+    expect(mockWorkOrderAPI.listAttachments).toHaveBeenCalledWith('wo-1');
+  });
+
+  it('shows the empty state when there are no attachments', async () => {
+    renderPage();
+
+    const card = await attachmentsCard();
+    expect(within(card).getByText(/No attachments yet/)).toBeInTheDocument();
+  });
+
+  it('uploads a file with a description (staff)', async () => {
+    localStorage.setItem('is_staff', 'true');
+
+    renderPage();
+
+    const card = await attachmentsCard();
+    const input = card.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [new File(['bytes'], 'datasheet.pdf', { type: 'application/pdf' })] },
+    });
+    // The chosen file surfaces before submit.
+    expect(within(card).getByText('datasheet.pdf')).toBeInTheDocument();
+
+    fireEvent.change(within(card).getByPlaceholderText(/nameplate photo/i), {
+      target: { value: 'Pump datasheet' },
+    });
+    fireEvent.click(within(card).getByRole('button', { name: 'Upload' }));
+
+    await waitFor(() => expect(mockWorkOrderAPI.uploadAttachment).toHaveBeenCalled());
+    const [woId, file, description] = mockWorkOrderAPI.uploadAttachment.mock.calls[0];
+    expect(woId).toBe('wo-1');
+    expect((file as File).name).toBe('datasheet.pdf');
+    expect(description).toBe('Pump datasheet');
+    // The list refreshes after a successful upload (initial load + reload).
+    await waitFor(() => expect(mockWorkOrderAPI.listAttachments).toHaveBeenCalledTimes(2));
+  });
+
+  it('omits the description from the payload when left blank (staff)', async () => {
+    localStorage.setItem('is_staff', 'true');
+
+    renderPage();
+
+    const card = await attachmentsCard();
+    const input = card.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [new File(['bytes'], 'nameplate.jpg', { type: 'image/jpeg' })] },
+    });
+    fireEvent.click(within(card).getByRole('button', { name: 'Upload' }));
+
+    await waitFor(() => expect(mockWorkOrderAPI.uploadAttachment).toHaveBeenCalled());
+    const [, , description] = mockWorkOrderAPI.uploadAttachment.mock.calls[0];
+    expect(description).toBeUndefined();
+  });
+
+  it('deletes an attachment (staff)', async () => {
+    localStorage.setItem('is_staff', 'true');
+    mockWorkOrderAPI.listAttachments.mockResolvedValue(listResponse([buildAttachment()]));
+
+    renderPage();
+
+    const card = await attachmentsCard();
+    const del = await within(card).findByRole('button', { name: /delete receipt\.pdf/i });
+    fireEvent.click(del);
+
+    await waitFor(() =>
+      expect(mockWorkOrderAPI.deleteAttachment).toHaveBeenCalledWith('wo-1', 'att-1'),
+    );
+    // The list refreshes after a successful delete (initial load + reload).
+    await waitFor(() => expect(mockWorkOrderAPI.listAttachments).toHaveBeenCalledTimes(2));
+  });
+
+  it('hides the upload + delete controls for a non-staff volunteer but still lists', async () => {
+    mockWorkOrderAPI.listAttachments.mockResolvedValue(listResponse([buildAttachment()]));
+
+    renderPage();
+
+    const card = await attachmentsCard();
+    // Read is open — the row and its download link are visible...
+    await within(card).findByRole('link', { name: 'receipt.pdf' });
+    // ...but every write affordance is gone.
+    expect(within(card).queryByRole('button', { name: 'Upload' })).not.toBeInTheDocument();
+    expect(within(card).queryByText('Add attachment')).not.toBeInTheDocument();
+    expect(
+      within(card).queryByRole('button', { name: /delete receipt\.pdf/i }),
+    ).not.toBeInTheDocument();
+    expect(card.querySelector('input[type="file"]')).toBeNull();
+  });
+});

--- a/frontend/src/pages/WorkOrderPage.tsx
+++ b/frontend/src/pages/WorkOrderPage.tsx
@@ -35,6 +35,7 @@ import {
   IconDownload,
   IconFileText,
   IconLock,
+  IconPaperclip,
   IconPhoto,
   IconPlayerPause,
   IconPlayerPlay,
@@ -56,6 +57,7 @@ import { inventoryAPI, maintenanceAPI, workOrderAPI } from '../services/api';
 import {
   WorkOrder,
   WorkOrderAdHocMaterialInput,
+  WorkOrderAttachment,
   WorkOrderMaterialUsage,
   WorkOrderStatus,
 } from '../types';
@@ -497,6 +499,20 @@ const WorkOrderPage: React.FC = () => {
   const [lotoNote, setLotoNote] = useState('');
   const [savingLotoNote, setSavingLotoNote] = useState(false);
   const resetPhotoRef = useRef<() => void>(null);
+  // op-rjsv: the WO's general attachments (op-7pjj backend). Fetched separately
+  // because the work-order payload deliberately carries no nested attachments
+  // field (would need a prefetch to dodge an N+1).
+  const [attachments, setAttachments] = useState<WorkOrderAttachment[]>([]);
+  const [attachmentFile, setAttachmentFile] = useState<File | null>(null);
+  const [attachmentDescription, setAttachmentDescription] = useState('');
+  const [uploadingAttachment, setUploadingAttachment] = useState(false);
+  const [deletingAttachmentId, setDeletingAttachmentId] = useState<string | null>(null);
+  const resetAttachmentRef = useRef<() => void>(null);
+  // Upload + delete are staff/SIG-admin only on the server
+  // (IsAuthenticatedOrStaffSigAdminWrite); any authenticated volunteer can still
+  // read the list. Mirror that gate so a volunteer never sees a control that
+  // would only 403.
+  const [isStaff, setIsStaff] = useState(false);
   // op-pzae: which reference document has its revision history expanded.
   const [openRevisions, setOpenRevisions] = useState<Record<string, boolean>>({});
   // op-m3so: in-flight timer calls (WO-level, and which step).
@@ -538,6 +554,30 @@ const WorkOrderPage: React.FC = () => {
   useEffect(() => {
     loadWorkOrder();
   }, [loadWorkOrder]);
+
+  // Staff/SIG-admin gate for the attachment controls (op-rjsv), read once from
+  // the same localStorage flags the rest of the app uses (see PurchaseOrderPage).
+  useEffect(() => {
+    setIsStaff(
+      localStorage.getItem('is_staff') === 'true' ||
+        localStorage.getItem('is_superuser') === 'true',
+    );
+  }, []);
+
+  const loadAttachments = useCallback(async () => {
+    if (!id) return;
+    try {
+      const res = await workOrderAPI.listAttachments(id);
+      setAttachments(res.data.results ?? []);
+    } catch {
+      // A failed attachments fetch must not blank the page — the work order
+      // itself still loaded. Leave the list as-is; a reload retries it.
+    }
+  }, [id]);
+
+  useEffect(() => {
+    loadAttachments();
+  }, [loadAttachments]);
 
   // op-768w: pull the PM template's per-unit estimates so the materials total
   // can say actual *against* estimate. One fetch per template; a corrective
@@ -1106,6 +1146,64 @@ const WorkOrderPage: React.FC = () => {
       });
     } finally {
       setUploadingStepPhoto(null);
+    }
+  };
+
+  // op-rjsv: general-attachment upload — a receipt, datasheet, or nameplate
+  // photo hung off the whole job (not per-step evidence). Multipart; the list
+  // reloads afterward so the new row shows without a full page refresh.
+  const handleUploadAttachment = async () => {
+    if (!workOrder || !attachmentFile) return;
+    setUploadingAttachment(true);
+    try {
+      await workOrderAPI.uploadAttachment(
+        workOrder.id,
+        attachmentFile,
+        attachmentDescription.trim() || undefined,
+      );
+      setAttachmentFile(null);
+      setAttachmentDescription('');
+      resetAttachmentRef.current?.();
+      await loadAttachments();
+      notifications.show({
+        title: 'Attachment uploaded',
+        message: 'File added to this work order.',
+        color: 'green',
+        icon: <IconCheck size={16} />,
+      });
+    } catch (err: unknown) {
+      notifications.show({
+        title: 'Error',
+        message: extractErrorMessage(err, 'Failed to upload attachment.'),
+        color: 'red',
+      });
+    } finally {
+      setUploadingAttachment(false);
+    }
+  };
+
+  const handleDeleteAttachment = async (attachment: WorkOrderAttachment) => {
+    if (!workOrder) return;
+    setDeletingAttachmentId(attachment.id);
+    try {
+      await workOrderAPI.deleteAttachment(workOrder.id, attachment.id);
+      await loadAttachments();
+      notifications.show({
+        title: 'Attachment removed',
+        message: `${
+          attachment.file_name || attachment.description || 'Attachment'
+        } removed from this work order.`,
+        color: 'green',
+        icon: <IconCheck size={16} />,
+      });
+    } catch (err: unknown) {
+      notifications.show({
+        title: 'Error',
+        message: extractErrorMessage(err, 'Failed to remove attachment.'),
+        color: 'red',
+      });
+    } finally {
+      setDeletingAttachmentId(null);
     }
   };
 
@@ -2215,6 +2313,139 @@ const WorkOrderPage: React.FC = () => {
               </Box>
             ))}
           </Group>
+        )}
+      </Card>
+
+      {/* op-rjsv: general attachments — the catch-all file list the internal
+          work order was missing (op-7pjj backend). A receipt, datasheet page, or
+          nameplate photo lives here; per-step evidence stays under its step and
+          the asset's controlled docs stay in the library below. Read is open to
+          every authenticated volunteer; upload + delete are staff/SIG-admin, so
+          the write controls are gated on `isStaff`. */}
+      <Card withBorder p="md" radius="md" mb="md">
+        <Group mb="sm" gap="xs">
+          <IconPaperclip size={18} />
+          <Title order={5}>Attachments</Title>
+          {attachments.length > 0 && (
+            <Badge color="gray" size="sm">
+              {attachments.length}
+            </Badge>
+          )}
+        </Group>
+
+        {attachments.length === 0 ? (
+          <Text size="sm" c="dimmed" ta="center" py="sm">
+            No attachments yet.
+            {isStaff ? ' Add a receipt, datasheet, or photo below.' : ''}
+          </Text>
+        ) : (
+          <Stack gap="sm">
+            {attachments.map((attachment) => (
+              <Group
+                key={attachment.id}
+                justify="space-between"
+                wrap="nowrap"
+                align="flex-start"
+              >
+                <Box style={{ flex: 1, minWidth: 0 }}>
+                  <Group gap="xs" wrap="wrap" align="center">
+                    {attachment.file_url ? (
+                      <Anchor
+                        href={attachment.file_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        size="sm"
+                        fw={500}
+                      >
+                        {attachment.file_name || 'Download'}
+                      </Anchor>
+                    ) : (
+                      <Text size="sm" fw={500}>
+                        {attachment.file_name || 'Attachment'}
+                      </Text>
+                    )}
+                    <Badge color="gray" variant="light" size="sm">
+                      {attachment.kind_display}
+                    </Badge>
+                  </Group>
+                  {attachment.description && (
+                    <Text size="sm" c="dimmed">
+                      {attachment.description}
+                    </Text>
+                  )}
+                  <Text size="xs" c="dimmed">
+                    {attachment.uploaded_by_name
+                      ? `Uploaded by ${attachment.uploaded_by_name}`
+                      : 'Uploaded'}{' '}
+                    on {formatDateOnly(attachment.uploaded_at)}
+                  </Text>
+                </Box>
+                {isStaff && (
+                  <ActionIcon
+                    variant="subtle"
+                    color="red"
+                    aria-label={`Delete ${
+                      attachment.file_name || attachment.description || 'attachment'
+                    }`}
+                    loading={deletingAttachmentId === attachment.id}
+                    disabled={deletingAttachmentId !== null}
+                    onClick={() => handleDeleteAttachment(attachment)}
+                  >
+                    <IconTrash size={16} />
+                  </ActionIcon>
+                )}
+              </Group>
+            ))}
+          </Stack>
+        )}
+
+        {isStaff && (
+          <>
+            <Divider my="sm" />
+            <Stack gap="xs">
+              <Text size="sm" fw={500}>
+                Add attachment
+              </Text>
+              <Group gap="xs" align="center">
+                <FileButton resetRef={resetAttachmentRef} onChange={setAttachmentFile}>
+                  {(props) => (
+                    <Button
+                      {...props}
+                      size="sm"
+                      variant="light"
+                      leftSection={<IconPaperclip size={16} />}
+                    >
+                      {attachmentFile ? 'Change file' : 'Choose file'}
+                    </Button>
+                  )}
+                </FileButton>
+                {attachmentFile && (
+                  <Text size="xs" c="dimmed" truncate>
+                    {attachmentFile.name}
+                  </Text>
+                )}
+              </Group>
+              <TextInput
+                label="Description (optional)"
+                placeholder="e.g. Nameplate photo, supplier receipt"
+                value={attachmentDescription}
+                onChange={(e) => setAttachmentDescription(e.currentTarget.value)}
+                maxLength={500}
+                disabled={uploadingAttachment}
+              />
+              <Group justify="flex-end">
+                <Button
+                  size="sm"
+                  leftSection={<IconUpload size={16} />}
+                  onClick={handleUploadAttachment}
+                  loading={uploadingAttachment}
+                  disabled={!attachmentFile}
+                >
+                  Upload
+                </Button>
+              </Group>
+            </Stack>
+          </>
         )}
       </Card>
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,7 +2,7 @@
  * API service for communicating with the Django backend
  */
 import axios from 'axios';
-import { ActiveMaintenanceRow, Asset, AssetCostRecoveryReport, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, InventoryItemMetrics, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LogUsageRequest, LogUsageResponse, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, MaintenanceTool, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderAdHocMaterialInput, WorkOrderLotoCompletion, WorkOrderMaterialUsage, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
+import { ActiveMaintenanceRow, Asset, AssetCostRecoveryReport, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, InventoryItemMetrics, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LogUsageRequest, LogUsageResponse, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, MaintenanceTool, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderAdHocMaterialInput, WorkOrderAttachment, WorkOrderLotoCompletion, WorkOrderMaterialUsage, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
 
 /**
  * Resolves the API base URL based on environment.
@@ -1530,6 +1530,34 @@ export const workOrderAPI = {
     api.post<WorkOrderPhoto>(`/inventory/work-orders/${workOrderId}/add_photo/`, formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
     }),
+
+  // op-rjsv: the internal WO's general attachments list (op-7pjj backend). The
+  // route is top-level and filtered by `?work_order=`, not nested on the work
+  // order, so `work_order` rides in the query on list and in the multipart body
+  // on upload. Paginated like every inventory list (PAGE_SIZE 50) — a work
+  // order never carries anywhere near a page of files.
+  listAttachments: (workOrderId: string) =>
+    api.get<{ count: number; next: string | null; previous: string | null; results: WorkOrderAttachment[] }>(
+      '/inventory/work-order-attachments/',
+      { params: { work_order: workOrderId } },
+    ),
+
+  uploadAttachment: (workOrderId: string, file: File, description?: string) => {
+    const formData = new FormData();
+    formData.append('work_order', workOrderId);
+    formData.append('file', file);
+    if (description) {
+      formData.append('description', description);
+    }
+    return api.post<WorkOrderAttachment>('/inventory/work-order-attachments/', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+  },
+
+  // `workOrderId` is unused in the URL (the detail route is keyed only by the
+  // attachment id) but kept for call-site symmetry with list/upload.
+  deleteAttachment: (workOrderId: string, attachmentId: string) =>
+    api.delete(`/inventory/work-order-attachments/${attachmentId}/`),
 
   uploadPdf: (file: File) => {
     const formData = new FormData();

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -862,6 +862,29 @@ export interface WorkOrderPhoto {
   uploaded_at: string;
 }
 
+/**
+ * A general file hung off a work order (op-7pjj / op-rjsv) — a receipt, a
+ * datasheet page, a nameplate photo. Distinct from `WorkOrderPhoto` (per-step
+ * or WO-level *evidence* images) and from the asset's document library: this is
+ * the internal WO's own catch-all attachments list, the same shape the purchase
+ * order and third-party work order carry. `file` is the multipart write field;
+ * `file_url` / `file_name` are what the list renders. Served from the top-level
+ * `inventory/work-order-attachments/?work_order=` route, not nested on the WO.
+ */
+export interface WorkOrderAttachment {
+  id: string;
+  work_order: string;
+  file: string;
+  file_url: string | null;
+  file_name: string | null;
+  kind: 'photo' | 'document' | 'other';
+  kind_display: string;
+  description: string;
+  uploaded_by: number | null;
+  uploaded_by_name: string | null;
+  uploaded_at: string;
+}
+
 export interface WorkOrderSubmissionPendingChange {
   kind: string;
   target_id: string | null;


### PR DESCRIPTION
## Web: WorkOrderPage attachments section (`op-rjsv`)

Web parity for the internal-WO attachments feature (backend op-7pjj / #956). Adds a full attachments list to the work-order page.

### What changed (frontend only)
- **`WorkOrderPage.tsx`** — Attachments section: read-only list (download link, kind, description, uploader + date) visible to **all authenticated users**; **staff-gated** multipart upload (file + optional description) and per-row delete — mirroring the server `IsAuthenticatedOrStaffSigAdminWrite` rule (any authenticated user reads; writes/deletes staff/Logistics/SIG-admin). Mantine idiom (WorkOrderPage is Mantine; the PO page it mirrors is plain HTML).
- **`services/api.ts`** — `workOrderAPI.listAttachments` / `uploadAttachment` / `deleteAttachment` against `/api/inventory/work-order-attachments/?work_order=`.
- **`types/index.ts`** — `WorkOrderAttachment`.

### Verification (mayor + worker)
- Based exactly on current `main` (`f31a463`, has #956) — no rebase.
- New `WorkOrderPageAttachments.test.tsx` (list/upload/delete/staff-gating, 6 pass); all 8 WorkOrderPage test files green (71); full frontend suite green (160 files / 1287 tests, exit 0); `lint` 0 errors; typecheck 0 new errors.

Completes the WO-attachments feature across backend (#956) + ScanTTY (#115) + web (this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
