### PR TITLE
feat(web): Inventory Purchase/Receipts tab + Committed-to breakdown (op-u9ap)

### DIFF
--- a/frontend/src/__tests__/components/CommittedBreakdown.test.tsx
+++ b/frontend/src/__tests__/components/CommittedBreakdown.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Tests for CommittedBreakdown (op-u9ap) — the "Committed to" strip that
+ * attributes an item's committed quantity (QC) to the open work orders and
+ * assets holding it, from the metrics payload's `committed_breakdown`
+ * (op-l4i0).
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import CommittedBreakdown from '../../components/inventory/CommittedBreakdown';
+import { CommittedBreakdownEntry } from '../../types';
+
+const renderBreakdown = (entries: CommittedBreakdownEntry[], totalCommitted: number) =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <CommittedBreakdown entries={entries} totalCommitted={totalCommitted} />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+const entries: CommittedBreakdownEntry[] = [
+  {
+    work_order_id: 'wo-1',
+    work_order_short_id: 'WO-1A2B3C4D',
+    asset_id: 'asset-1',
+    asset_name: 'Laser Cutter',
+    quantity: 3,
+  },
+  {
+    work_order_id: 'wo-2',
+    work_order_short_id: 'WO-9F8E7D6C',
+    asset_id: null,
+    asset_name: null,
+    quantity: 1,
+  },
+];
+
+describe('CommittedBreakdown', () => {
+  it('lists each work order with its asset and quantity, summing to QC', () => {
+    renderBreakdown(entries, 4);
+
+    const panel = screen.getByTestId('committed-breakdown');
+    expect(panel).toHaveTextContent('Committed to');
+    expect(panel).toHaveTextContent('4 committed across 2 open work orders');
+
+    const first = screen.getByTestId('committed-entry-wo-1');
+    expect(within(first).getByText('WO-1A2B3C4D')).toBeInTheDocument();
+    expect(within(first).getByText('Laser Cutter')).toBeInTheDocument();
+    expect(within(first).getByText('3')).toBeInTheDocument();
+  });
+
+  it('links each entry to its work order', () => {
+    renderBreakdown(entries, 4);
+
+    expect(screen.getByText('WO-1A2B3C4D').closest('a')).toHaveAttribute(
+      'href',
+      '/maintenance/work-orders/wo-1',
+    );
+  });
+
+  it('labels an asset-less work order rather than dropping the row', () => {
+    renderBreakdown(entries, 4);
+
+    const assetless = screen.getByTestId('committed-entry-wo-2');
+    expect(within(assetless).getByText('No asset')).toBeInTheDocument();
+    expect(within(assetless).getByText('1')).toBeInTheDocument();
+  });
+
+  it('formats a fractional committed quantity to two decimals', () => {
+    renderBreakdown(
+      [{ ...entries[0], quantity: 2.5 }],
+      2.5,
+    );
+
+    const panel = screen.getByTestId('committed-breakdown');
+    expect(panel).toHaveTextContent('2.50 committed across 1 open work order');
+    expect(within(screen.getByTestId('committed-entry-wo-1')).getByText('2.50')).toBeInTheDocument();
+  });
+
+  it('explains the empty case instead of showing a bare zero', () => {
+    renderBreakdown([], 0);
+
+    expect(screen.getByTestId('committed-breakdown-empty')).toHaveTextContent(
+      'Nothing is committed to an open work order.',
+    );
+  });
+});

--- a/frontend/src/__tests__/components/InventoryMetricsRow.test.tsx
+++ b/frontend/src/__tests__/components/InventoryMetricsRow.test.tsx
@@ -14,6 +14,7 @@ const buildMetrics = (overrides: Partial<InventoryItemMetrics> = {}): InventoryI
   quantity_on_order: 7,
   quantity_available: 6,
   quantity_committed: 4,
+  committed_breakdown: [],
   quantity_in_transit: 3,
   reorder_point: 5,
   lead_time_days: 14,

