### PR TITLE
fix: count freehand WO supplies in Actual Material Cost (op-4pzp)

### DIFF
--- a/backend/inventory/models/maintenance.py
+++ b/backend/inventory/models/maintenance.py
@@ -649,16 +649,51 @@ class WorkOrder(ElapsedTimerModel):
 
     @property
     def actual_material_cost(self) -> Decimal:
-        """Real money spent on materials for this job (op-768w).
+        """Real money spent on materials for this job (op-768w, op-4pzp).
 
-        Sums :attr:`WorkOrderMaterialUsage.actual_cost` over the lines actually
-        marked *used* — a planned-but-unused material cost nothing. Lines with
-        no recorded ``unit_cost`` contribute zero rather than blocking the
-        total, so a partially-priced job still reports what is known.
+        Sums :attr:`WorkOrderMaterialUsage.actual_cost` over the lines that cost
+        the job money, which is two different tests for the two kinds of row:
+
+        * **Ad-hoc** (``is_ad_hoc``) — typed in during the job: a freehand
+          supply or an out-of-pocket buy. A priced one counts the moment it is
+          added, ``was_used`` or not. That flag governs *stock*, and the money
+          left the wallet at the hardware store whether or not anyone
+          afterwards ticks a box about the shelf (op-4pzp).
+        * **Template-derived** — a frozen copy of the PM spec, so it is a
+          *plan* until someone marks it used. A planned-but-unused material
+          still costs nothing.
+
+        Lines with no recorded ``unit_cost`` contribute zero rather than
+        blocking the total, so a partially-priced job still reports what is
+        known.
 
         Reads ``material_usage.all()`` so a caller who prefetched it (every API
-        read path does) pays no extra query. This is the value downstream cost
-        reporting and the committee ledger charge consume.
+        read path does) pays no extra query. This is the job-cost roll-up the
+        cost-recovery/TCO reports and the actual-vs-estimated display consume.
+        The committee ledger charge deliberately does **not** — it books stock
+        leaving the shelf, so it reads :attr:`consumed_material_cost`.
+        """
+        return sum(
+            (
+                usage.actual_cost
+                for usage in self.material_usage.all()
+                if (usage.was_used or usage.is_ad_hoc) and usage.actual_cost is not None
+            ),
+            Decimal("0.00"),
+        )
+
+    @property
+    def consumed_material_cost(self) -> Decimal:
+        """Priced material this job actually drew down — the ledger's basis.
+
+        Only lines marked *used*, ad-hoc or not: the pre-op-4pzp reading of
+        :attr:`actual_material_cost`, kept as a number of its own because the
+        committee charge (``inventory.services.work_order_ledger``) books
+        ``DR 5100 committee supplies expense / CR 1300 inventory — supplies on
+        hand``. Crediting 1300 is an assertion that stock left the shelf, so an
+        ad-hoc line entered but never marked used — real job cost, and counted
+        by :attr:`actual_material_cost` — must not reach it, or the books write
+        down inventory that was never issued.
         """
         return sum(
             (

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -2516,8 +2516,9 @@ class WorkOrderSerializer(serializers.ModelSerializer):
     elapsed_seconds = serializers.SerializerMethodField()
     task_completions = WorkOrderTaskCompletionSerializer(many=True, read_only=True)
     material_usage = WorkOrderMaterialUsageSerializer(many=True, read_only=True)
-    # op-768w: real money spent on materials, summed over the *used* lines.
-    # Rides the ``material_usage`` prefetch, so it costs no extra query.
+    # op-768w/op-4pzp: real money spent on materials — every priced *used* line
+    # plus every priced *ad-hoc* one, whose cost is already spent whether or not
+    # anyone marks it used. Rides the ``material_usage`` prefetch, no extra query.
     actual_material_cost = serializers.DecimalField(max_digits=12, decimal_places=2, read_only=True)
     loto_completions = WorkOrderLotoCompletionSerializer(many=True, read_only=True)
     photos = WorkOrderPhotoSerializer(many=True, read_only=True)

--- a/backend/inventory/services/work_order_ledger.py
+++ b/backend/inventory/services/work_order_ledger.py
@@ -27,11 +27,20 @@ to own (see :attr:`WorkOrderMaterialUsage.stock_item`), so it would silently
 escape the charge.
 
 **One entry per job, not one per material line.** The basis is
-:attr:`WorkOrder.actual_material_cost` — ``quantity_used × unit_cost`` summed
+:attr:`WorkOrder.consumed_material_cost` — ``quantity_used × unit_cost`` summed
 over the lines actually marked *used*. Lines with no recorded cost contribute
 nothing rather than blocking the post, so a partially-priced job still charges
 what is known. Vendor invoices are a separate, still-unwired flow
 (``SourceType.VENDOR_INVOICE``): the basis here is **in-house consumption only**.
+
+That is deliberately *not* the same number the work-order screen and the cost
+reports show. Since op-4pzp those read :attr:`WorkOrder.actual_material_cost`,
+which counts a priced **ad-hoc** line the moment it is entered — money spent on
+the job, whether or not anyone ever marks it used. This entry credits ``1300
+Inventory — supplies on hand``, an assertion that stock left the shelf, so it
+stays keyed to consumption: charging it for a freehand line nobody drew from
+inventory would write down stock that was never issued. Job cost ≥ ledger
+charge, and the gap is exactly the out-of-pocket spend.
 
 **Reopening reverses; re-completing re-posts.** A charge is keyed
 ``wo_complete:<id>``, which makes re-saving a completed work order a no-op
@@ -155,7 +164,9 @@ def charge_completed_work_order(
         if not meta.is_reversed:
             return meta.transaction, None
 
-    amount = work_order.actual_material_cost or Decimal("0.00")
+    # Consumption, not job cost: see the "One entry per job" note above for why
+    # this is deliberately not ``actual_material_cost``.
+    amount = work_order.consumed_material_cost or Decimal("0.00")
     if amount <= 0:
         logger.warning(
             "Work order %s completed on committee-owned asset %s with no "

--- a/backend/inventory/services/work_order_reports.py
+++ b/backend/inventory/services/work_order_reports.py
@@ -118,19 +118,23 @@ def wo_estimated_material_cost(
 def wo_actual_material_cost(work_order: "WorkOrder") -> Optional[Decimal]:
     """Real money spent on materials for one work order, or ``None``.
 
