### PR TITLE
feat(inventory): count ad-hoc/per-WO usage in Committed + attribution (op-l4i0)

### DIFF
--- a/backend/inventory/models/maintenance.py
+++ b/backend/inventory/models/maintenance.py
@@ -645,7 +645,7 @@ class WorkOrder(ElapsedTimerModel):
         return self.short_id
 
     def __str__(self) -> str:
-        return f"WO-{str(self.id)[:8].upper()} — {self.display_title} ({self.get_status_display()})"
+        return f"{self.short_id} — {self.display_title} ({self.get_status_display()})"
 
     @property
     def actual_material_cost(self) -> Decimal:
@@ -680,10 +680,20 @@ class WorkOrder(ElapsedTimerModel):
             return False
         return timezone.now().date() > self.due_date
 
+    @staticmethod
+    def short_id_for(work_order_id) -> str:
+        """Short human-readable identifier built from a raw primary key.
+
+        The one place the ``WO-XXXXXXXX`` format lives, so a caller holding
+        only an id (a grouped-aggregate row, say) labels a work order exactly
+        the way a loaded instance does.
+        """
+        return f"WO-{str(work_order_id)[:8].upper()}"
+
     @property
     def short_id(self) -> str:
         """Return a short human-readable identifier for this work order."""
-        return f"WO-{str(self.id)[:8].upper()}"
+        return WorkOrder.short_id_for(self.id)
 
     #: ``started_at`` rides along because ``start_timer`` stamps it.
     TIMER_FIELDS = ElapsedTimerModel.TIMER_FIELDS + ("started_at",)

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -822,6 +822,21 @@ class DemandForecastSerializer(serializers.ModelSerializer):
         ]
 
 
+class CommittedBreakdownEntrySerializer(serializers.Serializer):
+    """One work order holding part of an item's committed quantity (QC).
+
+    The attribution side of ``quantity_committed``: which job — and so which
+    machine — the reserved stock is going to. Entries sum to
+    ``quantity_committed`` and arrive oldest work order first.
+    """
+
+    work_order_id = serializers.UUIDField()
+    work_order_short_id = serializers.CharField()  # e.g. "WO-1A2B3C4D"
+    asset_id = serializers.UUIDField(allow_null=True)  # null on an asset-less work order
+    asset_name = serializers.CharField(allow_null=True)
+    quantity = serializers.FloatField()
+
+
 class InventoryMetricsSerializer(serializers.Serializer):
     """Computed stock + cost metrics for the inventory-item detail view.
 
@@ -840,6 +855,7 @@ class InventoryMetricsSerializer(serializers.Serializer):
     quantity_on_order = serializers.IntegerField()  # QOO — open PO units
     quantity_available = serializers.FloatField()  # QA — QOH minus QC
     quantity_committed = serializers.FloatField()  # QC — open work-order demand
+    committed_breakdown = CommittedBreakdownEntrySerializer(many=True)  # which WOs/assets hold QC
     quantity_in_transit = serializers.IntegerField()  # QIT — partially-received (⊆ QOO)
     reorder_point = serializers.IntegerField()  # RP — reorder_quantity
     lead_time_days = serializers.IntegerField(allow_null=True)  # Lead — average_lead_time

--- a/backend/inventory/services/item_metrics.py
+++ b/backend/inventory/services/item_metrics.py
@@ -8,7 +8,7 @@ item (the ``/metrics/`` detail action) and a whole page of items (the
 ``compute_item_metrics_batch`` is the workhorse: given an iterable of already
 loaded ``InventoryItem`` instances (typically one paginated page) it returns
 ``{item_id: payload}`` using a BOUNDED number of grouped-aggregate queries —
-five, independent of how many items are passed — so the list endpoint never
+six, independent of how many items are passed — so the list endpoint never
 degrades into an N+1. ``compute_item_metrics`` is the single-item convenience
 wrapper the detail action uses.
 
@@ -16,9 +16,9 @@ The ``payload`` dict shape is the pinned contract consumed by
 ``InventoryMetricsSerializer`` and the ScanTTY worker — do not rename keys.
 """
 
-from django.db.models import ExpressionWrapper, F, IntegerField, Sum
+from django.db.models import ExpressionWrapper, F, IntegerField, Q, Sum
 
-from inventory.models import ItemSupplier, MaintenanceMaterial, WorkOrder
+from inventory.models import ItemSupplier, MaintenanceMaterial, WorkOrder, WorkOrderMaterialUsage
 from reorder_queue.models import PurchaseOrder, PurchaseOrderItem
 
 # PO statuses that count as "on order" (QOO): units committed on a live PO that
