### PR TITLE
Inventory UoM Phase 2a: reorder trigger + suggested qty at the count level

### DIFF
--- a/backend/index_cards/services.py
+++ b/backend/index_cards/services.py
@@ -295,7 +295,7 @@ class IndexCardRenderer:
             # Get image bottom position (reuse logic from _draw_left_section)
             info_y = current_y - 0.1 * inch
             info_lines = [
-                f"Reorder at: {self._pluralize(item.minimum_cases if item.use_case_based_reorder else item.minimum_stock, 'case' if item.use_case_based_reorder else 'unit')}",
+                self._reorder_at_line(item),
             ]
             if item.average_lead_time:
                 info_lines.append(f"Avg Lead: {self._pluralize(item.average_lead_time, 'day')}")
@@ -360,16 +360,9 @@ class IndexCardRenderer:
     ) -> None:
         """Draw the left section with stock info and product image."""
         # Draw Kanban stock info (reorder point and lead times)
-        if item.use_case_based_reorder:
-            # Case-based reordering display
-            info_lines = [
-                f"Reorder at: {self._pluralize(item.minimum_cases, 'case')}",
-            ]
-        else:
-            # Traditional unit-based display
-            info_lines = [
-                f"Reorder at: {self._pluralize(item.minimum_stock, 'unit')}",
-            ]
+        info_lines = [
+            self._reorder_at_line(item),
+        ]
 
         # Add average lead time from primary supplier
         if item.average_lead_time:
@@ -819,6 +812,20 @@ class IndexCardRenderer:
 
     def _calculate_desired_stock(self, item: InventoryItem) -> int:
         return max(item.minimum_stock + item.reorder_quantity, item.reorder_quantity)
+
+    def _reorder_at_line(self, item: InventoryItem) -> str:
+        """The card's "Reorder at:" line, worded for how the item is counted.
+
+        One helper because the shelf-position arrow re-measures the same line to
+        find the image bottom, and the two must not drift apart. The service
+        picks the column that the item's ``count_mode`` gives meaning to —
+        cases for a legacy case-based item, packs of ``count_level`` for a
+        pack-counting one, base units otherwise (op-es7c).
+        """
+        from inventory.services.packaging import reorder_threshold
+
+        threshold, unit = reorder_threshold(item)
+        return f"Reorder at: {self._pluralize(threshold, unit)}"
 
     def _get_longest_lead_time(self, item: InventoryItem) -> int | None:
         """Get the longest lead time across all suppliers for this item."""

--- a/backend/index_cards/tests/test_services.py
+++ b/backend/index_cards/tests/test_services.py
@@ -190,3 +190,51 @@ class IndexCardRendererTests(TestCase):
 
         # Clean up temporary media directory
         shutil.rmtree(settings.MEDIA_ROOT, ignore_errors=True)
+
+
+class ReorderAtLineTests(TestCase):
+    """The card's "Reorder at:" line names the unit the item is counted in (op-es7c).
+
+    One helper feeds both the drawn line and the shelf-arrow's height
+    measurement, so these assertions pin the text for both.
+    """
+
+    def setUp(self) -> None:
+        self.renderer = IndexCardRenderer(base_url="http://localhost:3000")
+
+    def _item(self, **kwargs) -> InventoryItem:
+        defaults = {
+            "name": "Nitrile gloves",
+            "reorder_quantity": 5,
+            "current_stock": 2,
+            "minimum_stock": 3,
+        }
+        return InventoryItem.objects.create(**{**defaults, **kwargs})
+
+    def test_plain_item_reads_in_base_units(self) -> None:
+        item = self._item(minimum_stock=3)
+
+        self.assertEqual(self.renderer._reorder_at_line(item), "Reorder at: 3 units")
+
+    def test_case_based_item_still_reads_in_cases(self) -> None:
+        item = self._item(use_case_based_reorder=True, minimum_cases=1)
+
+        self.assertEqual(self.renderer._reorder_at_line(item), "Reorder at: 1 case")
+
+    def test_pack_counting_item_reads_in_its_own_packs(self) -> None:
+        from inventory.models import PackagingLevel
+
+        item = self._item(base_unit="glove", minimum_stock=2)
+        case = PackagingLevel.objects.create(item=item, name="box", sort_order=0, base_units=100)
+        PackagingLevel.objects.create(item=item, name="glove", sort_order=1, base_units=1)
+        item.count_mode = InventoryItem.CountMode.BY_LEVEL
+        item.count_level = case
+        item.save(update_fields=["count_mode", "count_level"])
+
+        self.assertEqual(self.renderer._reorder_at_line(item), "Reorder at: 2 boxes")
+
+    def test_custom_base_unit_labels_an_each_item(self) -> None:
+        """An item that opted into a named base unit gets that noun, not "unit"."""
+        item = self._item(base_unit="sheet", minimum_stock=500)
+
+        self.assertEqual(self.renderer._reorder_at_line(item), "Reorder at: 500 sheets")

