### PR TITLE
PO detail: line target-type label + line-items running total (op-49th + op-r1sg)

### DIFF
--- a/frontend/src/__tests__/pages/PurchaseOrderPage.test.tsx
+++ b/frontend/src/__tests__/pages/PurchaseOrderPage.test.tsx
@@ -376,6 +376,147 @@ describe('PurchaseOrderPage line item rendering', () => {
   });
 });
 
+describe('PurchaseOrderPage line target-type label (op-49th)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem('token', 'test-token');
+    localStorage.setItem('is_staff', 'true');
+  });
+
+  test('labels every line with its target type, falling back to — for an unknown type', async () => {
+    const line = (id: string, item_type: string | null) => ({
+      id,
+      item_type,
+      description: 'Custom Panel',
+      item_details: { id: 'i1', name: `Item ${id}`, sku: `SKU-${id}` },
+      asset_details: { id: 'a1', name: `Asset ${id}`, asset_tag: `AT-${id}`, location_name: null },
+      quantity_ordered: 1,
+      quantity_received: 0,
+      quantity_pending: 1,
+      is_fully_received: false,
+      unit_cost_ordered: '1.00',
+      unit_cost_actual: null,
+      estimated_cost: '1.00',
+      actual_cost: null,
+      expected_shipment_date: null,
+      notes: '',
+      is_voided: false,
+      voided_at: null,
+      void_reason: '',
+    });
+
+    (api.purchaseOrderAPI.getOrder as jest.Mock).mockResolvedValue({
+      data: {
+        ...baseOrder,
+        attachments: [],
+        items: [
+          line('inv', 'inventory_item'),
+          line('ast', 'asset'),
+          line('free', 'freeform'),
+          line('none', null),
+        ],
+      },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('line-item-type')).toHaveLength(4);
+    });
+    expect(
+      screen.getAllByTestId('line-item-type').map((node) => node.textContent),
+    ).toEqual(['Inventory item', 'Asset', 'Freeform', '—']);
+  });
+});
+
+describe('PurchaseOrderPage line-items running total (op-r1sg)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem('token', 'test-token');
+    localStorage.setItem('is_staff', 'true');
+  });
+
+  const costLine = (
+    id: string,
+    overrides: Partial<{ estimated_cost: string; actual_cost: string | null; is_voided: boolean }>,
+  ) => ({
+    id,
+    item_type: 'inventory_item',
+    description: null,
+    item_details: { id: `i-${id}`, name: `Item ${id}`, sku: `SKU-${id}` },
+    asset_details: null,
+    quantity_ordered: 1,
+    quantity_received: 0,
+    quantity_pending: 1,
+    is_fully_received: false,
+    unit_cost_ordered: '1.00',
+    unit_cost_actual: null,
+    estimated_cost: '0.00',
+    actual_cost: null,
+    expected_shipment_date: null,
+    notes: '',
+    is_voided: false,
+    voided_at: null,
+    void_reason: '',
+    ...overrides,
+  });
+
+  test('sums the active lines and excludes voided ones', async () => {
+    (api.purchaseOrderAPI.getOrder as jest.Mock).mockResolvedValue({
+      data: {
+        ...baseOrder,
+        attachments: [],
+        items: [
+          costLine('a', { estimated_cost: '10.00' }),
+          costLine('b', { estimated_cost: '48.00' }),
+          costLine('c', { estimated_cost: '12.00', is_voided: true }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    const total = await screen.findByTestId('po-items-total');
+    expect(total).toHaveTextContent('$58.00');
+    // Nothing to reconcile while every line is still at its ordered cost.
+    expect(total).not.toHaveTextContent(/estimated/i);
+  });
+
+  test('follows the displayed line costs and spells out the estimated sum when they diverge', async () => {
+    (api.purchaseOrderAPI.getOrder as jest.Mock).mockResolvedValue({
+      data: {
+        ...baseOrder,
+        attachments: [],
+        items: [
+          // Received at a higher unit cost than ordered — the Line Cost column
+          // shows the actual, so the footer must too.
+          costLine('a', { estimated_cost: '10.00', actual_cost: '12.00' }),
+          costLine('b', { estimated_cost: '48.00' }),
+        ],
+      },
+    });
+
+    renderPage();
+
+    const total = await screen.findByTestId('po-items-total');
+    expect(total).toHaveTextContent('$60.00');
+    expect(total).toHaveTextContent('(estimated: $58.00)');
+  });
+
+  test('omits the total row entirely when the order has no lines', async () => {
+    (api.purchaseOrderAPI.getOrder as jest.Mock).mockResolvedValue({
+      data: { ...baseOrder, attachments: [], items: [] },
+    });
+
+    renderPage();
+
+    await screen.findByText('No line items found');
+    expect(screen.queryByTestId('po-items-total')).not.toBeInTheDocument();
+  });
+});
+
 describe('PurchaseOrderPage receive items (oms-s0hj4)', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/frontend/src/pages/PurchaseOrderPage.tsx
+++ b/frontend/src/pages/PurchaseOrderPage.tsx
@@ -113,6 +113,25 @@ interface PurchaseOrder {
   void_reason: string;
 }
 
+/**
+ * What KIND of thing a line orders (op-49th) — deliberately distinct from
+ * op-shb9's "Ordered For" column, which is the job/committee the line was
+ * bought *for*.
+ *
+ * Caveat: a line raised from a reorder request is indistinguishable from a
+ * hand-added inventory line on the wire (the serializer carries no reorder FK),
+ * so it reads as "Inventory item" here. A real "Reorder" badge needs a backend
+ * `reorder_request` field on the line first.
+ */
+const ITEM_TYPE_LABELS: Record<NonNullable<PurchaseOrderItem['item_type']>, string> = {
+  inventory_item: 'Inventory item',
+  asset: 'Asset',
+  freeform: 'Freeform',
+};
+
+const getItemTypeLabel = (item: PurchaseOrderItem): string =>
+  (item.item_type && ITEM_TYPE_LABELS[item.item_type]) || '—';
+
 const getItemNameAndSku = (item: PurchaseOrderItem): { itemName: string; itemSku: string } => {
   if (item.item_type === 'asset') {
     return {
@@ -898,6 +917,22 @@ const PurchaseOrderPage: React.FC = () => {
 
   const receivableItems = getReceivableItems(order);
 
+  // Detail-page running total (op-r1sg). Summed from the rendered lines rather
+  // than read off order.estimated_total so it stays live when a line is cost-
+  // edited or voided in place; the two should agree, which makes the footer a
+  // free sanity check on the stored create-time snapshot.
+  //
+  // Voided lines are excluded (matching the backend's effective_estimated_total)
+  // and each line contributes exactly what its "Line Cost" cell displays —
+  // actual where known, estimated otherwise. Where those diverge, the footer
+  // also spells out the pure estimated sum, which is what estimated_total holds.
+  const activeItems = order.items.filter((item) => !item.is_voided);
+  const sumLines = (pick: (item: PurchaseOrderItem) => string | null) =>
+    activeItems.reduce((total, item) => total + (parseFloat(pick(item) || '0') || 0), 0);
+  const lineCostTotal = sumLines((item) => item.actual_cost || item.estimated_cost);
+  const estimatedLineTotal = sumLines((item) => item.estimated_cost);
+  const totalsDiffer = lineCostTotal.toFixed(2) !== estimatedLineTotal.toFixed(2);
+
   // Status-gated hero affordances: Send (draft→sent) and Confirm (sent→confirmed)
   // surface the existing PO lifecycle transitions alongside receive/mark-delivered.
   const heroActions: React.ReactNode[] = [];
@@ -1490,6 +1525,11 @@ const PurchaseOrderPage: React.FC = () => {
                 <tr key={item.id} className={item.is_voided ? 'voided-item' : ''}>
                   <td>
                     {itemName}
+                    <div>
+                      <span className="item-type-badge" data-testid="line-item-type">
+                        {getItemTypeLabel(item)}
+                      </span>
+                    </div>
                     {item.item_type === 'asset' && item.asset_details?.location_name && (
                       <div style={{ fontSize: '0.875rem', color: '#64748b', marginTop: '0.25rem' }}>
                         Location: {item.asset_details.location_name}
@@ -1745,6 +1785,24 @@ const PurchaseOrderPage: React.FC = () => {
               })
             )}
           </tbody>
+          {order.items.length > 0 && (
+            <tfoot>
+              <tr className="items-total-row">
+                <td colSpan={5} className="items-total-label">
+                  Total
+                </td>
+                <td className="items-total-value" data-testid="po-items-total">
+                  {formatCurrency(lineCostTotal.toFixed(2))}
+                  {totalsDiffer && (
+                    <div className="items-total-estimated">
+                      (estimated: {formatCurrency(estimatedLineTotal.toFixed(2))})
+                    </div>
+                  )}
+                </td>
+                <td colSpan={4} />
+              </tr>
+            </tfoot>
+          )}
         </table>
       </section>
       </div>

--- a/frontend/src/styles/PurchaseOrderPage.css
+++ b/frontend/src/styles/PurchaseOrderPage.css
@@ -138,6 +138,45 @@
   background-color: #f8fafc;
 }
 
+/* Line target-type label (op-49th): the item's KIND. Kept in the item cell,
+   away from the "Ordered For" column, which answers a different question. */
+.item-type-badge {
+  display: inline-block;
+  margin-top: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.75rem;
+  background-color: #eef2ff;
+  color: #4338ca;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+/* Running total under the Line Cost column (op-r1sg). */
+.items-table tfoot td {
+  padding: 1rem;
+  border-top: 2px solid #cbd5e1;
+  background-color: #f8fafc;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.items-total-label {
+  text-align: right;
+  font-size: 0.875rem;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.items-total-estimated {
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: #64748b;
+}
+
 .no-data {
   text-align: center;
   color: #94a3b8;


### PR DESCRIPTION
The web halves of two PO-mgmt asks (the ScanTTY halves shipped in #120). Detail page only; frontend-only, no backend.

## op-49th — line target-type label
Each PO line now shows a friendly **Inventory item / Asset / Freeform** label (from `item_type`; null → "—"). Placed distinctly from op-shb9's "Ordered For" column (this is the item's *kind*, not what it was ordered for).
⚠️ Reorder-request-sourced lines are indistinguishable from inventory on the wire, so they read as **"Inventory item."** A real "Reorder" badge would need a backend `reorder_request` FK — flagging in case you want it.

## op-r1sg — line-items running total
Adds a `<tfoot>` **Total** to the items table, summed from the rendered non-voided lines (so it stays live when a line is cost-edited or voided in place; voided excluded, matching `effective_estimated_total`). Shows the estimated sum alongside when actuals differ, making the footer a cheap cross-check against the header's estimated total. (The create-form already had a live grand total — untouched.)

## Verified
node24 eslint clean on the changed file; `vitest PurchaseOrderPage.test.tsx` 39 passed (worker added +141 test lines). Full CI will gate.

Beads: op-49th + op-r1sg (web halves). Closes both once merged.