@@ -48,12 +48,148 @@ def _cost_trend(current_unit_cost, last_po_unit_cost):
     return "flat"
 
 
+def _committed_by_item(item_ids):
+    """Return ``({item_id: total}, {item_id: [breakdown_entry, ...]})`` (2 queries).
+
+    QC is the open-work-order demand that has **not yet drawn down**
+    ``current_stock``. Two kinds of row express that demand, and the rule that
+    reconciles them is per **(work order, item)**:
+
+    * **Actual usage rows** (:class:`WorkOrderMaterialUsage`) are authoritative
+      for a work order that has materialised any for the item. An un-consumed
+      row (``was_used`` False and no ``applied_quantity``) is demand; a consumed
+      one contributes nothing, because its units have already left
+      ``current_stock``. That is what stops a material consumed while its work
+      order is still open from being subtracted twice — once from stock and
+      again as committed.
+    * **Template materials** (:class:`MaintenanceMaterial` on the work order's
+      PM task) are the fallback for a work order that has not materialised
+      usage rows for the item yet — one created straight from a template, or
+      one whose rows were deleted.
+
+    A template material is counted **at most once** even when its task carries
+    several open work orders (a task with two open WOs needs the material once,
+    not twice — the pre-existing rule), and is attributed to the oldest such
+    work order that has not materialised usage rows for the item.
+
+    The breakdown is the attribution side of the same numbers: one entry per
+    (work order, item) pair holding a non-zero share of QC, so
+    ``sum(entry["quantity"]) == total`` for every item. Entries are ordered
+    oldest work order first.
+    """
+    # ``(item_id, work_order_id)`` -> committed quantity. A pair is fed by
+    # EITHER usage rows or template materials, never both (see below).
+    demand = {}
+    # Pairs whose work order has materialised usage rows for the item — the
+    # template fallback is switched off for exactly these.
+    materialised = set()
+    # work_order_id -> (created_at, asset_id, asset_name), for attribution.
+    work_orders = {}
+
+    # Actual usage on open work orders. ``stock_item`` prefers the row's own
+    # ``inventory_item`` (how an ad-hoc line links stock) and falls back to the
+    # template spec's; both columns come back so the same precedence can be
+    # applied here, off one query, without loading rows. (1 query)
+    for (
+        direct_item_id,
+        spec_item_id,
+        work_order_id,
+        quantity_used,
+        was_used,
+        applied_quantity,
+        asset_id,
+        asset_name,
+        created_at,
+    ) in (
+        WorkOrderMaterialUsage.objects.filter(
+            Q(inventory_item_id__in=item_ids)
+            | Q(inventory_item__isnull=True, material__inventory_item_id__in=item_ids),
+            work_order__status__in=OPEN_WO_STATUSES,
+        )
+        .values_list(
+            "inventory_item_id",
+            "material__inventory_item_id",
+            "work_order_id",
+            "quantity_used",
+            "was_used",
+            "applied_quantity",
+            "work_order__asset_id",
+            "work_order__asset__name",
+            "work_order__created_at",
+        )
+        .order_by()  # clear Meta ordering; the rows are grouped in Python
+    ):
+        item_id = direct_item_id if direct_item_id is not None else spec_item_id
+        work_orders[work_order_id] = (created_at, asset_id, asset_name)
+        key = (item_id, work_order_id)
+        materialised.add(key)
+        if was_used or applied_quantity is not None:
+            continue  # already consumed — these units are out of current_stock
+        demand[key] = demand.get(key, 0.0) + float(quantity_used or 0)
+
+    # Template materials on open work orders. DISTINCT over (material, work
+    # order) so a task with several open work orders yields one candidate row
+    # per work order — the material's quantity is still counted once, in the
+    # reconciliation loop below. (1 query)
+    template_candidates = {}
+    for material_id, item_id, quantity, work_order_id, asset_id, asset_name, created_at in (
+        MaintenanceMaterial.objects.filter(
+            inventory_item_id__in=item_ids,
+            maintenance_item__work_orders__status__in=OPEN_WO_STATUSES,
+        )
+        .values_list(
+            "id",
+            "inventory_item_id",
+            "quantity",
+            "maintenance_item__work_orders__id",
+            "maintenance_item__work_orders__asset_id",
+            "maintenance_item__work_orders__asset__name",
+            "maintenance_item__work_orders__created_at",
+        )
+        .order_by()  # clear Meta ordering so DISTINCT dedupes purely by the row
+        .distinct()
+    ):
+        work_orders[work_order_id] = (created_at, asset_id, asset_name)
+        candidate = template_candidates.setdefault(material_id, (item_id, quantity, []))
+        candidate[2].append(work_order_id)
+
+    def _age(work_order_id):
+        """Sort key: oldest work order first, id breaking a created_at tie."""
+        return (work_orders[work_order_id][0], str(work_order_id))
+
+    for item_id, quantity, candidate_work_orders in template_candidates.values():
+        fallback = [wo for wo in candidate_work_orders if (item_id, wo) not in materialised]
+        if not fallback:
+            continue  # every open work order materialised its own rows
+        key = (item_id, min(fallback, key=_age))
+        demand[key] = demand.get(key, 0.0) + float(quantity or 0)
+
+    totals = {}
+    breakdown = {}
+    for (item_id, work_order_id), quantity in sorted(demand.items(), key=lambda kv: _age(kv[0][1])):
+        totals[item_id] = totals.get(item_id, 0.0) + quantity
+        if not quantity:
+            continue  # nothing committed here — don't clutter the attribution
+        _created_at, asset_id, asset_name = work_orders[work_order_id]
+        breakdown.setdefault(item_id, []).append(
+            {
+                "work_order_id": work_order_id,
+                "work_order_short_id": WorkOrder.short_id_for(work_order_id),
+                "asset_id": asset_id,
+                "asset_name": asset_name,
+                "quantity": quantity,
+            }
+        )
+
+    return totals, breakdown
+
+
 def compute_item_metrics_batch(items):
     """Return ``{item_id: metrics_payload}`` for ``items`` in bounded queries.
 
     ``items`` is an iterable of already-loaded ``InventoryItem`` instances
     (typically a single paginated page). The number of database queries is
-    constant — five grouped aggregates — regardless of how many items are
+    constant — six grouped aggregates — regardless of how many items are
     passed, so the list endpoint stays O(1) in queries rather than O(n). Every
     item id in ``items`` is present in the result (with zeros / ``None`` where
     there is no PO / work-order / supplier data).
@@ -107,21 +243,11 @@ def compute_item_metrics_batch(items):
         )
     }
 
-    # QC — quantity committed to open work orders. Select DISTINCT materials
-    # first: a task with several open work orders would otherwise multiply the
-    # join and double-count the material's quantity. Sum per item in Python so
-    # this stays a single query. (1 query)
-    quantity_committed = {}
-    for _material_id, item_id, quantity in (
-        MaintenanceMaterial.objects.filter(
-            inventory_item_id__in=item_ids,
-            maintenance_item__work_orders__status__in=OPEN_WO_STATUSES,
-        )
-        .values_list("id", "inventory_item_id", "quantity")
-        .order_by()  # clear Meta ordering so DISTINCT dedupes purely by material
-        .distinct()
-    ):
-        quantity_committed[item_id] = quantity_committed.get(item_id, 0.0) + float(quantity or 0)
+    # QC — quantity committed to open work orders, plus the per-work-order
+    # attribution of it. Covers both the PM-template materials and the actual
+    # (including ad-hoc) usage rows, reconciled so neither double-counts the
+    # other — see ``_committed_by_item``. (2 queries)
+    quantity_committed, committed_breakdown = _committed_by_item(item_ids)
 
     # Most-recent PO unit cost per item (drives cost_trend / last_po_unit_cost).
     # Rows arrive newest-first within each item; keep the first one seen. (1 query)
@@ -165,6 +291,7 @@ def compute_item_metrics_batch(items):
             "quantity_on_order": quantity_on_order.get(item.id, 0),
             "quantity_available": float(item.current_stock) - committed,
             "quantity_committed": committed,
+            "committed_breakdown": committed_breakdown.get(item.id, []),
             "quantity_in_transit": quantity_in_transit.get(item.id, 0),
             "reorder_point": item.reorder_quantity,
             "lead_time_days": lead_time_days,

--- a/backend/inventory/tests/test_inventory_list_metrics.py
+++ b/backend/inventory/tests/test_inventory_list_metrics.py
@@ -18,7 +18,13 @@ import pytest
 from rest_framework import status
 
 from donations.tests.factories import DispositionFactory, DonationFactory, DonationItemFactory
-from inventory.models import FixtureRefillRequest, MaintenanceItem, MaintenanceMaterial, WorkOrder
+from inventory.models import (
+    FixtureRefillRequest,
+    MaintenanceItem,
+    MaintenanceMaterial,
+    WorkOrder,
+    WorkOrderMaterialUsage,
+)
 from inventory.tests.factories import AssetFactory, FixtureFactory, InventoryItemFactory
 from reorder_queue.models import PurchaseOrder, PurchaseOrderItem, ReorderRequest
 from reorder_queue.tests.factories import UserFactory
@@ -32,6 +38,7 @@ METRICS_FIELDS = {
     "quantity_on_order",
     "quantity_available",
     "quantity_committed",
+    "committed_breakdown",
     "quantity_in_transit",
     "reorder_point",
     "lead_time_days",
@@ -171,6 +178,40 @@ class TestListMetricsValues:
         assert metrics["quantity_committed"] == 4.0  # not 8.0
         assert metrics["quantity_available"] == 6.0
 
+    def test_ad_hoc_work_order_demand_is_committed_and_attributed_per_row(self, api_client):
+        """The batch path counts ad-hoc usage rows and attributes them, per item."""
+        asset = AssetFactory(name="Lathe")
+        a = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=1)
+        b = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=1)
+        work_order = WorkOrder.objects.create(asset=asset, status=WorkOrder.Status.OPEN)
+        WorkOrderMaterialUsage.objects.create(
+            work_order=work_order,
+            is_ad_hoc=True,
+            inventory_item=a,
+            material_name="ad-hoc widget",
+            quantity_planned=Decimal("2.00"),
+            quantity_used=Decimal("2.00"),
+        )
+
+        results = _results(api_client.get(_list_url(with_metrics=True)))
+        ma = _row_for(results, a)["metrics"]
+        mb = _row_for(results, b)["metrics"]
+
+        assert ma["quantity_committed"] == 2.0
+        assert ma["quantity_available"] == 8.0
+        assert ma["committed_breakdown"] == [
+            {
+                "work_order_id": str(work_order.id),
+                "work_order_short_id": work_order.short_id,
+                "asset_id": str(asset.id),
+                "asset_name": "Lathe",
+                "quantity": 2.0,
+            }
+        ]
+        # ... and the other item on the same page is untouched by it.
+        assert mb["quantity_committed"] == 0.0
+        assert mb["committed_breakdown"] == []
+
     def test_case_based_item_reports_case_cost_and_size(self, api_client):
         item = InventoryItemFactory(
             image=None,
@@ -216,10 +257,23 @@ def _count_queries(api_client, url):
 
 
 def _make_active_item(asset):
-    """An item with a PO line and a committed material, so the aggregates hit rows."""
+    """An item every metrics aggregate hits rows for.
+
+    A PO line, a PM-template committed material, and an ad-hoc work-order usage
+    row — so the committed pair of queries (template + actual usage) is
+    exercised with real rows and an N+1 in either would show up here.
+    """
     item = InventoryItemFactory(image=None, current_stock=15, reorder_quantity=2)
     _open_po_line(item, quantity_ordered=5, po_status=PurchaseOrder.Status.SENT)
     _commit_material(item, asset, quantity="1", wo_statuses=[WorkOrder.Status.OPEN])
+    WorkOrderMaterialUsage.objects.create(
+        work_order=WorkOrder.objects.create(asset=asset, status=WorkOrder.Status.OPEN),
+        is_ad_hoc=True,
+        inventory_item=item,
+        material_name="ad-hoc widget",
+        quantity_planned=Decimal("1.00"),
+        quantity_used=Decimal("1.00"),
+    )
     return item
 
 
@@ -248,8 +302,10 @@ class TestListMetricsQueryBudget:
         # ...and adds the SAME number of queries for 6 items as for 2 — batched,
         # not per-row (an N+1 would make the 6-item delta larger).
         assert metrics_6 - base_6 == metrics_2 - base_2
-        # ...and that constant is small (a handful of grouped aggregates).
-        assert metrics_6 - base_6 <= 6
+        # ...and that constant is exactly the six grouped aggregates the batch
+        # helper runs: on-order, in-transit, committed-from-usage,
+        # committed-from-template, last PO cost, primary supplier.
+        assert metrics_6 - base_6 == 6
 
     def test_default_path_is_unaffected(self, api_client):
         """No param -> no metrics work: same query count for 2 vs 6 items' overhead."""