--- a/backend/inventory/management/commands/bridge_case_reorder_to_packaging.py
+++ b/backend/inventory/management/commands/bridge_case_reorder_to_packaging.py
@@ -1,0 +1,175 @@
+"""Move legacy case-based items onto the unified packaging model (op-es7c).
+
+Before the UoM work an item could be reordered "by the case" via three columns
+of its own — ``use_case_based_reorder`` / ``minimum_cases`` / ``reorder_cases``
+— with the case size read off the *primary supplier's*
+``quantity_per_package``. Phase 1 introduced the item's own packaging chain and
+``count_mode``, and phase 2a made ``needs_reorder`` and the suggested reorder
+quantity honour it. This command bridges the former into the latter, on demand:
+it is NOT a data migration and nothing runs it automatically.
+
+For each eligible item it writes a two-rung chain (case = the supplier's
+quantity per package, base = 1), points ``count_mode``/``count_level`` at the
+case rung, and copies ``minimum_cases``/``reorder_cases`` into
+``minimum_stock``/``reorder_quantity`` — which for a pack-counting item are read
+in cases. The legacy columns are deliberately left in place; deprecating them is
+a later step.
+
+⚠️ THE ONE BEHAVIOUR SHIFT, reported per item so it is never a surprise: the
+legacy trigger compares a FRACTIONAL case count (``current_stock / qpp <=
+minimum_cases``) while a pack-counting item compares WHOLE packs
+(``floor(current_stock / qpp) <= minimum_stock``). They agree whenever stock is
+a whole number of cases; with a part-used case sitting just above the threshold
+the bridged item trips one partial case earlier — which is the point of counting
+in whole packs, but it is a change. The report prints ``needs reorder: X -> Y``
+for every item and flags the ones that flip.
+
+Eligibility (everything else is skipped, with the reason):
+
+* ``use_case_based_reorder`` is set;
+* the primary supplier link has ``quantity_per_package > 1`` (at 1 there is no
+  case to model, and a 1-unit "case" rung would be an invalid chain);
+* the item has no packaging levels yet — an item someone already configured is
+  never rewritten, which is what makes re-running safe.
+
+Usage::
+
+    python manage.py bridge_case_reorder_to_packaging            # dry run
+    python manage.py bridge_case_reorder_to_packaging --apply    # write
+"""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from inventory.models import InventoryItem, PackagingLevel
+from inventory.services.packaging import validate_packaging_chain
+
+CASE_LEVEL_NAME = "case"
+
+
+class Command(BaseCommand):
+    help = (
+        "Bridge legacy case-based reorder items onto packaging levels + count_mode "
+        "(dry run unless --apply)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Write the changes. Without it the command only reports what it would do.",
+        )
+
+    def handle(self, *args, **options):
+        apply_changes = options["apply"]
+
+        items = (
+            InventoryItem.objects.filter(use_case_based_reorder=True)
+            .select_related("count_level")
+            .prefetch_related("item_suppliers__supplier", "packaging_levels")
+            .order_by("name", "id")
+        )
+
+        bridged = 0
+        skipped: dict[str, int] = {}
+        flipped = 0
+
+        with transaction.atomic():
+            for item in items:
+                reason = self._skip_reason(item)
+                if reason:
+                    skipped[reason] = skipped.get(reason, 0) + 1
+                    self.stdout.write(f"  skip ({reason}): {item.name}")
+                    continue
+
+                case_size = item.primary_item_supplier.quantity_per_package
+                before = item.needs_reorder
+                # The bridged trigger, computed without writing: whole cases
+                # against the threshold minimum_cases becomes.
+                after = (item.current_stock // case_size) <= item.minimum_cases
+
+                self._report(item, case_size, before, after)
+                if before != after:
+                    flipped += 1
+
+                if apply_changes:
+                    self._bridge(item, case_size)
+                bridged += 1
+
+            if not apply_changes:
+                # Nothing should have been written, but roll back regardless so a
+                # future edit to _report cannot leak a write out of a dry run.
+                transaction.set_rollback(True)
+
+        self.stdout.write("")
+        verb = "Bridged" if apply_changes else "Would bridge"
+        self.stdout.write(self.style.SUCCESS(f"{verb} {bridged} item(s)."))
+        if flipped:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"{flipped} item(s) change whether they currently need reordering "
+                    "(whole-pack vs fractional-case comparison) — marked CHANGES above."
+                )
+            )
+        for reason, count in sorted(skipped.items()):
+            self.stdout.write(f"Skipped {count} item(s): {reason}.")
+        if not apply_changes:
+            self.stdout.write("Dry run — nothing written. Re-run with --apply to commit.")
+
+    def _skip_reason(self, item: InventoryItem) -> str | None:
+        """Why ``item`` cannot be bridged, or ``None`` when it can."""
+        if item.packaging_levels.all():
+            return "already has packaging levels"
+        link = item.primary_item_supplier
+        if link is None:
+            return "no supplier to take a case size from"
+        if not link.quantity_per_package or link.quantity_per_package <= 1:
+            return "supplier quantity_per_package is not more than 1"
+        return None
+
+    def _report(self, item: InventoryItem, case_size: int, before: bool, after: bool) -> None:
+        marker = self.style.WARNING("  CHANGES") if before != after else ""
+        self.stdout.write(
+            f"  {item.name} [{item.sku}]: 1 case = {case_size} {item.base_unit}"
+            f" | minimum_stock {item.minimum_stock} -> {item.minimum_cases}"
+            f" | reorder_quantity {item.reorder_quantity} -> {item.reorder_cases}"
+            f" | count_mode {item.count_mode} -> {InventoryItem.CountMode.BY_LEVEL}"
+            f" | needs reorder: {before} -> {after}{marker}"
+        )
+
+    def _bridge(self, item: InventoryItem, case_size: int) -> None:
+        """Write the two-rung chain and point the item's counting at the case rung."""
+        case_level = PackagingLevel.objects.create(
+            item=item,
+            name=CASE_LEVEL_NAME,
+            sort_order=0,
+            base_units=case_size,
+        )
+        PackagingLevel.objects.create(
+            item=item,
+            name=item.base_unit or "unit",
+            sort_order=1,
+            base_units=1,
+        )
+        # Validate the chain as a SET — PackagingLevel.clean() rejects a rung
+        # judged alone (the first rung of a new chain has no base rung yet), so
+        # the set-level validator is the only correct check here. Queried fresh
+        # rather than through ``item.packaging_levels``, whose prefetch cache
+        # was filled (empty) before these two rows existed.
+        validate_packaging_chain(list(PackagingLevel.objects.filter(item=item)))
+
+        item.count_mode = InventoryItem.CountMode.BY_LEVEL
+        item.count_level = case_level
+        item.minimum_stock = item.minimum_cases
+        item.reorder_quantity = item.reorder_cases
+        item.save(
+            update_fields=[
+                "count_mode",
+                "count_level",
+                "minimum_stock",
+                "reorder_quantity",
+                "updated_at",
+            ]
+        )

--- a/backend/inventory/management/commands/bridge_case_reorder_to_packaging.py
+++ b/backend/inventory/management/commands/bridge_case_reorder_to_packaging.py
@@ -56,10 +56,16 @@ class Command(BaseCommand):
     )
 
     def add_arguments(self, parser):
-        parser.add_argument(
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
             "--apply",
             action="store_true",
             help="Write the changes. Without it the command only reports what it would do.",
+        )
+        group.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report without writing. This is the default; the flag just says so out loud.",
         )
 
     def handle(self, *args, **options):

--- a/backend/inventory/management/commands/bridge_case_reorder_to_packaging.py
+++ b/backend/inventory/management/commands/bridge_case_reorder_to_packaging.py
@@ -92,9 +92,14 @@ class Command(BaseCommand):
 
                 case_size = item.primary_item_supplier.quantity_per_package
                 before = item.needs_reorder
-                # The bridged trigger, computed without writing: whole cases
-                # against the threshold minimum_cases becomes.
-                after = (item.current_stock // case_size) <= item.minimum_cases
+                # What the trigger will say once bridged, computed without
+                # writing: WHOLE cases against minimum_cases, which is the
+                # value minimum_stock is about to take. Retirement still wins
+                # over stock in both modes, so it short-circuits here too —
+                # otherwise a retired item would be reported as flipping.
+                after = not item.is_retired and (item.current_stock // case_size) <= (
+                    item.minimum_cases
+                )
 
                 self._report(item, case_size, before, after)
                 if before != after:

--- a/backend/inventory/models/core.py
+++ b/backend/inventory/models/core.py
@@ -520,17 +520,36 @@ class InventoryItem(OwnableModel):
     def needs_reorder(self) -> bool:
         """Check if item stock is below minimum and needs reordering.
 
+        Compares stock to the reorder point *at the granularity the item is
+        counted in* (op-es7c):
+
+        * ``count_mode=each`` — unchanged, and it is what every pre-existing
+          item is: case-based items compare ``current_cases`` to
+          ``minimum_cases``, everything else ``current_stock`` to
+          ``minimum_stock``, both in base units.
+        * ``by_level`` / ``open_closed`` — whole packs of ``count_level``
+          against ``minimum_stock``, which for these modes is a threshold in the
+          item's COUNT unit (cases/reams/sealed packs). ``count_mode`` is the
+          source of truth here: the legacy ``use_case_based_reorder`` /
+          ``minimum_cases`` pair is deliberately not consulted.
+
         Pure stock math — despite the name it never touches ``reorder_requests``,
         so it is prefetch-safe and is intentionally NOT part of the
         ``reorder_requests`` N+1 fix (issue #890). Do not add a reorder-request
-        query here.
+        query here. The database-side twin lives in
+        ``inventory.services.packaging.low_stock_q``.
         """
+        from inventory.services.packaging import count_at_level, counts_in_packs
+
         # Retired items are phased out: never flagged for reorder, regardless of
         # stock level. This is the central chokepoint for every property-based
         # low-stock surface (reorder_status, low_stock action, serializer
         # needs_reorder field, admin, AssetPart, Fixture refill).
         if self.is_retired:
             return False
+        if counts_in_packs(self):
+            # Counted in whole packs: minimum_stock is the threshold in those packs.
+            return count_at_level(self) <= self.minimum_stock
         if self.use_case_based_reorder:
             # For case-based reordering, calculate current cases and compare to minimum cases
             current_cases = self.current_cases

--- a/backend/inventory/serializers.py
+++ b/backend/inventory/serializers.py
@@ -588,6 +588,7 @@ class InventoryItemSerializer(serializers.ModelSerializer):
     # counting granularity without changing it.
     packaging_levels = PackagingLevelSerializer(many=True, required=False)
     on_hand_display = serializers.SerializerMethodField()
+    reorder_display = serializers.SerializerMethodField()
 
     class Meta:
         model = InventoryItem
@@ -620,6 +621,7 @@ class InventoryItemSerializer(serializers.ModelSerializer):
             "open_container_count",
             "packaging_levels",
             "on_hand_display",
+            "reorder_display",
             # ML demand-forecast opt-in (read+write; default OFF). The "ping me"
             # toggle that puts an item into the reorder_alerts notify set.
             "reorder_alerts_enabled",
@@ -723,6 +725,19 @@ class InventoryItemSerializer(serializers.ModelSerializer):
         from inventory.services.packaging import on_hand_display
 
         return on_hand_display(obj)
+
+    def get_reorder_display(self, obj):
+        """Reorder point + current count in one unit (op-es7c).
+
+        Lets a client label the threshold correctly per mode ("reorder at 2
+        cases") without re-deriving which of ``minimum_stock``/``minimum_cases``
+        the item's ``count_mode`` gives meaning to. Reads only ``count_level``
+        (already select_related on every queryset that serialises items) and
+        ``item_suppliers`` (already prefetched), so it costs no extra query.
+        """
+        from inventory.services.packaging import reorder_display
+
+        return reorder_display(obj)
 
     def get_active_reorder_request(self, obj):
         """Return details of the active reorder request if any."""

--- a/backend/inventory/services/packaging.py
+++ b/backend/inventory/services/packaging.py
@@ -6,6 +6,20 @@ remains the canonical BASE-unit quantity that every reorder / purchase /
 usage flow reads, and these helpers only convert it between rungs or format it
 for display.
 
+Phase 2a (op-es7c) adds the *reorder* half: :func:`count_at_level` (the whole
+count in the unit an item is counted in), :func:`base_reorder_quantity` (how
+much to suggest ordering, still stored in base units) and :func:`low_stock_q`
+(the SQL twin of ``needs_reorder``). ``each`` items — including legacy
+``use_case_based_reorder`` ones — route through the same helpers and come out
+byte-for-byte where they were; only an item opted into a pack-counting
+``count_mode`` takes the new path.
+
+⚠️ For the pack-counting modes, ``InventoryItem.minimum_stock`` and
+``reorder_quantity`` are read as thresholds/amounts in the item's COUNT unit
+(cases, reams, sealed packs), not base units. That reinterpretation is the
+point of the unification: one pair of columns drives reordering at whatever
+granularity the item is counted at. ``each`` keeps their base-unit meaning.
+
 The validators are shared deliberately: ``PackagingLevel.clean()`` calls
 :func:`validate_packaging_chain` for single-row saves, and
 ``InventoryItemSerializer.validate`` calls it for the nested (bulk) write,
@@ -18,6 +32,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Iterable, Optional, Sequence
 
 from django.core.exceptions import ValidationError
+from django.db.models import ExpressionWrapper, F, IntegerField, Q
 
 if TYPE_CHECKING:
     from inventory.models.core import InventoryItem, PackagingLevel
@@ -101,6 +116,154 @@ def on_hand_display(item: "InventoryItem") -> dict:
         "remainder_base": remainder,
         "text": f"{whole} {level.name}(s)",
     }