--- a/frontend/src/__tests__/components/PurchaseReceiptsPanel.test.tsx
+++ b/frontend/src/__tests__/components/PurchaseReceiptsPanel.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Tests for PurchaseReceiptsPanel (op-u9ap) — the "Purchase / Receipts" tab
+ * rendering GET /inventory/items/<id>/purchase_history/ (op-96uo): per-order
+ * unit costs plus every delivery, grouped by order.
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import PurchaseReceiptsPanel from '../../components/inventory/PurchaseReceiptsPanel';
+import { ItemPurchaseHistory } from '../../types';
+
+const renderPanel = (history: ItemPurchaseHistory | null) =>
+  render(
+    <MantineProvider>
+      <MemoryRouter>
+        <PurchaseReceiptsPanel history={history} />
+      </MemoryRouter>
+    </MantineProvider>,
+  );
+
+// One item, two orders: the second was cheaper per unit and shipped in two
+// packages — the case the tab exists to make visible.
+const history: ItemPurchaseHistory = {
+  order_costs: [
+    {
+      purchase_order: 11,
+      po_number: 'PO-0001',
+      order_date: '2026-01-05T10:00:00Z',
+      status: 'received',
+      quantity_ordered: 10,
+      unit_cost_ordered: '3.2500',
+      unit_cost_actual: '3.5000',
+    },
+    {
+      purchase_order: 12,
+      po_number: 'PO-0002',
+      order_date: '2026-02-05T10:00:00Z',
+      status: 'ordered',
+      quantity_ordered: 25,
+      unit_cost_ordered: '2.1000',
+      unit_cost_actual: null,
+    },
+  ],
+  deliveries: [
+    {
+      purchase_order: 11,
+      po_number: 'PO-0001',
+      delivery_date: '2026-01-12T10:00:00Z',
+      tracking_number: '1Z-AAA',
+      carrier: 'UPS',
+      quantity_received: 10,
+      receipt_notes: 'All good',
+      is_complete: true,
+    },
+    {
+      purchase_order: 12,
+      po_number: 'PO-0002',
+      delivery_date: '2026-02-10T10:00:00Z',
+      tracking_number: '1Z-BBB',
+      carrier: 'FedEx',
+      quantity_received: 15,
+      receipt_notes: 'Backordered remainder',
+      is_complete: false,
+    },
+    {
+      purchase_order: 12,
+      po_number: 'PO-0002',
+      delivery_date: '2026-02-18T10:00:00Z',
+      tracking_number: '1Z-CCC',
+      carrier: 'FedEx',
+      quantity_received: 10,
+      receipt_notes: '',
+      is_complete: true,
+    },
+  ],
+};
+
+describe('PurchaseReceiptsPanel', () => {
+  it('renders the per-order cost history with ordered and actual unit costs', () => {
+    renderPanel(history);
+
+    const costs = screen.getByTestId('order-cost-history');
+    expect(within(costs).getByText('PO-0001')).toBeInTheDocument();
+    expect(within(costs).getByText('received')).toBeInTheDocument();
+    expect(within(costs).getByText('10')).toBeInTheDocument();
+    // Cost drifted between the two orders — both numbers are on screen.
+    expect(within(costs).getByText('$3.25')).toBeInTheDocument();
+    expect(within(costs).getByText('$3.50')).toBeInTheDocument();
+    expect(within(costs).getByText('$2.10')).toBeInTheDocument();
+    // No actual cost yet on the open order.
+    expect(within(costs).getByText('—')).toBeInTheDocument();
+  });
+
+  it('links each order line to its purchase order by pk', () => {
+    renderPanel(history);
+
+    const costs = screen.getByTestId('order-cost-history');
+    expect(within(costs).getByText('PO-0001').closest('a')).toHaveAttribute(
+      'href',
+      '/purchasing/orders/11',
+    );
+  });
+
+  it('groups deliveries by order so one order shows all of its tracking numbers', () => {
+    renderPanel(history);
+
+    const singleShipment = screen.getByTestId('delivery-group-11');
+    expect(singleShipment).toHaveTextContent('1 delivery');
+    expect(singleShipment).toHaveTextContent('1Z-AAA');
+    expect(singleShipment).toHaveTextContent('UPS');
+    expect(singleShipment).toHaveTextContent('All good');
+    expect(singleShipment).toHaveTextContent('Complete');
+
+    const splitShipment = screen.getByTestId('delivery-group-12');
+    expect(splitShipment).toHaveTextContent('2 deliveries');
+    expect(splitShipment).toHaveTextContent('1Z-BBB');
+    expect(splitShipment).toHaveTextContent('1Z-CCC');
+    expect(splitShipment).toHaveTextContent('Partial');
+    // Each package's own receipt is separate — quantities are not merged.
+    expect(splitShipment).toHaveTextContent('15');
+    expect(splitShipment).toHaveTextContent('10');
+  });
+
+  it('labels an order that has no po_number by its pk and still links it', () => {
+    renderPanel({
+      order_costs: [
+        {
+          purchase_order: 42,
+          po_number: null,
+          order_date: '2026-03-01T10:00:00Z',
+          status: 'draft',
+          quantity_ordered: 4,
+          unit_cost_ordered: '1.0000',
+          unit_cost_actual: null,
+        },
+      ],
+      deliveries: [],
+    });
+
+    const link = screen.getByText('PO #42');
+    expect(link.closest('a')).toHaveAttribute('href', '/purchasing/orders/42');
+  });
+
+  it('renders empty-state copy for both sections when the item has no history', () => {
+    renderPanel({ order_costs: [], deliveries: [] });
+
+    expect(screen.getByText('This item has never been ordered.')).toBeInTheDocument();
+    expect(screen.getByText('No deliveries recorded for this item.')).toBeInTheDocument();
+  });
+
+  it('degrades to the empty state when the payload never loaded', () => {
+    renderPanel(null);
+
+    expect(screen.getByText('This item has never been ordered.')).toBeInTheDocument();
+    expect(screen.getByText('No deliveries recorded for this item.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/InventoryItemDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemDetailPage.test.tsx
@@ -96,6 +96,7 @@ describe('InventoryItemDetailPage', () => {
     quantity_on_order: 20,
     quantity_available: 8,
     quantity_committed: 2,
+    committed_breakdown: [],
     quantity_in_transit: 5,
     reorder_point: 20,
     lead_time_days: 7,
@@ -122,6 +123,9 @@ describe('InventoryItemDetailPage', () => {
     });
     (api.assetsAPI.listAssets as jest.Mock).mockResolvedValue({
       data: { results: [] },
+    });
+    (api.inventoryAPI.getPurchaseHistory as jest.Mock).mockResolvedValue({
+      data: { order_costs: [], deliveries: [] },
     });
   });
 
@@ -567,5 +571,150 @@ describe('InventoryItemDetailPage', () => {
     // The item view is intact; only the metrics strip is absent.
     expect(screen.queryByTestId('inventory-metrics-row')).not.toBeInTheDocument();
     consoleError.mockRestore();
+  });
+
+  // ---- op-u9ap: Purchase / Receipts tab (#969) ----
+
+  it('loads the purchase history and renders order costs plus deliveries grouped by order', async () => {
+    (api.inventoryAPI.getPurchaseHistory as jest.Mock).mockResolvedValue({
+      data: {
+        order_costs: [
+          {
+            purchase_order: 7,
+            po_number: 'PO-0007',
+            order_date: '2026-01-05T10:00:00Z',
+            status: 'received',
+            quantity_ordered: 12,
+            unit_cost_ordered: '4.5000',
+            unit_cost_actual: '4.7500',
+          },
+        ],
+        deliveries: [
+          {
+            purchase_order: 7,
+            po_number: 'PO-0007',
+            delivery_date: '2026-01-10T10:00:00Z',
+            tracking_number: '1Z-FIRST',
+            carrier: 'UPS',
+            quantity_received: 8,
+            receipt_notes: 'Short shipped',
+            is_complete: false,
+          },
+          {
+            purchase_order: 7,
+            po_number: 'PO-0007',
+            delivery_date: '2026-01-17T10:00:00Z',
+            tracking_number: '1Z-SECOND',
+            carrier: 'UPS',
+            quantity_received: 4,
+            receipt_notes: '',
+            is_complete: true,
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item')).toBeInTheDocument();
+    });
+    expect(api.inventoryAPI.getPurchaseHistory).toHaveBeenCalledWith('test-id');
+
+    fireEvent.click(screen.getByRole('tab', { name: /Purchase \/ Receipts/i }));
+
+    const costs = await screen.findByTestId('order-cost-history');
+    expect(costs).toHaveTextContent('PO-0007');
+    expect(costs).toHaveTextContent('$4.50');
+    expect(costs).toHaveTextContent('$4.75');
+
+    // One order, two tracking numbers — the whole point of grouping by PO.
+    const group = screen.getByTestId('delivery-group-7');
+    expect(group).toHaveTextContent('2 deliveries');
+    expect(group).toHaveTextContent('1Z-FIRST');
+    expect(group).toHaveTextContent('1Z-SECOND');
+    expect(group).toHaveTextContent('Short shipped');
+  });
+
+  it('shows the purchase/receipts empty states when the item has no orders', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: /Purchase \/ Receipts/i }));
+
+    expect(await screen.findByText('This item has never been ordered.')).toBeInTheDocument();
+    expect(screen.getByText('No deliveries recorded for this item.')).toBeInTheDocument();
+  });
+
+  it('still renders the item when the purchase-history call fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (api.inventoryAPI.getPurchaseHistory as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: /Purchase \/ Receipts/i }));
+    expect(await screen.findByText('This item has never been ordered.')).toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
+  // ---- op-u9ap: committed-quantity attribution (#970) ----
+
+  it('attributes the committed quantity to its work orders under the metrics row', async () => {
+    (api.inventoryAPI.getItemMetrics as jest.Mock).mockResolvedValue({
+      data: {
+        ...mockMetrics,
+        quantity_committed: 4,
+        committed_breakdown: [
+          {
+            work_order_id: 'wo-1',
+            work_order_short_id: 'WO-1A2B3C4D',
+            asset_id: 'asset-1',
+            asset_name: 'Laser Cutter',
+            quantity: 3,
+          },
+          {
+            work_order_id: 'wo-2',
+            work_order_short_id: 'WO-9F8E7D6C',
+            asset_id: null,
+            asset_name: null,
+            quantity: 1,
+          },
+        ],
+      },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item')).toBeInTheDocument();
+    });
+
+    const breakdown = await screen.findByTestId('committed-breakdown');
+    expect(breakdown).toHaveTextContent('Committed to');
+    // The rows sum to the QC cell shown in the strip above them.
+    expect(screen.getByTestId('metric-qc')).toHaveTextContent('4');
+    expect(breakdown).toHaveTextContent('WO-1A2B3C4D');
+    expect(breakdown).toHaveTextContent('Laser Cutter');
+    expect(breakdown).toHaveTextContent('WO-9F8E7D6C');
+    expect(breakdown).toHaveTextContent('No asset');
+  });
+
+  it('explains an empty committed breakdown rather than hiding it', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Item')).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId('committed-breakdown-empty')).toHaveTextContent(
+      'Nothing is committed to an open work order.'
+    );
   });
 });

--- a/frontend/src/components/inventory/CommittedBreakdown.tsx
+++ b/frontend/src/components/inventory/CommittedBreakdown.tsx
@@ -1,0 +1,77 @@
+/**
+ * CommittedBreakdown — "Committed to" attribution strip that sits directly
+ * under the QA/QC metrics row on the inventory item detail page (op-u9ap).
+ *
+ * Renders the `committed_breakdown` entries carried in the metrics payload
+ * (op-l4i0): which open work orders — and so which machines — hold the item's
+ * committed quantity. Entries arrive oldest work order first and sum to QC, so
+ * this is the answer to "why is available less than on hand, and who has it?".
+ *
+ * Purely presentational; the page fetches the metrics and passes them in.
+ */
+import { Anchor, Group, Paper, Stack, Text } from '@mantine/core';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { CommittedBreakdownEntry } from '../../types';
+
+interface CommittedBreakdownProps {
+  entries: CommittedBreakdownEntry[];
+  totalCommitted: number;
+}
+
+// Committed quantities are floats (a template can commit a fraction of a
+// unit), so only show decimals when there are any. Mirrors InventoryMetricsRow.
+const formatQuantity = (value: number): string =>
+  Number.isInteger(value) ? String(value) : value.toFixed(2);
+
+const CommittedBreakdown: React.FC<CommittedBreakdownProps> = ({ entries, totalCommitted }) => (
+  <Paper withBorder p="md" radius="md" data-testid="committed-breakdown">
+    <Group justify="space-between" align="baseline" mb={entries.length === 0 ? 0 : 'xs'}>
+      <Text size="xs" c="dimmed" fw={700} tt="uppercase">
+        Committed to
+      </Text>
+      <Text size="sm" c="dimmed">
+        {formatQuantity(totalCommitted)} committed across {entries.length} open work order
+        {entries.length === 1 ? '' : 's'}
+      </Text>
+    </Group>
+    {entries.length === 0 ? (
+      <Text size="sm" c="dimmed" mt="xs" data-testid="committed-breakdown-empty">
+        Nothing is committed to an open work order.
+      </Text>
+    ) : (
+      <Stack gap={4}>
+        {entries.map((entry) => (
+          <Group
+            key={entry.work_order_id}
+            justify="space-between"
+            gap="sm"
+            wrap="nowrap"
+            data-testid={`committed-entry-${entry.work_order_id}`}
+          >
+            <Group gap="xs" wrap="nowrap">
+              <Anchor
+                component={Link}
+                to={`/maintenance/work-orders/${entry.work_order_id}`}
+                size="sm"
+              >
+                {entry.work_order_short_id}
+              </Anchor>
+              {/* A work order need not target an asset (op-svut), so the
+                  machine column degrades instead of disappearing. */}
+              <Text size="sm" c={entry.asset_name ? undefined : 'dimmed'}>
+                {entry.asset_name || 'No asset'}
+              </Text>
+            </Group>
+            <Text size="sm" fw={600}>
+              {formatQuantity(entry.quantity)}
+            </Text>
+          </Group>
+        ))}
+      </Stack>
+    )}
+  </Paper>
+);
+
+export default CommittedBreakdown;

--- a/frontend/src/components/inventory/PurchaseReceiptsPanel.tsx
+++ b/frontend/src/components/inventory/PurchaseReceiptsPanel.tsx
@@ -1,0 +1,183 @@
+/**
+ * PurchaseReceiptsPanel — the "Purchase / Receipts" tab of the inventory item
+ * detail page (op-u9ap), rendering GET
+ * /api/inventory/items/<id>/purchase_history/ (op-96uo).
+ *
+ * Two views of the same provenance:
+ *  - **Order cost history** — one row per purchase-order line, oldest first, so
+ *    what we paid per order (and how it drifted) is visible on one screen.
+ *  - **Deliveries / tracking** — delivery rows grouped by purchase order, so a
+ *    partially-shipped order shows all of its tracking numbers under one
+ *    heading. Grouping is by the PO **pk**, never `po_number`, which is
+ *    nullable.
+ *
+ * Purely presentational: the page fetches the payload and passes it in.
+ */
+import { Anchor, Badge, Card, Stack, Table, Text, Title } from '@mantine/core';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { ItemDelivery, ItemPurchaseHistory } from '../../types';
+
+interface PurchaseReceiptsPanelProps {
+  history: ItemPurchaseHistory | null;
+}
+
+// Money arrives as a DRF decimal string ("3.2500"); show it as currency.
+const formatMoney = (value: string | null): string =>
+  value == null || value === '' ? '—' : `$${parseFloat(value).toFixed(2)}`;
+
+const formatDate = (value: string): string => new Date(value).toLocaleDateString();
+
+// A PO without a number is still a real order — label it by pk so the row is
+// never anonymous and the link still works.
+const poLabel = (poNumber: string | null, purchaseOrder: number): string =>
+  poNumber || `PO #${purchaseOrder}`;
+
+const PurchaseOrderLink: React.FC<{ poNumber: string | null; purchaseOrder: number }> = ({
+  poNumber,
+  purchaseOrder,
+}) => (
+  <Anchor component={Link} to={`/purchasing/orders/${purchaseOrder}`}>
+    {poLabel(poNumber, purchaseOrder)}
+  </Anchor>
+);
+
+interface DeliveryGroup {
+  purchaseOrder: number;
+  poNumber: string | null;
+  rows: ItemDelivery[];
+}
+
+/**
+ * Group deliveries by purchase order, preserving the backend's oldest-first
+ * ordering both between groups and within one.
+ */
+const groupDeliveries = (deliveries: ItemDelivery[]): DeliveryGroup[] => {
+  const groups = new Map<number, DeliveryGroup>();
+  deliveries.forEach((row) => {
+    const existing = groups.get(row.purchase_order);
+    if (existing) {
+      existing.rows.push(row);
+    } else {
+      groups.set(row.purchase_order, {
+        purchaseOrder: row.purchase_order,
+        poNumber: row.po_number,
+        rows: [row],
+      });
+    }
+  });
+  return Array.from(groups.values());
+};
+
+const PurchaseReceiptsPanel: React.FC<PurchaseReceiptsPanelProps> = ({ history }) => {
+  const orderCosts = history?.order_costs || [];
+  const deliveryGroups = groupDeliveries(history?.deliveries || []);
+
+  return (
+    <Stack gap="md">
+      <Card withBorder p="md" data-testid="order-cost-history">
+        <Title order={4} mb="xs">
+          Order cost history
+        </Title>
+        <Text size="sm" c="dimmed" mb="md">
+          What this item cost on each purchase order, oldest first.
+        </Text>
+        {orderCosts.length === 0 ? (
+          <Text c="dimmed">This item has never been ordered.</Text>
+        ) : (
+          <Table>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>PO</Table.Th>
+                <Table.Th>Ordered</Table.Th>
+                <Table.Th>Status</Table.Th>
+                <Table.Th>Qty</Table.Th>
+                <Table.Th>Unit cost (ordered)</Table.Th>
+                <Table.Th>Unit cost (actual)</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {orderCosts.map((line, index) => (
+                // A PO can carry the same item on more than one line, so the pk
+                // alone is not unique — pair it with the row position.
+                <Table.Tr key={`${line.purchase_order}-${index}`}>
+                  <Table.Td>
+                    <PurchaseOrderLink
+                      poNumber={line.po_number}
+                      purchaseOrder={line.purchase_order}
+                    />
+                  </Table.Td>
+                  <Table.Td>{formatDate(line.order_date)}</Table.Td>
+                  <Table.Td>
+                    <Badge variant="light">{line.status}</Badge>
+                  </Table.Td>
+                  <Table.Td>{line.quantity_ordered}</Table.Td>
+                  <Table.Td>{formatMoney(line.unit_cost_ordered)}</Table.Td>
+                  <Table.Td>{formatMoney(line.unit_cost_actual)}</Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        )}
+      </Card>
+
+      <Card withBorder p="md" data-testid="deliveries-tracking">
+        <Title order={4} mb="xs">
+          Deliveries / tracking
+        </Title>
+        <Text size="sm" c="dimmed" mb="md">
+          Every receipt of this item, grouped by order. One order can ship in
+          several packages, each with its own tracking number.
+        </Text>
+        {deliveryGroups.length === 0 ? (
+          <Text c="dimmed">No deliveries recorded for this item.</Text>
+        ) : (
+          <Stack gap="lg">
+            {deliveryGroups.map((group) => (
+              <div key={group.purchaseOrder} data-testid={`delivery-group-${group.purchaseOrder}`}>
+                <Text size="sm" fw={600} mb="xs">
+                  <PurchaseOrderLink
+                    poNumber={group.poNumber}
+                    purchaseOrder={group.purchaseOrder}
+                  />{' '}
+                  — {group.rows.length} deliver{group.rows.length === 1 ? 'y' : 'ies'}
+                </Text>
+                <Table>
+                  <Table.Thead>
+                    <Table.Tr>
+                      <Table.Th>Received</Table.Th>
+                      <Table.Th>Tracking #</Table.Th>
+                      <Table.Th>Carrier</Table.Th>
+                      <Table.Th>Qty received</Table.Th>
+                      <Table.Th>Complete</Table.Th>
+                      <Table.Th>Receipt notes</Table.Th>
+                    </Table.Tr>
+                  </Table.Thead>
+                  <Table.Tbody>
+                    {group.rows.map((row, index) => (
+                      <Table.Tr key={`${group.purchaseOrder}-${row.delivery_date}-${index}`}>
+                        <Table.Td>{formatDate(row.delivery_date)}</Table.Td>
+                        <Table.Td>{row.tracking_number || '-'}</Table.Td>
+                        <Table.Td>{row.carrier || '-'}</Table.Td>
+                        <Table.Td>{row.quantity_received}</Table.Td>
+                        <Table.Td>
+                          <Badge color={row.is_complete ? 'green' : 'yellow'} variant="light">
+                            {row.is_complete ? 'Complete' : 'Partial'}
+                          </Badge>
+                        </Table.Td>
+                        <Table.Td>{row.receipt_notes || '-'}</Table.Td>
+                      </Table.Tr>
+                    ))}
+                  </Table.Tbody>
+                </Table>
+              </div>
+            ))}
+          </Stack>
+        )}
+      </Card>
+    </Stack>
+  );
+};
+
+export default PurchaseReceiptsPanel;

--- a/frontend/src/pages/InventoryItemDetailPage.tsx
+++ b/frontend/src/pages/InventoryItemDetailPage.tsx
@@ -25,14 +25,16 @@ import { IconArchive, IconArchiveOff, IconClipboardCheck, IconEdit, IconPackageE
 import { QRCodeSVG } from 'qrcode.react';
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import CommittedBreakdown from '../components/inventory/CommittedBreakdown';
 import InventoryMetricsRow from '../components/inventory/InventoryMetricsRow';
+import PurchaseReceiptsPanel from '../components/inventory/PurchaseReceiptsPanel';
 import SerializedComponentsPanel from '../components/inventory/SerializedComponentsPanel';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import NFPADiamond from '../components/NFPADiamond';
 import StockHistoryChart from '../components/StockHistoryChart';
 import { useNotifications } from '../hooks/useNotifications';
 import { assetsAPI, CycleCountPayload, inventoryAPI, reorderAPI, sigAPI } from '../services/api';
-import { Asset, InventoryItem, InventoryItemMetrics, ReorderRequest, SIG, StockHistory, UsageLog } from '../types';
+import { Asset, InventoryItem, InventoryItemMetrics, ItemPurchaseHistory, ReorderRequest, SIG, StockHistory, UsageLog } from '../types';
 import { showError } from '../utils/dialogs';
 
 // Cycle-count reason options (op-c7y4). Mirrors the reconciliation grid's
@@ -326,6 +328,7 @@ const InventoryItemDetailPage: React.FC = () => {
   const [metrics, setMetrics] = useState<InventoryItemMetrics | null>(null);
   const [usageLogs, setUsageLogs] = useState<UsageLog[]>([]);
   const [stockHistory, setStockHistory] = useState<StockHistory | null>(null);
+  const [purchaseHistory, setPurchaseHistory] = useState<ItemPurchaseHistory | null>(null);
   const [reorderHistory, setReorderHistory] = useState<ReorderRequest[]>([]);
   // Two *different* asset relationships, both surfaced on the Linked Assets
   // tab (op-qdfr). `linkedAssets` = Asset.inventory_item, i.e. the asset IS an
@@ -360,6 +363,7 @@ const InventoryItemDetailPage: React.FC = () => {
       metricsRes,
       usageLogsRes,
       stockHistoryRes,
+      purchaseHistoryRes,
       reorderRes,
       assetsRes,
       usedByRes,
@@ -368,6 +372,7 @@ const InventoryItemDetailPage: React.FC = () => {
       inventoryAPI.getItemMetrics(id),
       inventoryAPI.getUsageLogs(id),
       inventoryAPI.getStockHistory(id),
+      inventoryAPI.getPurchaseHistory(id),
       reorderAPI.listRequests({ status: undefined }),
       assetsAPI.listAssets({ inventory_item: id }),
       assetsAPI.listAssets({ consumable_for_item: id }),
@@ -395,6 +400,15 @@ const InventoryItemDetailPage: React.FC = () => {
       setStockHistory(stockHistoryRes.value.data);
     } else if (stockHistoryRes.status === 'rejected') {
       console.error('Error loading stock history:', stockHistoryRes.reason);
+    }
+
+    // Purchase/receipt provenance is auth-required (unlike the item read), so a
+    // rejection here is expected for an anonymous viewer — the tab degrades to
+    // its empty state rather than taking the page down.
+    if (purchaseHistoryRes.status === 'fulfilled' && purchaseHistoryRes.value) {
+      setPurchaseHistory(purchaseHistoryRes.value.data);
+    } else if (purchaseHistoryRes.status === 'rejected') {
+      console.error('Error loading purchase history:', purchaseHistoryRes.reason);
     }
 
     if (reorderRes.status === 'fulfilled') {
@@ -544,8 +558,18 @@ const InventoryItemDetailPage: React.FC = () => {
       </Group>
 
       {/* Prominent metrics strip — hard to get from a single screen otherwise
-          (issue-5): SKU · QOH · QOO · QA · QC · QIT · RP · Lead · Cost. */}
-      {metrics && <InventoryMetricsRow sku={item.sku} metrics={metrics} />}
+          (issue-5): SKU · QOH · QOO · QA · QC · QIT · RP · Lead · Cost. The
+          "Committed to" strip underneath attributes QC to the work orders (and
+          so the assets) holding it (op-l4i0). */}
+      {metrics && (
+        <>
+          <InventoryMetricsRow sku={item.sku} metrics={metrics} />
+          <CommittedBreakdown
+            entries={metrics.committed_breakdown || []}
+            totalCommitted={metrics.quantity_committed}
+          />
+        </>
+      )}
 
       {/* Tabs */}
       <Tabs value={activeTab} onChange={setActiveTab}>
@@ -553,6 +577,7 @@ const InventoryItemDetailPage: React.FC = () => {
           <Tabs.Tab value="overview">Overview</Tabs.Tab>
           <Tabs.Tab value="stock-history">Stock History</Tabs.Tab>
           <Tabs.Tab value="reorder-history">Reorder History</Tabs.Tab>
+          <Tabs.Tab value="purchase-receipts">Purchase / Receipts</Tabs.Tab>
           <Tabs.Tab value="usage-logs">Usage Logs</Tabs.Tab>
           <Tabs.Tab value="linked-assets">Linked Assets</Tabs.Tab>
           {/* Always present so a user looking to add a serial number can find
@@ -771,6 +796,13 @@ const InventoryItemDetailPage: React.FC = () => {
               </Table>
             )}
           </Card>
+        </Tabs.Panel>
+
+        {/* Purchase / Receipts Tab — per-order cost history plus every
+            delivery of this item, grouped by order so one order's several
+            tracking numbers read as one shipment set (op-96uo). */}
+        <Tabs.Panel value="purchase-receipts" pt="md">
+          <PurchaseReceiptsPanel history={purchaseHistory} />
         </Tabs.Panel>
 
         {/* Usage Logs Tab */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,7 +2,7 @@
  * API service for communicating with the Django backend
  */
 import axios from 'axios';
-import { ActiveMaintenanceRow, Asset, AssetCostRecoveryReport, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, InventoryItemMetrics, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LogUsageRequest, LogUsageResponse, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, MaintenanceTool, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, StockHistory, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderAdHocMaterialInput, WorkOrderLotoCompletion, WorkOrderMaterialUsage, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
+import { ActiveMaintenanceRow, Asset, AssetCostRecoveryReport, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, InventoryItemMetrics, ItemPurchaseHistory, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LogUsageRequest, LogUsageResponse, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, MaintenanceTool, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, StockHistory, Supplier, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderAdHocMaterialInput, WorkOrderLotoCompletion, WorkOrderMaterialUsage, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
 
 /**
  * Resolves the API base URL based on environment.
@@ -216,6 +216,12 @@ export const inventoryAPI = {
   // reorder-event dates + reorder/desired thresholds. Note the underscore.
   getStockHistory: (id: string) =>
     api.get<StockHistory>(`/inventory/items/${id}/stock_history/`),
+
+  // Purchase/receipt provenance (op-96uo backend) — per-order unit costs plus
+  // one row per delivery (tracking numbers). Auth-required; note the
+  // underscore, as with stock_history.
+  getPurchaseHistory: (id: string) =>
+    api.get<ItemPurchaseHistory>(`/inventory/items/${id}/purchase_history/`),
 
   getItemSuppliers: (itemId: string) =>
     api.get<{ results: ItemSupplier[] }>(`/inventory/item-suppliers/?item_id=${itemId}`),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -216,6 +216,18 @@ export interface InventoryItem {
 
 export type InventoryCostTrend = 'up' | 'down' | 'flat' | 'no_history';
 
+// One open work order holding part of an item's committed quantity (op-l4i0).
+// The attribution side of QC: which job — and so which machine — the reserved
+// stock is going to. Entries arrive oldest work order first and sum to
+// `quantity_committed`. `asset_id`/`asset_name` are null on an asset-less WO.
+export interface CommittedBreakdownEntry {
+  work_order_id: string;
+  work_order_short_id: string; // e.g. "WO-1A2B3C4D"
+  asset_id: string | null;
+  asset_name: string | null;
+  quantity: number;
+}
+
 // Computed stock + cost metrics for the item-detail metrics row (issue-5).
 // Served by GET /api/inventory/items/<id>/metrics/. Quantities are numbers;
 // money fields arrive as decimal strings (matching InventoryItem.unit_cost).
@@ -224,6 +236,7 @@ export interface InventoryItemMetrics {
   quantity_on_order: number; // QOO — open PO units
   quantity_available: number; // QA — on hand minus committed
   quantity_committed: number; // QC — open work-order demand
+  committed_breakdown: CommittedBreakdownEntry[]; // which WOs/assets hold QC
   quantity_in_transit: number; // QIT — partially-received (⊆ QOO)
   reorder_point: number; // RP
   lead_time_days: number | null; // Lead
@@ -232,6 +245,41 @@ export interface InventoryItemMetrics {
   last_po_unit_cost: string | null;
   is_case_based: boolean;
   case_size: number | null; // units per case
+}
+
+// Per-item purchase/receipt provenance (op-96uo) — payload of
+// GET /api/inventory/items/<id>/purchase_history/. Both lists are flat, oldest
+// first, and carry the PO pk (`purchase_order`) alongside `po_number` because
+// po_number is nullable and so is not a safe grouping key. Money fields arrive
+// as decimal strings (DRF DecimalField), like InventoryItem.unit_cost.
+
+// One purchase-order line: what this item cost on that order.
+export interface ItemOrderCost {
+  purchase_order: number;
+  po_number: string | null;
+  order_date: string;
+  status: string;
+  quantity_ordered: number;
+  unit_cost_ordered: string;
+  unit_cost_actual: string | null;
+}
+
+// One delivery of the item. A partially-shipped order yields several rows for
+// the same purchase_order, each with its own tracking number.
+export interface ItemDelivery {
+  purchase_order: number;
+  po_number: string | null;
+  delivery_date: string;
+  tracking_number: string;
+  carrier: string;
+  quantity_received: number;
+  receipt_notes: string;
+  is_complete: boolean;
+}
+
+export interface ItemPurchaseHistory {
+  order_costs: ItemOrderCost[];
+  deliveries: ItemDelivery[];
 }
 
 export interface UsageLog {


### PR DESCRIPTION
## Web: Inventory item Purchase/Receipts tab + Committed-to breakdown (`op-u9ap`)

Surfaces the two merged backend endpoints (#969 provenance, #970 committed attribution) on the Inventory Item Detail page. Completes Ian's inventory-detail asks #1 (per-order unit cost), #2 (order/tracking numbers), #3 (committed attribution), #5 (receipt records). Frontend-only.

### What changed
- **New "Purchase / Receipts" tab** (`PurchaseReceiptsPanel`) rendering `GET /api/inventory/items/<id>/purchase_history/`: an order-cost history table (PO link/date/status/qty/**ordered-vs-actual unit cost**) + **deliveries grouped by PO** (po_number is nullable → group by pk) so one order shows **all its tracking numbers**, carriers, qty received, receipt notes.
- **New "Committed to" strip** (`CommittedBreakdown`) under the QA/QC metrics row — WO short-id link + asset name + qty, from #970's `committed_breakdown`; asset-less WOs labeled, not dropped.
- `inventoryAPI.getPurchaseHistory` + `ItemOrderCost`/`ItemDelivery`/`ItemPurchaseHistory` DTOs; `committed_breakdown` added to the metrics DTO. Empty/failed-fetch states for both.

### Verify (worker): lint 0; full vitest 1308 passed/162 files (--testTimeout=15000; the 5s default trips a known unrelated *FormPage import-load flake); tsc src errors unchanged (74, none in new/edited files); 24 new tests. Frontend-only (no backend files). Based on current main `24b5da5`.
### Pairs with ScanTTY #119 (same surface). Closes the inventory-detail batch.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