-    Sums ``quantity_used × unit_cost`` over the lines marked *used* — the
-    op-768w capture. Returns ``None`` (not zero) when **no** used line carries a
-    ``unit_cost``, which is how a caller tells "this job cost nothing" from "this
-    job predates actual-cost capture" and falls back to the estimate.
+    Sums ``quantity_used × unit_cost`` over the lines that cost the job money —
+    the op-768w capture. Returns ``None`` (not zero) when **no** counted line
+    carries a ``unit_cost``, which is how a caller tells "this job cost nothing"
+    from "this job predates actual-cost capture" and falls back to the estimate.
 
     Reads ``material_usage.all()``, so a caller who prefetched it pays no extra
-    query. Mirrors :attr:`inventory.models.WorkOrder.actual_material_cost`, which
-    is the same sum flattened to ``0.00`` for the API surface.
+    query. Mirrors :attr:`inventory.models.WorkOrder.actual_material_cost` —
+    including its op-4pzp rule that an **ad-hoc** line counts as soon as it is
+    priced while a template line still has to be marked *used* — and is the same
+    sum flattened to ``0.00`` for the API surface. The two must move together:
+    a report that disagreed with the work-order screen about what a job cost is
+    the bug this mirror exists to avoid.
     """
     total = Decimal("0.00")
     priced = False
     for usage in work_order.material_usage.all():
-        if not usage.was_used:
+        if not (usage.was_used or usage.is_ad_hoc):
             continue
         line_cost = usage.actual_cost
         if line_cost is None:

--- a/backend/inventory/tests/test_cost_recovery.py
+++ b/backend/inventory/tests/test_cost_recovery.py
@@ -687,6 +687,53 @@ class TestCostRecoveryRecoverableInHouseWork:
         assert Decimal(block["subtotal_actual"]) == Decimal("0.00")
         assert Decimal(response.data["grand_total_actual"]) == Decimal("0.00")
 
+    def test_freehand_supply_bills_without_being_marked_used(self, authenticated_client):
+        """op-4pzp — the report reads the same rule as the work-order screen.
+
+        A priced ad-hoc line is money spent on the job the moment it is entered,
+        so it reaches the billable column without anyone toggling ``was_used``;
+        a planned-but-unused *template* line still costs nothing. If this report
+        used the older used-only rule it would quietly bill less than the work
+        order says the job cost.
+        """
+        client, _ = authenticated_client
+        asset = AssetFactory(asset_tag="A-FREE", is_cost_recoverable=True)
+        mi = MaintenanceItem.objects.create(
+            asset=asset, title="Sink repair", interval_days=None, estimated_cost=Decimal("0.00")
+        )
+        wo = _completed_wo(mi, completed_at=timezone.now() - timedelta(days=3))
+        # Out-of-pocket hardware-store run: priced, never toggled used.
+        freehand = _priced_usage(
+            wo, name="PVC fittings", quantity_used=Decimal("3.00"), unit_cost=Decimal("4.15")
+        )
+        freehand.was_used = False
+        freehand.save(update_fields=["was_used"])
+        # Template line off the PM spec, planned but never used → still nothing.
+        spare = MaintenanceMaterial.objects.create(
+            maintenance_item=mi,
+            name="Spare trap",
+            quantity=Decimal("1.00"),
+            estimated_cost_per_unit=Decimal("0.00"),
+        )
+        WorkOrderMaterialUsage.objects.create(
+            work_order=wo,
+            material=spare,
+            material_name=spare.name,
+            quantity_planned=Decimal("1.00"),
+            quantity_used=Decimal("1.00"),
+            unit_cost=Decimal("99.00"),
+            was_used=False,
+        )
+
+        response = client.get(URL, {"asset_ids": str(asset.id), "period": "past_month"})
+        assert response.status_code == status.HTTP_200_OK
+
+        wo.refresh_from_db()
+        svc = _assets_by_id(response)[str(asset.id)]["services"][0]
+        assert Decimal(svc["internal_cost"]) == Decimal("12.45")
+        assert Decimal(svc["actual_cost"]) == Decimal("12.45")
+        assert wo.actual_material_cost == Decimal("12.45")
+
     def test_actual_replaces_estimate_for_the_internal_figure(self, authenticated_client):
         """Where a real cost exists it wins over the template estimate — the
         Estimated column still reports the old number for reference."""
@@ -733,18 +780,30 @@ class TestCostRecoveryRecoverableInHouseWork:
         assert Decimal(svc["actual_cost"]) == Decimal("48.00")
 
     def test_planned_but_unused_priced_line_costs_nothing(self, authenticated_client):
-        """``was_used=False`` means the material was never consumed, so it is
-        not billable even with a price on it."""
+        """A *template* line with ``was_used=False`` was never consumed, so it is
+        not billable even with a price on it.
+
+        op-4pzp narrowed this to template lines: an ad-hoc one is money already
+        spent (see ``test_freehand_supply_bills_without_being_marked_used``),
+        while a line copied off the PM spec is only ever a plan until someone
+        marks it used.
+        """
         client, _ = authenticated_client
         asset = AssetFactory(asset_tag="A-UNUSED", is_cost_recoverable=True)
         mi = MaintenanceItem.objects.create(
             asset=asset, title="Aborted swap", interval_days=None, estimated_cost=Decimal("0.00")
         )
         wo = _completed_wo(mi, completed_at=timezone.now() - timedelta(days=3))
+        spare = MaintenanceMaterial.objects.create(
+            maintenance_item=mi,
+            name="Spare motor",
+            quantity=Decimal("1.00"),
+            estimated_cost_per_unit=Decimal("0.00"),
+        )
         WorkOrderMaterialUsage.objects.create(
             work_order=wo,
-            material_name="Spare motor",
-            is_ad_hoc=True,
+            material=spare,
+            material_name=spare.name,
             quantity_planned=Decimal("1.00"),
             quantity_used=Decimal("1.00"),
             was_used=False,

--- a/backend/inventory/tests/test_work_order_actual_materials.py
+++ b/backend/inventory/tests/test_work_order_actual_materials.py
@@ -707,28 +707,31 @@ class TestActualCostRollup:
         )
         assert usage.actual_cost is None
 
-    def test_wo_total_sums_only_used_lines(self):
-        wo = _corrective_wo()
+    def test_wo_total_sums_used_lines(self):
+        wo, template = _preventive_wo(quantity=Decimal("2.00"))
+        template.unit_cost = Decimal("10.00")
+        template.was_used = True
+        template.save(update_fields=["unit_cost", "was_used"])
         WorkOrderMaterialUsage.objects.create(
             work_order=wo,
             material=None,
             is_ad_hoc=True,
             material_name="Used",
             quantity_used=Decimal("2.00"),
-            unit_cost=Decimal("10.00"),
+            unit_cost=Decimal("5.00"),
             was_used=True,
         )
-        WorkOrderMaterialUsage.objects.create(
-            work_order=wo,
-            material=None,
-            is_ad_hoc=True,
-            material_name="Not used",
-            quantity_used=Decimal("5.00"),
-            unit_cost=Decimal("100.00"),
-            was_used=False,
-        )
 
-        assert wo.actual_material_cost == Decimal("20.00")
+        assert wo.actual_material_cost == Decimal("30.00")
+
+    def test_unused_template_line_still_costs_nothing(self):
+        """A planned-but-unused PM material is a plan, not a purchase."""
+        wo, template = _preventive_wo(quantity=Decimal("5.00"))
+        template.unit_cost = Decimal("100.00")
+        template.was_used = False
+        template.save(update_fields=["unit_cost", "was_used"])
+
+        assert wo.actual_material_cost == Decimal("0.00")
 
     def test_unpriced_used_line_contributes_zero_not_an_error(self):
         wo = _corrective_wo()
@@ -820,6 +823,217 @@ class TestActualCostRollup:
         assert Decimal(resp.json()["actual_material_cost"]) == Decimal("38.37")
         item.refresh_from_db()
         assert item.current_stock == 8
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# op-4pzp — a freehand (ad-hoc) supply costs the job the moment it is added
+# ─────────────────────────────────────────────────────────────────────────────
+class TestFreehandSupplyCountsImmediately:
+    """The bug: a tech adds an out-of-pocket supply *with a price* and the job's
+    Actual Material Cost stays at zero until someone separately marks the line
+    "used" — which is neither obvious nor what ``was_used`` is for. That flag
+    governs *stock*; the money left the wallet at the hardware store.
+
+    So a priced **ad-hoc** line counts on entry, ``was_used`` or not, and moves
+    no stock in the process. A **template** line is still a plan until it is
+    marked used.
+    """
+
+    def test_priced_ad_hoc_line_counts_before_it_is_marked_used(self):
+        wo = _corrective_wo()
+        usage = WorkOrderMaterialUsage.objects.create(
+            work_order=wo,
+            material=None,
+            is_ad_hoc=True,
+            material_name="Misc supplies — Ace Hardware",
+            quantity_used=Decimal("1.00"),
+            unit_cost=Decimal("23.87"),
+        )
+
+        assert usage.was_used is False
+        assert wo.actual_material_cost == Decimal("23.87")
+
+    def test_unpriced_ad_hoc_line_still_contributes_nothing(self):
+        """Unchanged: no ``unit_cost`` is no cost, however the line got here."""
+        wo = _corrective_wo()
+        WorkOrderMaterialUsage.objects.create(
+            work_order=wo,
+            material=None,
+            is_ad_hoc=True,
+            material_name="Shop rag",
+            quantity_used=Decimal("3.00"),
+        )
+
+        assert wo.actual_material_cost == Decimal("0.00")
+
+    def test_mixed_work_order_counts_each_kind_by_its_own_rule(self):
+        """One job, all four combinations, one total."""
+        wo, template_unused = _preventive_wo(quantity=Decimal("5.00"))
+        template_unused.unit_cost = Decimal("100.00")  # planned, never used → 0
+        template_unused.save(update_fields=["unit_cost"])
+        template_used = WorkOrderMaterialUsage.objects.create(
+            work_order=wo,
+            material=template_unused.material,
+            material_name="Gasket",
+            quantity_used=Decimal("2.00"),
+            unit_cost=Decimal("3.00"),  # used template line → 6.00
+            was_used=True,
+        )
+        assert template_used.is_ad_hoc is False
+        WorkOrderMaterialUsage.objects.create(
+            work_order=wo,
+            material=None,
+            is_ad_hoc=True,
+            material_name="Bolts — out of pocket",
+            quantity_used=Decimal("4.00"),
+            unit_cost=Decimal("1.25"),  # freehand, never toggled → 5.00
+        )
+        WorkOrderMaterialUsage.objects.create(
+            work_order=wo,
+            material=None,
+            is_ad_hoc=True,
+            material_name="Sealant",
+            quantity_used=Decimal("1.00"),
+            unit_cost=Decimal("9.00"),  # freehand and toggled → 9.00, once
+            was_used=True,
+        )
+
+        assert wo.actual_material_cost == Decimal("20.00")
+
+    def test_added_over_the_api_shows_up_without_a_toggle(self):
+        """Ian's report, end to end: add a freehand supply with a cost, read the
+        work order back, and the job's Actual Material Cost is already there."""
+        client, _u = _staff_client()
+        wo = _corrective_wo()
+
+        created = client.post(
+            _add_url(wo),
+            {"material_name": "PVC fittings", "quantity_used": "3", "unit_cost": "4.15"},
+            format="json",
+        )
+        assert created.status_code == status.HTTP_201_CREATED
+        assert created.json()["was_used"] is False
+
+        resp = client.get(reverse("workorder-detail", kwargs={"pk": wo.id}))
+
+        assert resp.status_code == status.HTTP_200_OK
+        assert Decimal(resp.json()["actual_material_cost"]) == Decimal("12.45")
+
+    def test_counting_a_freehand_line_moves_no_stock(self):
+        """Cost and stock stay decoupled: the line counts, the shelf does not
+        move until someone explicitly marks it used."""
+        client, _u = _staff_client()
+        wo = _corrective_wo()
+        item = _priced_item("7.25", current_stock=10)
+
+        line = client.post(
+            _add_url(wo),
+            {"material_name": "V-belt", "quantity_used": "2", "inventory_item": str(item.id)},
+            format="json",
+        ).json()
+
+        wo.refresh_from_db()
+        item.refresh_from_db()
+        usage = WorkOrderMaterialUsage.objects.get(id=line["id"])
+        assert wo.actual_material_cost == Decimal("14.50")
+        assert usage.was_used is False
+        assert usage.applied_quantity is None
+        assert item.current_stock == 10
+        assert UsageLog.objects.filter(item=item).count() == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# consumed_material_cost — the ledger's basis, deliberately a different number
+# ─────────────────────────────────────────────────────────────────────────────
+class TestConsumedMaterialCost:
+    """``actual_material_cost`` is what the job cost; ``consumed_material_cost``
+    is what left the shelf. They diverge by exactly the freehand spend, which is
+    why the committee charge (which credits *Inventory — supplies on hand*)
+    reads the second one. See ``test_work_order_committee_charge.py``.
+    """
+
+    def test_used_only_rule_survives_on_the_consumption_basis(self):
+        wo = _corrective_wo()
+        WorkOrderMaterialUsage.objects.create(
+            work_order=wo,
+            material=None,
+            is_ad_hoc=True,
+            material_name="Drawn from stock",
+            quantity_used=Decimal("2.00"),
+            unit_cost=Decimal("10.00"),
+            was_used=True,
+        )
+        WorkOrderMaterialUsage.objects.create(
+            work_order=wo,
+            material=None,
+            is_ad_hoc=True,
+            material_name="Out of pocket",
+            quantity_used=Decimal("1.00"),
+            unit_cost=Decimal("23.87"),
+        )
+
+        assert wo.actual_material_cost == Decimal("43.87")
+        assert wo.consumed_material_cost == Decimal("20.00")
+
+    def test_the_two_agree_when_every_line_was_used(self):
+        wo, usage = _preventive_wo(quantity=Decimal("2.00"))
+        usage.unit_cost = Decimal("6.00")
+        usage.was_used = True
+        usage.save(update_fields=["unit_cost", "was_used"])
+
+        assert wo.actual_material_cost == wo.consumed_material_cost == Decimal("12.00")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The report mirror — reports and the work-order screen must say the same thing
+# ─────────────────────────────────────────────────────────────────────────────
+class TestReportMirrorMatchesTheWorkOrder:
+    """``work_order_reports.wo_actual_material_cost`` is the same sum with a
+    ``None`` for "never priced" so the reports can fall back to the estimate. A
+    freehand line has to count there too, or the cost-recovery/TCO reports
+    disagree with the screen about what the job cost.
+    """
+
+    def test_freehand_line_reaches_the_report_sum(self):
+        from inventory.services.work_order_reports import wo_actual_material_cost
+
+        wo = _corrective_wo()
+        WorkOrderMaterialUsage.objects.create(
+            work_order=wo,
+            material=None,
+            is_ad_hoc=True,
+            material_name="Out of pocket",
+            quantity_used=Decimal("2.00"),
+            unit_cost=Decimal("11.50"),
+        )
+
+        assert wo_actual_material_cost(wo) == wo.actual_material_cost == Decimal("23.00")
+
+    def test_unpriced_job_still_reports_none_and_falls_back(self):
+        """The None-vs-zero contract is untouched: an ad-hoc line with no price
+        is not "this job cost nothing", it is "nobody priced this job"."""
+        from inventory.services.work_order_reports import wo_actual_material_cost
+
+        wo = _corrective_wo()
+        WorkOrderMaterialUsage.objects.create(
+            work_order=wo,
+            material=None,
+            is_ad_hoc=True,
+            material_name="Shop rag",
+            quantity_used=Decimal("1.00"),
+        )
+
+        assert wo_actual_material_cost(wo) is None
+
+    def test_unused_template_line_is_excluded_from_the_report_sum_too(self):
+        from inventory.services.work_order_reports import wo_actual_material_cost
+
+        wo, usage = _preventive_wo(quantity=Decimal("5.00"))
+        usage.unit_cost = Decimal("100.00")
+        usage.save(update_fields=["unit_cost"])
+
+        assert wo_actual_material_cost(wo) is None
+        assert wo.actual_material_cost == Decimal("0.00")
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/backend/inventory/tests/test_work_order_committee_charge.py
+++ b/backend/inventory/tests/test_work_order_committee_charge.py
@@ -259,6 +259,46 @@ class TestCompletionCharge:
 
         assert committee_balance(committee) == Decimal("10.00")
 
