### PR TITLE
feat(web): Inventory Linked Assets — show assets that use this item as a part (op-qdfr)

### DIFF
--- a/backend/inventory/tests/test_asset_consumable_for_item_filter.py
+++ b/backend/inventory/tests/test_asset_consumable_for_item_filter.py
@@ -95,6 +95,28 @@ class TestConsumableForItemFilter:
         assert str(printer.id) in ids
         assert str(unrelated.id) in ids
 
+    def test_rows_carry_the_asset_part_detail_for_the_queried_item(self):
+        """Each returned row nests its AssetPart rows under ``parts``, including
+        ``quantity_needed``/``is_required`` for the queried item.
+
+        The inventory-item detail page's "Assets that use this item" table reads
+        those through-model fields straight off the list payload rather than
+        making a second round-trip (op-qdfr) — this pins that contract.
+        """
+        item = InventoryItemFactory()
+        printer = AssetFactory(name="UV Printer")
+        AssetPartFactory(asset=printer, part=item, quantity_needed=3, is_required=True)
+
+        resp = _client().get(ASSETS_URL, {"consumable_for_item": str(item.id)})
+
+        assert resp.status_code == 200, resp.content
+        data = resp.data
+        results = data["results"] if isinstance(data, dict) and "results" in data else data
+        row = next(r for r in results if str(r["id"]) == str(printer.id))
+        link = next(p for p in row["parts"] if str(p["part"]) == str(item.id))
+        assert link["quantity_needed"] == 3
+        assert link["is_required"] is True
+
     def test_garbage_value_is_ignored_not_a_500(self):
         """A non-UUID value is ignored gracefully (unfiltered), not a server error."""
         item = InventoryItemFactory()

