### PR TITLE
feat(reorder): edit quantity_ordered on an existing PO line (op-yh4h)

### DIFF
--- a/backend/reorder_queue/services/__init__.py
+++ b/backend/reorder_queue/services/__init__.py
@@ -7,9 +7,11 @@ Views keep the serializers as the request/response boundary and keep their
 from .numbering import next_po_number
 from .purchase_orders import (
     add_business_days,
+    apply_line_quantity,
     confirm_order,
     create_purchase_order,
     mark_sent,
+    recalculate_estimated_total,
     update_reorder_requests_from_po,
     void_line_item,
     void_po,
@@ -18,10 +20,12 @@ from .receiving import create_lead_time_log, mark_delivered_receipt, receive_del
 
 __all__ = [
     "add_business_days",
+    "apply_line_quantity",
     "confirm_order",
     "create_purchase_order",
     "mark_sent",
     "next_po_number",
+    "recalculate_estimated_total",
     "update_reorder_requests_from_po",
     "void_line_item",
     "void_po",

--- a/backend/reorder_queue/services/purchase_orders.py
+++ b/backend/reorder_queue/services/purchase_orders.py
@@ -238,6 +238,48 @@ def create_purchase_order(validated_data, items_data, user):
     return purchase_order
 
 
+def apply_line_quantity(line_item, quantity):
+    """Set ``quantity_ordered`` on a line and re-derive its package count.
+
+    Does not save — the caller owns persistence (``update_item`` applies several
+    fields to a line and saves it once). ``order_in_packages`` is re-derived
+    with the same ceil-divide ``create_purchase_order`` uses for inventory
+    lines; asset and freeform lines carry no package information and keep the 0
+    they were created with.
+
+    The caller owns the value/voided/status/already-received guards.
+    """
+    line_item.quantity_ordered = quantity
+    if line_item.item_supplier_id is not None:
+        quantity_per_package = line_item.item_supplier.quantity_per_package or 1
+        line_item.order_in_packages = (quantity + quantity_per_package - 1) // quantity_per_package
+    return line_item
+
+
+def recalculate_estimated_total(purchase_order):
+    """Recompute and persist ``estimated_total`` from the PO's current lines.
+
+    Editing a line's quantity moves its ``estimated_cost``, which the stored
+    PO-level total was frozen from at create time. Voided lines stay in the
+    stored total (``effective_estimated_total`` is what subtracts them), so the
+    sum here matches what ``create_purchase_order`` wrote.
+
+    Reads the lines back from the database instead of ``purchase_order.items``:
+    the viewset prefetches ``items``, so the cached relation still holds the
+    pre-edit quantities after a line is updated.
+    """
+    total = sum(
+        (
+            line.estimated_cost
+            for line in PurchaseOrderItem.objects.filter(purchase_order=purchase_order)
+        ),
+        start=Decimal("0.00"),
+    )
+    purchase_order.estimated_total = total
+    purchase_order.save(update_fields=["estimated_total", "updated_at"])
+    return total
+
+
 def add_business_days(start_date, business_days):
     """Add business days to a date (excluding weekends)."""
     if isinstance(start_date, timezone.datetime):

--- a/backend/reorder_queue/tests/test_po_item_quantity_edit.py
+++ b/backend/reorder_queue/tests/test_po_item_quantity_edit.py
@@ -1,0 +1,326 @@
+"""Tests for editing ``quantity_ordered`` on a PO line item (op-yh4h).
+
+"We actually need 12, not 10" on an order that is already with the supplier.
+The line's stored package count and the PO-level estimated total are both
+derived from the quantity, so both have to move with it.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+
+import pytest
+from rest_framework.test import APIClient
+
+from inventory.models import InventoryItem, ItemSupplier, Supplier
+from inventory.tests.factories import CategoryFactory, LocationFactory
+from reorder_queue.models import PurchaseOrder, PurchaseOrderItem
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def staff_user():
+    return User.objects.create_user(username="quartermaster", password="x", is_staff=True)
+
+
+@pytest.fixture
+def staff_client(staff_user):
+    api = APIClient()
+    api.force_authenticate(user=staff_user)
+    return api
+
+
+@pytest.fixture
+def po_with_line(staff_user):
+    """A sent PO with one 10-unit inventory line at $2.50 (case of 5)."""
+    location = LocationFactory()
+    category = CategoryFactory()
+    item = InventoryItem.objects.create(
+        name="M3 hex bolt",
+        description="",
+        category=category,
+        location=location,
+        current_stock=0,
+        minimum_stock=5,
+        reorder_quantity=10,
+    )
+    supplier = Supplier.objects.create(name="Acme")
+    isup = ItemSupplier.objects.create(
+        item=item,
+        supplier=supplier,
+        supplier_sku="ACME-M3-100",
+        # Decimal, not str: ItemSupplier.save() derives package_cost as
+        # unit_cost * quantity_per_package, and a str would repeat instead.
+        unit_cost=Decimal("2.50"),
+        quantity_per_package=5,
+    )
+    po = PurchaseOrder.objects.create(
+        supplier=supplier,
+        created_by=staff_user,
+        status=PurchaseOrder.Status.SENT,
+        estimated_total=Decimal("25.00"),
+    )
+    line = PurchaseOrderItem.objects.create(
+        purchase_order=po,
+        item_supplier=isup,
+        quantity_ordered=10,
+        unit_cost_ordered="2.50",
+        order_in_packages=2,
+    )
+    return po, line
+
+
+def patch_line(client, po, line, payload):
+    return client.patch(
+        f"/api/reorders/purchase-orders/{po.id}/items/{line.id}/",
+        payload,
+        format="json",
+    )
+
+
+class TestQuantityOrderedUpdate:
+    def test_increase_quantity_applies_and_recomputes_totals(self, staff_client, po_with_line):
+        po, line = po_with_line
+
+        resp = patch_line(staff_client, po, line, {"quantity_ordered": 12})
+
+        assert resp.status_code == 200, resp.content
+        assert resp.json()["quantity_ordered"] == 12
+        # estimated_cost is derived: 12 * 2.50
+        assert Decimal(resp.json()["estimated_cost"]) == Decimal("30.00")
+
+        line.refresh_from_db()
+        assert line.quantity_ordered == 12
+        # 12 units at 5 per package -> 3 packages (ceil), same math as create
+        assert line.order_in_packages == 3
+
+        po.refresh_from_db()
+        assert po.estimated_total == Decimal("30.00")
+
+    def test_decrease_quantity_applies_and_recomputes_totals(self, staff_client, po_with_line):
+        po, line = po_with_line
+
+        resp = patch_line(staff_client, po, line, {"quantity_ordered": 4})
+
+        assert resp.status_code == 200, resp.content
+        line.refresh_from_db()
+        assert line.quantity_ordered == 4
+        assert line.order_in_packages == 1
+
+        po.refresh_from_db()
+        assert po.estimated_total == Decimal("10.00")
+
+    def test_string_quantity_accepted(self, staff_client, po_with_line):
+        """Form-encoded / scantty clients send the quantity as a string."""
+        po, line = po_with_line
+
+        resp = patch_line(staff_client, po, line, {"quantity_ordered": "7"})
+
+        assert resp.status_code == 200, resp.content
+        line.refresh_from_db()
+        assert line.quantity_ordered == 7
+
+    def test_other_lines_left_alone_in_po_total(self, staff_client, po_with_line):
+        po, line = po_with_line
+        other = PurchaseOrderItem.objects.create(
+            purchase_order=po,
+            description="Shipping crate",
+            quantity_ordered=1,
+            unit_cost_ordered="15.00",
+        )
+
+        resp = patch_line(staff_client, po, line, {"quantity_ordered": 20})
+
+        assert resp.status_code == 200, resp.content
+        other.refresh_from_db()
+        assert other.quantity_ordered == 1
+
+        po.refresh_from_db()
+        # 20 * 2.50 + 1 * 15.00
+        assert po.estimated_total == Decimal("65.00")
+
+    def test_freeform_line_quantity_edit_leaves_packages_zero(self, staff_client, po_with_line):
+        po, _line = po_with_line
+        freeform = PurchaseOrderItem.objects.create(
+            purchase_order=po,
+            description="Shipping crate",
+            quantity_ordered=1,
+            unit_cost_ordered="15.00",
+        )
+
+        resp = patch_line(staff_client, po, freeform, {"quantity_ordered": 3})
+
+        assert resp.status_code == 200, resp.content
+        freeform.refresh_from_db()
+        assert freeform.quantity_ordered == 3
+        assert freeform.order_in_packages == 0
+
+
+class TestQuantityOrderedGuards:
+    def test_below_quantity_received_rejected(self, staff_client, po_with_line):
+        po, line = po_with_line
+        line.quantity_received = 6
+        line.save()
+
+        resp = patch_line(staff_client, po, line, {"quantity_ordered": 5})
+
+        assert resp.status_code == 400
+        assert "already received" in resp.json()["error"]
+        line.refresh_from_db()
+        assert line.quantity_ordered == 10
+        po.refresh_from_db()
+        assert po.estimated_total == Decimal("25.00")
+
+    def test_equal_to_quantity_received_allowed(self, staff_client, po_with_line):
+        """Trimming an order down to exactly what showed up is the close-out case."""
+        po, line = po_with_line
+        line.quantity_received = 6
+        line.save()
+
+        resp = patch_line(staff_client, po, line, {"quantity_ordered": 6})
+
+        assert resp.status_code == 200, resp.content
+        line.refresh_from_db()
+        assert line.quantity_ordered == 6
+        assert line.is_fully_received is True
+
+    @pytest.mark.parametrize("bad_quantity", [0, -3, "abc", 2.5, None, ""])
+    def test_non_positive_integer_rejected(self, staff_client, po_with_line, bad_quantity):
+        po, line = po_with_line
+
+        resp = patch_line(staff_client, po, line, {"quantity_ordered": bad_quantity})
+
+        assert resp.status_code == 400, resp.content
+        line.refresh_from_db()
+        assert line.quantity_ordered == 10
+
+    def test_voided_line_rejected(self, staff_client, po_with_line):
+        po, line = po_with_line
+        line.is_voided = True
+        line.save()
+
+        resp = patch_line(staff_client, po, line, {"quantity_ordered": 12})
+
+        assert resp.status_code == 400
+        assert "voided" in resp.json()["error"]
+        line.refresh_from_db()
+        assert line.quantity_ordered == 10
+
+    @pytest.mark.parametrize(
+        "po_status",
+        [
+            PurchaseOrder.Status.RECEIVED,
+            PurchaseOrder.Status.CANCELLED,
+            PurchaseOrder.Status.VOIDED,
+        ],
+    )
+    def test_closed_purchase_order_rejected(self, staff_client, po_with_line, po_status):
+        po, line = po_with_line
+        po.status = po_status
+        po.save()
+
+        resp = patch_line(staff_client, po, line, {"quantity_ordered": 12})
+
+        assert resp.status_code == 400
+        line.refresh_from_db()
+        assert line.quantity_ordered == 10
+
+    @pytest.mark.parametrize(
+        "po_status",
+        [
+            PurchaseOrder.Status.DRAFT,
+            PurchaseOrder.Status.SENT,
+            PurchaseOrder.Status.CONFIRMED,
+            PurchaseOrder.Status.PARTIALLY_RECEIVED,
+        ],
+    )
+    def test_open_purchase_order_allowed(self, staff_client, po_with_line, po_status):
+        po, line = po_with_line
+        po.status = po_status
+        po.save()
+
+        resp = patch_line(staff_client, po, line, {"quantity_ordered": 12})
+
+        assert resp.status_code == 200, resp.content
+        line.refresh_from_db()
+        assert line.quantity_ordered == 12
+
+    def test_requires_authentication(self, po_with_line):
+        po, line = po_with_line
+
+        resp = patch_line(APIClient(), po, line, {"quantity_ordered": 12})
+
+        assert resp.status_code in (401, 403)
+        line.refresh_from_db()
+        assert line.quantity_ordered == 10
+
+
+class TestQuantityOrderedWithOtherFields:
+    def test_line_cost_uses_the_new_quantity(self, staff_client, po_with_line):
+        """A combined edit prices the line against what was just ordered."""
+        po, line = po_with_line
+
+        resp = patch_line(
+            staff_client,
+            po,
+            line,
+            {"quantity_ordered": 20, "line_cost": "50.00"},
+        )
+
+        assert resp.status_code == 200, resp.content
+        line.refresh_from_db()
+        assert line.quantity_ordered == 20
+        assert line.unit_cost_actual == Decimal("2.5000")
+
+    def test_existing_fields_still_update_without_quantity(self, staff_client, po_with_line):
+        po, line = po_with_line
+
+        resp = patch_line(
+            staff_client,
+            po,
+            line,
+            {
+                "expected_shipment_date": "2026-08-03",
+                "actual_shipment_date": "2026-08-05",
+                "notes": "back-ordered",
+                "unit_cost_actual": "3.25",
+            },
+        )
+
+        assert resp.status_code == 200, resp.content
+        line.refresh_from_db()
+        assert line.expected_shipment_date == date(2026, 8, 3)
+        assert line.actual_shipment_date == date(2026, 8, 5)
+        assert line.notes == "back-ordered"
+        assert line.unit_cost_actual == Decimal("3.2500")
+        assert line.quantity_ordered == 10
+
+    def test_notes_still_editable_on_a_voided_line(self, staff_client, po_with_line):
+        """The voided guard is scoped to the quantity, not the whole action."""
+        po, line = po_with_line
+        line.is_voided = True
+        line.save()
+
+        resp = patch_line(staff_client, po, line, {"notes": "supplier discontinued"})
+
+        assert resp.status_code == 200, resp.content
+        line.refresh_from_db()
+        assert line.notes == "supplier discontinued"
+
+    def test_unchanged_quantity_is_a_noop(self, staff_client, po_with_line):
+        po, line = po_with_line
+        po.estimated_total = Decimal("999.00")
+        po.save()
+
+        resp = patch_line(staff_client, po, line, {"quantity_ordered": 10, "notes": "same"})
+
+        assert resp.status_code == 200, resp.content
+        line.refresh_from_db()
+        assert line.quantity_ordered == 10
+        assert line.notes == "same"
+        po.refresh_from_db()
+        # No quantity movement -> the stored total is left exactly as it was.
+        assert po.estimated_total == Decimal("999.00")

--- a/backend/reorder_queue/views.py
+++ b/backend/reorder_queue/views.py
@@ -1353,6 +1353,67 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         except PurchaseOrderItem.DoesNotExist:
             return Response({"error": "Line item not found"}, status=status.HTTP_404_NOT_FOUND)
 
+        # Quantity edits (op-yh4h) — "we actually need 12, not 10" on an order
+        # that is already out. Applied before the cost branches below so a
+        # combined {quantity_ordered, line_cost} PATCH divides the line cost by
+        # the NEW quantity.
+        quantity_changed = False
+        if "quantity_ordered" in request.data:
+            raw_quantity = request.data["quantity_ordered"]
+            try:
+                new_quantity = int(str(raw_quantity))
+            except (TypeError, ValueError):
+                return Response(
+                    {"error": f"Invalid quantity ordered value: {raw_quantity!r}"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            if new_quantity < 1:
+                return Response(
+                    {"error": "Quantity ordered must be a positive integer"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            if line_item.is_voided:
+                return Response(
+                    {"error": "Cannot change the quantity of a voided line item"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            # Same window the receive flow treats as "in flight", plus draft.
+            # A closed order (received/cancelled/voided) is settled — reopening
+            # it by re-ordering more is a new PO, not a line edit.
+            if purchase_order.status not in [
+                PurchaseOrder.Status.DRAFT,
+                PurchaseOrder.Status.SENT,
+                PurchaseOrder.Status.CONFIRMED,
+                PurchaseOrder.Status.PARTIALLY_RECEIVED,
+            ]:
+                return Response(
+                    {
+                        "error": (
+                            "Quantity can only be changed while the purchase order is "
+                            "draft, sent, confirmed, or partially received"
+                        )
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            if new_quantity < line_item.quantity_received:
+                return Response(
+                    {
+                        "error": (
+                            f"Quantity ordered ({new_quantity}) cannot be less than the "
+                            f"quantity already received ({line_item.quantity_received})"
+                        )
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            if new_quantity != line_item.quantity_ordered:
+                services.apply_line_quantity(line_item, new_quantity)
+                quantity_changed = True
+
         # Allow updating expected_shipment_date and notes
         expected_shipment_date = request.data.get("expected_shipment_date")
         if expected_shipment_date is not None:
@@ -1462,7 +1523,12 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-        line_item.save()
+        with transaction.atomic():
+            line_item.save()
+            # The PO-level estimated_total is frozen at create time from each
+            # line's estimated_cost, so a quantity edit has to re-roll it.
+            if quantity_changed:
+                services.recalculate_estimated_total(purchase_order)
 
         from .serializers import PurchaseOrderItemSerializer
 


### PR DESCRIPTION
## Backend: edit quantity_ordered on an existing PO line (`op-yh4h`, Track B)

Lets a user change a line's **quantity** on an already-submitted PO — which existed nowhere before (ScanTTY, web, or backend).

### What changed
- `update_item` (`PATCH /reorders/purchase-orders/{pk}/items/{item_id}/`) now accepts `quantity_ordered`, applied **before** the cost branches so a combined `{quantity_ordered, line_cost}` PATCH prices against the new quantity.
- Guards (scoped to the quantity branch so other fields keep working): positive integer, not a voided line, PO status in draft/sent/confirmed/partially_received, and never below that line's `quantity_received`.
- Re-derives `order_in_packages` and re-rolls the stored `PurchaseOrder.estimated_total` via new `services.purchase_orders.apply_line_quantity()` + `recalculate_estimated_total()` (re-reads lines from the DB — the viewset prefetch is stale after a line save); line save + recompute share one transaction.

### Verify (worker, Postgres): 26 new tests (`test_po_item_quantity_edit.py`) green; full backend suite 3974 passed/4 skipped (2 known MEDIA_ROOT flakes); frontend 1290 green; black/isort/flake8 clean; permission-matrix byte-identical (no new endpoint).
### Note: branched off `d132f0e` (before #963/#964/#965 merged, due to a shared-checkout race); touches `update_item`/`services.purchase_orders`, disjoint from those PRs — should 3-way cleanly. Follow-ons (separate): ScanTTY po_edit qty field + web PurchaseOrderPage parity.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