+    def test_freehand_spend_is_job_cost_but_not_a_committee_charge(self):
+        """op-4pzp — the audited split, asserted from both sides.
+
+        A priced ad-hoc line counts toward the job's Actual Material Cost the
+        moment it is entered. The charge does **not** follow it: this entry
+        credits ``1300 Inventory — supplies on hand``, so charging for a
+        freehand supply nobody drew from stock would write down inventory that
+        was never issued. Job cost ≥ ledger charge, and the gap is exactly the
+        out-of-pocket spend.
+        """
+        client, _user = _staff_client()
+        committee = _committee("Metalworking SIG")
+        wo = _corrective_wo(committee)
+        _line(wo, unit_cost="10.00", quantity="1.00")  # drawn from stock
+        _line(wo, unit_cost="23.87", was_used=False, name="Ace Hardware run")  # freehand
+
+        _complete(client, wo)
+
+        wo.refresh_from_db()
+        assert wo.actual_material_cost == Decimal("33.87")
+        assert wo.consumed_material_cost == Decimal("10.00")
+        assert committee_balance(committee) == Decimal("10.00")
+
+    def test_freehand_only_job_charges_nothing_and_warns(self):
+        """Nothing left the shelf, so there is nothing to book — even though the
+        job did cost money. The committee hears about it through the same
+        no-cost warning rather than a silent zero."""
+        client, _user = _staff_client()
+        committee = _committee("Fiber Arts SIG")
+        wo = _corrective_wo(committee)
+        _line(wo, unit_cost="23.87", was_used=False, name="Ace Hardware run")
+
+        resp = _complete(client, wo)
+
+        wo.refresh_from_db()
+        assert wo.actual_material_cost == Decimal("23.87")
+        assert Transaction.objects.count() == 0
+        assert resp.data["warning"] == NO_COST_WARNING
+        assert committee_balance(committee) == Decimal("0.00")
+
     def test_space_owned_job_posts_nothing(self):
         """No committee owns the machine — the ledger is untouched, no warning."""
         client, _user = _staff_client()

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -6536,6 +6536,12 @@ class AssetReportViewSet(viewsets.ViewSet):
                 if not (start_date <= completed_date <= end_date):
                     continue
                 for usage in wo.material_usage.all():
