### PR TITLE
PO list: find and resume saved drafts (op-nr6h)

### DIFF
--- a/backend/reorder_queue/tests/test_api.py
+++ b/backend/reorder_queue/tests/test_api.py
@@ -2096,6 +2096,73 @@ class TestPurchaseOrderListVoidHandling:
 
 
 @pytest.mark.integration
+class TestPurchaseOrderListDraftFilter:
+    """Tests for op-nr6h: a saved draft PO must be findable again.
+
+    Creating a PO leaves it in ``draft``, and the web list now offers a "Draft"
+    filter option that sends ``?status=draft`` to narrow to unsent orders.
+    These guard that the query param actually surfaces the draft, that the
+    all-line-items-voided filter (oms-a8o, above) does not swallow a draft that
+    has line items, and that drafts stay server-side private from the public
+    list. No view change was needed — these pin the behaviour the web relies on.
+    """
+
+    def _make_po(self, user, *, po_status, item_count=1):
+        supplier = SupplierFactory()
+        purchase_order = PurchaseOrder.objects.create(
+            supplier=supplier,
+            status=po_status,
+            created_by=user,
+        )
+        for _ in range(item_count):
+            PurchaseOrderItem.objects.create(
+                purchase_order=purchase_order,
+                item_supplier=ItemSupplierFactory(supplier=supplier),
+                quantity_ordered=5,
+                unit_cost_ordered=Decimal("10.00"),
+            )
+        purchase_order.calculate_estimated_total()
+        purchase_order.save()
+        return purchase_order
+
+    def test_status_draft_lists_a_draft_with_items(self, authenticated_client):
+        """?status=draft returns the draft — it is not hidden by the void filter."""
+        client, user = authenticated_client
+        draft_po = self._make_po(user, po_status=PurchaseOrder.Status.DRAFT)
+        sent_po = self._make_po(user, po_status=PurchaseOrder.Status.SENT)
+
+        url = reverse("purchaseorder-list")
+        response = client.get(url, {"status": "draft"})
+
+        assert response.status_code == status.HTTP_200_OK
+        listed_ids = {row["id"] for row in response.data["results"]}
+        assert draft_po.id in listed_ids
+        assert sent_po.id not in listed_ids
+
+    def test_unfiltered_list_still_includes_the_draft_for_staff(self, authenticated_client):
+        """An authenticated user's unfiltered list is not restricted to sent+."""
+        client, user = authenticated_client
+        draft_po = self._make_po(user, po_status=PurchaseOrder.Status.DRAFT)
+
+        url = reverse("purchaseorder-list")
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert draft_po.id in {row["id"] for row in response.data["results"]}
+
+    def test_status_draft_hides_drafts_from_anonymous_users(self, api_client):
+        """Drafts stay private: the public list is active+settled only."""
+        user = User.objects.create_user(username="po-draft-owner", password="pw12345678")
+        self._make_po(user, po_status=PurchaseOrder.Status.DRAFT)
+
+        url = reverse("purchaseorder-list")
+        response = api_client.get(url, {"status": "draft"})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["results"] == []
+
+
+@pytest.mark.integration
 class TestPurchaseOrderAutoTransitionToSent:
     """DRAFT -> SENT auto-transition when a sales order number is attached (oms-qdxss).
 

--- a/frontend/src/__tests__/pages/PurchaseOrderListPage.test.tsx
+++ b/frontend/src/__tests__/pages/PurchaseOrderListPage.test.tsx
@@ -132,6 +132,87 @@ describe('PurchaseOrderListPage', () => {
   });
 });
 
+/**
+ * op-nr6h: a PO is saved as a draft, but the default list only shows active and
+ * settled orders — so the status filter has to offer "Draft" for a saved draft
+ * to be findable (and, from its row, resumable) after you navigate away.
+ */
+describe('PurchaseOrderListPage draft filter', () => {
+  const draftOrder = {
+    id: 'po-draft-1',
+    po_number: 'PO-2026-009',
+    supplier_details: 'Acme Supplies',
+    status: 'draft',
+    status_label: 'Draft',
+    order_date: '2026-02-02',
+    expected_delivery_date: null,
+    estimated_total: '75.00',
+    actual_total: null,
+    total_items: 2,
+    total_quantity: 4,
+    is_fully_received: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('offers Draft as a status filter option', async () => {
+    (api.purchaseOrderAPI.listOrders as jest.Mock).mockResolvedValue({
+      data: { results: [] },
+    });
+
+    renderPage();
+
+    const filter = await screen.findByLabelText(/Filter by Status/);
+    expect(within(filter).getByRole('option', { name: 'Draft' })).toHaveValue('draft');
+  });
+
+  it('requests ?status=draft when Draft is selected', async () => {
+    (api.purchaseOrderAPI.listOrders as jest.Mock).mockResolvedValue({
+      data: { results: [] },
+    });
+
+    renderPage();
+
+    // The initial load is unfiltered (all active & settled).
+    await waitFor(() => {
+      expect(api.purchaseOrderAPI.listOrders).toHaveBeenCalledWith(undefined);
+    });
+
+    (api.purchaseOrderAPI.listOrders as jest.Mock).mockResolvedValue({
+      data: { results: [draftOrder] },
+    });
+    await userEvent.selectOptions(await screen.findByLabelText(/Filter by Status/), 'draft');
+
+    await waitFor(() => {
+      expect(api.purchaseOrderAPI.listOrders).toHaveBeenCalledWith({ status: 'draft' });
+    });
+  });
+
+  it('lists a draft with its own badge and a link back to the order', async () => {
+    (api.purchaseOrderAPI.listOrders as jest.Mock).mockResolvedValue({
+      data: { results: [draftOrder] },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('PO-2026-009')).toBeInTheDocument();
+    });
+    // 'Draft' is also a filter <option>; scope to the status badge.
+    const badge = screen.getByText('Draft', { selector: '.status-badge' });
+    expect(badge).toHaveClass('status-draft');
+    // Resumable: the row links to the detail page, where a draft can be edited
+    // and sent to the supplier.
+    expect(screen.getByRole('link', { name: 'View Details →' })).toHaveAttribute(
+      'href',
+      '/purchasing/orders/po-draft-1'
+    );
+  });
+});
+
 describe('PurchaseOrderListPage sorting', () => {
   const baseOrder = {
     id: 'po-1',

--- a/frontend/src/pages/PurchaseOrderListPage.tsx
+++ b/frontend/src/pages/PurchaseOrderListPage.tsx
@@ -154,6 +154,7 @@ const PurchaseOrderListPage: React.FC = () => {
 
   const getStatusClass = (status: string) => {
     const statusMap: { [key: string]: string } = {
+      draft: 'status-draft',
       sent: 'status-sent',
       confirmed: 'status-confirmed',
       partially_received: 'status-partially-received',
@@ -219,6 +220,10 @@ const PurchaseOrderListPage: React.FC = () => {
           className="status-filter-select"
         >
           <option value="">All Active & Settled</option>
+          {/* Narrows to saved-but-unsent orders so a draft can be found and
+              resumed. Only signed-in users see drafts at all; the public list
+              is restricted to active and settled orders server-side. */}
+          <option value="draft">Draft</option>
           <option value="sent">Sent to Supplier</option>
           <option value="confirmed">Confirmed by Supplier</option>
           <option value="partially_received">Partially Received</option>

--- a/frontend/src/styles/PurchaseOrderListPage.css
+++ b/frontend/src/styles/PurchaseOrderListPage.css
@@ -204,6 +204,13 @@
   display: inline-block;
 }
 
+/* Unsent work-in-progress: muted amber so a draft reads as "not yet ordered"
+   rather than as another in-flight order. */
+.status-badge.status-draft {
+  background-color: #fef9c3;
+  color: #854d0e;
+}
+
 .status-badge.status-sent {
   background-color: #dbeafe;
   color: #1e40af;


### PR DESCRIPTION
Ian's PO-mgmt ask #5: "save a PO as a draft." Creating a PO already leaves it in `draft` status — the gap was purely **discoverability**: the web PO list had no way to filter to drafts, so a saved draft was invisible once you navigated away.

## Change
- Adds a **"Draft"** option to the PO-list status filter → requests `?status=draft`, listing saved-but-unsent orders so they can be found and clicked into to resume (edit lines + Send to Supplier on the detail page). A "Draft" status badge distinguishes the rows.
- **No backend source change** — `PurchaseOrderViewSet` already honors `?status=draft` for authenticated users (public list stays restricted to active/settled). Added a backend test asserting `?status=draft` returns a draft-with-items for an authenticated user.

## Verified
node24 eslint clean; `vitest PurchaseOrderListPage.test.tsx` 13 passed; backend `test_api.py` draft-filter test runs in CI.

Bead: op-nr6h. This completes the 5-feature PO-management batch.