--- a/backend/inventory/tests/test_inventory_metrics.py
+++ b/backend/inventory/tests/test_inventory_metrics.py
@@ -15,7 +15,13 @@ from django.utils import timezone
 import pytest
 from rest_framework import status
 
-from inventory.models import MaintenanceItem, MaintenanceMaterial, WorkOrder
+from inventory.models import (
+    MaintenanceItem,
+    MaintenanceMaterial,
+    WorkOrder,
+    WorkOrderMaterialUsage,
+)
+from inventory.services.work_order_material_usage import apply_material_usage
 from inventory.tests.factories import AssetFactory, InventoryItemFactory
 from reorder_queue.models import PurchaseOrder, PurchaseOrderItem
 from reorder_queue.tests.factories import UserFactory
@@ -27,6 +33,7 @@ CONTRACT_FIELDS = {
     "quantity_on_order",
     "quantity_available",
     "quantity_committed",
+    "committed_breakdown",
     "quantity_in_transit",
     "reorder_point",
     "lead_time_days",
@@ -35,6 +42,14 @@ CONTRACT_FIELDS = {
     "last_po_unit_cost",
     "is_case_based",
     "case_size",
+}
+
+BREAKDOWN_FIELDS = {
+    "work_order_id",
+    "work_order_short_id",
+    "asset_id",
+    "asset_name",
+    "quantity",
 }
 
 
@@ -74,15 +89,65 @@ def _po_line(
 
 def _committed_material(item, asset, *, quantity, wo_statuses):
     """Attach ``quantity`` of ``item`` to a fresh task carrying ``wo_statuses``."""
+    material, _work_orders = _template_material(
+        item, asset, quantity=quantity, wo_statuses=wo_statuses
+    )
+    return material
+
+
+def _template_material(item, asset, *, quantity, wo_statuses):
+    """A PM template material plus the work orders generated off its task.
+
+    Returns ``(material, work_orders)`` so a test can materialise the frozen
+    usage rows a real generated work order carries (``_materialise_usage``).
+    """
     task = MaintenanceItem.objects.create(asset=asset, title="task")
-    for wo_status in wo_statuses:
+    work_orders = [
         WorkOrder.objects.create(maintenance_item=task, status=wo_status)
-    return MaintenanceMaterial.objects.create(
+        for wo_status in wo_statuses
+    ]
+    material = MaintenanceMaterial.objects.create(
         maintenance_item=task,
         inventory_item=item,
         name="widget",
         quantity=Decimal(quantity),
     )
+    return material, work_orders
+
+
+def _materialise_usage(work_order, material, *, quantity=None):
+    """The frozen usage row a *generated* work order carries per template material.
+
+    Mirrors ``generate_work_order``: quantity planned and quantity used both
+    start at the template's quantity, and the row starts un-used.
+    """
+    quantity = material.quantity if quantity is None else Decimal(quantity)
+    return WorkOrderMaterialUsage.objects.create(
+        work_order=work_order,
+        material=material,
+        material_name=material.name,
+        quantity_planned=quantity,
+        quantity_used=quantity,
+        unit=material.unit,
+    )
+
+
+def _ad_hoc_usage(item, *, work_order, quantity, material_name="ad-hoc widget"):
+    """An ad-hoc material line typed in during the job (op-768w), linked to stock."""
+    return WorkOrderMaterialUsage.objects.create(
+        work_order=work_order,
+        material=None,
+        is_ad_hoc=True,
+        inventory_item=item,
+        material_name=material_name,
+        quantity_planned=Decimal(quantity),
+        quantity_used=Decimal(quantity),
+    )
+
+
+def _corrective_work_order(asset, *, status=WorkOrder.Status.OPEN):
+    """A template-less work order — the only kind ad-hoc materials can hang off."""
+    return WorkOrder.objects.create(asset=asset, status=status)
 
 
 class TestMetricsEndpointContract:
@@ -237,6 +302,316 @@ class TestQuantityCommittedAndAvailable:
 
         assert data["quantity_committed"] == 5.0
         assert data["quantity_available"] == -4.0
+
+
+class TestCommittedFromWorkOrderMaterialUsage:
+    """QC counts the ACTUAL material rows too, not just PM-template specs.
+
+    A corrective work order has no template at all, so every material on it is
+    an ad-hoc ``WorkOrderMaterialUsage`` row — exactly the demand that used to
+    be invisible to QC.
+    """
+
+    def test_ad_hoc_line_on_an_open_work_order_is_committed(self, api_client):
+        item = InventoryItemFactory(image=None, current_stock=20, reorder_quantity=1)
+        _ad_hoc_usage(item, work_order=_corrective_work_order(AssetFactory()), quantity="3")
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_committed"] == 3.0
+        assert data["quantity_available"] == 17.0  # 20 on hand - 3 assigned to the job
+
+    @pytest.mark.parametrize(
+        "wo_status",
+        [WorkOrder.Status.OPEN, WorkOrder.Status.IN_PROGRESS, WorkOrder.Status.BLOCKED],
+    )
+    def test_every_open_status_commits(self, api_client, wo_status):
+        item = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=1)
+        work_order = _corrective_work_order(AssetFactory(), status=wo_status)
+        _ad_hoc_usage(item, work_order=work_order, quantity="2")
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_committed"] == 2.0
+
+    def test_completed_work_order_is_not_committed(self, api_client):
+        item = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=1)
+        work_order = _corrective_work_order(AssetFactory(), status=WorkOrder.Status.COMPLETED)
+        _ad_hoc_usage(item, work_order=work_order, quantity="4")
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_committed"] == 0.0
+        assert data["quantity_available"] == 10.0
+        assert data["committed_breakdown"] == []
+
+    def test_consuming_the_line_moves_it_out_of_committed_not_double_counts(self, api_client):
+        """The same line before and after it is marked used: never subtracted twice.
+
+        Before: stock is untouched and the units are committed. After: the units
+        have left ``current_stock``, so QC must drop them — available is the
+        same number either side of the consume.
+        """
+        item = InventoryItemFactory(image=None, current_stock=20, reorder_quantity=1)
+        usage = _ad_hoc_usage(item, work_order=_corrective_work_order(AssetFactory()), quantity="3")
+
+        before = api_client.get(_metrics_url(item)).json()
+        assert before["current_stock"] == 20
+        assert before["quantity_committed"] == 3.0
+        assert before["quantity_available"] == 17.0
+
+        apply_material_usage(usage, was_used=True)  # the one apply seam (op-uh8z)
+
+        after = api_client.get(_metrics_url(item)).json()
+        assert after["current_stock"] == 17  # stock actually moved
+        assert after["quantity_committed"] == 0.0  # ... so it is no longer committed
+        assert after["quantity_available"] == 17.0  # ... and available did not move twice
+        assert after["committed_breakdown"] == []
+
+    def test_reversing_the_consume_puts_the_line_back_into_committed(self, api_client):
+        item = InventoryItemFactory(image=None, current_stock=20, reorder_quantity=1)
+        usage = _ad_hoc_usage(item, work_order=_corrective_work_order(AssetFactory()), quantity="3")
+        apply_material_usage(usage, was_used=True)
+        apply_material_usage(usage, was_used=False)  # un-marked: stock restored
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["current_stock"] == 20
+        assert data["quantity_committed"] == 3.0
+        assert data["quantity_available"] == 17.0
+
+    def test_out_of_pocket_line_with_no_stock_link_commits_nothing(self, api_client):
+        """An unlinked (flag-only) line moves no stock, so it reserves none either."""
+        item = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=1)
+        WorkOrderMaterialUsage.objects.create(
+            work_order=_corrective_work_order(AssetFactory()),
+            material=None,
+            is_ad_hoc=True,
+            inventory_item=None,
+            material_name="bought at the hardware store",
+            quantity_planned=Decimal("5.00"),
+            quantity_used=Decimal("5.00"),
+            unit_cost=Decimal("9.99"),
+        )
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_committed"] == 0.0
+        assert data["quantity_available"] == 10.0
+
+    def test_ad_hoc_and_template_demand_add_up(self, api_client):
+        """Mixed sources on one item: a PM template WO plus a corrective WO."""
+        item = InventoryItemFactory(image=None, current_stock=20, reorder_quantity=1)
+        asset = AssetFactory()
+        _committed_material(item, asset, quantity="3", wo_statuses=[WorkOrder.Status.OPEN])
+        _ad_hoc_usage(item, work_order=_corrective_work_order(asset), quantity="2")
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_committed"] == 5.0  # 3 template + 2 ad-hoc
+        assert data["quantity_available"] == 15.0
+
+    def test_multiple_lines_on_one_work_order_sum(self, api_client):
+        item = InventoryItemFactory(image=None, current_stock=20, reorder_quantity=1)
+        work_order = _corrective_work_order(AssetFactory())
+        _ad_hoc_usage(item, work_order=work_order, quantity="2", material_name="first")
+        _ad_hoc_usage(item, work_order=work_order, quantity="3", material_name="second")
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_committed"] == 5.0
+        assert len(data["committed_breakdown"]) == 1  # one work order, one entry
+        assert data["committed_breakdown"][0]["quantity"] == 5.0
+
+
+class TestCommittedTemplateVsUsageReconciliation:
+    """A generated work order carries BOTH a template spec and a frozen usage
+    row for it. Counting each would double the demand, so the actual rows win
+    per work order and the template is the fallback for a work order that has
+    not materialised any.
+    """
+
+    def test_template_material_still_counts_when_no_usage_rows_exist(self, api_client):
+        """Pre-existing behavior, unchanged: the spec is the only signal there is."""
+        item = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=1)
+        _committed_material(item, AssetFactory(), quantity="4", wo_statuses=[WorkOrder.Status.OPEN])
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_committed"] == 4.0
+        assert data["quantity_available"] == 6.0
+
+    def test_materialised_usage_row_supersedes_its_template_spec(self, api_client):
+        item = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=1)
+        material, work_orders = _template_material(
+            item, AssetFactory(), quantity="4", wo_statuses=[WorkOrder.Status.OPEN]
+        )
+        _materialise_usage(work_orders[0], material)
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_committed"] == 4.0  # not 8.0 — counted once
+        assert data["quantity_available"] == 6.0
+        assert len(data["committed_breakdown"]) == 1
+
+    def test_usage_row_quantity_wins_over_the_template_quantity(self, api_client):
+        """Edited on the job (2 instead of the planned 4): QC follows the real row."""
+        item = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=1)
+        material, work_orders = _template_material(
+            item, AssetFactory(), quantity="4", wo_statuses=[WorkOrder.Status.OPEN]
+        )
+        _materialise_usage(work_orders[0], material, quantity="2")
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_committed"] == 2.0
+        assert data["quantity_available"] == 8.0
+
+    def test_consumed_template_material_is_not_transiently_double_counted(self, api_client):
+        """The flagged bug: a material consumed while its work order is STILL open.
+
+        Stock has already dropped, so the template spec must stop being counted
+        as committed — otherwise the same units are subtracted twice.
+        """
+        item = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=1)
+        material, work_orders = _template_material(
+            item, AssetFactory(), quantity="4", wo_statuses=[WorkOrder.Status.OPEN]
+        )
+        usage = _materialise_usage(work_orders[0], material)
+
+        apply_material_usage(usage, was_used=True)
+        work_orders[0].refresh_from_db()
+        assert work_orders[0].status == WorkOrder.Status.OPEN  # job is not finished
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["current_stock"] == 6  # 10 - 4 consumed
+        assert data["quantity_committed"] == 0.0  # NOT 4.0 (the double-count)
+        assert data["quantity_available"] == 6.0  # NOT 2.0
+
+    def test_template_falls_back_to_the_work_order_that_has_no_usage_rows(self, api_client):
+        """Two open work orders off one task, only one of them materialised.
+
+        The material is still needed for the un-materialised job, so it counts
+        once — attributed to that work order, not to the materialised one.
+        """
+        item = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=1)
+        material, work_orders = _template_material(
+            item,
+            AssetFactory(),
+            quantity="4",
+            wo_statuses=[WorkOrder.Status.OPEN, WorkOrder.Status.IN_PROGRESS],
+        )
+        materialised, bare = work_orders
+        usage = _materialise_usage(materialised, material)
+        apply_material_usage(usage, was_used=True)  # that job consumed its share
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["current_stock"] == 6
+        assert data["quantity_committed"] == 4.0  # the still-unstarted job's share
+        assert [entry["work_order_id"] for entry in data["committed_breakdown"]] == [str(bare.id)]
+
+    def test_template_material_not_double_counted_across_open_work_orders(self, api_client):
+        """Pre-existing rule kept: one material, one count, however many WOs."""
+        item = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=1)
+        _committed_material(
+            item,
+            AssetFactory(),
+            quantity="4",
+            wo_statuses=[WorkOrder.Status.OPEN, WorkOrder.Status.IN_PROGRESS],
+        )
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_committed"] == 4.0  # not 8.0
+        assert len(data["committed_breakdown"]) == 1  # attributed to exactly one WO
+
+
+class TestCommittedBreakdown:
+    """``committed_breakdown`` — WHERE the committed stock is going."""
+
+    def test_lists_each_work_order_with_its_asset_and_quantity(self, api_client):
+        item = InventoryItemFactory(image=None, current_stock=20, reorder_quantity=1)
+        lathe = AssetFactory(name="Lathe")
+        mill = AssetFactory(name="Mill")
+        lathe_wo = _corrective_work_order(lathe)
+        mill_wo = _corrective_work_order(mill)
+        _ad_hoc_usage(item, work_order=lathe_wo, quantity="3")
+        _ad_hoc_usage(item, work_order=mill_wo, quantity="2")
+        # Oldest first, whatever order the rows were written in.
+        now = timezone.now()
+        WorkOrder.objects.filter(pk=mill_wo.pk).update(created_at=now - timedelta(days=2))
+        WorkOrder.objects.filter(pk=lathe_wo.pk).update(created_at=now - timedelta(days=1))
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_committed"] == 5.0
+        assert data["committed_breakdown"] == [
+            {
+                "work_order_id": str(mill_wo.id),
+                "work_order_short_id": mill_wo.short_id,
+                "asset_id": str(mill.id),
+                "asset_name": "Mill",
+                "quantity": 2.0,
+            },
+            {
+                "work_order_id": str(lathe_wo.id),
+                "work_order_short_id": lathe_wo.short_id,
+                "asset_id": str(lathe.id),
+                "asset_name": "Lathe",
+                "quantity": 3.0,
+            },
+        ]
+
+    def test_entries_sum_to_quantity_committed(self, api_client):
+        item = InventoryItemFactory(image=None, current_stock=50, reorder_quantity=1)
+        asset = AssetFactory()
+        _committed_material(item, asset, quantity="3", wo_statuses=[WorkOrder.Status.OPEN])
+        _ad_hoc_usage(item, work_order=_corrective_work_order(asset), quantity="2")
+        _ad_hoc_usage(item, work_order=_corrective_work_order(asset), quantity="7")
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        entries = data["committed_breakdown"]
+        assert len(entries) == 3
+        assert all(set(entry) == BREAKDOWN_FIELDS for entry in entries)
+        assert sum(entry["quantity"] for entry in entries) == data["quantity_committed"] == 12.0
+
+    def test_is_empty_when_nothing_is_committed(self, api_client):
+        item = InventoryItemFactory(image=None, current_stock=5, reorder_quantity=1)
+
+        data = api_client.get(_metrics_url(item)).json()
+
+        assert data["quantity_committed"] == 0.0
+        assert data["committed_breakdown"] == []
+
+    def test_template_material_is_attributed_to_its_work_orders_asset(self, api_client):
+        item = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=1)
+        asset = AssetFactory(name="Bandsaw")
+        _material, work_orders = _template_material(
+            item, asset, quantity="4", wo_statuses=[WorkOrder.Status.OPEN]
+        )
+
+        entry = api_client.get(_metrics_url(item)).json()["committed_breakdown"][0]
+
+        assert entry["work_order_id"] == str(work_orders[0].id)
+        assert entry["work_order_short_id"] == work_orders[0].short_id
+        assert entry["asset_id"] == str(asset.id)
+        assert entry["asset_name"] == "Bandsaw"
+        assert entry["quantity"] == 4.0
+
+    def test_another_items_demand_never_leaks_into_this_ones_breakdown(self, api_client):
+        mine = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=1)
+        theirs = InventoryItemFactory(image=None, current_stock=10, reorder_quantity=1)
+        work_order = _corrective_work_order(AssetFactory())
+        _ad_hoc_usage(mine, work_order=work_order, quantity="1", material_name="mine")
+        _ad_hoc_usage(theirs, work_order=work_order, quantity="9", material_name="theirs")
+
+        data = api_client.get(_metrics_url(mine)).json()
+
+        assert data["quantity_committed"] == 1.0
+        assert [entry["quantity"] for entry in data["committed_breakdown"]] == [1.0]
 
 
 class TestCostAndTrend:


### PR DESCRIPTION
## Backend: count ad-hoc/per-WO material usage in Committed + attribute it (`op-l4i0`)

**Ian's ask #3 (full):** WO-assigned quantities should subtract from Available and be attributed. The QA/QC split existed but `quantity_committed` only counted PM-template materials — it missed the **ad-hoc/corrective-WO** usage Ian is now doing.

### What changed (`item_metrics.py`, backend-only)
- `quantity_committed` now counts **un-consumed `WorkOrderMaterialUsage`** rows (ad-hoc + per-WO) alongside PM-template `MaintenanceMaterial`, reconciled **per (work order, item)**: actual usage rows are authoritative for a WO that materialised any (a `was_used`/applied row contributes **0** — its units already left `current_stock`, killing the transient double-count); the template is the fallback for a WO with no usage rows yet, counted at most once across several open WOs.
- Added **`committed_breakdown`** to the metrics payload: one entry per WO holding a share of QC (`work_order_id`/`short_id`/`asset_id`/`asset_name`/`quantity`), oldest first, summing to `quantity_committed` — the "assign it to an asset" attribution.
- `quantity_available = current_stock − quantity_committed` unchanged. No migration, no new endpoint (permission matrix unchanged).

### Verify (worker, Postgres): 52 tests (28 new) in test_inventory_metrics + test_inventory_list_metrics; full backend suite 3994 passed (2 pre-existing MEDIA_ROOT flakes, 11/11 on clean media); frontend 1290; black/isort/flake8 clean; permission-matrix 896 match; makemigrations clean. Batch helper still constant queries/page. Based on current main `29fd41a`.
### Follow-on: web + ScanTTY surface `committed_breakdown` under the Available/Committed metric.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