+                    # Consumption, not cost: this listing answers "what was drawn
+                    # for this asset", so it stays on ``was_used`` and does NOT
+                    # take op-4pzp's "a priced ad-hoc line counts on entry" rule
+                    # (that governs ``WorkOrder.actual_material_cost``). There is
+                    # no total here for the two to disagree about — every row is
+                    # one material line.
                     if not usage.was_used:
                         continue
                     estimated_cost = None

--- a/docs/accounting.md
+++ b/docs/accounting.md
@@ -392,10 +392,18 @@ charge on the way in, reverse on the way out.
 
 - **The committee is the asset's owner** — `work_order.asset.owning_group` (the
   `OwnableModel` mixin). A job on a space- or user-owned machine posts **nothing**.
-- **The basis is `WorkOrder.actual_material_cost`** — `quantity_used × unit_cost`
+- **The basis is `WorkOrder.consumed_material_cost`** — `quantity_used × unit_cost`
   summed over the lines actually marked *used* (op-768w capture). Unused lines and
   lines with no recorded cost contribute nothing, so a partially-priced job still
   charges what is known.
+- **The charge is not the job's cost, and is not meant to be** (op-4pzp). What the
+  work-order screen and the cost-recovery/TCO reports show is
+  `WorkOrder.actual_material_cost`, which since op-4pzp also counts a priced
+  **ad-hoc** line the moment it is entered — a freehand or out-of-pocket supply is
+  money spent whether or not anyone marks it used. This entry credits
+  `1300 Inventory — supplies on hand`, i.e. asserts stock left the shelf, so it
+  stays keyed to consumption. Job cost ≥ ledger charge, and the gap is exactly the
+  freehand spend that never came out of inventory.
 - **Material lines are not filtered by their own ownership.** The asset's committee
   is the cost centre, so shop stock, the committee's own stock, and out-of-pocket
   receipts are all charged alike. Filtering to lines whose inventory item carries