+
+
+def counts_in_packs(item: "InventoryItem") -> bool:
+    """True when ``item`` is counted in whole packs of a usable ``count_level``.
+
+    The single predicate every mode-aware caller branches on (op-es7c). It is
+    deliberately conservative: a half-configured item — a pack-counting
+    ``count_mode`` with no ``count_level``, or one pointing at a rung that holds
+    less than a base unit — reads as ``False`` and keeps today's base-unit
+    behaviour instead of raising, mirroring :func:`on_hand_display`'s fallback.
+    """
+    if item.count_mode == item.CountMode.EACH:
+        return False
+    level = item.count_level
+    return level is not None and level.base_units >= 1
+
+
+def count_at_level(item: "InventoryItem") -> int:
+    """The item's whole count expressed in the unit it is *counted* in.
+
+    * ``each`` → ``current_stock`` (base units), i.e. today's number.
+    * ``by_level`` / ``open_closed`` → whole packs of ``count_level``. A partial
+      pack is not a countable pack, and under ``open_closed`` that is exactly
+      the sealed count — the open container is not counted.
+
+    Falls back to ``current_stock`` for a pack-counting item with no usable
+    ``count_level`` (see :func:`counts_in_packs`).
+    """
+    if not counts_in_packs(item):
+        return item.current_stock
+    whole, _ = to_level_count(item.current_stock, item.count_level)
+    return whole
+
+
+def reorder_threshold(item: "InventoryItem") -> tuple[int, str]:
+    """``(threshold, unit noun)`` naming the item's reorder point as a human reads it.
+
+    Pack-counting items read ``minimum_stock`` in their ``count_level``'s unit;
+    legacy ``use_case_based_reorder`` items keep their ``minimum_cases``/"case"
+    wording; everything else is ``minimum_stock`` base units. Callers own
+    pluralisation.
+    """
+    if counts_in_packs(item):
+        return item.minimum_stock, item.count_level.name
+    if item.use_case_based_reorder:
+        return item.minimum_cases, "case"
+    return item.minimum_stock, item.base_unit or "unit"
+
+
+def base_reorder_quantity(item: "InventoryItem") -> int:
+    """How much to suggest ordering, in BASE units, before any supplier rounding.
+
+    The stored ``ReorderRequest``/``PurchaseOrderItem`` quantity stays in base
+    units — only the derivation is mode-aware:
+
+    * ``each`` → UNCHANGED: ``max(minimum_stock - current_stock, reorder_quantity)``
+      base units, which callers may still round up to a whole supplier package.
+    * pack-counting → the same arithmetic one rung up, in the item's count unit,
+      then converted through ``count_level``. With stock at the reorder point
+      that is exactly ``reorder_quantity × count_level.base_units``; the
+      shortage clause only bites for an item that fell far below its minimum,
+      and is the count-level twin of the ``each`` behaviour rather than a new
+      rule. Supplier packaging plays no part — a pack-counting item already
+      orders whole packs of its OWN chain.
+    """
+    if not counts_in_packs(item):
+        shortage = max(0, item.minimum_stock - item.current_stock)
+        return max(shortage, item.reorder_quantity)
+
+    shortage_levels = max(0, item.minimum_stock - count_at_level(item))
+    return max(shortage_levels, item.reorder_quantity) * item.count_level.base_units
+
+
+def reorder_display(item: "InventoryItem") -> dict:
+    """Reorder point + current count in one unit, ready to label a UI (op-es7c).
+
+    ``{mode, unit, threshold, current, reorder_quantity, needs_reorder, text}``
+    — every quantity expressed in ``unit``, so a caller can render
+    "1 case on hand · reorder at 2 cases" without knowing which columns the
+    item's ``count_mode`` gives meaning to.
+    """
+    threshold, unit = reorder_threshold(item)
+    if counts_in_packs(item):
+        current: float = count_at_level(item)
+        quantity = item.reorder_quantity
+    elif item.use_case_based_reorder:
+        current = item.current_cases
+        quantity = item.reorder_cases
+    else:
+        current = item.current_stock
+        quantity = item.reorder_quantity
+
+    def _plural(count) -> str:
+        return unit if count == 1 else f"{unit}s"
+
+    return {
+        "mode": item.count_mode,
+        "unit": unit,
+        "threshold": threshold,
+        "current": current,
+        "reorder_quantity": quantity,
+        "needs_reorder": item.needs_reorder,
+        "text": (
+            f"{current} {_plural(current)} on hand · "
+            f"reorder at {threshold} {_plural(threshold)}"
+        ),
+    }
+
+
+def low_stock_q() -> Q:
+    """``Q`` selecting items at/below their reorder point — the SQL twin of ``needs_reorder``.
+
+    For the reorder-queue surfaces that pre-filter in the database rather than
+    walking the property. ``each`` items keep EXACTLY today's predicate,
+    ``current_stock <= minimum_stock`` — including ``use_case_based_reorder``
+    ones, whose SQL filter has always been that base-unit comparison even though
+    the property compares cases (a pre-existing divergence this deliberately
+    preserves). Pack-counting items compare WHOLE packs instead::
+
+        floor(current_stock / base_units) <= minimum_stock
+        ⟺ current_stock < (minimum_stock + 1) × base_units
+
+    The two branches are exact complements — the second is De Morgan's of
+    :func:`counts_in_packs`, spelled positively so the nullable ``count_level``
+    join is never negated.
+    """
+    from inventory.models.core import InventoryItem
+
+    pack_modes = [InventoryItem.CountMode.BY_LEVEL, InventoryItem.CountMode.OPEN_CLOSED]
+
+    counted_in_packs = Q(
+        count_mode__in=pack_modes,
+        count_level__isnull=False,
+        count_level__base_units__gte=1,
+    )
+    counted_in_base = (
+        ~Q(count_mode__in=pack_modes)
+        | Q(count_level__isnull=True)
+        | Q(count_level__base_units__lt=1)
+    )
+    pack_threshold = ExpressionWrapper(
+        (F("minimum_stock") + 1) * F("count_level__base_units"),
+        output_field=IntegerField(),
+    )
+
+    return (counted_in_base & Q(current_stock__lte=F("minimum_stock"))) | (
+        counted_in_packs & Q(current_stock__lt=pack_threshold)
+    )
 
 
 def validate_packaging_chain(levels: Iterable[Any]) -> None:

--- a/backend/inventory/tests/test_reorder_at_level.py
+++ b/backend/inventory/tests/test_reorder_at_level.py
@@ -14,12 +14,15 @@ item's OWN count unit rather than base units.
 
 from io import StringIO
 
+from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.db.models import F
+from django.utils.crypto import get_random_string
 
 import pytest
 from rest_framework import status
 from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
 
 from inventory.models import InventoryItem, PackagingLevel
 from inventory.services.packaging import (
@@ -33,6 +36,20 @@ from inventory.services.packaging import (
 from inventory.tests.factories import InventoryItemFactory
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def staff_api_client():
+    """Reconciliation is staff/SIG-admin gated (``_can_reconcile``)."""
+    user = get_user_model().objects.create_user(
+        username=get_random_string(8),
+        email=f"{get_random_string(6)}@example.com",
+        password=get_random_string(24),
+        is_staff=True,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
 
 
 # A case of 12 bottles: the case is the counting rung, the bottle is the base
@@ -551,3 +568,75 @@ class TestBridgeCaseReorderCommand:
         assert list(
             item.packaging_levels.order_by("sort_order").values_list("name", flat=True)
         ) == ["case", "bottle"]
+
+
+class TestReconciliationAutoReorderIsModeAware:
+    """A counted-stock reconciliation raises its auto-reorder at the count level.
+
+    Reconciliation duplicates the reorder trigger inline rather than calling
+    ``needs_reorder``, and stores ``reorder_quantity`` straight into the
+    request. For a pack-counting item both of those read pack amounts, so both
+    have to convert (op-es7c); for an ``each`` item both are identities.
+    """
+
+    URL = "/api/inventory/reconciliations/batch/"
+
+    def _post(self, client, item, actual_count):
+        from inventory.models import StockReconciliation
+
+        return client.post(
+            self.URL,
+            {
+                "rows": [
+                    {
+                        "item_id": str(item.id),
+                        "actual_count": actual_count,
+                        "reason": StockReconciliation.ReasonCode.USED_WITHOUT_SCAN,
+                    }
+                ]
+            },
+            format="json",
+        )
+
+    def test_each_item_reorder_quantity_unchanged(self, staff_api_client):
+        from reorder_queue.models import ReorderRequest
+
+        item = InventoryItemFactory(
+            image=None, current_stock=20, minimum_stock=10, reorder_quantity=25
+        )
+
+        response = self._post(staff_api_client, item, 3)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["reorders_created"] == 1
+        assert ReorderRequest.objects.get(item=item).quantity == 25
+
+    def test_pack_counted_item_converts_to_base_units(self, staff_api_client):
+        """Counting 35 bottles leaves 2 whole cases against a 2-case minimum."""
+        from reorder_queue.models import ReorderRequest
+
+        item = _pack_item(case_size=12, current_stock=100, minimum_stock=2, reorder_quantity=3)
+
+        response = self._post(staff_api_client, item, 35)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["reorders_created"] == 1
+        # 3 cases of 12 bottles — NOT the bare 3 that the pack count would be.
+        assert ReorderRequest.objects.get(item=item).quantity == 36
+
+    def test_pack_counted_item_above_its_reorder_point_raises_nothing(self, staff_api_client):
+        """36 bottles is 3 whole cases, above the 2-case minimum.
+
+        The old base-unit comparison (36 <= 2) also said "no", so this pins the
+        other half of the trigger: raw base units must not be compared against a
+        pack threshold in EITHER direction.
+        """
+        from reorder_queue.models import ReorderRequest
+
+        item = _pack_item(case_size=12, current_stock=100, minimum_stock=2, reorder_quantity=3)
+
+        response = self._post(staff_api_client, item, 36)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["reorders_created"] == 0
+        assert not ReorderRequest.objects.filter(item=item).exists()

--- a/backend/inventory/tests/test_reorder_at_level.py
+++ b/backend/inventory/tests/test_reorder_at_level.py
@@ -1,0 +1,553 @@
+"""Mode-aware reordering: trigger + suggested quantity at the count level (op-es7c, phase 2a).
+
+Phase 1 (op-hzji) added the packaging chain and ``count_mode`` without letting
+any quantity flow read them. Phase 2a lets exactly two things read them — when
+an item needs reordering, and how much to suggest ordering — and nothing else.
+
+The load-bearing assertion of the whole module is the FIRST class: an item in
+``count_mode=each`` (which is every item that exists today, including the legacy
+``use_case_based_reorder`` ones) must come out of these code paths exactly where
+it went in. Everything after that covers items deliberately opted into a
+pack-counting mode, where ``minimum_stock``/``reorder_quantity`` are read in the
+item's OWN count unit rather than base units.
+"""
+
+from io import StringIO
+
+from django.core.management import call_command
+from django.db.models import F
+
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from inventory.models import InventoryItem, PackagingLevel
+from inventory.services.packaging import (
+    base_reorder_quantity,
+    count_at_level,
+    counts_in_packs,
+    low_stock_q,
+    reorder_display,
+    reorder_threshold,
+)
+from inventory.tests.factories import InventoryItemFactory
+
+pytestmark = pytest.mark.django_db
+
+
+# A case of 12 bottles: the case is the counting rung, the bottle is the base
+# unit ``current_stock`` is always kept in.
+def _pack_item(mode=InventoryItem.CountMode.BY_LEVEL, case_size=12, **kwargs):
+    """An item counted in whole cases of ``case_size`` base units."""
+    kwargs.setdefault("image", None)
+    kwargs.setdefault("base_unit", "bottle")
+    item = InventoryItemFactory(**kwargs)
+    case = PackagingLevel.objects.create(item=item, name="case", sort_order=0, base_units=case_size)
+    PackagingLevel.objects.create(item=item, name="bottle", sort_order=1, base_units=1)
+    item.count_mode = mode
+    # ``each`` must not name a level (InventoryItem._clean_count_mode), so an
+    # item built in that mode keeps the chain but is still counted in base units.
+    item.count_level = None if mode == InventoryItem.CountMode.EACH else case
+    item.save(update_fields=["count_mode", "count_level"])
+    return item
+
+
+class TestEachItemsAreUntouched:
+    """The regression guard: nothing changes for an item in ``count_mode=each``."""
+
+    @pytest.mark.parametrize(
+        "current_stock,minimum_stock,expected",
+        [(4, 10, True), (10, 10, True), (11, 10, False), (0, 0, True), (1, 0, False)],
+    )
+    def test_plain_unit_reorder_point_unchanged(self, current_stock, minimum_stock, expected):
+        item = InventoryItemFactory(
+            image=None, current_stock=current_stock, minimum_stock=minimum_stock
+        )
+
+        assert item.count_mode == InventoryItem.CountMode.EACH
+        assert item.needs_reorder is expected
+
+    def test_case_based_item_still_compares_fractional_cases(self):
+        """``use_case_based_reorder`` keeps its own columns and its own arithmetic.
+
+        24 units at 10 per case is 2.4 cases, which is above a 2-case minimum —
+        the legacy comparison is fractional, and phase 2a must not round it.
+        """
+        item = InventoryItemFactory(
+            image=None,
+            current_stock=24,
+            minimum_stock=0,
+            use_case_based_reorder=True,
+            minimum_cases=2,
+            quantity_per_package=10,
+        )
+
+        assert item.current_cases == 2.4
+        assert item.needs_reorder is False
+
+        item.current_stock = 20
+        assert item.needs_reorder is True
+
+    def test_case_based_item_without_supplier_packaging_falls_back_to_units(self):
+        """qpp of 1 leaves ``current_cases`` as the raw stock — unchanged behaviour."""
+        item = InventoryItemFactory(
+            image=None,
+            current_stock=3,
+            use_case_based_reorder=True,
+            minimum_cases=5,
+            quantity_per_package=1,
+        )
+
+        assert item.current_cases == 3
+        assert item.needs_reorder is True
+
+    def test_retired_item_never_needs_reorder(self):
+        item = InventoryItemFactory(image=None, current_stock=0, minimum_stock=10, is_retired=True)
+
+        assert item.needs_reorder is False
+
+    def test_packaging_levels_alone_do_not_opt_an_item_in(self):
+        """A chain is inert until ``count_mode`` says to count with it.
+
+        This is the shape a half-migrated item takes: the rungs exist (maybe the
+        admin added them for display) but the item is still counted in base
+        units, and the legacy case columns still drive it.
+        """
+        item = _pack_item(
+            mode=InventoryItem.CountMode.EACH,
+            case_size=12,
+            current_stock=24,
+            minimum_stock=100,
+            use_case_based_reorder=True,
+            minimum_cases=1,
+            quantity_per_package=12,
+        )
+
+        assert item.packaging_levels.count() == 2
+        assert counts_in_packs(item) is False
+        # 2 cases against a 1-case minimum: the LEGACY comparison, not
+        # minimum_stock=100, which would have said True.
+        assert item.needs_reorder is False
+
+    def test_suggested_quantity_unchanged_for_each_items(self):
+        """``max(shortage, reorder_quantity)`` in base units, exactly as before."""
+        plenty = InventoryItemFactory(
+            image=None, current_stock=8, minimum_stock=10, reorder_quantity=25
+        )
+        depleted = InventoryItemFactory(
+            image=None, current_stock=0, minimum_stock=100, reorder_quantity=25
+        )
+
+        assert base_reorder_quantity(plenty) == 25
+        assert base_reorder_quantity(depleted) == 100
+
+
+class TestCountAtLevel:
+    """``count_at_level`` — the whole count in the unit the item is counted in."""
+
+    def test_each_returns_base_units(self):
+        item = InventoryItemFactory(image=None, current_stock=37)
+
+        assert counts_in_packs(item) is False
+        assert count_at_level(item) == 37
+
+    def test_by_level_returns_whole_packs(self):
+        """29 bottles at 12 per case is 2 whole cases — the partial one is not counted."""
+        item = _pack_item(case_size=12, current_stock=29)
+
+        assert counts_in_packs(item) is True
+        assert count_at_level(item) == 2
+
+    def test_open_closed_counts_sealed_packs_only(self):
+        item = _pack_item(
+            mode=InventoryItem.CountMode.OPEN_CLOSED,
+            case_size=12,
+            current_stock=29,
+            open_container_count=1,
+        )
+
+        assert count_at_level(item) == 2
+
+    def test_exact_multiple_has_no_remainder(self):
+        item = _pack_item(case_size=12, current_stock=36)
+
+        assert count_at_level(item) == 3
+
+    def test_missing_count_level_falls_back_to_base_units(self):
+        """A half-configured item must degrade, never crash."""
+        item = _pack_item(case_size=12, current_stock=29)
+        item.count_level = None
+
+        assert counts_in_packs(item) is False
+        assert count_at_level(item) == 29
+
+    def test_zero_base_units_level_falls_back_to_base_units(self):
+        """A rung written around the validators is treated as unusable, not fatal."""
+        item = _pack_item(case_size=12, current_stock=29)
+        PackagingLevel.objects.filter(pk=item.count_level_id).update(base_units=0)
+        item.refresh_from_db()
+
+        assert counts_in_packs(item) is False
+        assert count_at_level(item) == 29
+
+
+class TestNeedsReorderAtLevel:
+    """The trigger for pack-counting items: whole packs vs ``minimum_stock``."""
+
+    @pytest.mark.parametrize(
+        "current_stock,expected",
+        # minimum_stock=2 cases of 12: 2 whole cases or fewer trips it.
+        [(0, True), (23, True), (24, True), (35, True), (36, False), (100, False)],
+    )
+    def test_by_level_trips_on_whole_pack_count(self, current_stock, expected):
+        item = _pack_item(case_size=12, current_stock=current_stock, minimum_stock=2)
+
+        assert item.needs_reorder is expected
+
+    def test_open_closed_ignores_the_open_container(self):
+        """36 bottles is 3 sealed cases; opening one leaves 2 sealed + the open one.
+
+        The sealed count is what trips the reorder point, so the same stock reads
+        differently once a case is opened — which is the whole point of the mode.
+        """
+        item = _pack_item(
+            mode=InventoryItem.CountMode.OPEN_CLOSED,
+            case_size=12,
+            current_stock=36,
+            minimum_stock=2,
+        )
+        assert item.needs_reorder is False
+
+        # A case is opened and half-used: 30 bottles = 2 sealed + 1 open.
+        item.current_stock = 30
+        item.open_container_count = 1
+        assert count_at_level(item) == 2
+        assert item.needs_reorder is True
+
+    def test_count_mode_is_the_source_of_truth_not_the_legacy_columns(self):
+        """A pack-counting item never consults ``use_case_based_reorder``.
+
+        The legacy columns are set to values that would say the OPPOSITE, so a
+        path that still read them would fail this.
+        """
+        item = _pack_item(
+            case_size=12,
+            current_stock=24,
+            minimum_stock=2,
+            use_case_based_reorder=True,
+            minimum_cases=1,
+            quantity_per_package=12,
+        )
+
+        # Legacy math: 24/12 = 2.0 cases > 1 minimum case -> False.
+        assert item.current_cases == 2.0
+        # Pack-counting math: 2 whole cases <= 2 minimum -> True.
+        assert item.needs_reorder is True
+
+    def test_retired_pack_counting_item_never_needs_reorder(self):
+        item = _pack_item(case_size=12, current_stock=0, minimum_stock=2, is_retired=True)
+
+        assert item.needs_reorder is False
+
+
+class TestSuggestedQuantityAtLevel:
+    """``base_reorder_quantity`` — still base units, derived at the count level."""
+
+    def test_new_mode_derives_base_from_reorder_quantity_times_level(self):
+        item = _pack_item(case_size=12, current_stock=24, minimum_stock=2, reorder_quantity=3)
+
+        # 3 cases of 12 bottles.
+        assert base_reorder_quantity(item) == 36
+
+    def test_new_mode_covers_a_deep_shortage(self):
+        """The count-level twin of the ``each`` shortage clause."""
+        item = _pack_item(case_size=12, current_stock=0, minimum_stock=10, reorder_quantity=3)
+
+        # 10 cases short beats the 3-case standing quantity.
+        assert base_reorder_quantity(item) == 120
+
+    def test_open_closed_uses_the_sealed_count_for_the_shortage(self):
+        item = _pack_item(
+            mode=InventoryItem.CountMode.OPEN_CLOSED,
+            case_size=12,
+            current_stock=30,
+            open_container_count=1,
+            minimum_stock=6,
+            reorder_quantity=1,
+        )
+
+        # 2 sealed cases against a 6-case minimum -> 4 cases short.
+        assert base_reorder_quantity(item) == 48
+
+    def test_half_configured_item_uses_base_unit_math(self):
+        item = _pack_item(case_size=12, current_stock=5, minimum_stock=10, reorder_quantity=3)
+        item.count_level = None
+
+        assert base_reorder_quantity(item) == 5
+
+
+class TestLowStockQuerysetFilter:
+    """``low_stock_q`` — the SQL twin, and its ``each`` parity guarantee."""
+
+    def test_each_selection_is_byte_for_byte_the_old_filter(self):
+        """Every shape of ``each`` item, selected by both predicates, must match."""
+        InventoryItemFactory(image=None, current_stock=1, minimum_stock=10)
+        InventoryItemFactory(image=None, current_stock=10, minimum_stock=10)
+        InventoryItemFactory(image=None, current_stock=50, minimum_stock=10)
+        InventoryItemFactory(
+            image=None,
+            current_stock=3,
+            minimum_stock=10,
+            use_case_based_reorder=True,
+            minimum_cases=2,
+            quantity_per_package=12,
+        )
+        # A chain present but not opted into: still an ``each`` item.
+        _pack_item(mode=InventoryItem.CountMode.EACH, current_stock=5, minimum_stock=10)
+
+        legacy = set(
+            InventoryItem.objects.filter(current_stock__lte=F("minimum_stock")).values_list(
+                "id", flat=True
+            )
+        )
+        current = set(InventoryItem.objects.filter(low_stock_q()).values_list("id", flat=True))
+
+        assert legacy == current
+        assert legacy  # the comparison would be vacuous on an empty set
+
+    def test_pack_counting_item_selected_on_whole_packs(self):
+        """The item the old base-unit filter could never have found.
+
+        35 bottles is far above a ``minimum_stock`` of 2, so
+        ``current_stock <= minimum_stock`` says no — but it is only 2 whole
+        cases, which is at the reorder point.
+        """
+        low = _pack_item(case_size=12, current_stock=35, minimum_stock=2)
+        stocked = _pack_item(case_size=12, current_stock=36, minimum_stock=2)
+
+        selected = set(InventoryItem.objects.filter(low_stock_q()).values_list("id", flat=True))
+
+        assert low.id in selected
+        assert stocked.id not in selected
+
+    def test_filter_agrees_with_the_property_across_modes(self):
+        """The SQL predicate and ``needs_reorder`` must not drift.
+
+        Retirement is excluded from the comparison: the property short-circuits
+        on it and the callers add ``is_retired=False`` alongside the filter.
+        Legacy case-based items are excluded too — their SQL filter has ALWAYS
+        been the base-unit comparison while the property compares cases, a
+        pre-existing divergence phase 2a deliberately preserves.
+        """
+        items = [
+            InventoryItemFactory(image=None, current_stock=1, minimum_stock=10),
+            InventoryItemFactory(image=None, current_stock=99, minimum_stock=10),
+            _pack_item(case_size=12, current_stock=35, minimum_stock=2),
+            _pack_item(case_size=12, current_stock=36, minimum_stock=2),
+            _pack_item(
+                mode=InventoryItem.CountMode.OPEN_CLOSED,
+                case_size=12,
+                current_stock=30,
+                minimum_stock=2,
+                open_container_count=1,
+            ),
+        ]
+        selected = set(InventoryItem.objects.filter(low_stock_q()).values_list("id", flat=True))
+
+        for item in items:
+            assert (item.id in selected) is item.needs_reorder, item.id
+
+
+class TestReorderDisplay:
+    """The presentation helper P3 will label thresholds with."""
+
+    def test_pack_counting_item_reads_in_its_own_unit(self):
+        item = _pack_item(case_size=12, current_stock=35, minimum_stock=2, reorder_quantity=3)
+
+        assert reorder_threshold(item) == (2, "case")
+        display = reorder_display(item)
+        assert display["unit"] == "case"
+        assert display["threshold"] == 2
+        assert display["current"] == 2
+        assert display["reorder_quantity"] == 3
+        assert display["needs_reorder"] is True
+        assert display["text"] == "2 cases on hand · reorder at 2 cases"
+
+    def test_case_based_item_reads_in_cases(self):
+        item = InventoryItemFactory(
+            image=None,
+            current_stock=24,
+            use_case_based_reorder=True,
+            minimum_cases=2,
+            reorder_cases=4,
+            quantity_per_package=10,
+        )
+
+        assert reorder_threshold(item) == (2, "case")
+        display = reorder_display(item)
+        assert display["current"] == 2.4
+        assert display["reorder_quantity"] == 4
+
+    def test_plain_item_reads_in_base_units(self):
+        item = InventoryItemFactory(
+            image=None, current_stock=5, minimum_stock=10, reorder_quantity=25
+        )
+
+        assert reorder_threshold(item) == (10, "unit")
+        display = reorder_display(item)
+        assert display["mode"] == InventoryItem.CountMode.EACH
+        assert display["current"] == 5
+        assert display["threshold"] == 10
+        assert display["reorder_quantity"] == 25
+
+    def test_serializer_exposes_needs_reorder_and_reorder_display(self, authenticated_client):
+        client, _ = authenticated_client
+        item = _pack_item(case_size=12, current_stock=35, minimum_stock=2, reorder_quantity=3)
+
+        response = client.get(reverse("inventoryitem-detail", kwargs={"pk": str(item.id)}))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["needs_reorder"] is True
+        assert response.data["reorder_display"]["unit"] == "case"
+        assert response.data["reorder_display"]["threshold"] == 2
+        assert response.data["reorder_display"]["current"] == 2
+
+
+class TestBridgeCaseReorderCommand:
+    """``bridge_case_reorder_to_packaging`` — opt-in migration of legacy case items."""
+
+    def _run(self, *args):
+        out = StringIO()
+        call_command("bridge_case_reorder_to_packaging", *args, stdout=out)
+        return out.getvalue()
+
+    def _eligible_item(self, **kwargs):
+        kwargs.setdefault("image", None)
+        kwargs.setdefault("current_stock", 24)
+        kwargs.setdefault("minimum_stock", 999)
+        kwargs.setdefault("reorder_quantity", 999)
+        kwargs.setdefault("quantity_per_package", 12)
+        return InventoryItemFactory(
+            use_case_based_reorder=True,
+            minimum_cases=2,
+            reorder_cases=4,
+            **kwargs,
+        )
+
+    def test_dry_run_reports_and_writes_nothing(self):
+        item = self._eligible_item()
+
+        output = self._run()
+
+        assert "Would bridge 1 item(s)." in output
+        assert "1 case = 12 unit" in output
+        assert "minimum_stock 999 -> 2" in output
+        assert "reorder_quantity 999 -> 4" in output
+        assert "Dry run" in output
+
+        item.refresh_from_db()
+        assert item.count_mode == InventoryItem.CountMode.EACH
+        assert item.count_level is None
+        assert item.minimum_stock == 999
+        assert not item.packaging_levels.exists()
+
+    def test_apply_builds_the_chain_and_maps_the_thresholds(self):
+        item = self._eligible_item()
+
+        output = self._run("--apply")
+
+        assert "Bridged 1 item(s)." in output
+        item.refresh_from_db()
+        assert item.count_mode == InventoryItem.CountMode.BY_LEVEL
+        assert item.count_level.name == "case"
+        assert item.count_level.base_units == 12
+        assert item.minimum_stock == 2
+        assert item.reorder_quantity == 4
+        assert list(
+            item.packaging_levels.order_by("sort_order").values_list("name", "base_units")
+        ) == [("case", 12), ("unit", 1)]
+        # The legacy columns stay put — deprecating them is a later step.
+        assert item.use_case_based_reorder is True
+        assert item.minimum_cases == 2
+        assert item.reorder_cases == 4
+
+    def test_bridged_item_keeps_its_reorder_verdict(self):
+        """Equivalence: a whole number of cases trips identically before and after."""
+        item = self._eligible_item(current_stock=24)
+        before = item.needs_reorder
+
+        self._run("--apply")
+
+        item.refresh_from_db()
+        assert before is True
+        assert item.needs_reorder is before
+
+    def test_bridged_item_keeps_a_negative_verdict_too(self):
+        item = self._eligible_item(current_stock=36)
+        before = item.needs_reorder
+
+        self._run("--apply")
+
+        item.refresh_from_db()
+        assert before is False
+        assert item.needs_reorder is before
+
+    def test_partial_case_at_the_threshold_is_reported_as_changing(self):
+        """The one documented shift: fractional cases vs whole packs.
+
+        30 units at 12 per case is 2.5 cases — above a 2-case minimum by the
+        legacy comparison, but only 2 WHOLE cases once the item counts packs.
+        The command has to say so before anyone applies it.
+        """
+        item = self._eligible_item(current_stock=30)
+        assert item.needs_reorder is False
+
+        output = self._run()
+
+        assert "needs reorder: False -> True" in output
+        assert "CHANGES" in output
+        assert "1 item(s) change whether they currently need reordering" in output
+
+        self._run("--apply")
+        item.refresh_from_db()
+        assert item.needs_reorder is True
+
+    def test_is_idempotent(self):
+        item = self._eligible_item()
+        self._run("--apply")
+
+        output = self._run("--apply")
+
+        assert "Bridged 0 item(s)." in output
+        assert "already has packaging levels" in output
+        item.refresh_from_db()
+        assert item.packaging_levels.count() == 2
+        assert item.minimum_stock == 2
+
+    def test_skips_items_without_a_supplier_case_size(self):
+        item = self._eligible_item(quantity_per_package=1)
+
+        output = self._run("--apply")
+
+        assert "Bridged 0 item(s)." in output
+        assert "supplier quantity_per_package is not more than 1" in output
+        item.refresh_from_db()
+        assert item.count_mode == InventoryItem.CountMode.EACH
+
+    def test_ignores_items_that_are_not_case_based(self):
+        item = InventoryItemFactory(image=None, quantity_per_package=12)
+
+        output = self._run("--apply")
+
+        assert "Bridged 0 item(s)." in output
+        assert item.name not in output
+
+    def test_names_the_base_rung_after_the_items_base_unit(self):
+        item = self._eligible_item(base_unit="bottle")
+
+        self._run("--apply")
+
+        item.refresh_from_db()
+        assert list(
+            item.packaging_levels.order_by("sort_order").values_list("name", flat=True)
+        ) == ["case", "bottle"]

--- a/backend/inventory/tests/test_reorder_at_level.py
+++ b/backend/inventory/tests/test_reorder_at_level.py
@@ -451,6 +451,12 @@ class TestBridgeCaseReorderCommand:
             **kwargs,
         )
 
+    def test_dry_run_flag_is_accepted_and_matches_the_default(self):
+        """``--dry-run`` is the default; typing it out loud must not be an error."""
+        self._eligible_item()
+
+        assert self._run("--dry-run") == self._run()
+
     def test_dry_run_reports_and_writes_nothing(self):
         item = self._eligible_item()
 

--- a/backend/inventory/tests/test_reorder_at_level.py
+++ b/backend/inventory/tests/test_reorder_at_level.py
@@ -535,6 +535,15 @@ class TestBridgeCaseReorderCommand:
         item.refresh_from_db()
         assert item.needs_reorder is True
 
+    def test_retired_item_is_never_reported_as_flipping(self):
+        """Retirement wins over stock in both modes, so the verdict cannot change."""
+        self._eligible_item(current_stock=30, is_retired=True)
+
+        output = self._run()
+
+        assert "needs reorder: False -> False" in output
+        assert "CHANGES" not in output
+
     def test_is_idempotent(self):
         item = self._eligible_item()
         self._run("--apply")

--- a/backend/inventory/views.py
+++ b/backend/inventory/views.py
@@ -118,6 +118,7 @@ from .serializers import (
     WorkOrderTaskCompletionSerializer,
     WorkOrderValidationSerializer,
 )
+from .services.packaging import count_at_level, counts_in_packs
 from .services.problem_auto_resolve import resolve_problems_for_work_order
 
 
@@ -7571,11 +7572,21 @@ def _apply_reconciliation_row(user, item, actual_count, reason, notes="", skip_r
     reorder_created = False
     # Retired items are phased out: reconciliation must never auto-create a
     # ReorderRequest for them, even when the counted stock is at/below minimum.
-    if not skip_reorder and not item.is_retired and actual <= item.minimum_stock:
+    #
+    # Both the trigger and the quantity are read at the granularity the item is
+    # counted in (op-es7c). For an ``each`` item — every item that exists today —
+    # ``count_at_level`` IS ``current_stock`` (just set to ``actual``) and the
+    # multiplier is 1, so this is byte-for-byte the previous comparison and the
+    # previous quantity. For an item counted in whole packs, ``minimum_stock``
+    # and ``reorder_quantity`` are amounts in ITS packs, so comparing raw base
+    # units against them — or storing a pack count as if it were base units —
+    # would be wrong in both directions.
+    if not skip_reorder and not item.is_retired and count_at_level(item) <= item.minimum_stock:
         from reorder_queue.models import ReorderRequest
 
         requested_by = (user.get_full_name() or user.username).strip()
-        reorder_quantity = item.reorder_quantity or 1
+        base_units_per_count = item.count_level.base_units if counts_in_packs(item) else 1
+        reorder_quantity = (item.reorder_quantity or 1) * base_units_per_count
         reorder = ReorderRequest.objects.create(
             item=item,
             quantity=reorder_quantity,

--- a/backend/reorder_queue/tests/test_api.py
+++ b/backend/reorder_queue/tests/test_api.py
@@ -2438,3 +2438,102 @@ class TestReorderDataExcludesRetired:
         assert str(retired.id) not in listed_item_ids
         # Only the active item counts toward the active-request tally.
         assert response.data["items_with_requests"] == 1
+
+
+@pytest.mark.integration
+class TestReorderQuantityIsModeAware:
+    """Suggested reorder quantities honour the item's counting granularity (op-es7c).
+
+    The stored/quoted quantity stays in BASE units in every mode — only the
+    derivation moves. An ``each`` item keeps the supplier-package round-up it has
+    always had; an item counted in whole packs of its OWN chain is quoted in
+    those packs instead, because rounding its case count up to a *second*,
+    unrelated supplier case size would silently inflate the order.
+    """
+
+    REORDER_DATA_URL = "/api/reorders/purchase-orders/reorder_data/"
+    OPTIMIZED_URL = "/api/reorders/purchase-orders/create_optimized_order/"
+
+    def _pack_item(self, **kwargs):
+        """A low-stock item counted in whole cases of 12 base units."""
+        from inventory.models import InventoryItem, PackagingLevel
+
+        kwargs.setdefault("image", None)
+        kwargs.setdefault("base_unit", "bottle")
+        item = InventoryItemFactory(**kwargs)
+        case = PackagingLevel.objects.create(item=item, name="case", sort_order=0, base_units=12)
+        PackagingLevel.objects.create(item=item, name="bottle", sort_order=1, base_units=1)
+        item.count_mode = InventoryItem.CountMode.BY_LEVEL
+        item.count_level = case
+        item.save(update_fields=["count_mode", "count_level"])
+        return item
+
+    def _line_for(self, response, item):
+        lines = [
+            line
+            for group in response.data["suppliers"]
+            for line in group["items"]
+            if line["item_id"] == str(item.id)
+        ]
+        assert lines, f"{item.name} missing from reorder_data"
+        return lines[0]
+
+    def test_reorder_data_quotes_pack_counted_items_in_their_own_packs(self):
+        """3 cases of 12 = 36 bottles, NOT re-rounded to the supplier's 50-packs."""
+        client = APIClient()
+        user = User.objects.create_user(username="packs", password="pw")
+        client.force_authenticate(user=user)
+
+        # 35 bottles is only 2 whole cases, at a 2-case reorder point.
+        item = self._pack_item(
+            current_stock=35, minimum_stock=2, reorder_quantity=3, quantity_per_package=50
+        )
+
+        response = client.get(self.REORDER_DATA_URL)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert self._line_for(response, item)["suggested_quantity"] == 36
+
+    def test_reorder_data_still_rounds_each_items_to_supplier_packages(self):
+        """The unchanged path: an ``each`` item rounds up to whole supplier packs."""
+        client = APIClient()
+        user = User.objects.create_user(username="eaches", password="pw")
+        client.force_authenticate(user=user)
+
+        item = InventoryItemFactory(
+            image=None,
+            current_stock=1,
+            minimum_stock=10,
+            reorder_quantity=25,
+            quantity_per_package=10,
+        )
+
+        response = client.get(self.REORDER_DATA_URL)
+
+        assert response.status_code == status.HTTP_200_OK
+        # max(shortage 9, reorder 25) = 25 -> 3 packages of 10.
+        assert self._line_for(response, item)["suggested_quantity"] == 30
+
+    def test_optimized_order_recommends_whole_packs_of_the_items_chain(self):
+        """``unit_cost=None`` sidesteps the optimizer's pre-existing Decimal*float bug."""
+        client = APIClient()
+        user = User.objects.create_user(username="optimized", password="pw")
+        client.force_authenticate(user=user)
+
+        item = self._pack_item(
+            current_stock=35,
+            minimum_stock=2,
+            reorder_quantity=3,
+            quantity_per_package=50,
+            unit_cost=None,
+        )
+
+        response = client.post(self.OPTIMIZED_URL, {}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        quantities = {
+            str(line["item_id"]): line["recommended_quantity"]
+            for rec in response.data.get("recommendations", [])
+            for line in rec["items"]
+        }
+        assert quantities[str(item.id)] == 36

--- a/backend/reorder_queue/views.py
+++ b/backend/reorder_queue/views.py
@@ -21,6 +21,7 @@ from rest_framework.response import Response
 from rest_framework_simplejwt.authentication import JWTAuthentication
 
 from inventory.models import InventoryItem, Supplier
+from inventory.services.packaging import base_reorder_quantity, counts_in_packs, low_stock_q
 
 from . import services
 from .audit import record_event as record_audit_event
@@ -754,10 +755,13 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         """Create an optimized purchase order based on current needs and supplier analysis."""
 
         # Get items that need reordering (retired items are phased out and
-        # excluded — no optimized order line for them).
+        # excluded — no optimized order line for them). ``low_stock_q`` compares
+        # stock to the reorder point at the granularity each item is counted in;
+        # for the ``each`` items that is exactly the old
+        # ``current_stock <= minimum_stock`` (op-es7c).
         low_stock_items = (
-            InventoryItem.objects.filter(current_stock__lte=F("minimum_stock"), is_retired=False)
-            .select_related("category", "location")
+            InventoryItem.objects.filter(low_stock_q(), is_retired=False)
+            .select_related("category", "location", "count_level")
             .prefetch_related("item_suppliers__supplier")
         )
 
@@ -856,20 +860,21 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
                 is_retired=False,
             )
             .distinct()
-            .select_related("category", "location")
+            .select_related("category", "location", "count_level")
             .prefetch_related("item_suppliers__supplier", "reorder_requests")
         )
 
-        # Also get items that need reordering (current_stock <= minimum_stock)
+        # Also get items that need reordering (stock at/below the reorder point,
+        # compared at whatever granularity each item is counted in — op-es7c)
         # but exclude those already in items_with_requests
         low_stock_items = (
             InventoryItem.objects.filter(
-                current_stock__lte=F("minimum_stock"),
+                low_stock_q(),
                 is_active=True,
                 is_retired=False,
             )
             .exclude(id__in=items_with_requests.values_list("id", flat=True))
-            .select_related("category", "location")
+            .select_related("category", "location", "count_level")
             .prefetch_related("item_suppliers__supplier")
         )
 
@@ -903,17 +908,23 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
                         "avg_lead_time": 0,
                     }
 
-                # Calculate suggested quantity
+                # Calculate suggested quantity (base units, mode-aware — op-es7c)
                 # If item has an active reorder request, use that quantity
                 active_request = item.get_active_reorder_request()
                 if active_request:
                     suggested_qty = active_request.quantity
                 else:
-                    shortage = max(0, item.minimum_stock - item.current_stock)
-                    suggested_qty = max(shortage, item.reorder_quantity)
+                    suggested_qty = base_reorder_quantity(item)
 
-                # Adjust for package quantities
-                if item_supplier.quantity_per_package and item_supplier.quantity_per_package > 1:
+                # Adjust for package quantities. Supplier packaging only rounds
+                # items counted in base units: a pack-counting item already
+                # ordered whole packs of its own chain above, and re-rounding to
+                # a supplier's case would silently inflate that.
+                if (
+                    not counts_in_packs(item)
+                    and item_supplier.quantity_per_package
+                    and item_supplier.quantity_per_package > 1
+                ):
                     packages_needed = (
                         suggested_qty + item_supplier.quantity_per_package - 1
                     ) // item_supplier.quantity_per_package
@@ -1103,10 +1114,17 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
         return scored_suppliers[0][0] if scored_suppliers else None
 
     def _calculate_optimal_quantity(self, item, supplier):
-        """Calculate optimal order quantity considering package sizes and stock needs."""
-        # Calculate basic reorder quantity
-        shortage = max(0, item.minimum_stock - item.current_stock)
-        base_quantity = max(shortage, item.reorder_quantity)
+        """Calculate optimal order quantity considering package sizes and stock needs.
+
+        Always base units. For an item counted in whole packs the item's own
+        packaging chain sets the quantity and the supplier's case size is not
+        applied on top (op-es7c); ``each`` items keep the supplier round-up.
+        """
+        # Calculate basic reorder quantity (mode-aware; each = today's math)
+        base_quantity = base_reorder_quantity(item)
+
+        if counts_in_packs(item):
+            return base_quantity
 
         # Adjust for package quantities if available
         if supplier.quantity_per_package and supplier.quantity_per_package > 1:


### PR DESCRIPTION
**Phase 2a of the inventory UoM epic** (builds on #979). Makes the reorder *logic* mode-aware. Stock transactions (PO/receive/usage entry) are Phase 2b — unchanged here.

## What it does
- **`needs_reorder` is mode-aware:**
  - `each` (every existing item, incl. those using today's case-based-reorder toggle) → **identical behaviour** — case items still compare `current_cases` to `minimum_cases`, others `current_stock` to `minimum_stock`.
  - `by_level` / `open_closed` → compares whole packs (`count_at_level`) to `minimum_stock`, now read as a threshold **in the item's count unit** (cases / reams / sealed packs). `count_mode` is the source of truth; the legacy toggle isn't consulted for these.
- **Suggested reorder quantity** for new-mode items derives from `reorder_quantity` in count units × the level's base-unit size (the stored request/PO quantity stays in base units — only the derivation changes).
- New `count_at_level()` service helper (+ a SQL twin so queryset filtering stays consistent with the Python property).
- Reconciliation-triggered auto-reorder also reads the count level; the printed reorder **index cards** show the right unit.
- **Optional bridge** (`manage.py bridge_case_reorder_to_packaging`, `--dry-run` default): converts existing `use_case_based_reorder` items into a 2-rung `by_level` chain, mapping `minimum_cases→minimum_stock` / `reorder_cases→reorder_quantity`. On-demand, idempotent — not a forced migration. Legacy columns left in place.

## Safety / flag
- **Every `each` item behaves identically** (regression-guarded in tests). Only opted-in modes change.
- ⚠️ For new modes, `minimum_stock` / `reorder_quantity` are reinterpreted as **count-unit** thresholds; the item form (Phase 3) will label them per mode ("Minimum: 2 cases").

## Tests
`test_reorder_at_level.py` (+553) + reorder_queue/index_cards test additions: all three modes, EACH regression guard (incl. a case-based item), the bridge command (dry-run + apply + idempotence + pre/post equivalence), count_at_level + null-level fallback.

Bead: op-es7c. (Worker was finishing its local suite on a loaded box — CI is the authoritative gate; I'll fold in any post-suite fix.)