--- a/frontend/src/__tests__/pages/InventoryItemDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemDetailPage.test.tsx
@@ -380,8 +380,94 @@ describe('InventoryItemDetailPage', () => {
 
     fireEvent.click(screen.getByRole('tab', { name: /Linked Assets/i }));
     expect(
-      await screen.findByText('No assets linked to this inventory item.')
+      await screen.findByText('No assets use this item as a part.')
     ).toBeInTheDocument();
+    expect(
+      screen.getByText('No assets are an instance of this inventory item.')
+    ).toBeInTheDocument();
+  });
+
+  // ---- op-qdfr: assets that USE this item as a part (AssetPart) ----
+
+  it('requests the assets that use this item as a part and renders them with AssetPart detail', async () => {
+    const consumingAsset = {
+      id: 'asset-consumer',
+      name: 'Laser Cutter',
+      asset_tag: 'AT-LASER',
+      status: 'active' as const,
+      location_name: 'Fab Lab',
+      inventory_item: null,
+      parts: [
+        {
+          id: 'part-link-1',
+          asset: 'asset-consumer',
+          part: 'test-id',
+          part_name: 'Test Item',
+          quantity_needed: 3,
+          is_required: true,
+          maintenance_interval_days: 90,
+          last_replaced_at: null,
+        },
+      ],
+    };
+
+    (api.assetsAPI.listAssets as jest.Mock).mockImplementation((params: any) =>
+      Promise.resolve({
+        data: { results: params?.consumable_for_item ? [consumingAsset] : [] },
+      })
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item')).toBeInTheDocument();
+    });
+
+    // The page asks for the AssetPart relationship, not just inventory_item.
+    expect(api.assetsAPI.listAssets).toHaveBeenCalledWith({
+      consumable_for_item: 'test-id',
+    });
+    expect(api.assetsAPI.listAssets).toHaveBeenCalledWith({ inventory_item: 'test-id' });
+
+    fireEvent.click(screen.getByRole('tab', { name: /Linked Assets/i }));
+
+    // The two relationships are labeled distinctly so they aren't conflated.
+    const usingSection = await screen.findByTestId('assets-using-item');
+    expect(usingSection).toHaveTextContent('Assets that use this item');
+    expect(screen.getByTestId('assets-of-this-type')).toHaveTextContent(
+      'Assets of this type'
+    );
+
+    // The consuming asset lands in the "uses this item" section, enriched with
+    // the through-model detail — and not in the "is this item" section.
+    expect(usingSection).toHaveTextContent('Laser Cutter');
+    expect(usingSection).toHaveTextContent('AT-LASER');
+    expect(usingSection).toHaveTextContent('3');
+    expect(usingSection).toHaveTextContent('Required');
+    expect(screen.getByTestId('assets-of-this-type')).toHaveTextContent(
+      'No assets are an instance of this inventory item.'
+    );
+  });
+
+  it('still renders the item when the used-by-assets call fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (api.assetsAPI.listAssets as jest.Mock).mockImplementation((params: any) =>
+      params?.consumable_for_item
+        ? Promise.reject(new Error('boom'))
+        : Promise.resolve({ data: { results: [] } })
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: /Linked Assets/i }));
+    expect(
+      await screen.findByText('No assets use this item as a part.')
+    ).toBeInTheDocument();
+    consoleError.mockRestore();
   });
 
   it('renders the not-found state when the item load is forbidden (403)', async () => {

--- a/frontend/src/pages/InventoryItemDetailPage.tsx
+++ b/frontend/src/pages/InventoryItemDetailPage.tsx
@@ -3,7 +3,6 @@
  * Comprehensive detail view with tabs for overview, stock history, reorder history, usage logs, and linked assets
  */
 import {
-    ActionIcon,
     Alert,
     Badge,
     Button,
@@ -328,7 +327,12 @@ const InventoryItemDetailPage: React.FC = () => {
   const [usageLogs, setUsageLogs] = useState<UsageLog[]>([]);
   const [stockHistory, setStockHistory] = useState<StockHistory | null>(null);
   const [reorderHistory, setReorderHistory] = useState<ReorderRequest[]>([]);
+  // Two *different* asset relationships, both surfaced on the Linked Assets
+  // tab (op-qdfr). `linkedAssets` = Asset.inventory_item, i.e. the asset IS an
+  // instance of this item type. `usedByAssets` = the AssetPart through-model,
+  // i.e. assets that consume this item as a part. Conflating them was the bug.
   const [linkedAssets, setLinkedAssets] = useState<Asset[]>([]);
+  const [usedByAssets, setUsedByAssets] = useState<Asset[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<string | null>('overview');
   const [cycleCountOpen, setCycleCountOpen] = useState(false);
@@ -351,15 +355,23 @@ const InventoryItemDetailPage: React.FC = () => {
     // and show "Item not found" even though the item exists — uid0 hit
     // this on items with no linked-assets filter match where assetsAPI
     // returned a 400.
-    const [itemRes, metricsRes, usageLogsRes, stockHistoryRes, reorderRes, assetsRes] =
-      await Promise.allSettled([
-        inventoryAPI.getItem(id),
-        inventoryAPI.getItemMetrics(id),
-        inventoryAPI.getUsageLogs(id),
-        inventoryAPI.getStockHistory(id),
-        reorderAPI.listRequests({ status: undefined }),
-        assetsAPI.listAssets({ inventory_item: id }),
-      ]);
+    const [
+      itemRes,
+      metricsRes,
+      usageLogsRes,
+      stockHistoryRes,
+      reorderRes,
+      assetsRes,
+      usedByRes,
+    ] = await Promise.allSettled([
+      inventoryAPI.getItem(id),
+      inventoryAPI.getItemMetrics(id),
+      inventoryAPI.getUsageLogs(id),
+      inventoryAPI.getStockHistory(id),
+      reorderAPI.listRequests({ status: undefined }),
+      assetsAPI.listAssets({ inventory_item: id }),
+      assetsAPI.listAssets({ consumable_for_item: id }),
+    ]);
 
     if (itemRes.status === 'fulfilled') {
       setItem(itemRes.value.data);
@@ -396,6 +408,12 @@ const InventoryItemDetailPage: React.FC = () => {
       setLinkedAssets(assetsRes.value.data.results || []);
     } else {
       console.error('Error loading linked assets:', assetsRes.reason);
+    }
+
+    if (usedByRes.status === 'fulfilled') {
+      setUsedByAssets(usedByRes.value.data.results || []);
+    } else {
+      console.error('Error loading assets that use this item:', usedByRes.reason);
     }
 
     setLoading(false);
@@ -786,48 +804,122 @@ const InventoryItemDetailPage: React.FC = () => {
           </Card>
         </Tabs.Panel>
 
-        {/* Linked Assets Tab */}
+        {/* Linked Assets Tab — two distinct relationships, never conflated:
+            (1) assets that CONSUME this item as a part (AssetPart), which is
+            what people mean by "what uses this?", and (2) assets that ARE an
+            instance of this item type (Asset.inventory_item). (op-qdfr) */}
         <Tabs.Panel value="linked-assets" pt="md">
-          <Card withBorder p="md">
-            <Title order={4} mb="md">
-              Linked Assets
-            </Title>
-            {linkedAssets.length === 0 ? (
-              <Text c="dimmed">No assets linked to this inventory item.</Text>
-            ) : (
-              <Table>
-                <Table.Thead>
-                  <Table.Tr>
-                    <Table.Th>Asset Name</Table.Th>
-                    <Table.Th>Asset Tag</Table.Th>
-                    <Table.Th>Status</Table.Th>
-                    <Table.Th>Location</Table.Th>
-                    <Table.Th>Actions</Table.Th>
-                  </Table.Tr>
-                </Table.Thead>
-                <Table.Tbody>
-                  {linkedAssets.map((asset) => (
-                    <Table.Tr key={asset.id}>
-                      <Table.Td>{asset.name}</Table.Td>
-                      <Table.Td>{asset.asset_tag || '-'}</Table.Td>
-                      <Table.Td>
-                        <Badge color={asset.status === 'active' ? 'green' : 'gray'}>{asset.status}</Badge>
-                      </Table.Td>
-                      <Table.Td>{asset.location_name || '-'}</Table.Td>
-                      <Table.Td>
-                        <ActionIcon
-                          variant="subtle"
-                          onClick={() => navigate(`/inventory/scan/asset/${asset.id}`)}
-                        >
-                          View
-                        </ActionIcon>
-                      </Table.Td>
+          <Stack gap="md">
+            <Card withBorder p="md" data-testid="assets-using-item">
+              <Title order={4} mb="xs">
+                Assets that use this item
+              </Title>
+              <Text size="sm" c="dimmed" mb="md">
+                Equipment that lists this item as a part or consumable.
+              </Text>
+              {usedByAssets.length === 0 ? (
+                <Text c="dimmed">No assets use this item as a part.</Text>
+              ) : (
+                <Table>
+                  <Table.Thead>
+                    <Table.Tr>
+                      <Table.Th>Asset Name</Table.Th>
+                      <Table.Th>Asset Tag</Table.Th>
+                      <Table.Th>Qty Needed</Table.Th>
+                      <Table.Th>Required</Table.Th>
+                      <Table.Th>Status</Table.Th>
+                      <Table.Th>Location</Table.Th>
+                      <Table.Th>Actions</Table.Th>
                     </Table.Tr>
-                  ))}
-                </Table.Tbody>
-              </Table>
-            )}
-          </Card>
+                  </Table.Thead>
+                  <Table.Tbody>
+                    {usedByAssets.map((asset) => {
+                      // The asset payload already nests its AssetPart rows, so
+                      // the through-model detail for *this* item is free — no
+                      // extra round-trip and no new endpoint.
+                      const partLink = (asset.parts || []).find((p) => p.part === id);
+                      return (
+                        <Table.Tr key={asset.id}>
+                          <Table.Td>{asset.name}</Table.Td>
+                          <Table.Td>{asset.asset_tag || '-'}</Table.Td>
+                          <Table.Td>{partLink ? partLink.quantity_needed : '-'}</Table.Td>
+                          <Table.Td>
+                            {partLink ? (
+                              <Badge color={partLink.is_required ? 'red' : 'gray'} variant="light">
+                                {partLink.is_required ? 'Required' : 'Optional'}
+                              </Badge>
+                            ) : (
+                              '-'
+                            )}
+                          </Table.Td>
+                          <Table.Td>
+                            <Badge color={asset.status === 'active' ? 'green' : 'gray'}>
+                              {asset.status}
+                            </Badge>
+                          </Table.Td>
+                          <Table.Td>{asset.location_name || '-'}</Table.Td>
+                          <Table.Td>
+                            <Button
+                              size="xs"
+                              variant="subtle"
+                              onClick={() => navigate(`/inventory/scan/asset/${asset.id}`)}
+                            >
+                              View
+                            </Button>
+                          </Table.Td>
+                        </Table.Tr>
+                      );
+                    })}
+                  </Table.Tbody>
+                </Table>
+              )}
+            </Card>
+
+            <Card withBorder p="md" data-testid="assets-of-this-type">
+              <Title order={4} mb="xs">
+                Assets of this type
+              </Title>
+              <Text size="sm" c="dimmed" mb="md">
+                Tracked assets that are an instance of this inventory item.
+              </Text>
+              {linkedAssets.length === 0 ? (
+                <Text c="dimmed">No assets are an instance of this inventory item.</Text>
+              ) : (
+                <Table>
+                  <Table.Thead>
+                    <Table.Tr>
+                      <Table.Th>Asset Name</Table.Th>
+                      <Table.Th>Asset Tag</Table.Th>
+                      <Table.Th>Status</Table.Th>
+                      <Table.Th>Location</Table.Th>
+                      <Table.Th>Actions</Table.Th>
+                    </Table.Tr>
+                  </Table.Thead>
+                  <Table.Tbody>
+                    {linkedAssets.map((asset) => (
+                      <Table.Tr key={asset.id}>
+                        <Table.Td>{asset.name}</Table.Td>
+                        <Table.Td>{asset.asset_tag || '-'}</Table.Td>
+                        <Table.Td>
+                          <Badge color={asset.status === 'active' ? 'green' : 'gray'}>{asset.status}</Badge>
+                        </Table.Td>
+                        <Table.Td>{asset.location_name || '-'}</Table.Td>
+                        <Table.Td>
+                          <Button
+                            size="xs"
+                            variant="subtle"
+                            onClick={() => navigate(`/inventory/scan/asset/${asset.id}`)}
+                          >
+                            View
+                          </Button>
+                        </Table.Td>
+                      </Table.Tr>
+                    ))}
+                  </Table.Tbody>
+                </Table>
+              )}
+            </Card>
+          </Stack>
         </Tabs.Panel>
 
         {/* Serialized Units Tab — per-unit lifecycle for serialized items.


### PR DESCRIPTION
## Web: Inventory item "Linked Assets" — show assets that USE this item as a part (`op-qdfr`)

**Ian's ask #4:** "for items where assets have inventory items from day one, include those in the item detail." The relationship (`AssetPart`) and endpoint (`?consumable_for_item=`) existed; the tab was just wired to the wrong parameter.

### What changed (frontend)
- The "Linked Assets" tab now loads `assetsAPI.listAssets({ consumable_for_item: id })` **alongside** the existing `inventory_item` call, and renders **two distinctly-labeled sections**: **"Assets that use this item"** (AssetPart through-model, with `quantity_needed` + `is_required` read off the nested parts already on the asset payload) and **"Assets of this type"** (`Asset.inventory_item`), each with its own empty state.
- Drive-by fix: swapped the text-labelled `ActionIcon` "View" controls for `Button` (ActionIcon was clipping the label to "/iew").
- Backend unchanged; added one test pinning the list-payload contract the new columns read.

### Verify (worker): vitest InventoryItemDetailPage* 32 pass; test:fast 1292 pass; lint 0; tsc 0; build ok; backend `test_asset_consumable_for_item_filter` 6 pass; **live Playwright browser drive 10/10** (UV Laser Cutter renders under "Assets that use this item" qty 3 / Required, doesn't leak). Based on current main `29fd41a`. ScanTTY parity shipped separately (#118).
🤖 Generated with [Claude Code](https://claude.com/claude-code)