### PR DESCRIPTION
## Fix: freehand (ad-hoc) WO supplies now count in Actual Material Cost (`op-4pzp`)

**Ian (prod):** adding a freehand/out-of-pocket supply to a work order with a price didn't show in the job's Actual Material Cost until it was separately marked "used."

### Fix (per Ian: count immediately, don't touch stock)
- `WorkOrder.actual_material_cost` now counts a priced line when it's **used OR ad-hoc** — so a freehand supply counts the moment it's added. Template lines still require `was_used` (a planned-but-unused PM material costs nothing). `add_material`/`was_used`/stock paths untouched — a freehand line still moves no stock.
- Matched the parallel sum `work_order_reports.wo_actual_material_cost()` (feeds B5 cost-recovery + TCO) so reports and the WO screen agree.
- **Ledger audit (careful call):** the B6 committee charge deliberately does **not** follow — it credits *Inventory — supplies on hand*, which asserts stock left the shelf; a freehand buy never came from inventory. The ledger keeps its own basis via a new `WorkOrder.consumed_material_cost` (used-only sum), so **every committee charge amount is byte-identical**. Documented in `work_order_ledger` + docs/accounting.md.
- Web/ScanTTY actual-vs-estimated pick this up via the unchanged serializer field.

### Verify (worker, Postgres): backend 3988 passed/4 skipped; frontend 1290 passed; black/isort/flake8 clean; makemigrations --check clean. No migration, no new endpoint, no permission-matrix change. Based on current main `29fd41a`.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
