### PR TITLE
fix(reorder): guard mark_received against double-counting stock (op-xm28)

### DIFF
--- a/backend/reorder_queue/tests/test_api.py
+++ b/backend/reorder_queue/tests/test_api.py
@@ -445,6 +445,111 @@ class TestReorderRequestAPI:
         assert request_obj.status == ReorderRequest.Status.RECEIVED
         assert request_obj.actual_delivery is not None
 
+    def test_mark_received_twice_adds_stock_only_once(self, authenticated_client):
+        """A second mark-received is a no-op — it must not re-add the quantity."""
+        client, _user = authenticated_client
+        item = InventoryItemFactory(current_stock=10)
+        request_obj = ReorderRequestFactory(
+            item=item, quantity=50, status=ReorderRequest.Status.ORDERED
+        )
+
+        url = reverse("reorderrequest-mark-received", kwargs={"pk": request_obj.pk})
+        first = client.post(url, format="json")
+        assert first.status_code == status.HTTP_200_OK
+
+        item.refresh_from_db()
+        assert item.current_stock == 60  # 10 + 50
+        request_obj.refresh_from_db()
+        first_delivery = request_obj.actual_delivery
+
+        # Stale tab / double click: same request posted again.
+        second = client.post(url, format="json")
+
+        assert second.status_code == status.HTTP_200_OK
+        assert second.data["status"] == ReorderRequest.Status.RECEIVED
+
+        item.refresh_from_db()
+        assert item.current_stock == 60  # unchanged — no second increment
+
+        request_obj.refresh_from_db()
+        assert request_obj.status == ReorderRequest.Status.RECEIVED
+        assert request_obj.actual_delivery == first_delivery
+
+    def test_mark_received_after_po_receipt_leaves_stock_unchanged(self, authenticated_client):
+        """A request already received via a PO receipt must not bump stock again.
+
+        The receipt moves the stock itself, so a late manual mark-received on
+        the closed request would double-count the same delivery.
+        """
+        client, user = authenticated_client
+        item = InventoryItemFactory(current_stock=0)
+        item_supplier = ItemSupplierFactory(item=item, quantity_per_package=1)
+        request_obj = ReorderRequestFactory(
+            item=item, quantity=5, status=ReorderRequest.Status.ORDERED
+        )
+        purchase_order = PurchaseOrder.objects.create(
+            po_number=f"PO-MR-{item_supplier.id}",
+            supplier=item_supplier.supplier,
+            status=PurchaseOrder.Status.SENT,
+            created_by=user,
+            sent_by=user,
+            sent_at=timezone.now() - timedelta(days=3),
+        )
+        PurchaseOrderItem.objects.create(
+            purchase_order=purchase_order,
+            item_supplier=item_supplier,
+            quantity_ordered=5,
+            quantity_received=0,
+            unit_cost_ordered=Decimal("10.00"),
+            order_in_packages=5,
+        )
+
+        deliver_url = reverse("purchaseorder-mark-delivered", kwargs={"pk": purchase_order.pk})
+        delivered = client.post(
+            deliver_url,
+            {"delivery_date": timezone.now().date().isoformat()},
+            format="json",
+        )
+        assert delivered.status_code == status.HTTP_200_OK
+
+        item.refresh_from_db()
+        assert item.current_stock == 5  # the receipt moved the stock
+
+        request_obj.refresh_from_db()
+        if request_obj.status != ReorderRequest.Status.RECEIVED:
+            # Auto-close on full receipt (op-hjz3) may not be present on this
+            # branch; close it by hand so the stale-click scenario is the same.
+            request_obj.status = ReorderRequest.Status.RECEIVED
+            request_obj.save(update_fields=["status"])
+
+        url = reverse("reorderrequest-mark-received", kwargs={"pk": request_obj.pk})
+        response = client.post(url, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        item.refresh_from_db()
+        assert item.current_stock == 5  # still just the one delivery
+
+    def test_mark_received_on_cancelled_request_is_rejected(self, authenticated_client):
+        """A cancelled request can't be received, and never touches stock."""
+        client, _user = authenticated_client
+        item = InventoryItemFactory(current_stock=10)
+        request_obj = ReorderRequestFactory(
+            item=item, quantity=50, status=ReorderRequest.Status.CANCELLED
+        )
+
+        url = reverse("reorderrequest-mark-received", kwargs={"pk": request_obj.pk})
+        response = client.post(url, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "cancelled" in response.data["detail"].lower()
+
+        item.refresh_from_db()
+        assert item.current_stock == 10
+
+        request_obj.refresh_from_db()
+        assert request_obj.status == ReorderRequest.Status.CANCELLED
+        assert request_obj.actual_delivery is None
+
     def test_cancel_request(self, authenticated_client):
         """Test cancelling a reorder request."""
         client, user = authenticated_client

--- a/backend/reorder_queue/views.py
+++ b/backend/reorder_queue/views.py
@@ -476,16 +476,41 @@ class ReorderRequestViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=["post"], permission_classes=[IsAuthenticated])
     def mark_received(self, request, pk=None):
-        """Mark a request as received and update inventory."""
-        reorder = self.get_object()
-        reorder.status = ReorderRequest.Status.RECEIVED
-        reorder.actual_delivery = request.data.get("actual_delivery", timezone.now().date())
-        reorder.save()
+        """Mark a request as received and update inventory.
 
-        # Update inventory stock
-        item = reorder.item
-        item.current_stock += reorder.quantity
-        item.save()
+        The stock bump only happens on the transition *into* ``received``, so
+        the action is idempotent: re-posting to an already-received request is
+        a no-op that returns it unchanged rather than adding ``quantity`` to
+        inventory a second time. That covers a double-click, a stale browser
+        tab, and a request already closed by a purchase-order receipt (which
+        moves the stock itself). A cancelled request cannot be received.
+
+        The guard re-reads the row under ``select_for_update`` inside the
+        transaction that also writes the stock, so two clicks in flight at once
+        can't both pass it.
+        """
+        reorder = self.get_object()
+
+        with transaction.atomic():
+            reorder = ReorderRequest.objects.select_for_update().get(pk=reorder.pk)
+
+            if reorder.status == ReorderRequest.Status.RECEIVED:
+                return Response(self.get_serializer(reorder).data)
+
+            if reorder.status == ReorderRequest.Status.CANCELLED:
+                return Response(
+                    {"detail": "Cannot receive a cancelled reorder request."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            reorder.status = ReorderRequest.Status.RECEIVED
+            reorder.actual_delivery = request.data.get("actual_delivery", timezone.now().date())
+            reorder.save()
+
+            # Update inventory stock
+            item = reorder.item
+            item.current_stock += reorder.quantity
+            item.save()
 
         serializer = self.get_serializer(reorder)
         return Response(serializer.data)


### PR DESCRIPTION
## Guard mark_received against double-counting stock (`op-xm28`)

**Latent bug** surfaced while building op-hjz3 (#963, PO receipt → auto-close reorder request). `ReorderRequestViewSet.mark_received` had no status guard and incremented stock unconditionally, so hitting it on an already-received request double-counts inventory. With #963 making auto-close common, a stale "mark received" click (double-click / stale tab after an auto-close) could double-count.

### Fix (`backend/reorder_queue/views.py`, `mark_received`)
- Stock bump now only happens on the transition **into** RECEIVED.
- Already-RECEIVED → **no-op 200** with the request unchanged (safe double-click / stale tab).
- CANCELLED → **400**, matching the sibling PO void action's "already voided" shape.
- The row is re-read under `select_for_update` inside the same `transaction.atomic()` as the status flip + stock write, so two in-flight clicks can't both pass the guard.
- `actual_delivery` behavior unchanged.

### Verification (worker, Postgres)
- 3 new tests in `reorder_queue/tests/test_api.py` (twice → stock added once; already-received via a real PO receipt → not bumped again; cancelled → rejected + stock untouched), all verified **RED against unpatched** `views.py`; pre-existing `test_mark_received` stays green.
- reorder_queue + inventory **1592 passed / 4 skipped** (2 known MEDIA_ROOT `--reuse-db` artifacts, green after clearing); black/isort/flake8 clean at CI versions; `makemigrations --check` no drift; permission-matrix 896 endpoints match (no permission change); frontend untouched.

Branch based on current `main` (`d132f0e`). Independent of #963 and the BACKEND-13 fix (different method/files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
