### PR TITLE
Inventory UoM Phase 3: web UI for the packaging matrix

### DIFF
--- a/frontend/src/__tests__/components/PackagingChainEditor.test.tsx
+++ b/frontend/src/__tests__/components/PackagingChainEditor.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Tests for PackagingChainEditor (op-lkxl): add / edit / remove / reorder the
+ * rungs of an item's packaging chain, and the derived "1 case = 10 reams" line
+ * that makes the chain readable while it is being typed.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import PackagingChainEditor from '../../components/inventory/PackagingChainEditor';
+import { PackagingRow, blankPackagingRow, validatePackagingChain } from '../../utils/packaging';
+
+const makeRow = (name: string, base_units: number | ''): PackagingRow => ({
+  ...blankPackagingRow(),
+  name,
+  base_units,
+});
+
+/**
+ * The editor is controlled, so the harness owns the rows exactly as the item
+ * form does — that is what makes "click down, assert the new order" meaningful.
+ */
+const Harness: React.FC<{ initial?: PackagingRow[] }> = ({ initial = [] }) => {
+  const [rows, setRows] = useState<PackagingRow[]>(initial);
+  return (
+    <MantineProvider env="test">
+      <PackagingChainEditor
+        rows={rows}
+        onChange={setRows}
+        baseUnit="sheet"
+        errors={validatePackagingChain(rows)}
+      />
+    </MantineProvider>
+  );
+};
+
+const renderEditor = (initial?: PackagingRow[]) => render(<Harness initial={initial} />);
+
+describe('PackagingChainEditor', () => {
+  it('says the item is counted in base units when there is no chain', () => {
+    renderEditor();
+
+    expect(screen.getByTestId('packaging-chain-empty')).toHaveTextContent(
+      'counted in sheets'
+    );
+    expect(screen.queryByTestId('packaging-chain-table')).not.toBeInTheDocument();
+  });
+
+  it('adds a level', () => {
+    renderEditor();
+
+    fireEvent.click(screen.getByTestId('packaging-add-level'));
+
+    expect(screen.getByTestId('packaging-row-0')).toBeInTheDocument();
+    expect(screen.getByTestId('packaging-row-name-0')).toHaveValue('');
+  });
+
+  it('edits a level name and size', () => {
+    renderEditor();
+    fireEvent.click(screen.getByTestId('packaging-add-level'));
+
+    fireEvent.change(screen.getByTestId('packaging-row-name-0'), {
+      target: { value: 'case' },
+    });
+    fireEvent.change(screen.getByTestId('packaging-row-base-units-0'), {
+      target: { value: '500' },
+    });
+
+    expect(screen.getByTestId('packaging-row-name-0')).toHaveValue('case');
+    expect(screen.getByTestId('packaging-row-base-units-0')).toHaveValue('500');
+  });
+
+  it('removes a level', () => {
+    renderEditor([makeRow('case', 500), makeRow('sheet', 1)]);
+
+    fireEvent.click(screen.getByTestId('packaging-row-remove-0'));
+
+    expect(screen.getAllByTestId(/^packaging-row-\d+$/)).toHaveLength(1);
+    expect(screen.getByTestId('packaging-row-name-0')).toHaveValue('sheet');
+  });
+
+  it('reorders levels, which is what changes their sort_order on save', () => {
+    renderEditor([makeRow('case', 500), makeRow('ream', 100), makeRow('sheet', 1)]);
+
+    fireEvent.click(screen.getByTestId('packaging-row-down-0'));
+
+    expect(screen.getByTestId('packaging-row-name-0')).toHaveValue('ream');
+    expect(screen.getByTestId('packaging-row-name-1')).toHaveValue('case');
+
+    fireEvent.click(screen.getByTestId('packaging-row-up-1'));
+
+    expect(screen.getByTestId('packaging-row-name-0')).toHaveValue('case');
+    expect(screen.getByTestId('packaging-row-name-1')).toHaveValue('ream');
+  });
+
+  it('pins the outermost row against moving up and the innermost against moving down', () => {
+    renderEditor([makeRow('case', 500), makeRow('sheet', 1)]);
+
+    expect(screen.getByTestId('packaging-row-up-0')).toBeDisabled();
+    expect(screen.getByTestId('packaging-row-down-1')).toBeDisabled();
+    expect(screen.getByTestId('packaging-row-down-0')).not.toBeDisabled();
+  });
+
+  it('shows the derived "1 case = N reams" ratio, and nothing for the base rung', () => {
+    renderEditor([makeRow('case', 1000), makeRow('ream', 100), makeRow('sheet', 1)]);
+
+    expect(screen.getByTestId('packaging-row-per-parent-0')).toHaveTextContent(
+      '1 case = 10 reams'
+    );
+    expect(screen.getByTestId('packaging-row-per-parent-1')).toHaveTextContent(
+      '1 ream = 100 sheets'
+    );
+    expect(screen.queryByTestId('packaging-row-per-parent-2')).not.toBeInTheDocument();
+  });
+
+  it('recomputes the ratio as a size is edited', () => {
+    renderEditor([makeRow('case', 1000), makeRow('sheet', 1)]);
+
+    expect(screen.getByTestId('packaging-row-per-parent-0')).toHaveTextContent(
+      '1 case = 1000 sheets'
+    );
+
+    fireEvent.change(screen.getByTestId('packaging-row-base-units-0'), {
+      target: { value: '12' },
+    });
+
+    expect(screen.getByTestId('packaging-row-per-parent-0')).toHaveTextContent(
+      '1 case = 12 sheets'
+    );
+  });
+
+  it('surfaces the chain rules while the chain is invalid', () => {
+    renderEditor([makeRow('case', 10), makeRow('ream', 10), makeRow('sheet', 1)]);
+
+    expect(screen.getByTestId('packaging-chain-errors')).toHaveTextContent(
+      /'ream' must hold fewer base units than 'case'/
+    );
+  });
+
+  it('shows no errors for a valid chain', () => {
+    renderEditor([makeRow('case', 1000), makeRow('sheet', 1)]);
+
+    expect(screen.queryByTestId('packaging-chain-errors')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/InventoryItemDetailPage.packaging.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemDetailPage.packaging.test.tsx
@@ -1,0 +1,475 @@
+/**
+ * Tests for the packaging matrix on InventoryItemDetailPage (op-lkxl, phase 3):
+ * on-hand rendered at the item's counting granularity, the pack chain, counting
+ * at the level (`at_level`), and the open/finish pack transitions.
+ *
+ * The invariant asserted alongside them: an each-mode item reads and posts in
+ * base units exactly as it did before the matrix existed — no `at_level`, no
+ * pack controls.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { NotificationProvider } from '../../contexts/NotificationContext';
+import InventoryItemDetailPage from '../../pages/InventoryItemDetailPage';
+import * as api from '../../services/api';
+
+vi.mock('../../services/api');
+
+vi.mock('../../utils/dialogs', async () => ({
+  showError: vi.fn(),
+}));
+
+vi.mock('qrcode.react', async () => ({
+  QRCodeSVG: () => <div data-testid="qr-code">QR Code</div>,
+}));
+
+vi.mock('recharts', async () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  LineChart: () => <div data-testid="line-chart" />,
+  Line: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  Tooltip: () => <div />,
+}));
+
+const mockNavigate = jest.fn();
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useNavigate: () => mockNavigate,
+}));
+
+const PAPER_CHAIN = [
+  { id: 11, name: 'case', sort_order: 0, base_units: 1000, per_parent: 10 },
+  { id: 12, name: 'ream', sort_order: 1, base_units: 100, per_parent: 100 },
+  { id: 13, name: 'sheet', sort_order: 2, base_units: 1, per_parent: null },
+];
+
+const makeItem = (overrides: Record<string, unknown> = {}) => ({
+  id: 'test-id',
+  name: 'Copy paper',
+  description: '',
+  sku: 'PAPER-001',
+  category: 1,
+  category_name: 'Supplies',
+  location: 'Shelf A',
+  current_stock: 450,
+  minimum_stock: 2,
+  reorder_quantity: 4,
+  unit_cost: '0.02',
+  supplier_name: '',
+  needs_reorder: false,
+  has_pending_reorder: false,
+  is_active: true,
+  image: null,
+  thumbnail: null,
+  qr_code: null,
+  use_case_based_reorder: false,
+  minimum_cases: 0,
+  reorder_cases: 0,
+  current_cases: 0,
+  supplier: null,
+  supplier_sku: '',
+  supplier_url: '',
+  average_lead_time: 7,
+  notes: '',
+  total_value: '9.00',
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+  ownership_type: 'space' as const,
+  owning_user: null,
+  owning_group: null,
+  reorder_status: '',
+  expected_delivery_date: null,
+  active_reorder_request: null,
+  is_hazardous: false,
+  msds_url: null,
+  nfpa_health_hazard: null,
+  nfpa_fire_hazard: null,
+  nfpa_instability_hazard: null,
+  nfpa_special_hazards: '',
+  nfpa_fire_diamond_display: '',
+  hazmat_compliance_status: '',
+  has_complete_nfpa_data: false,
+  last_counted_at: null,
+  days_since_last_count: null,
+  base_unit: 'unit',
+  count_mode: 'each' as const,
+  count_level: null,
+  open_container_count: 0,
+  packaging_levels: [],
+  ...overrides,
+});
+
+/** A by_level paper item: 450 sheets = 4 whole reams. */
+const byLevelItem = (overrides: Record<string, unknown> = {}) =>
+  makeItem({
+    base_unit: 'sheet',
+    count_mode: 'by_level',
+    count_level: 12,
+    packaging_levels: PAPER_CHAIN,
+    on_hand_display: {
+      mode: 'by_level',
+      level: 'ream',
+      level_count: 4,
+      remainder_base: 50,
+      text: '4 ream(s)',
+    },
+    ...overrides,
+  });
+
+/** An open_closed glove item: 3 sealed boxes plus one opened. */
+const openClosedItem = (overrides: Record<string, unknown> = {}) =>
+  makeItem({
+    name: 'Nitrile gloves',
+    base_unit: 'glove',
+    current_stock: 300,
+    open_container_count: 1,
+    count_mode: 'open_closed',
+    count_level: 21,
+    packaging_levels: [
+      { id: 21, name: 'box', sort_order: 0, base_units: 100, per_parent: 100 },
+      { id: 22, name: 'glove', sort_order: 1, base_units: 1, per_parent: null },
+    ],
+    on_hand_display: {
+      mode: 'open_closed',
+      level: 'box',
+      sealed: 3,
+      open: 1,
+      text: '3 sealed + 1 open',
+    },
+    ...overrides,
+  });
+
+const setupItem = (item: Record<string, unknown>) => {
+  (api.inventoryAPI.getItem as jest.Mock).mockResolvedValue({ data: item });
+  (api.inventoryAPI.getItemMetrics as jest.Mock).mockResolvedValue({ data: null });
+  (api.inventoryAPI.getUsageLogs as jest.Mock).mockResolvedValue({ data: { results: [] } });
+  (api.reorderAPI.listRequests as jest.Mock).mockResolvedValue({ data: { results: [] } });
+  (api.assetsAPI.listAssets as jest.Mock).mockResolvedValue({ data: { results: [] } });
+  (api.sigAPI.listMySIGs as jest.Mock).mockResolvedValue({ data: { results: [] } });
+};
+
+const cycleCountResponse = (overrides: Record<string, unknown> = {}) => ({
+  data: {
+    id: 'test-id',
+    current_stock: 300,
+    last_counted_at: '2026-07-29T00:00:00Z',
+    days_since_last_count: 0,
+    reconciliation: {
+      id: 1,
+      projected_count: 450,
+      actual_count: 300,
+      delta: -150,
+      reason: 'miscounted',
+      reconciled_at: '2026-07-29T00:00:00Z',
+      reconciled_by: 1,
+    },
+    ...overrides,
+  },
+});
+
+const renderPage = () =>
+  render(
+    <MantineProvider env="test">
+      <NotificationProvider>
+        <MemoryRouter initialEntries={['/inventory/items/test-id']}>
+          <Routes>
+            <Route path="/inventory/items/:id" element={<InventoryItemDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </NotificationProvider>
+    </MantineProvider>
+  );
+
+const loaded = () => waitFor(() => expect(screen.getByTestId('item-on-hand')).toBeInTheDocument());
+
+describe('InventoryItemDetailPage — on-hand at the count level', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders base units for an each-mode item, as it always has', async () => {
+    setupItem(makeItem({ current_stock: 10 }));
+    renderPage();
+    await loaded();
+
+    expect(screen.getByTestId('item-on-hand')).toHaveTextContent('10 units');
+    expect(screen.getByTestId('item-minimum-stock')).toHaveTextContent('2 units');
+    expect(screen.getByTestId('item-reorder-quantity')).toHaveTextContent('4 units');
+    // None of the pack surfaces appear for an each-mode item.
+    expect(screen.queryByTestId('item-pack-chain')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('item-base-units')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pack-container-controls')).not.toBeInTheDocument();
+  });
+
+  it("renders the server's pack text plus the base-unit total for a by_level item", async () => {
+    setupItem(byLevelItem());
+    renderPage();
+    await loaded();
+
+    expect(screen.getByTestId('item-on-hand')).toHaveTextContent('4 ream(s)');
+    expect(screen.getByTestId('item-base-units')).toHaveTextContent('450 sheets');
+    // Thresholds are read in the counting unit for a pack-counting item.
+    expect(screen.getByTestId('item-minimum-stock')).toHaveTextContent('2 reams');
+    expect(screen.getByTestId('item-reorder-quantity')).toHaveTextContent('4 reams');
+  });
+
+  it('shows the pack chain and what the item is counted in', async () => {
+    setupItem(byLevelItem());
+    renderPage();
+    await loaded();
+
+    const chain = screen.getByTestId('item-pack-chain');
+    expect(chain).toHaveTextContent('1 case = 10 reams');
+    expect(chain).toHaveTextContent('1 ream = 100 sheets');
+    expect(chain).toHaveTextContent('Counted in reams');
+  });
+
+  it('renders sealed + open for an open_closed item', async () => {
+    setupItem(openClosedItem());
+    renderPage();
+    await loaded();
+
+    expect(screen.getByTestId('item-on-hand')).toHaveTextContent('3 sealed + 1 open');
+    expect(screen.getByTestId('item-pack-chain')).toHaveTextContent(
+      'Counted in boxes (sealed + open)'
+    );
+  });
+
+  it('falls back to base units for a half-configured pack item', async () => {
+    setupItem(
+      byLevelItem({
+        count_level: null,
+        on_hand_display: { mode: 'each', base_units: 450, unit: 'sheet', text: '450 sheet' },
+      })
+    );
+    renderPage();
+    await loaded();
+
+    expect(screen.getByTestId('item-on-hand')).toHaveTextContent('450 sheets');
+    expect(screen.getByTestId('item-minimum-stock')).toHaveTextContent('2 units');
+    expect(screen.queryByTestId('pack-container-controls')).not.toBeInTheDocument();
+  });
+});
+
+describe('InventoryItemDetailPage — counting at the level', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('counts an each-mode item in base units, with no at_level flag', async () => {
+    setupItem(makeItem({ current_stock: 10 }));
+    (api.inventoryAPI.cycleCount as jest.Mock).mockResolvedValue(cycleCountResponse());
+    renderPage();
+    await loaded();
+
+    fireEvent.click(screen.getByTestId('cycle-count-button'));
+    await screen.findByTestId('cycle-count-submit');
+
+    // Seeded from base-unit stock, and no open-container field.
+    expect(screen.getByTestId('cycle-count-qty')).toHaveValue('10');
+    expect(screen.queryByTestId('cycle-count-open-containers')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('cycle-count-submit'));
+
+    await waitFor(() => expect(api.inventoryAPI.cycleCount).toHaveBeenCalledTimes(1));
+    const payload = (api.inventoryAPI.cycleCount as jest.Mock).mock.calls[0][1];
+    expect(payload.counted_qty).toBe(10);
+    expect(payload).not.toHaveProperty('at_level');
+    expect(payload).not.toHaveProperty('open_count');
+  });
+
+  it('counts a by_level item in packs and posts at_level', async () => {
+    setupItem(byLevelItem());
+    (api.inventoryAPI.cycleCount as jest.Mock).mockResolvedValue(
+      cycleCountResponse({
+        counted_unit: 'ream',
+        on_hand_display: { mode: 'by_level', level: 'ream', level_count: 3, text: '3 ream(s)' },
+      })
+    );
+    renderPage();
+    await loaded();
+
+    fireEvent.click(screen.getByTestId('cycle-count-button'));
+    await screen.findByTestId('cycle-count-submit');
+
+    // Labelled and seeded in the item's own unit — 4 whole reams, not 450 sheets.
+    expect(screen.getByLabelText(/Counted quantity \(reams\)/)).toBeInTheDocument();
+    expect(screen.getByTestId('cycle-count-qty')).toHaveValue('4');
+
+    fireEvent.change(screen.getByTestId('cycle-count-qty'), { target: { value: '3' } });
+    fireEvent.click(screen.getByTestId('cycle-count-submit'));
+
+    await waitFor(() => expect(api.inventoryAPI.cycleCount).toHaveBeenCalledTimes(1));
+    expect((api.inventoryAPI.cycleCount as jest.Mock).mock.calls[0][1]).toEqual(
+      expect.objectContaining({ counted_qty: 3, at_level: true })
+    );
+    expect((api.inventoryAPI.cycleCount as jest.Mock).mock.calls[0][1]).not.toHaveProperty(
+      'open_count'
+    );
+  });
+
+  it('counts an open_closed item as sealed packs plus the open tally', async () => {
+    setupItem(openClosedItem());
+    (api.inventoryAPI.cycleCount as jest.Mock).mockResolvedValue(cycleCountResponse());
+    renderPage();
+    await loaded();
+
+    fireEvent.click(screen.getByTestId('cycle-count-button'));
+    await screen.findByTestId('cycle-count-submit');
+
+    // Seeded from the sealed count, with the open tally alongside it.
+    expect(screen.getByTestId('cycle-count-qty')).toHaveValue('3');
+    expect(screen.getByTestId('cycle-count-open-containers')).toHaveValue('1');
+
+    fireEvent.change(screen.getByTestId('cycle-count-open-containers'), {
+      target: { value: '2' },
+    });
+    fireEvent.click(screen.getByTestId('cycle-count-submit'));
+
+    await waitFor(() => expect(api.inventoryAPI.cycleCount).toHaveBeenCalledTimes(1));
+    expect((api.inventoryAPI.cycleCount as jest.Mock).mock.calls[0][1]).toEqual(
+      expect.objectContaining({ counted_qty: 3, at_level: true, open_count: 2 })
+    );
+  });
+
+  it('logs usage in packs for a pack-counting item', async () => {
+    setupItem(byLevelItem());
+    (api.inventoryAPI.logUsage as jest.Mock).mockResolvedValue({
+      data: { quantity_used: 100, charged_group: null, ledger_transaction: null, total_cost: null },
+    });
+    renderPage();
+    await loaded();
+
+    fireEvent.click(screen.getByTestId('log-usage-button'));
+    await screen.findByTestId('log-usage-submit');
+
+    expect(screen.getByLabelText(/Quantity used \(reams\)/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('log-usage-submit'));
+
+    await waitFor(() => expect(api.inventoryAPI.logUsage).toHaveBeenCalledTimes(1));
+    expect((api.inventoryAPI.logUsage as jest.Mock).mock.calls[0][1]).toEqual(
+      expect.objectContaining({ quantity: 1, at_level: true })
+    );
+  });
+
+  it('logs usage in base units for an each-mode item, with no at_level flag', async () => {
+    setupItem(makeItem());
+    (api.inventoryAPI.logUsage as jest.Mock).mockResolvedValue({
+      data: { quantity_used: 1, charged_group: null, ledger_transaction: null, total_cost: null },
+    });
+    renderPage();
+    await loaded();
+
+    fireEvent.click(screen.getByTestId('log-usage-button'));
+    await screen.findByTestId('log-usage-submit');
+    fireEvent.click(screen.getByTestId('log-usage-submit'));
+
+    await waitFor(() => expect(api.inventoryAPI.logUsage).toHaveBeenCalledTimes(1));
+    expect((api.inventoryAPI.logUsage as jest.Mock).mock.calls[0][1]).not.toHaveProperty(
+      'at_level'
+    );
+  });
+});
+
+describe('InventoryItemDetailPage — open / finish a pack', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens a sealed pack and reloads the item', async () => {
+    setupItem(openClosedItem());
+    (api.inventoryAPI.packContainer as jest.Mock).mockResolvedValue({
+      data: {
+        transition: 'open',
+        id: 'test-id',
+        current_stock: 200,
+        open_container_count: 2,
+        on_hand_display: { mode: 'open_closed', level: 'box', sealed: 2, open: 2, text: '2 sealed + 2 open' },
+        usage_log: null,
+      },
+    });
+    renderPage();
+    await loaded();
+
+    expect(screen.getByTestId('open-pack-button')).toHaveTextContent('Open a box');
+    fireEvent.click(screen.getByTestId('open-pack-button'));
+
+    await waitFor(() => expect(api.inventoryAPI.packContainer).toHaveBeenCalledTimes(1));
+    expect(api.inventoryAPI.packContainer).toHaveBeenCalledWith('test-id', 'open');
+    // Reloaded so the sealed + open split refreshes (initial load + reload).
+    await waitFor(() =>
+      expect((api.inventoryAPI.getItem as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(2)
+    );
+  });
+
+  it('finishes the open pack', async () => {
+    setupItem(openClosedItem());
+    (api.inventoryAPI.packContainer as jest.Mock).mockResolvedValue({
+      data: {
+        transition: 'finish',
+        id: 'test-id',
+        current_stock: 300,
+        open_container_count: 0,
+        on_hand_display: { mode: 'open_closed', level: 'box', sealed: 3, open: 0, text: '3 sealed + 0 open' },
+        usage_log: null,
+      },
+    });
+    renderPage();
+    await loaded();
+
+    fireEvent.click(screen.getByTestId('finish-pack-button'));
+
+    await waitFor(() => expect(api.inventoryAPI.packContainer).toHaveBeenCalledTimes(1));
+    expect(api.inventoryAPI.packContainer).toHaveBeenCalledWith('test-id', 'finish');
+  });
+
+  it('disables opening with no sealed pack left and finishing with none open', async () => {
+    setupItem(
+      openClosedItem({
+        current_stock: 0,
+        open_container_count: 0,
+        on_hand_display: {
+          mode: 'open_closed',
+          level: 'box',
+          sealed: 0,
+          open: 0,
+          text: '0 sealed + 0 open',
+        },
+      })
+    );
+    renderPage();
+    await loaded();
+
+    expect(screen.getByTestId('open-pack-button')).toBeDisabled();
+    expect(screen.getByTestId('finish-pack-button')).toBeDisabled();
+  });
+
+  it('leaves the item alone when a transition is rejected', async () => {
+    setupItem(openClosedItem());
+    (api.inventoryAPI.packContainer as jest.Mock).mockRejectedValue({
+      response: { status: 400, data: { detail: 'No sealed pack to open.' } },
+    });
+    renderPage();
+    await loaded();
+
+    fireEvent.click(screen.getByTestId('open-pack-button'));
+
+    await waitFor(() => expect(api.inventoryAPI.packContainer).toHaveBeenCalledTimes(1));
+    // The error goes to a toast (not asserted — no <Notifications/> in this
+    // tree); what matters here is that nothing reloaded and the button is live
+    // again for a retry.
+    await waitFor(() => expect(screen.getByTestId('open-pack-button')).not.toBeDisabled());
+    expect((api.inventoryAPI.getItem as jest.Mock).mock.calls).toHaveLength(1);
+  });
+
+  it('offers no pack controls for a by_level item — the transitions are open_closed only', async () => {
+    setupItem(byLevelItem());
+    renderPage();
+    await loaded();
+
+    expect(screen.queryByTestId('pack-container-controls')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/InventoryItemFormPage.packaging.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemFormPage.packaging.test.tsx
@@ -1,0 +1,414 @@
+/**
+ * Tests for the packaging matrix on InventoryItemFormPage (op-lkxl, phase 3):
+ * the pack-chain editor, the count-mode + counting-level pickers, the
+ * mode-aware threshold labels, and the two-step save (multipart item, then the
+ * nested chain + counting level as JSON — `count_level` is a pk that cannot
+ * exist until the chain has been written).
+ *
+ * The load-bearing invariant, asserted here as well as in the untouched
+ * baseline suite: an each-mode item sends exactly what it always sent.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import InventoryItemFormPage from '../../pages/InventoryItemFormPage';
+import * as api from '../../services/api';
+
+vi.mock('../../services/api');
+
+vi.mock('../../utils/dialogs', async () => ({
+  promptInput: vi.fn(() => Promise.resolve(null)),
+  showError: vi.fn(),
+}));
+
+vi.mock('qrcode.react', async () => ({
+  QRCodeSVG: () => <div data-testid="qr-code">QR Code</div>,
+}));
+
+vi.mock('../../components/NFPADiamond', async () => ({
+  __esModule: true,
+  default: () => <div data-testid="nfpa-diamond">NFPA Diamond</div>,
+}));
+
+vi.mock('../../components/SupplierRelationshipForm', async () => ({
+  __esModule: true,
+  default: () => <div data-testid="supplier-form" />,
+}));
+
+const mockNavigate = jest.fn();
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useNavigate: () => mockNavigate,
+}));
+
+const baseItem = {
+  id: 'test-id',
+  name: 'Copy paper',
+  description: '',
+  sku: 'PAPER-001',
+  category: 1,
+  category_name: 'Supplies',
+  location: 'Shelf A',
+  current_stock: 450,
+  minimum_stock: 2,
+  reorder_quantity: 4,
+  unit_cost: '0.01',
+  supplier_name: '',
+  needs_reorder: false,
+  has_pending_reorder: false,
+  is_active: true,
+  image: null,
+  thumbnail: null,
+  qr_code: null,
+  use_case_based_reorder: false,
+  minimum_cases: 0,
+  reorder_cases: 0,
+  current_cases: 0,
+  supplier: null,
+  supplier_sku: '',
+  supplier_url: '',
+  average_lead_time: 7,
+  notes: '',
+  total_value: '4.50',
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+  ownership_type: 'space' as const,
+  owning_user: null,
+  owning_group: null,
+  reorder_status: '',
+  expected_delivery_date: null,
+  active_reorder_request: null,
+  is_hazardous: false,
+  msds_url: null,
+  nfpa_health_hazard: null,
+  nfpa_fire_hazard: null,
+  nfpa_instability_hazard: null,
+  nfpa_special_hazards: '',
+  nfpa_fire_diamond_display: '',
+  hazmat_compliance_status: '',
+  has_complete_nfpa_data: false,
+  last_counted_at: null,
+  days_since_last_count: null,
+  base_unit: 'sheet',
+  count_mode: 'each' as const,
+  count_level: null,
+  open_container_count: 0,
+  packaging_levels: [],
+};
+
+const PAPER_CHAIN = [
+  { id: 11, name: 'case', sort_order: 0, base_units: 1000, per_parent: 10 },
+  { id: 12, name: 'ream', sort_order: 1, base_units: 100, per_parent: 100 },
+  { id: 13, name: 'sheet', sort_order: 2, base_units: 1, per_parent: null },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (api.inventoryAPI.listCategories as jest.Mock).mockResolvedValue({
+    data: { results: [{ id: 1, name: 'Supplies', slug: 'supplies', description: '', parent: null }] },
+  });
+  (api.inventoryAPI.listLocations as jest.Mock).mockResolvedValue({
+    data: { results: [{ id: 1, name: 'Shelf A', description: '', is_active: true }] },
+  });
+  (api.inventoryAPI.listSuppliers as jest.Mock).mockResolvedValue({ data: { results: [] } });
+  (api.inventoryAPI.getItemSuppliers as jest.Mock).mockResolvedValue({ data: { results: [] } });
+});
+
+const renderCreate = () =>
+  render(
+    <MantineProvider env="test">
+      <MemoryRouter initialEntries={['/inventory/items/new']}>
+        <Routes>
+          <Route path="/inventory/items/new" element={<InventoryItemFormPage />} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>
+  );
+
+const renderEdit = (item: Record<string, unknown>) => {
+  (api.inventoryAPI.getItem as jest.Mock).mockResolvedValue({ data: item });
+  return render(
+    <MantineProvider env="test">
+      <MemoryRouter initialEntries={['/inventory/items/test-id/edit']}>
+        <Routes>
+          <Route path="/inventory/items/:id/edit" element={<InventoryItemFormPage />} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>
+  );
+};
+
+// Only the name has no usable default, and every fireEvent re-renders the whole
+// form — so the create tests stay under the 5s budget by typing just that.
+const fillRequiredFields = () => {
+  fireEvent.change(screen.getAllByLabelText(/^Name/i)[0], { target: { value: 'Copy paper' } });
+};
+
+/** Type a whole chain into the editor, adding rows as needed. */
+const enterChain = (rows: [string, string][]) => {
+  rows.forEach(([name, size], index) => {
+    fireEvent.click(screen.getByTestId('packaging-add-level'));
+    fireEvent.change(screen.getByTestId(`packaging-row-name-${index}`), {
+      target: { value: name },
+    });
+    fireEvent.change(screen.getByTestId(`packaging-row-base-units-${index}`), {
+      target: { value: size },
+    });
+  });
+};
+
+/** Pick an option out of a Mantine Select by its test id. */
+const chooseOption = async (testId: string, optionName: RegExp) => {
+  fireEvent.click(screen.getByTestId(testId));
+  fireEvent.click(await screen.findByRole('option', { name: optionName }));
+};
+
+describe('InventoryItemFormPage — units & packaging', () => {
+  it('renders the packaging section with the chain editor and count-mode picker', async () => {
+    renderCreate();
+
+    await waitFor(() => expect(screen.getByTestId('page-hero-title')).toBeInTheDocument());
+    expect(screen.getByTestId('packaging-chain-editor')).toBeInTheDocument();
+    expect(screen.getByTestId('item-count-mode')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Base unit/i)).toBeInTheDocument();
+    // The counting level only exists for the pack-counting modes.
+    expect(screen.queryByTestId('item-count-level')).not.toBeInTheDocument();
+  });
+
+  it('reveals the counting-level select when a pack-counting mode is chosen', async () => {
+    renderCreate();
+
+    await waitFor(() => expect(screen.getByTestId('item-count-mode')).toBeInTheDocument());
+    enterChain([
+      ['case', '1000'],
+      ['sheet', '1'],
+    ]);
+    await chooseOption('item-count-mode', /By packaging level/i);
+
+    const levelSelect = await screen.findByTestId('item-count-level');
+    expect(levelSelect).toBeInTheDocument();
+    fireEvent.click(levelSelect);
+    expect(await screen.findByRole('option', { name: 'case' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'sheet' })).toBeInTheDocument();
+  });
+
+  it('relabels the reorder thresholds in the counting unit', async () => {
+    renderCreate();
+
+    await waitFor(() => expect(screen.getByTestId('item-count-mode')).toBeInTheDocument());
+    // Each-mode: today's bare labels, with no unit parenthetical.
+    expect(screen.getAllByLabelText(/Minimum Stock/i).length).toBeGreaterThan(0);
+    expect(screen.queryByLabelText(/Minimum Stock \(/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Reorder Quantity \(/)).not.toBeInTheDocument();
+
+    enterChain([
+      ['case', '1000'],
+      ['sheet', '1'],
+    ]);
+    await chooseOption('item-count-mode', /By packaging level/i);
+    await chooseOption('item-count-level', /^case$/);
+
+    expect(await screen.findByLabelText(/Minimum Stock \(cases\)/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Reorder Quantity \(cases\)/)).toBeInTheDocument();
+  });
+
+  it('blocks a save whose chain breaks the shrinking rule, before any request', async () => {
+    renderCreate();
+
+    await waitFor(() => expect(screen.getByTestId('item-count-mode')).toBeInTheDocument());
+    fillRequiredFields();
+    enterChain([
+      ['case', '10'],
+      ['ream', '10'],
+      ['sheet', '1'],
+    ]);
+
+    fireEvent.click(screen.getByText('Create Item'));
+
+    expect(
+      await screen.findByText(/must hold fewer base units than 'case'/)
+    ).toBeInTheDocument();
+    expect(api.inventoryAPI.createItem).not.toHaveBeenCalled();
+  });
+
+  it('blocks a pack-counting save with no counting level chosen', async () => {
+    renderCreate();
+
+    await waitFor(() => expect(screen.getByTestId('item-count-mode')).toBeInTheDocument());
+    fillRequiredFields();
+    enterChain([
+      ['case', '1000'],
+      ['sheet', '1'],
+    ]);
+    await chooseOption('item-count-mode', /Sealed \+ open/i);
+
+    fireEvent.click(screen.getByText('Create Item'));
+
+    expect(await screen.findByText(/Choose which packaging level/)).toBeInTheDocument();
+    expect(api.inventoryAPI.createItem).not.toHaveBeenCalled();
+  });
+
+  it('saves the chain then the counting level, in that order', async () => {
+    (api.inventoryAPI.createItem as jest.Mock).mockResolvedValue({
+      data: { ...baseItem, id: 'new-id', packaging_levels: [] },
+    });
+    // What the server gives back for the two rungs typed below.
+    (api.inventoryAPI.updateItem as jest.Mock).mockResolvedValue({
+      data: {
+        ...baseItem,
+        id: 'new-id',
+        packaging_levels: [
+          { id: 11, name: 'case', sort_order: 0, base_units: 1000, per_parent: 1000 },
+          { id: 13, name: 'sheet', sort_order: 1, base_units: 1, per_parent: null },
+        ],
+      },
+    });
+
+    renderCreate();
+
+    await waitFor(() => expect(screen.getByTestId('item-count-mode')).toBeInTheDocument());
+    fillRequiredFields();
+    fireEvent.change(screen.getByLabelText(/Base unit/i), { target: { value: 'sheet' } });
+    enterChain([
+      ['case', '1000'],
+      ['sheet', '1'],
+    ]);
+    await chooseOption('item-count-mode', /By packaging level/i);
+    // The INNER rung, so resolving its pk cannot pass by accident on "first".
+    await chooseOption('item-count-level', /^sheet$/);
+
+    fireEvent.click(screen.getByText('Create Item'));
+
+    await waitFor(() => expect(api.inventoryAPI.updateItem).toHaveBeenCalledTimes(2));
+
+    // The item itself still goes as multipart, and carries the base unit.
+    const formData = (api.inventoryAPI.createItem as jest.Mock).mock.calls[0][0] as FormData;
+    expect(formData.get('base_unit')).toBe('sheet');
+    expect(formData.get('count_mode')).toBeNull();
+
+    // Then the chain, largest rung first with sort_order = position.
+    expect((api.inventoryAPI.updateItem as jest.Mock).mock.calls[0]).toEqual([
+      'new-id',
+      {
+        packaging_levels: [
+          { name: 'case', sort_order: 0, base_units: 1000 },
+          { name: 'sheet', sort_order: 1, base_units: 1 },
+        ],
+      },
+    ]);
+
+    // Then the mode + the pk of the chosen rung, resolved from the saved chain
+    // by sort_order (position), which is the identity the serializer upserts on.
+    expect((api.inventoryAPI.updateItem as jest.Mock).mock.calls[1]).toEqual([
+      'new-id',
+      { count_mode: 'by_level', count_level: 13 },
+    ]);
+    expect(mockNavigate).toHaveBeenCalledWith('/inventory/items/new-id');
+  });
+
+  it('folds the mode into the chain write when dropping back to each', async () => {
+    (api.inventoryAPI.updateItem as jest.Mock).mockResolvedValue({
+      data: { ...baseItem, packaging_levels: [] },
+    });
+
+    renderEdit({
+      ...baseItem,
+      count_mode: 'by_level',
+      count_level: 11,
+      packaging_levels: PAPER_CHAIN,
+    });
+
+    await waitFor(() => expect(screen.getByDisplayValue('Copy paper')).toBeInTheDocument());
+    // Hydrated: three rungs, counted in cases.
+    expect(screen.getAllByTestId(/^packaging-row-\d+$/)).toHaveLength(3);
+    expect(screen.getByTestId('item-count-level')).toHaveValue('case');
+
+    // Remove the middle rung and go back to counting base units.
+    fireEvent.click(screen.getByTestId('packaging-row-remove-1'));
+    await chooseOption('item-count-mode', /^Each/);
+
+    fireEvent.click(screen.getByText('Save Changes'));
+
+    // The multipart write, then ONE JSON write carrying chain + mode together:
+    // dropping to each clears count_level, so no pk has to be resolved first.
+    await waitFor(() => expect(api.inventoryAPI.updateItem).toHaveBeenCalledTimes(2));
+    expect((api.inventoryAPI.updateItem as jest.Mock).mock.calls[1]).toEqual([
+      'test-id',
+      {
+        packaging_levels: [
+          { name: 'case', sort_order: 0, base_units: 1000 },
+          { name: 'sheet', sort_order: 1, base_units: 1 },
+        ],
+        count_mode: 'each',
+        count_level: null,
+      },
+    ]);
+  });
+
+  it('hydrates an open_closed item and re-sends its counting level unchanged', async () => {
+    (api.inventoryAPI.updateItem as jest.Mock).mockResolvedValue({
+      data: { ...baseItem, packaging_levels: PAPER_CHAIN },
+    });
+
+    renderEdit({
+      ...baseItem,
+      count_mode: 'open_closed',
+      count_level: 12,
+      open_container_count: 1,
+      packaging_levels: PAPER_CHAIN,
+    });
+
+    await waitFor(() => expect(screen.getByDisplayValue('Copy paper')).toBeInTheDocument());
+    expect(screen.getByTestId('item-count-mode')).toHaveValue(
+      'Sealed + open (count sealed packs, track the open one)'
+    );
+    expect(screen.getByTestId('item-count-level')).toHaveValue('ream');
+    // Thresholds are read in the counting unit for this mode.
+    expect(screen.getByLabelText(/Minimum Stock \(reams\)/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Save Changes'));
+
+    // Nothing packaging-related changed, so only the multipart write happens.
+    await waitFor(() => expect(api.inventoryAPI.updateItem).toHaveBeenCalledTimes(1));
+    expect((api.inventoryAPI.updateItem as jest.Mock).mock.calls[0][1]).toBeInstanceOf(FormData);
+  });
+
+  it('sends no packaging follow-up for an each-mode item with no chain', async () => {
+    (api.inventoryAPI.updateItem as jest.Mock).mockResolvedValue({ data: baseItem });
+
+    renderEdit(baseItem);
+
+    await waitFor(() => expect(screen.getByDisplayValue('Copy paper')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Save Changes'));
+
+    await waitFor(() => expect(api.inventoryAPI.updateItem).toHaveBeenCalledTimes(1));
+    expect((api.inventoryAPI.updateItem as jest.Mock).mock.calls[0][1]).toBeInstanceOf(FormData);
+    expect(mockNavigate).toHaveBeenCalledWith('/inventory/items/test-id');
+  });
+
+  it('reports a failed packaging follow-up without pretending the item did not save', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (api.inventoryAPI.createItem as jest.Mock).mockResolvedValue({
+      data: { ...baseItem, id: 'new-id' },
+    });
+    (api.inventoryAPI.updateItem as jest.Mock).mockRejectedValue({
+      response: { status: 400, data: { detail: 'chain rejected' } },
+    });
+
+    renderCreate();
+
+    await waitFor(() => expect(screen.getByTestId('item-count-mode')).toBeInTheDocument());
+    fillRequiredFields();
+    enterChain([
+      ['case', '1000'],
+      ['sheet', '1'],
+    ]);
+    fireEvent.click(screen.getByText('Create Item'));
+
+    expect(
+      await screen.findByText(/Item saved, but the packaging setup failed: chain rejected/)
+    ).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalledWith('/inventory/items/new-id');
+    consoleError.mockRestore();
+  });
+});

--- a/frontend/src/__tests__/pages/InventoryItemFormPage.packaging.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemFormPage.packaging.test.tsx
@@ -13,6 +13,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import InventoryItemFormPage from '../../pages/InventoryItemFormPage';
 import * as api from '../../services/api';
+import { COUNT_MODE_LABELS } from '../../utils/packaging';
 
 vi.mock('../../services/api');
 
@@ -157,13 +158,40 @@ const enterChain = (rows: [string, string][]) => {
   });
 };
 
-/** Pick an option out of a Mantine Select by its test id. */
-const chooseOption = async (testId: string, optionName: RegExp) => {
-  fireEvent.click(screen.getByTestId(testId));
-  fireEvent.click(await screen.findByRole('option', { name: optionName }));
+/**
+ * Open a Mantine Select and return its own options.
+ *
+ * Deliberately plain attribute queries rather than `findByRole('option')`: role
+ * queries compute the accessibility tree over the whole document, and this
+ * form's DOM is big enough that a handful of them push a test past vitest's 5s
+ * budget when the suite runs in parallel. Scoped through the input's
+ * `aria-controls` because every select on the page keeps its options mounted
+ * once opened.
+ */
+const openOptions = (testId: string): HTMLElement[] => {
+  const input = screen.getByTestId(testId);
+  fireEvent.click(input);
+  const dropdownId = input.getAttribute('aria-controls');
+  const dropdown = dropdownId ? document.getElementById(dropdownId) : null;
+  return Array.from(
+    (dropdown ?? document).querySelectorAll<HTMLElement>('[data-combobox-option]')
+  );
 };
 
-describe('InventoryItemFormPage — units & packaging', () => {
+/** Pick an option out of a Mantine Select by its label. */
+const chooseOption = (testId: string, label: string) => {
+  const option = openOptions(testId).find((element) => element.textContent === label);
+  if (!option) {
+    throw new Error(`no "${label}" option in ${testId}`);
+  }
+  fireEvent.click(option);
+};
+
+// This page is the repo's biggest form, and these tests drive it hard (chain
+// rows + two selects + a submit). One render already costs ~1s here, so the
+// default 5s per-test budget is genuinely tight once the whole suite runs in
+// parallel — hence the explicit, generous timeout rather than thinner coverage.
+describe('InventoryItemFormPage — units & packaging', { timeout: 30000 }, () => {
   it('renders the packaging section with the chain editor and count-mode picker', async () => {
     renderCreate();
 
@@ -183,13 +211,14 @@ describe('InventoryItemFormPage — units & packaging', () => {
       ['case', '1000'],
       ['sheet', '1'],
     ]);
-    await chooseOption('item-count-mode', /By packaging level/i);
+    chooseOption('item-count-mode', COUNT_MODE_LABELS.by_level);
 
-    const levelSelect = await screen.findByTestId('item-count-level');
-    expect(levelSelect).toBeInTheDocument();
-    fireEvent.click(levelSelect);
-    expect(await screen.findByRole('option', { name: 'case' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'sheet' })).toBeInTheDocument();
+    expect(screen.getByTestId('item-count-level')).toBeInTheDocument();
+    // The chain's rungs are the options, in chain order.
+    expect(openOptions('item-count-level').map((option) => option.textContent)).toEqual([
+      'case',
+      'sheet',
+    ]);
   });
 
   it('relabels the reorder thresholds in the counting unit', async () => {
@@ -205,8 +234,8 @@ describe('InventoryItemFormPage — units & packaging', () => {
       ['case', '1000'],
       ['sheet', '1'],
     ]);
-    await chooseOption('item-count-mode', /By packaging level/i);
-    await chooseOption('item-count-level', /^case$/);
+    chooseOption('item-count-mode', COUNT_MODE_LABELS.by_level);
+    chooseOption('item-count-level', 'case');
 
     expect(await screen.findByLabelText(/Minimum Stock \(cases\)/)).toBeInTheDocument();
     expect(screen.getByLabelText(/Reorder Quantity \(cases\)/)).toBeInTheDocument();
@@ -240,7 +269,7 @@ describe('InventoryItemFormPage — units & packaging', () => {
       ['case', '1000'],
       ['sheet', '1'],
     ]);
-    await chooseOption('item-count-mode', /Sealed \+ open/i);
+    chooseOption('item-count-mode', COUNT_MODE_LABELS.open_closed);
 
     fireEvent.click(screen.getByText('Create Item'));
 
@@ -273,9 +302,9 @@ describe('InventoryItemFormPage — units & packaging', () => {
       ['case', '1000'],
       ['sheet', '1'],
     ]);
-    await chooseOption('item-count-mode', /By packaging level/i);
+    chooseOption('item-count-mode', COUNT_MODE_LABELS.by_level);
     // The INNER rung, so resolving its pk cannot pass by accident on "first".
-    await chooseOption('item-count-level', /^sheet$/);
+    chooseOption('item-count-level', 'sheet');
 
     fireEvent.click(screen.getByText('Create Item'));
 
@@ -325,7 +354,7 @@ describe('InventoryItemFormPage — units & packaging', () => {
 
     // Remove the middle rung and go back to counting base units.
     fireEvent.click(screen.getByTestId('packaging-row-remove-1'));
-    await chooseOption('item-count-mode', /^Each/);
+    chooseOption('item-count-mode', COUNT_MODE_LABELS.each);
 
     fireEvent.click(screen.getByText('Save Changes'));
 
@@ -359,9 +388,7 @@ describe('InventoryItemFormPage — units & packaging', () => {
     });
 
     await waitFor(() => expect(screen.getByDisplayValue('Copy paper')).toBeInTheDocument());
-    expect(screen.getByTestId('item-count-mode')).toHaveValue(
-      'Sealed + open (count sealed packs, track the open one)'
-    );
+    expect(screen.getByTestId('item-count-mode')).toHaveValue(COUNT_MODE_LABELS.open_closed);
     expect(screen.getByTestId('item-count-level')).toHaveValue('ream');
     // Thresholds are read in the counting unit for this mode.
     expect(screen.getByLabelText(/Minimum Stock \(reams\)/)).toBeInTheDocument();

--- a/frontend/src/__tests__/pages/InventoryItemFormPage.test.tsx
+++ b/frontend/src/__tests__/pages/InventoryItemFormPage.test.tsx
@@ -46,7 +46,12 @@ vi.mock('react-router-dom', async () => ({
   useNavigate: () => mockNavigate,
 }));
 
-describe('InventoryItemFormPage', () => {
+// Every test here renders the repo's biggest form, which costs ~2s in jsdom on
+// its own and more once 168 files import in parallel — "renders create form" has
+// a history of tripping the default 5s per-test budget on a loaded box, and the
+// packaging section (op-lkxl) added another Select to the page. The budget is
+// stated explicitly so a slow box reports slow tests rather than red ones.
+describe('InventoryItemFormPage', { timeout: 30000 }, () => {
   const mockCategories = [
     { id: 1, name: 'Tools', slug: 'tools', description: 'Tools category', parent: null },
   ];

--- a/frontend/src/__tests__/utils/packaging.test.ts
+++ b/frontend/src/__tests__/utils/packaging.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Tests for the packaging / unit-of-measure helpers (op-lkxl, phase 3).
+ *
+ * These are the client twins of `inventory/services/packaging.py`, so the cases
+ * mirror the backend's rules: a chain shrinks toward exactly one base rung, a
+ * pack-counting item needs a resolvable counting level, and anything
+ * half-configured degrades to base units rather than throwing.
+ */
+import { InventoryItem, PackagingLevel } from '../../types';
+import {
+  PackagingRow,
+  baseUnitOf,
+  blankPackagingRow,
+  countLevelOf,
+  countUnitOf,
+  countsInPacks,
+  describePackChain,
+  onHandLabel,
+  perParent,
+  pluralizeUnit,
+  resolveCountLevelError,
+  toPackagingPayload,
+  toPackagingRows,
+  validatePackagingChain,
+} from '../../utils/packaging';
+
+const row = (name: string, base_units: number | ''): PackagingRow => ({
+  ...blankPackagingRow(),
+  name,
+  base_units,
+});
+
+const level = (
+  id: number,
+  name: string,
+  sort_order: number,
+  base_units: number
+): PackagingLevel => ({
+  id,
+  name,
+  sort_order,
+  base_units,
+  per_parent: null,
+});
+
+const PAPER_CHAIN = [
+  level(1, 'case', 0, 1000),
+  level(2, 'ream', 1, 100),
+  level(3, 'sheet', 2, 1),
+];
+
+const makeItem = (overrides: Partial<InventoryItem> = {}): InventoryItem =>
+  ({
+    id: 'item-1',
+    name: 'Copy paper',
+    current_stock: 10,
+    minimum_stock: 2,
+    reorder_quantity: 4,
+    ...overrides,
+  }) as InventoryItem;
+
+describe('validatePackagingChain', () => {
+  it('accepts an empty chain — such an item is simply counted in base units', () => {
+    expect(validatePackagingChain([])).toEqual([]);
+  });
+
+  it('accepts a strictly shrinking chain ending in the base rung', () => {
+    expect(
+      validatePackagingChain([row('case', 1000), row('ream', 100), row('sheet', 1)])
+    ).toEqual([]);
+  });
+
+  it('requires every level to be named', () => {
+    expect(validatePackagingChain([row('case', 12), row('', 1)])).toContain(
+      'Every packaging level needs a name.'
+    );
+  });
+
+  it('requires every level to hold at least one base unit', () => {
+    expect(validatePackagingChain([row('case', 12), row('sheet', '')])).toContain(
+      'Every packaging level must hold at least one base unit.'
+    );
+  });
+
+  it('requires exactly one base rung', () => {
+    const errors = validatePackagingChain([row('case', 12), row('half', 1), row('sheet', 1)]);
+    expect(errors.join(' ')).toMatch(/Exactly one packaging level must be the base unit/);
+  });
+
+  it('rejects a chain with no base rung at all', () => {
+    const errors = validatePackagingChain([row('case', 12), row('ream', 6)]);
+    expect(errors.join(' ')).toMatch(/found 0/);
+  });
+
+  it('requires the base rung to be listed last', () => {
+    const errors = validatePackagingChain([row('sheet', 1), row('case', 12)]);
+    expect(errors).toContain('The base packaging level must be the innermost (listed last).');
+  });
+
+  it('requires each level to be smaller than the one containing it', () => {
+    const errors = validatePackagingChain([row('case', 10), row('ream', 10), row('sheet', 1)]);
+    expect(errors.join(' ')).toMatch(/'ream' must hold fewer base units than 'case'/);
+  });
+});
+
+describe('resolveCountLevelError', () => {
+  const rows = [row('case', 12), row('unit', 1)];
+
+  it('is silent for each-mode, which must have no counting level', () => {
+    expect(resolveCountLevelError('each', null, rows)).toBeNull();
+    expect(resolveCountLevelError('each', rows[0].key, rows)).toBeNull();
+  });
+
+  it('requires a counting level for the pack-counting modes', () => {
+    expect(resolveCountLevelError('by_level', null, rows)).toMatch(/Choose which packaging level/);
+    expect(resolveCountLevelError('open_closed', null, rows)).toMatch(
+      /Choose which packaging level/
+    );
+  });
+
+  it('requires the counting level to be one of the rows being saved', () => {
+    expect(resolveCountLevelError('by_level', 'pkg-does-not-exist', rows)).toMatch(
+      /must be one of the packaging levels above/
+    );
+  });
+
+  it('accepts a level that is in the chain', () => {
+    expect(resolveCountLevelError('by_level', rows[0].key, rows)).toBeNull();
+  });
+});
+
+describe('toPackagingPayload / toPackagingRows', () => {
+  it('derives sort_order from row position, outermost first', () => {
+    expect(toPackagingPayload([row('case', 1000), row('ream', 100), row('sheet', 1)])).toEqual([
+      { name: 'case', sort_order: 0, base_units: 1000 },
+      { name: 'ream', sort_order: 1, base_units: 100 },
+      { name: 'sheet', sort_order: 2, base_units: 1 },
+    ]);
+  });
+
+  it('trims names and does not send a pk — the serializer upserts on sort_order', () => {
+    const payload = toPackagingPayload([row('  case  ', 12), row('unit', 1)]);
+    expect(payload[0]).toEqual({ name: 'case', sort_order: 0, base_units: 12 });
+    expect(payload[0]).not.toHaveProperty('id');
+  });
+
+  it('orders server levels outermost-first regardless of arrival order', () => {
+    const rows = toPackagingRows([PAPER_CHAIN[2], PAPER_CHAIN[0], PAPER_CHAIN[1]]);
+    expect(rows.map((r) => r.name)).toEqual(['case', 'ream', 'sheet']);
+    expect(rows.map((r) => r.id)).toEqual([1, 2, 3]);
+  });
+
+  it('round-trips an empty chain', () => {
+    expect(toPackagingRows(undefined)).toEqual([]);
+    expect(toPackagingRows(null)).toEqual([]);
+  });
+});
+
+describe('perParent', () => {
+  const rows = [row('case', 1000), row('ream', 100), row('sheet', 1)];
+
+  it('is how many of the next rung down fit in this one', () => {
+    expect(perParent(rows, 0)).toBe(10);
+    expect(perParent(rows, 1)).toBe(100);
+  });
+
+  it('is null for the base rung, which contains nothing', () => {
+    expect(perParent(rows, 2)).toBeNull();
+  });
+
+  it('is null while a row is half-typed', () => {
+    expect(perParent([row('case', ''), row('unit', 1)], 0)).toBeNull();
+  });
+});
+
+describe('countsInPacks / countUnitOf', () => {
+  it('is false for an each-mode item, which keeps base units', () => {
+    const item = makeItem({ count_mode: 'each', packaging_levels: PAPER_CHAIN });
+    expect(countsInPacks(item)).toBe(false);
+    expect(countUnitOf(item)).toBe('unit');
+  });
+
+  it('is false for an item that has not opted in at all', () => {
+    expect(countsInPacks(makeItem())).toBe(false);
+  });
+
+  it('is true for a by_level item with a resolvable counting level', () => {
+    const item = makeItem({
+      count_mode: 'by_level',
+      count_level: 2,
+      packaging_levels: PAPER_CHAIN,
+    });
+    expect(countsInPacks(item)).toBe(true);
+    expect(countLevelOf(item)?.name).toBe('ream');
+    expect(countUnitOf(item)).toBe('ream');
+  });
+
+  it('degrades to base units for a half-configured pack item', () => {
+    const item = makeItem({
+      count_mode: 'by_level',
+      count_level: null,
+      packaging_levels: PAPER_CHAIN,
+      base_unit: 'sheet',
+    });
+    expect(countsInPacks(item)).toBe(false);
+    expect(countUnitOf(item)).toBe('sheet');
+  });
+});
+
+describe('onHandLabel', () => {
+  it('renders base units for an each-mode item, exactly as before the matrix existed', () => {
+    const item = makeItem({
+      current_stock: 10,
+      count_mode: 'each',
+      on_hand_display: { mode: 'each', base_units: 10, unit: 'unit', text: '10 unit' },
+    });
+    expect(onHandLabel(item)).toBe('10 units');
+  });
+
+  it('renders base units for an item with no packaging payload at all', () => {
+    expect(onHandLabel(makeItem({ current_stock: 3 }))).toBe('3 units');
+  });
+
+  it('honours a custom base unit and singular counts', () => {
+    expect(onHandLabel(makeItem({ current_stock: 1, base_unit: 'sheet' }))).toBe('1 sheet');
+    expect(onHandLabel(makeItem({ current_stock: 5, base_unit: 'sheet' }))).toBe('5 sheets');
+  });
+
+  it("renders the server's text for a by_level item", () => {
+    const item = makeItem({
+      current_stock: 450,
+      count_mode: 'by_level',
+      on_hand_display: {
+        mode: 'by_level',
+        level: 'ream',
+        level_count: 4,
+        remainder_base: 50,
+        text: '4 ream(s)',
+      },
+    });
+    expect(onHandLabel(item)).toBe('4 ream(s)');
+  });
+
+  it("renders the server's sealed + open text for an open_closed item", () => {
+    const item = makeItem({
+      current_stock: 36,
+      count_mode: 'open_closed',
+      on_hand_display: {
+        mode: 'open_closed',
+        level: 'box',
+        sealed: 3,
+        open: 1,
+        text: '3 sealed + 1 open',
+      },
+    });
+    expect(onHandLabel(item)).toBe('3 sealed + 1 open');
+  });
+});
+
+describe('describePackChain', () => {
+  it('describes one line per non-base rung', () => {
+    expect(describePackChain(PAPER_CHAIN)).toEqual([
+      '1 case = 10 reams',
+      '1 ream = 100 sheets',
+    ]);
+  });
+
+  it('says nothing about a bare base rung or an absent chain', () => {
+    expect(describePackChain([level(1, 'unit', 0, 1)])).toEqual([]);
+    expect(describePackChain(undefined)).toEqual([]);
+  });
+
+  it('keeps a singular ratio singular', () => {
+    expect(describePackChain([level(1, 'pair', 0, 2), level(2, 'glove', 1, 1)])).toEqual([
+      '1 pair = 2 gloves',
+    ]);
+    expect(describePackChain([level(1, 'sleeve', 0, 1), level(2, 'cup', 1, 1)])).toEqual([
+      '1 sleeve = 1 cup',
+    ]);
+  });
+});
+
+describe('pluralizeUnit / baseUnitOf', () => {
+  it('pluralises everything but one', () => {
+    expect(pluralizeUnit('case', 1)).toBe('case');
+    expect(pluralizeUnit('case', 0)).toBe('cases');
+    expect(pluralizeUnit('case', 2)).toBe('cases');
+  });
+
+  it('pluralises a sibilant ending properly — "box" is a common level name', () => {
+    expect(pluralizeUnit('box', 2)).toBe('boxes');
+    expect(pluralizeUnit('box', 1)).toBe('box');
+    expect(pluralizeUnit('brush', 3)).toBe('brushes');
+    expect(pluralizeUnit('glass', 3)).toBe('glasses');
+  });
+
+  it("defaults to the backend's own default base unit", () => {
+    expect(baseUnitOf({ base_unit: undefined })).toBe('unit');
+    expect(baseUnitOf({ base_unit: '   ' })).toBe('unit');
+    expect(baseUnitOf({ base_unit: 'sheet' })).toBe('sheet');
+  });
+});

--- a/frontend/src/components/inventory/PackagingChainEditor.tsx
+++ b/frontend/src/components/inventory/PackagingChainEditor.tsx
@@ -1,0 +1,184 @@
+/**
+ * Packaging-chain editor for the inventory item form (op-lkxl, phase 3).
+ *
+ * Edits an item's `packaging_levels` as an ordered list, largest rung first —
+ * "case, ream, sheet". The row's position IS its `sort_order` (0 = outermost),
+ * so moving a row up/down is the whole of "reorder"; `base_units` is always how
+ * many BASE units one of that rung holds, which is what makes the derived
+ * "1 case = 10 reams" line computable without a second column to keep in sync.
+ *
+ * Purely controlled: the parent owns the rows and does the saving. Validation
+ * messages come from the shared `validatePackagingChain` so the form and the
+ * backend agree on what a legal chain is.
+ */
+import { ActionIcon, Button, Group, NumberInput, Stack, Table, Text, TextInput } from '@mantine/core';
+import { IconArrowDown, IconArrowUp, IconPlus, IconTrash } from '@tabler/icons-react';
+import React from 'react';
+import { PackagingRow, blankPackagingRow, perParent, pluralizeUnit } from '../../utils/packaging';
+
+interface PackagingChainEditorProps {
+  rows: PackagingRow[];
+  onChange: (rows: PackagingRow[]) => void;
+  /** The item's base unit, used to label the innermost rung's size. */
+  baseUnit: string;
+  /** Chain-level validation messages, rendered under the table. */
+  errors?: string[];
+}
+
+const PackagingChainEditor: React.FC<PackagingChainEditorProps> = ({
+  rows,
+  onChange,
+  baseUnit,
+  errors = [],
+}) => {
+  const unit = baseUnit.trim() || 'unit';
+
+  const updateRow = (index: number, patch: Partial<PackagingRow>) => {
+    onChange(rows.map((row, i) => (i === index ? { ...row, ...patch } : row)));
+  };
+
+  const removeRow = (index: number) => {
+    onChange(rows.filter((_, i) => i !== index));
+  };
+
+  const moveRow = (index: number, delta: number) => {
+    const target = index + delta;
+    if (target < 0 || target >= rows.length) return;
+    const next = [...rows];
+    [next[index], next[target]] = [next[target], next[index]];
+    onChange(next);
+  };
+
+  const addRow = () => {
+    onChange([...rows, blankPackagingRow()]);
+  };
+
+  return (
+    <Stack gap="xs" data-testid="packaging-chain-editor">
+      <Text size="sm" fw={500}>
+        Packaging chain
+      </Text>
+      <Text size="xs" c="dimmed">
+        Largest package first, ending with the base unit. Each level says how many{' '}
+        {pluralizeUnit(unit, 2)} it holds — a case of 10 reams of 100 sheets is 1000, 100, 1.
+      </Text>
+
+      {rows.length === 0 ? (
+        <Text size="sm" c="dimmed" data-testid="packaging-chain-empty">
+          No packaging levels — this item is counted in {pluralizeUnit(unit, 2)}.
+        </Text>
+      ) : (
+        <Table data-testid="packaging-chain-table">
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Level name</Table.Th>
+              <Table.Th>{pluralizeUnit(unit, 2)} held</Table.Th>
+              <Table.Th>Contains</Table.Th>
+              <Table.Th />
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {rows.map((row, index) => {
+              const ratio = perParent(rows, index);
+              const below = rows[index + 1];
+              return (
+                <Table.Tr key={row.key} data-testid={`packaging-row-${index}`}>
+                  <Table.Td>
+                    <TextInput
+                      aria-label={`Level ${index + 1} name`}
+                      placeholder="case"
+                      value={row.name}
+                      onChange={(e) => updateRow(index, { name: e.currentTarget.value })}
+                      data-testid={`packaging-row-name-${index}`}
+                    />
+                  </Table.Td>
+                  <Table.Td>
+                    <NumberInput
+                      aria-label={`Level ${index + 1} base units`}
+                      placeholder="1"
+                      min={1}
+                      allowDecimal={false}
+                      allowNegative={false}
+                      value={row.base_units}
+                      onChange={(v) =>
+                        updateRow(index, { base_units: v === '' ? '' : Number(v) })
+                      }
+                      data-testid={`packaging-row-base-units-${index}`}
+                    />
+                  </Table.Td>
+                  <Table.Td>
+                    {ratio !== null && below ? (
+                      <Text size="sm" c="dimmed" data-testid={`packaging-row-per-parent-${index}`}>
+                        1 {row.name.trim() || 'level'} = {ratio}{' '}
+                        {pluralizeUnit(below.name.trim() || 'level', ratio)}
+                      </Text>
+                    ) : (
+                      <Text size="sm" c="dimmed">
+                        —
+                      </Text>
+                    )}
+                  </Table.Td>
+                  <Table.Td>
+                    <Group gap={4} justify="flex-end" wrap="nowrap">
+                      <ActionIcon
+                        variant="subtle"
+                        aria-label={`Move level ${index + 1} up`}
+                        disabled={index === 0}
+                        onClick={() => moveRow(index, -1)}
+                        data-testid={`packaging-row-up-${index}`}
+                      >
+                        <IconArrowUp size={16} />
+                      </ActionIcon>
+                      <ActionIcon
+                        variant="subtle"
+                        aria-label={`Move level ${index + 1} down`}
+                        disabled={index === rows.length - 1}
+                        onClick={() => moveRow(index, 1)}
+                        data-testid={`packaging-row-down-${index}`}
+                      >
+                        <IconArrowDown size={16} />
+                      </ActionIcon>
+                      <ActionIcon
+                        variant="subtle"
+                        color="red"
+                        aria-label={`Remove level ${index + 1}`}
+                        onClick={() => removeRow(index)}
+                        data-testid={`packaging-row-remove-${index}`}
+                      >
+                        <IconTrash size={16} />
+                      </ActionIcon>
+                    </Group>
+                  </Table.Td>
+                </Table.Tr>
+              );
+            })}
+          </Table.Tbody>
+        </Table>
+      )}
+
+      {errors.length > 0 && (
+        <Stack gap={2} data-testid="packaging-chain-errors">
+          {errors.map((message) => (
+            <Text key={message} size="xs" c="red">
+              {message}
+            </Text>
+          ))}
+        </Stack>
+      )}
+
+      <Group>
+        <Button
+          variant="light"
+          size="xs"
+          leftSection={<IconPlus size={14} />}
+          onClick={addRow}
+          data-testid="packaging-add-level"
+        >
+          Add packaging level
+        </Button>
+      </Group>
+    </Stack>
+  );
+};
+
+export default PackagingChainEditor;

--- a/frontend/src/pages/InventoryItemDetailPage.tsx
+++ b/frontend/src/pages/InventoryItemDetailPage.tsx
@@ -765,12 +765,10 @@ const InventoryItemDetailPage: React.FC = () => {
                             {line}
                           </Text>
                         ))}
-                        {countUnit && (
-                          <Text size="sm" c="dimmed">
-                            Counted in {pluralizeUnit(countUnit, 2)}
-                            {item.count_mode === 'open_closed' ? ' (sealed + open)' : ''}
-                          </Text>
-                        )}
+                        <Text size="sm" c="dimmed">
+                          Counted in {pluralizeUnit(countUnit, 2)}
+                          {item.count_mode === 'open_closed' ? ' (sealed + open)' : ''}
+                        </Text>
                       </Stack>
                     </div>
                   )}
@@ -788,7 +786,7 @@ const InventoryItemDetailPage: React.FC = () => {
                         disabled={sealedCount === 0 || packBusy !== null}
                         data-testid="open-pack-button"
                       >
-                        Open a {countUnit || 'pack'}
+                        Open a {countUnit}
                       </Button>
                       <Button
                         size="xs"
@@ -799,7 +797,7 @@ const InventoryItemDetailPage: React.FC = () => {
                         disabled={openCount === 0 || packBusy !== null}
                         data-testid="finish-pack-button"
                       >
-                        Finish open {countUnit || 'pack'}
+                        Finish open {countUnit}
                       </Button>
                     </Group>
                   )}

--- a/frontend/src/pages/InventoryItemDetailPage.tsx
+++ b/frontend/src/pages/InventoryItemDetailPage.tsx
@@ -21,7 +21,7 @@ import {
     Textarea,
     Title,
 } from '@mantine/core';
-import { IconArchive, IconArchiveOff, IconClipboardCheck, IconEdit, IconPackageExport, IconQrcode } from '@tabler/icons-react';
+import { IconArchive, IconArchiveOff, IconBoxOff, IconBoxSeam, IconClipboardCheck, IconEdit, IconPackageExport, IconQrcode } from '@tabler/icons-react';
 import { QRCodeSVG } from 'qrcode.react';
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -33,9 +33,19 @@ import WorkspacePage from '../components/landing/WorkspacePage';
 import NFPADiamond from '../components/NFPADiamond';
 import StockHistoryChart from '../components/StockHistoryChart';
 import { useNotifications } from '../hooks/useNotifications';
-import { assetsAPI, CycleCountPayload, inventoryAPI, reorderAPI, sigAPI } from '../services/api';
+import { assetsAPI, CycleCountPayload, inventoryAPI, PackTransition, reorderAPI, sigAPI } from '../services/api';
 import { Asset, InventoryItem, InventoryItemMetrics, ItemPurchaseHistory, ReorderRequest, SIG, StockHistory, UsageLog } from '../types';
 import { showError } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+import {
+  baseUnitOf,
+  countLevelOf,
+  countUnitOf,
+  countsInPacks,
+  describePackChain,
+  onHandLabel,
+  pluralizeUnit,
+} from '../utils/packaging';
 
 // Cycle-count reason options (op-c7y4). Mirrors the reconciliation grid's
 // user-facing set — the system-only `vision_supply_check` reason is omitted.
@@ -52,6 +62,17 @@ interface CycleCountModalProps {
   itemId: string;
   itemName: string;
   currentStock: number;
+  /**
+   * Packaging context (op-lkxl). When `packCounted` is true the count is
+   * entered — and posted — in whole `countUnit` packs (`at_level`); otherwise
+   * the modal is exactly the base-unit form it has always been. `openCount` is
+   * only used by `open_closed` items, whose count is "sealed packs + open ones".
+   */
+  packCounted: boolean;
+  countUnit: string;
+  countAtLevel: number;
+  isOpenClosed: boolean;
+  openCount: number;
   opened: boolean;
   onClose: () => void;
   onCounted: () => void;
@@ -61,17 +82,29 @@ interface CycleCountModalProps {
  * Modal for recording a physical cycle count. Mirrors the reconciliation form
  * controls: counted quantity, reason, notes, and a skip-reorder toggle. On
  * success it reloads the parent item so days-since-last-count refreshes.
+ *
+ * For a pack-counting item the quantity is entered in the item's own unit
+ * ("4 cases") and posted with `at_level: true`; the flag is deliberately NOT
+ * sent for anything else, because the backend contract is that a quantity means
+ * base units unless a caller opts in.
  */
 const CycleCountModal: React.FC<CycleCountModalProps> = ({
   itemId,
   itemName,
   currentStock,
+  packCounted,
+  countUnit,
+  countAtLevel,
+  isOpenClosed,
+  openCount,
   opened,
   onClose,
   onCounted,
 }) => {
   const notifications = useNotifications();
-  const [countedQty, setCountedQty] = useState<number | ''>(currentStock);
+  const seededQty = packCounted ? countAtLevel : currentStock;
+  const [countedQty, setCountedQty] = useState<number | ''>(seededQty);
+  const [openContainers, setOpenContainers] = useState<number | ''>(openCount);
   const [reason, setReason] = useState<CycleCountPayload['reason']>('miscounted');
   const [notes, setNotes] = useState('');
   const [skipReorder, setSkipReorder] = useState(false);
@@ -81,12 +114,13 @@ const CycleCountModal: React.FC<CycleCountModalProps> = ({
   // so the operator starts from the number they're reconciling against.
   useEffect(() => {
     if (opened) {
-      setCountedQty(currentStock);
+      setCountedQty(seededQty);
+      setOpenContainers(openCount);
       setReason('miscounted');
       setNotes('');
       setSkipReorder(false);
     }
-  }, [opened, currentStock]);
+  }, [opened, seededQty, openCount]);
 
   const handleSubmit = async () => {
     if (countedQty === '' || countedQty < 0) {
@@ -100,11 +134,18 @@ const CycleCountModal: React.FC<CycleCountModalProps> = ({
         reason,
         notes: notes || undefined,
         skip_reorder: skipReorder,
+        // Opt-in only: an each-mode item sends neither key and is read in base
+        // units, exactly as before the packaging matrix existed.
+        ...(packCounted ? { at_level: true } : {}),
+        ...(packCounted && isOpenClosed && openContainers !== ''
+          ? { open_count: openContainers }
+          : {}),
       });
       const delta = data.reconciliation.delta;
+      const onHand = data.on_hand_display?.text ?? `${data.current_stock}`;
       notifications.showSuccess(
         'Cycle count recorded',
-        `On-hand set to ${data.current_stock} (Δ ${delta >= 0 ? '+' : ''}${delta}).`
+        `On-hand set to ${onHand} (Δ ${delta >= 0 ? '+' : ''}${delta}).`
       );
       onCounted();
       onClose();
@@ -120,8 +161,18 @@ const CycleCountModal: React.FC<CycleCountModalProps> = ({
     <Modal opened={opened} onClose={onClose} title={`Cycle Count — ${itemName}`} centered>
       <Stack gap="md">
         <NumberInput
-          label="Counted quantity"
-          description="Physical count of units on the shelf"
+          label={
+            packCounted
+              ? `Counted quantity (${pluralizeUnit(countUnit, 2)})`
+              : 'Counted quantity'
+          }
+          description={
+            packCounted
+              ? `Whole ${pluralizeUnit(countUnit, 2)} on the shelf${
+                  isOpenClosed ? ' — sealed only' : ''
+                }`
+              : 'Physical count of units on the shelf'
+          }
           value={countedQty}
           onChange={(v) => setCountedQty(v === '' ? '' : Number(v))}
           min={0}
@@ -130,6 +181,18 @@ const CycleCountModal: React.FC<CycleCountModalProps> = ({
           required
           data-testid="cycle-count-qty"
         />
+        {packCounted && isOpenClosed && (
+          <NumberInput
+            label="Open containers"
+            description={`Opened ${pluralizeUnit(countUnit, 2)} in use — not counted as stock`}
+            value={openContainers}
+            onChange={(v) => setOpenContainers(v === '' ? '' : Number(v))}
+            min={0}
+            allowDecimal={false}
+            allowNegative={false}
+            data-testid="cycle-count-open-containers"
+          />
+        )}
         <Select
           label="Reason"
           data={CYCLE_COUNT_REASONS}
@@ -169,6 +232,11 @@ interface LogUsageModalProps {
   itemId: string;
   itemName: string;
   unitCost: string | null;
+  /** op-lkxl: enter + post usage in whole packs when the item is counted that way. */
+  packCounted: boolean;
+  countUnit: string;
+  /** Base units in one counting pack — 1 for an each-mode item. Prices the charge. */
+  packBaseUnits: number;
   opened: boolean;
   onClose: () => void;
   onLogged: () => void;
@@ -185,6 +253,9 @@ const LogUsageModal: React.FC<LogUsageModalProps> = ({
   itemId,
   itemName,
   unitCost,
+  packCounted,
+  countUnit,
+  packBaseUnits,
   opened,
   onClose,
   onLogged,
@@ -217,8 +288,10 @@ const LogUsageModal: React.FC<LogUsageModalProps> = ({
   // Only meaningful when a committee is selected; mirrors the backend's
   // snapshot of unit_cost × quantity at consume time. Keyed off unitCost (not
   // qty) so clearing the quantity field shows $0.00 rather than the wrong
-  // "no unit cost" hint.
-  const projectedCharge = unitCost != null ? (parseFloat(unitCost) * qty).toFixed(2) : null;
+  // "no unit cost" hint. unit_cost is per BASE unit, so a pack entry is priced
+  // through the pack's size — the same conversion the server does.
+  const projectedCharge =
+    unitCost != null ? (parseFloat(unitCost) * qty * packBaseUnits).toFixed(2) : null;
 
   const handleSubmit = async () => {
     if (quantity === '' || quantity < 1) {
@@ -232,6 +305,9 @@ const LogUsageModal: React.FC<LogUsageModalProps> = ({
         quantity,
         notes: notes || undefined,
         charged_group: chargedGroup ?? undefined,
+        // Opt-in only (op-ev14): without this the quantity is base units, which
+        // is what every each-mode item must keep meaning.
+        ...(packCounted ? { at_level: true } : {}),
       });
       if (data.warning) {
         // Committee recorded but no unit cost → nothing posted. Non-error tone.
@@ -264,8 +340,12 @@ const LogUsageModal: React.FC<LogUsageModalProps> = ({
     <Modal opened={opened} onClose={onClose} title={`Use / Log Usage — ${itemName}`} centered>
       <Stack gap="md">
         <NumberInput
-          label="Quantity used"
-          description="Units consumed from stock"
+          label={packCounted ? `Quantity used (${pluralizeUnit(countUnit, 2)})` : 'Quantity used'}
+          description={
+            packCounted
+              ? `Whole ${pluralizeUnit(countUnit, 2)} consumed from stock`
+              : 'Units consumed from stock'
+          }
           value={quantity}
           onChange={(v) => setQuantity(v === '' ? '' : Number(v))}
           min={1}
@@ -341,6 +421,9 @@ const InventoryItemDetailPage: React.FC = () => {
   const [cycleCountOpen, setCycleCountOpen] = useState(false);
   const [logUsageOpen, setLogUsageOpen] = useState(false);
   const [retiring, setRetiring] = useState(false);
+  // Which pack transition is in flight, so both buttons disable together.
+  const [packBusy, setPackBusy] = useState<PackTransition | null>(null);
+  const notifications = useNotifications();
 
   useEffect(() => {
     if (id) {
@@ -445,6 +528,36 @@ const InventoryItemDetailPage: React.FC = () => {
     }
   };
 
+  /**
+   * Open a sealed pack, or finish the open one (op-ev14 `pack-container`).
+   *
+   * Only reachable for an `open_closed` item. Opening IS consumption under that
+   * mode — the backend drops stock by the pack's base units, bumps the open
+   * tally and writes a usage log — so the page reloads afterwards to pick up
+   * the new sealed + open split.
+   */
+  const handlePackTransition = async (transition: PackTransition) => {
+    if (!id) return;
+
+    setPackBusy(transition);
+    try {
+      const response = await inventoryAPI.packContainer(id, transition);
+      const text = response?.data?.on_hand_display?.text;
+      notifications.showSuccess(
+        transition === 'open' ? 'Pack opened' : 'Open pack finished',
+        text ? `On hand: ${text}.` : undefined
+      );
+      await loadData();
+    } catch (err) {
+      notifications.showError(
+        transition === 'open' ? 'Could not open a pack' : 'Could not finish the open pack',
+        extractErrorMessage(err, 'Please try again.')
+      );
+    } finally {
+      setPackBusy(null);
+    }
+  };
+
   // Retire / un-retire (op-jv7r). Mirrors handleGenerateQR: call the action
   // then reload so the badge + button label reflect the new state. Toggles by
   // the item's current is_retired.
@@ -492,6 +605,16 @@ const InventoryItemDetailPage: React.FC = () => {
       </WorkspacePage>
     );
   }
+
+  // Packaging matrix (op-lkxl). `packCounted` is the one predicate the new
+  // surfaces branch on: false for an each-mode item AND for a half-configured
+  // one, which keeps everything below on today's base-unit behaviour.
+  const packCounted = countsInPacks(item);
+  const baseUnit = baseUnitOf(item);
+  const countUnit = countUnitOf(item);
+  const chainLines = describePackChain(item.packaging_levels);
+  const sealedCount = item.on_hand_display?.sealed ?? 0;
+  const openCount = item.on_hand_display?.open ?? item.open_container_count ?? 0;
 
   return (
     <WorkspacePage
@@ -611,10 +734,75 @@ const InventoryItemDetailPage: React.FC = () => {
                   <Title order={4}>Stock Information</Title>
                   <Group justify="space-between">
                     <Text size="sm">Current Stock:</Text>
-                    <Text size="sm" fw={600} c={item.needs_reorder ? 'red' : undefined}>
-                      {item.current_stock} {item.use_case_based_reorder ? 'units' : 'units'}
+                    <Text
+                      size="sm"
+                      fw={600}
+                      c={item.needs_reorder ? 'red' : undefined}
+                      data-testid="item-on-hand"
+                    >
+                      {onHandLabel(item)}
                     </Text>
                   </Group>
+                  {/* Pack-counting items also show the canonical base-unit
+                      number, because that is what every PO, usage log and
+                      reorder quantity is stored in (op-lkxl). */}
+                  {packCounted && (
+                    <Group justify="space-between">
+                      <Text size="sm">Base units:</Text>
+                      <Text size="sm" c="dimmed" data-testid="item-base-units">
+                        {item.current_stock} {pluralizeUnit(baseUnit, item.current_stock)}
+                      </Text>
+                    </Group>
+                  )}
+                  {chainLines.length > 0 && (
+                    <div data-testid="item-pack-chain">
+                      <Text size="sm" fw={500} mb="xs">
+                        Packaging
+                      </Text>
+                      <Stack gap={2}>
+                        {chainLines.map((line) => (
+                          <Text key={line} size="sm" c="dimmed">
+                            {line}
+                          </Text>
+                        ))}
+                        {countUnit && (
+                          <Text size="sm" c="dimmed">
+                            Counted in {pluralizeUnit(countUnit, 2)}
+                            {item.count_mode === 'open_closed' ? ' (sealed + open)' : ''}
+                          </Text>
+                        )}
+                      </Stack>
+                    </div>
+                  )}
+                  {/* Open / finish a pack — the two container moves an
+                      open_closed item makes, and the only stock path that
+                      expresses them (op-ev14). Opening consumes the pack. */}
+                  {item.count_mode === 'open_closed' && packCounted && (
+                    <Group gap="sm" data-testid="pack-container-controls">
+                      <Button
+                        size="xs"
+                        variant="light"
+                        leftSection={<IconBoxOff size={14} />}
+                        onClick={() => handlePackTransition('open')}
+                        loading={packBusy === 'open'}
+                        disabled={sealedCount === 0 || packBusy !== null}
+                        data-testid="open-pack-button"
+                      >
+                        Open a {countUnit || 'pack'}
+                      </Button>
+                      <Button
+                        size="xs"
+                        variant="light"
+                        leftSection={<IconBoxSeam size={14} />}
+                        onClick={() => handlePackTransition('finish')}
+                        loading={packBusy === 'finish'}
+                        disabled={openCount === 0 || packBusy !== null}
+                        data-testid="finish-pack-button"
+                      >
+                        Finish open {countUnit || 'pack'}
+                      </Button>
+                    </Group>
+                  )}
                   {item.use_case_based_reorder && (
                     <Group justify="space-between">
                       <Text size="sm">Current Cases:</Text>
@@ -625,14 +813,22 @@ const InventoryItemDetailPage: React.FC = () => {
                   )}
                   <Group justify="space-between">
                     <Text size="sm">Minimum Stock:</Text>
-                    <Text size="sm">
-                      {item.use_case_based_reorder ? `${item.minimum_cases} cases` : `${item.minimum_stock} units`}
+                    <Text size="sm" data-testid="item-minimum-stock">
+                      {packCounted
+                        ? `${item.minimum_stock} ${pluralizeUnit(countUnit, item.minimum_stock)}`
+                        : item.use_case_based_reorder
+                          ? `${item.minimum_cases} cases`
+                          : `${item.minimum_stock} units`}
                     </Text>
                   </Group>
                   <Group justify="space-between">
                     <Text size="sm">Reorder Quantity:</Text>
-                    <Text size="sm">
-                      {item.use_case_based_reorder ? `${item.reorder_cases} cases` : `${item.reorder_quantity} units`}
+                    <Text size="sm" data-testid="item-reorder-quantity">
+                      {packCounted
+                        ? `${item.reorder_quantity} ${pluralizeUnit(countUnit, item.reorder_quantity)}`
+                        : item.use_case_based_reorder
+                          ? `${item.reorder_cases} cases`
+                          : `${item.reorder_quantity} units`}
                     </Text>
                   </Group>
                   <Group justify="space-between">
@@ -974,6 +1170,13 @@ const InventoryItemDetailPage: React.FC = () => {
         itemId={item.id}
         itemName={item.name}
         currentStock={item.current_stock}
+        packCounted={packCounted}
+        countUnit={countUnit}
+        countAtLevel={
+          item.on_hand_display?.level_count ?? item.on_hand_display?.sealed ?? item.current_stock
+        }
+        isOpenClosed={item.count_mode === 'open_closed'}
+        openCount={openCount}
         opened={cycleCountOpen}
         onClose={() => setCycleCountOpen(false)}
         onCounted={loadData}
@@ -983,6 +1186,9 @@ const InventoryItemDetailPage: React.FC = () => {
         itemId={item.id}
         itemName={item.name}
         unitCost={item.unit_cost}
+        packCounted={packCounted}
+        countUnit={countUnit}
+        packBaseUnits={countLevelOf(item)?.base_units ?? 1}
         opened={logUsageOpen}
         onClose={() => setLogUsageOpen(false)}
         onLogged={loadData}

--- a/frontend/src/pages/InventoryItemFormPage.tsx
+++ b/frontend/src/pages/InventoryItemFormPage.tsx
@@ -3,7 +3,7 @@
  * Create/Edit form for inventory items with all fields
  */
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Alert, Button, Group, Modal, Paper, Stack, Switch, Text, TextInput, Title } from '@mantine/core';
+import { Alert, Button, Group, Modal, Paper, Select, Stack, Switch, Text, TextInput, Title } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
 import { Controller, Resolver, useForm } from 'react-hook-form';
@@ -17,12 +17,33 @@ import { FormLayout } from '../components/forms/FormLayout';
 import { FormNumberInput } from '../components/forms/FormNumberInput';
 import { FormSelect } from '../components/forms/FormSelect';
 import { FormTextarea } from '../components/forms/FormTextarea';
+import PackagingChainEditor from '../components/inventory/PackagingChainEditor';
 import WorkspacePage from '../components/landing/WorkspacePage';
-import { inventoryAPI } from '../services/api';
-import { Category, InventoryItem, ItemSupplier, Location, Supplier } from '../types';
+import { InventoryItemPackagingPayload, inventoryAPI } from '../services/api';
+import { Category, InventoryItem, ItemCountMode, ItemSupplier, Location, Supplier } from '../types';
 import { promptInput, showError } from '../utils/dialogs';
 import { InventoryItemFormData, inventoryItemSchema } from '../utils/formSchemas';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
+import {
+  COUNT_MODE_LABELS,
+  PackagingRow,
+  pluralizeUnit,
+  resolveCountLevelError,
+  toPackagingPayload,
+  toPackagingRows,
+  validatePackagingChain,
+} from '../utils/packaging';
+
+// The count-mode picker, in the order a user grows into it (op-lkxl).
+const COUNT_MODE_OPTIONS: { value: ItemCountMode; label: string }[] = [
+  { value: 'each', label: COUNT_MODE_LABELS.each },
+  { value: 'by_level', label: COUNT_MODE_LABELS.by_level },
+  { value: 'open_closed', label: COUNT_MODE_LABELS.open_closed },
+];
+
+/** Chain rows as compared for dirtiness — position, name and size, nothing else. */
+const chainSignature = (rows: PackagingRow[]): string =>
+  JSON.stringify(rows.map((row) => [row.name.trim(), row.base_units]));
 
 const InventoryItemFormPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -41,6 +62,20 @@ const InventoryItemFormPage: React.FC = () => {
   const [_newLocationName, setNewLocationName] = useState('');
   const [supplierRelationships, setSupplierRelationships] = useState<SupplierRelationship[]>([]);
 
+  // Packaging matrix (op-lkxl). Held outside react-hook-form because it does
+  // not go through the multipart body: `packaging_levels` is a nested list and
+  // `count_level` is a pk that only exists once the chain has been saved, so
+  // these are written as a JSON follow-up in onSubmit. `countLevelKey` names a
+  // chain ROW (not a pk), so the selection survives reorders and new rungs.
+  const [packagingRows, setPackagingRows] = useState<PackagingRow[]>([]);
+  const [countMode, setCountMode] = useState<ItemCountMode>('each');
+  const [countLevelKey, setCountLevelKey] = useState<string | null>(null);
+  const [savedPackaging, setSavedPackaging] = useState<{
+    signature: string;
+    countMode: ItemCountMode;
+    countLevelId: number | null;
+  }>({ signature: chainSignature([]), countMode: 'each', countLevelId: null });
+
   const {
     control,
     handleSubmit,
@@ -56,6 +91,7 @@ const InventoryItemFormPage: React.FC = () => {
       name: '',
       description: '',
       sku: '',
+      base_unit: 'unit',
       current_stock: 0,
       minimum_stock: 0,
       reorder_quantity: 1,
@@ -84,6 +120,17 @@ const InventoryItemFormPage: React.FC = () => {
   const isHazardous = watch('is_hazardous');
   const useCaseBasedReorder = watch('use_case_based_reorder');
   const isSerialized = watch('is_serialized');
+  const baseUnit = (watch('base_unit') || '').trim() || 'unit';
+
+  // Client twins of the backend validators, so an impossible chain is caught
+  // before the request rather than coming back as a 400.
+  const chainErrors = validatePackagingChain(packagingRows);
+  const countLevelError = resolveCountLevelError(countMode, countLevelKey, packagingRows);
+  const countLevelRow = packagingRows.find((row) => row.key === countLevelKey) ?? null;
+  // Thresholds are read in the COUNT unit for the pack-counting modes, so the
+  // min/reorder inputs say which unit they mean (op-es7c's contract shift).
+  const thresholdUnit =
+    countMode !== 'each' && countLevelRow?.name.trim() ? countLevelRow.name.trim() : null;
 
   useEffect(() => {
     loadInitialData();
@@ -126,6 +173,7 @@ const InventoryItemFormPage: React.FC = () => {
         name: item.name,
         description: item.description,
         sku: item.sku,
+        base_unit: item.base_unit || 'unit',
         current_stock: item.current_stock,
         minimum_stock: item.minimum_stock,
         reorder_quantity: item.reorder_quantity,
@@ -151,6 +199,20 @@ const InventoryItemFormPage: React.FC = () => {
         is_retired: item.is_retired ?? false,
         notes: item.notes || '',
         image_url: item.image ? (item.image.startsWith('http') ? item.image : '') : '',
+      });
+
+      // Hydrate the packaging chain + counting mode, and remember what the
+      // server already has so a save that touches none of it sends no extra
+      // request (the common case: an each-mode item with no chain).
+      const rows = toPackagingRows(item.packaging_levels);
+      const mode = item.count_mode ?? 'each';
+      setPackagingRows(rows);
+      setCountMode(mode);
+      setCountLevelKey(rows.find((row) => row.id === item.count_level)?.key ?? null);
+      setSavedPackaging({
+        signature: chainSignature(rows),
+        countMode: mode,
+        countLevelId: item.count_level ?? null,
       });
 
       // Map supplier relationships
@@ -194,7 +256,66 @@ const InventoryItemFormPage: React.FC = () => {
     }
   };
 
+  /**
+   * Save the packaging matrix for an item that already exists (op-lkxl).
+   *
+   * Separate from the multipart item write for two reasons: `packaging_levels`
+   * is a nested list, and `count_level` is a pk — a rung the user just added has
+   * no pk until the chain is saved. So the chain goes first, then the mode +
+   * counting level resolved from the saved chain by `sort_order` (which is the
+   * row's position, the identity the serializer upserts on).
+   *
+   * Sends nothing when nothing packaging-related changed.
+   */
+  const savePackaging = async (savedItem: InventoryItem) => {
+    const signature = chainSignature(packagingRows);
+    const chainDirty = signature !== savedPackaging.signature;
+    const countLevelIndex = packagingRows.findIndex((row) => row.key === countLevelKey);
+    const needsLevel = countMode !== 'each';
+
+    let chain = savedItem.packaging_levels ?? [];
+
+    if (chainDirty) {
+      const payload: InventoryItemPackagingPayload = {
+        packaging_levels: toPackagingPayload(packagingRows),
+      };
+      // Fold the mode in when no pk has to be resolved — dropping to each-mode
+      // clears count_level, so chain + mode is one legal write.
+      if (!needsLevel) {
+        payload.count_mode = 'each';
+        payload.count_level = null;
+      }
+      const response = await inventoryAPI.updateItem(savedItem.id, payload);
+      chain = response?.data?.packaging_levels ?? [];
+      if (!needsLevel) return;
+    }
+
+    const countLevelId = needsLevel
+      ? chain.find((level) => level.sort_order === countLevelIndex)?.id ?? null
+      : null;
+    if (needsLevel && countLevelId === null) {
+      // `detail` so extractErrorMessage surfaces it like a backend error would.
+      throw { detail: 'the saved packaging chain did not come back with the counting level.' };
+    }
+    const modeDirty =
+      countMode !== savedPackaging.countMode || countLevelId !== savedPackaging.countLevelId;
+    if (!modeDirty) return;
+
+    await inventoryAPI.updateItem(savedItem.id, {
+      count_mode: countMode,
+      count_level: countLevelId,
+    });
+  };
+
   const onSubmit = async (data: InventoryItemFormData) => {
+    // Refuse an impossible chain here rather than sending it: the backend
+    // rejects the same combinations, but the item write would already have
+    // landed by then.
+    if (chainErrors.length > 0 || countLevelError) {
+      setError([...chainErrors, countLevelError].filter(Boolean).join(' '));
+      return;
+    }
+
     try {
       setSaving(true);
       setError(null);
@@ -242,6 +363,22 @@ const InventoryItemFormPage: React.FC = () => {
 
       // Save supplier relationships
       // TODO: Implement supplier relationship saving via ItemSupplier API
+
+      // The packaging matrix rides a JSON follow-up. It is reported separately
+      // because the item itself is already saved by this point — the user needs
+      // to know which half failed.
+      try {
+        await savePackaging(savedItem);
+      } catch (err: any) {
+        console.error('Error saving packaging setup:', err);
+        setError(
+          `Item saved, but the packaging setup failed: ${extractErrorMessage(
+            err,
+            'please try again.'
+          )}`
+        );
+        return;
+      }
 
       navigate(`/inventory/items/${savedItem.id}`);
     } catch (err: any) {
@@ -340,6 +477,63 @@ const InventoryItemFormPage: React.FC = () => {
                 ),
               },
               {
+                // Unit of measure / packaging matrix (op-lkxl). Every control
+                // here is opt-in: an item with no chain and count mode "each"
+                // behaves — and reads — exactly as it did before this section
+                // existed.
+                title: 'Units & Packaging',
+                children: (
+                  <>
+                    <FormInput
+                      name="base_unit"
+                      control={control}
+                      label="Base unit"
+                      placeholder="unit"
+                      description="The smallest unit you count — sheet, glove, bolt. Stock is always stored in these."
+                    />
+                    <PackagingChainEditor
+                      rows={packagingRows}
+                      onChange={setPackagingRows}
+                      baseUnit={baseUnit}
+                      errors={chainErrors}
+                    />
+                    <Select
+                      label="Count mode"
+                      description="How stock is counted for this item."
+                      data={COUNT_MODE_OPTIONS}
+                      value={countMode}
+                      onChange={(value) => {
+                        const next = (value as ItemCountMode) || 'each';
+                        setCountMode(next);
+                        if (next === 'each') {
+                          setCountLevelKey(null);
+                        }
+                      }}
+                      allowDeselect={false}
+                      data-testid="item-count-mode"
+                    />
+                    {countMode !== 'each' && (
+                      <Select
+                        label="Counted in"
+                        description="Which packaging level whole counts are taken in."
+                        placeholder={
+                          packagingRows.length === 0
+                            ? 'Add a packaging level first'
+                            : 'Select a packaging level'
+                        }
+                        data={packagingRows
+                          .filter((row) => row.name.trim())
+                          .map((row) => ({ value: row.key, label: row.name.trim() }))}
+                        value={countLevelKey}
+                        onChange={setCountLevelKey}
+                        error={countLevelError}
+                        data-testid="item-count-level"
+                      />
+                    )}
+                  </>
+                ),
+              },
+              {
                 title: 'Stock Settings',
                 children: (
                   <>
@@ -347,20 +541,36 @@ const InventoryItemFormPage: React.FC = () => {
                       name="current_stock"
                       control={control}
                       label="Current Stock"
+                      description={
+                        thresholdUnit
+                          ? `In ${pluralizeUnit(baseUnit, 2)}. Count in ${pluralizeUnit(
+                              thresholdUnit,
+                              2
+                            )} from the item page.`
+                          : undefined
+                      }
                       min={0}
                       required
                     />
                     <FormNumberInput
                       name="minimum_stock"
                       control={control}
-                      label="Minimum Stock"
+                      label={
+                        thresholdUnit
+                          ? `Minimum Stock (${pluralizeUnit(thresholdUnit, 2)})`
+                          : 'Minimum Stock'
+                      }
                       min={0}
                       required
                     />
                     <FormNumberInput
                       name="reorder_quantity"
                       control={control}
-                      label="Reorder Quantity"
+                      label={
+                        thresholdUnit
+                          ? `Reorder Quantity (${pluralizeUnit(thresholdUnit, 2)})`
+                          : 'Reorder Quantity'
+                      }
                       min={1}
                       required
                     />

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,7 +2,7 @@
  * API service for communicating with the Django backend
  */
 import axios from 'axios';
-import { ActiveMaintenanceRow, Asset, AssetCostRecoveryReport, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, InventoryItemMetrics, ItemPurchaseHistory, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LogUsageRequest, LogUsageResponse, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, MaintenanceTool, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, StockHistory, Supplier, SupplierAgreement, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderAdHocMaterialInput, WorkOrderLotoCompletion, WorkOrderMaterialUsage, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
+import { ActiveMaintenanceRow, Asset, AssetCostRecoveryReport, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, InventoryItem, InventoryItemMetrics, ItemCountMode, ItemOnHandDisplay, ItemPurchaseHistory, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LogUsageRequest, LogUsageResponse, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, MaintenanceTool, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, StockHistory, Supplier, SupplierAgreement, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderAdHocMaterialInput, WorkOrderLotoCompletion, WorkOrderMaterialUsage, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
 
 /**
  * Resolves the API base URL based on environment.
@@ -319,7 +319,7 @@ export const inventoryAPI = {
   getSupplierAnalytics: (id: string) =>
     api.get(`/inventory/suppliers/${id}/analytics/`),
 
-  createItem: (data: FormData | Partial<InventoryItem>) => {
+  createItem: (data: FormData | Partial<InventoryItem> | InventoryItemPackagingPayload) => {
     if (data instanceof FormData) {
       return api.post<InventoryItem>('/inventory/items/', data, {
         headers: {
@@ -330,7 +330,10 @@ export const inventoryAPI = {
     return api.post<InventoryItem>('/inventory/items/', data);
   },
 
-  updateItem: (id: string, data: FormData | Partial<InventoryItem>) => {
+  updateItem: (
+    id: string,
+    data: FormData | Partial<InventoryItem> | InventoryItemPackagingPayload
+  ) => {
     if (data instanceof FormData) {
       return api.patch<InventoryItem>(`/inventory/items/${id}/`, data, {
         headers: {
@@ -340,6 +343,17 @@ export const inventoryAPI = {
     }
     return api.patch<InventoryItem>(`/inventory/items/${id}/`, data);
   },
+
+  // Open a sealed pack / finish the open one, for `open_closed` items (op-ev14).
+  // Opening IS consumption under that mode — stock drops by the pack's base
+  // units, the open tally rises, and a usage log is written; finishing only
+  // clears the open tally. Anything else (a non-open_closed item, no sealed pack
+  // left, no open pack) is a 400.
+  packContainer: (itemId: string, transition: PackTransition, notes?: string) =>
+    api.post<PackContainerResponse>(`/inventory/items/${itemId}/pack-container/`, {
+      transition,
+      ...(notes ? { notes } : {}),
+    }),
 
   updateStock: (id: string, quantity: number) =>
     api.patch<InventoryItem>(`/inventory/items/${id}/`, { current_stock: quantity }),
@@ -437,6 +451,13 @@ export interface CycleCountPayload {
   reason: ReconciliationRow['reason'];
   skip_reorder?: boolean;
   notes?: string;
+  // op-ev14, opt-in: read `counted_qty` as a count of whole `count_level` packs
+  // instead of base units. Omitting it keeps the base-unit reading every
+  // each-mode caller depends on; sending it for an item that is not counted in
+  // packs is a 400. `open_count` sets an `open_closed` item's open-container
+  // tally in the same reconciliation.
+  at_level?: boolean;
+  open_count?: number;
 }
 
 export interface CycleCountResponse {
@@ -444,6 +465,9 @@ export interface CycleCountResponse {
   current_stock: number;
   last_counted_at: string | null;
   days_since_last_count: number | null;
+  // op-ev14 echoes the unit the count was read in plus the refreshed on-hand.
+  counted_unit?: string;
+  on_hand_display?: ItemOnHandDisplay;
   reconciliation: {
     id: number;
     projected_count: number;
@@ -453,6 +477,45 @@ export interface CycleCountResponse {
     reconciled_at: string;
     reconciled_by: number;
   };
+}
+
+// ---- Packaging matrix write payloads (op-hzji/op-ev14 backend, op-lkxl web) ----
+
+/**
+ * One rung of the nested-writable `packaging_levels` chain. The pk is
+ * deliberately absent: the serializer upserts rungs on `(item, sort_order)`, so
+ * position carries identity and a kept rung keeps its pk (and any `count_level`
+ * FK pointing at it).
+ */
+export interface PackagingLevelInput {
+  name: string;
+  sort_order: number;
+  base_units: number;
+}
+
+/**
+ * The packaging half of an item write. Sent as JSON rather than folded into the
+ * form's multipart body because `packaging_levels` is a nested list, and
+ * `count_level` is a pk that can only be resolved once the chain exists.
+ */
+export interface InventoryItemPackagingPayload {
+  base_unit?: string;
+  count_mode?: ItemCountMode;
+  count_level?: number | null;
+  packaging_levels?: PackagingLevelInput[];
+  /** Set on-hand as a count of whole `count_level` packs; not with current_stock. */
+  current_stock_at_level?: number;
+}
+
+export type PackTransition = 'open' | 'finish';
+
+export interface PackContainerResponse {
+  transition: PackTransition;
+  id: string;
+  current_stock: number;
+  open_container_count: number;
+  on_hand_display: ItemOnHandDisplay;
+  usage_log: UsageLog | null;
 }
 
 export interface StockReconciliation {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -137,6 +137,65 @@ export interface ItemSupplier {
   updated_at: string;
 }
 
+// ---- Unit of measure / packaging matrix (op-hzji P1, op-es7c P2a, op-ev14 P2b) ----
+
+/**
+ * How an item is counted.
+ *
+ * `each` is the default and what every legacy item is: quantities are the
+ * item's base unit. `by_level` counts whole packs of `count_level` (4 cases);
+ * `open_closed` counts sealed packs plus a tally of opened ones.
+ */
+export type ItemCountMode = 'each' | 'by_level' | 'open_closed';
+
+/**
+ * One rung of an item's packaging chain. `sort_order` 0 is the outermost /
+ * largest rung and increases toward the base rung, whose `base_units` is 1.
+ * `per_parent` ("1 case = 10 reams") is derived server-side and is null for
+ * the base rung.
+ */
+export interface PackagingLevel {
+  id: number;
+  name: string;
+  sort_order: number;
+  base_units: number;
+  per_parent: number | null;
+}
+
+/**
+ * `InventoryItem.current_stock` expressed at the item's counting granularity —
+ * read-only, computed from the canonical base-unit count. Which optional keys
+ * are present depends on `mode`: `each` → unit/base_units, `by_level` →
+ * level/level_count/remainder_base, `open_closed` → level/sealed/open. `text`
+ * is always present and is the label to render.
+ */
+export interface ItemOnHandDisplay {
+  mode: ItemCountMode;
+  text: string;
+  unit?: string;
+  base_units?: number;
+  level?: string;
+  level_count?: number;
+  remainder_base?: number;
+  sealed?: number;
+  open?: number;
+}
+
+/**
+ * Reorder point + current count in ONE unit (op-es7c), so a caller can label
+ * the pair without knowing which columns the item's `count_mode` gives meaning
+ * to. For a pack-counting item every quantity here is in `unit` (cases/reams).
+ */
+export interface ItemReorderDisplay {
+  mode: ItemCountMode;
+  unit: string;
+  threshold: number;
+  current: number;
+  reorder_quantity: number;
+  needs_reorder: boolean;
+  text: string;
+}
+
 export interface InventoryItem {
   id: string;
   name: string;
@@ -230,6 +289,20 @@ export interface InventoryItem {
   // and whole days since (null when the item has never been counted).
   last_counted_at: string | null;
   days_since_last_count: number | null;
+  // Unit of measure / packaging matrix (op-hzji + op-es7c + op-ev14). Additive
+  // and opt-in: an item that sets none of these counts individual base units
+  // exactly as it always has, so every field is optional on the wire as far as
+  // the web is concerned. `base_unit`/`count_mode`/`count_level`/
+  // `open_container_count`/`packaging_levels` are writable; `on_hand_display`
+  // and `reorder_display` are server-rendered presentations of the canonical
+  // base-unit `current_stock`.
+  base_unit?: string;
+  count_mode?: ItemCountMode;
+  count_level?: number | null;
+  open_container_count?: number;
+  packaging_levels?: PackagingLevel[];
+  on_hand_display?: ItemOnHandDisplay;
+  reorder_display?: ItemReorderDisplay;
 }
 
 export type InventoryCostTrend = 'up' | 'down' | 'flat' | 'no_history';
@@ -343,6 +416,11 @@ export interface LogUsageRequest {
   quantity: number;
   notes?: string;
   charged_group?: number;
+  // op-ev14: opt in to reading `quantity` as a count of whole `count_level`
+  // packs instead of base units. Omitted (the default) means base units, which
+  // is what every each-mode item must keep sending; sending it for an item that
+  // is not counted in packs is a 400, never a silent base-unit reading.
+  at_level?: boolean;
 }
 
 // Response from POST /inventory/items/{id}/log_usage/: the UsageLog plus the
@@ -355,6 +433,11 @@ export interface LogUsageResponse extends UsageLog {
   total_cost: string | null;
   ledger_transaction: number | null;
   warning?: string;
+  // op-ev14 echoes the number as sent plus the unit the server read it in
+  // (`quantity_used` above is always base units), and the refreshed on-hand.
+  entered_quantity?: number;
+  entered_unit?: string;
+  on_hand_display?: ItemOnHandDisplay;
 }
 
 export type ReorderStatus = 'pending' | 'approved' | 'ordered' | 'received' | 'cancelled';

--- a/frontend/src/utils/formSchemas.ts
+++ b/frontend/src/utils/formSchemas.ts
@@ -63,6 +63,12 @@ export const inventoryItemSchema = z
     image: z.union([z.instanceof(File), z.string().url(), z.null()]).optional(),
     image_url: z.string().url('Invalid URL').optional().or(z.literal('')),
 
+    // Unit of measure (op-hzji). The smallest unit the item is counted in;
+    // every legacy item is "unit". The rest of the packaging matrix
+    // (count_mode / count_level / packaging_levels) is saved as JSON outside
+    // this multipart form — see InventoryItemFormPage.
+    base_unit: z.string().max(40, 'Base unit must be 40 characters or less').optional(),
+
     // Stock Settings
     current_stock: z.number().int().min(0, 'Stock cannot be negative').default(0),
     minimum_stock: z.number().int().min(0, 'Minimum stock cannot be negative').default(0),

--- a/frontend/src/utils/packaging.ts
+++ b/frontend/src/utils/packaging.ts
@@ -1,0 +1,228 @@
+/**
+ * Unit-of-measure / packaging-chain helpers for the web UI (op-lkxl, phase 3).
+ *
+ * The client-side twin of `backend/inventory/services/packaging.py`: the same
+ * chain rules, so the item form rejects an impossible chain before the request
+ * instead of round-tripping a 400, and the same "is this item counted in
+ * packs?" predicate every mode-aware surface branches on.
+ *
+ * The backend stays the authority — anything these helpers let through is still
+ * validated server-side, and `on_hand_display` / `reorder_display` text is
+ * rendered by the server. Nothing here converts stock: `current_stock` remains
+ * the canonical base-unit count.
+ */
+import { InventoryItem, ItemCountMode, PackagingLevel } from '../types';
+
+/** The two `count_mode`s that count whole packs rather than base units. */
+export const PACK_COUNT_MODES: ItemCountMode[] = ['by_level', 'open_closed'];
+
+export const COUNT_MODE_LABELS: Record<ItemCountMode, string> = {
+  each: 'Each (count base units)',
+  by_level: 'By packaging level (count whole packs)',
+  open_closed: 'Sealed + open (count sealed packs, track the open one)',
+};
+
+/**
+ * A chain rung as the form edits it. `sort_order` is deliberately absent: the
+ * editor keeps rows largest-first and derives `sort_order` from the row's index
+ * on save, which is exactly the backend's convention (0 = outermost). `key` is
+ * a client-only stable identity so the count-level selection survives reorders
+ * and inserts, and `base_units` allows '' for a half-typed row.
+ */
+export interface PackagingRow {
+  key: string;
+  id?: number;
+  name: string;
+  base_units: number | '';
+}
+
+let rowKeySeq = 0;
+
+/** Mint a stable client-side key for a new chain row. */
+export const newPackagingRowKey = (): string => `pkg-${++rowKeySeq}`;
+
+/** An empty editor row, ready to type into. */
+export const blankPackagingRow = (): PackagingRow => ({
+  key: newPackagingRowKey(),
+  name: '',
+  base_units: '',
+});
+
+/** Server chain → editor rows, ordered outermost-first. */
+export const toPackagingRows = (levels?: PackagingLevel[] | null): PackagingRow[] =>
+  [...(levels ?? [])]
+    .sort((a, b) => a.sort_order - b.sort_order)
+    .map((level) => ({
+      key: newPackagingRowKey(),
+      id: level.id,
+      name: level.name,
+      base_units: level.base_units,
+    }));
+
+/**
+ * Editor rows → the nested `packaging_levels` write payload. `sort_order` is
+ * the row index, so "largest first" in the UI is "sort_order 0 is outermost" on
+ * the wire. The pk is deliberately not sent: the serializer upserts on
+ * `(item, sort_order)`, so a rung that keeps its position keeps its pk.
+ */
+export const toPackagingPayload = (
+  rows: PackagingRow[]
+): { name: string; sort_order: number; base_units: number }[] =>
+  rows.map((row, index) => ({
+    name: row.name.trim(),
+    sort_order: index,
+    base_units: row.base_units === '' ? 0 : Number(row.base_units),
+  }));
+
+/**
+ * Validate a chain the way `validate_packaging_chain` does, returning every
+ * problem found (empty array = valid). An empty chain is valid: an item with no
+ * packaging levels is simply counted in base units.
+ */
+export const validatePackagingChain = (rows: PackagingRow[]): string[] => {
+  if (rows.length === 0) return [];
+
+  const errors: string[] = [];
+
+  if (rows.some((row) => !row.name.trim())) {
+    errors.push('Every packaging level needs a name.');
+  }
+  if (rows.some((row) => row.base_units === '' || Number(row.base_units) < 1)) {
+    errors.push('Every packaging level must hold at least one base unit.');
+  }
+  if (errors.length > 0) return errors;
+
+  const sizes = rows.map((row) => Number(row.base_units));
+  const baseRungs = sizes.filter((size) => size === 1);
+  if (baseRungs.length !== 1) {
+    errors.push(
+      'Exactly one packaging level must be the base unit (holding 1 base unit); ' +
+        `found ${baseRungs.length}.`
+    );
+  } else if (sizes[sizes.length - 1] !== 1) {
+    errors.push('The base packaging level must be the innermost (listed last).');
+  }
+
+  rows.forEach((row, index) => {
+    if (index === 0) return;
+    if (sizes[index] >= sizes[index - 1]) {
+      errors.push(
+        `Packaging level '${row.name.trim()}' must hold fewer base units than ` +
+          `'${rows[index - 1].name.trim()}' that contains it.`
+      );
+    }
+  });
+
+  return errors;
+};
+
+/**
+ * Why `countLevelKey` is wrong for `countMode`, or null if the pair fits —
+ * the client twin of `resolve_count_level_error`.
+ */
+export const resolveCountLevelError = (
+  countMode: ItemCountMode,
+  countLevelKey: string | null,
+  rows: PackagingRow[]
+): string | null => {
+  if (countMode === 'each') return null;
+  if (!countLevelKey) {
+    return 'Choose which packaging level this item is counted in.';
+  }
+  if (!rows.some((row) => row.key === countLevelKey)) {
+    return 'The counting level must be one of the packaging levels above.';
+  }
+  return null;
+};
+
+/**
+ * How many of the next rung down fit in this one — the "1 case = 10 reams"
+ * number, computed the way `PackagingLevelSerializer.get_per_parent` does.
+ * Null for the base (last) rung, which has nothing below it.
+ */
+export const perParent = (rows: PackagingRow[], index: number): number | null => {
+  const own = rows[index]?.base_units;
+  const below = rows[index + 1]?.base_units;
+  if (own === '' || own === undefined || below === '' || below === undefined) return null;
+  if (Number(below) < 1) return null;
+  const ratio = Number(own) / Number(below);
+  return Number.isFinite(ratio) ? ratio : null;
+};
+
+/**
+ * `unit` pluralised for `count`. Handles the sibilant ending the naive `+ "s"`
+ * gets wrong ("box" → "boxes", not "boxs"), because packaging levels are named
+ * by hand and "box" is one of the commonest ones. Deliberately a shade better
+ * than the backend's own `_plural`, which only ever appends "s" — nothing
+ * compares the two strings, and no server-rendered text is re-pluralised here.
+ */
+export const pluralizeUnit = (unit: string, count: number): string => {
+  if (count === 1) return unit;
+  return /(s|x|z|ch|sh)$/i.test(unit) ? `${unit}es` : `${unit}s`;
+};
+
+/** The item's base unit, defaulting to the backend's own default. */
+export const baseUnitOf = (item: Pick<InventoryItem, 'base_unit'>): string =>
+  item.base_unit?.trim() || 'unit';
+
+/** The rung an item is counted in, or null. */
+export const countLevelOf = (item: InventoryItem): PackagingLevel | null =>
+  (item.packaging_levels ?? []).find((level) => level.id === item.count_level) ?? null;
+
+/**
+ * True when the item is counted in whole packs of a usable counting level —
+ * the client twin of `counts_in_packs`, and deliberately just as conservative:
+ * a half-configured item (a pack mode with no resolvable `count_level`) reads
+ * false and keeps today's base-unit behaviour.
+ */
+export const countsInPacks = (item: InventoryItem): boolean => {
+  if (!item.count_mode || item.count_mode === 'each') return false;
+  const level = countLevelOf(item);
+  return level !== null && level.base_units >= 1;
+};
+
+/**
+ * The noun a quantity for this item is entered/reported in — the counting
+ * rung's name for a pack-counting item, the base unit otherwise. Mirrors
+ * `count_unit`, so the UI labels an input with the unit the server will read it
+ * in.
+ */
+export const countUnitOf = (item: InventoryItem): string => {
+  const level = countsInPacks(item) ? countLevelOf(item) : null;
+  return level ? level.name : baseUnitOf(item);
+};
+
+/**
+ * The on-hand label for an item.
+ *
+ * Pack-counting items render the server's `on_hand_display.text` verbatim, so
+ * web, ScanTTY and the index card all say the same thing. Each-mode items keep
+ * today's base-unit rendering (pluralised `base_unit`, which is "unit" for
+ * every item that has not opted in) — the phase invariant is that an each item
+ * looks exactly as it did before the packaging matrix existed.
+ */
+export const onHandLabel = (item: InventoryItem): string => {
+  const display = item.on_hand_display;
+  if (display && display.mode !== 'each' && display.text) {
+    return display.text;
+  }
+  const unit = baseUnitOf(item);
+  return `${item.current_stock} ${pluralizeUnit(unit, item.current_stock)}`;
+};
+
+/**
+ * One "1 case = 10 reams" line per non-base rung, innermost rung excluded.
+ * Empty for an item with no chain (or a single base rung, which describes
+ * nothing).
+ */
+export const describePackChain = (levels?: PackagingLevel[] | null): string[] => {
+  const ordered = [...(levels ?? [])].sort((a, b) => a.sort_order - b.sort_order);
+  const lines: string[] = [];
+  ordered.forEach((level, index) => {
+    const below = ordered[index + 1];
+    if (!below || below.base_units < 1) return;
+    const ratio = level.base_units / below.base_units;
+    lines.push(`1 ${level.name} = ${ratio} ${pluralizeUnit(below.name, ratio)}`);
+  });
+  return lines;
+};


### PR DESCRIPTION
**Phase 3 of the UoM epic** — the web UI, on top of the merged backend (#979/#980/#981). each-mode items look and behave exactly as today; the new surfaces appear only for items with a pack chain + non-each mode.

## What it adds
- **`PackagingChainEditor`** component: build/edit/reorder an item's pack chain (`case → ream → sheet`), showing the derived "1 case = N reams". Saved nested with the item.
- **Item form**: `base_unit`, `count_mode` (each / by level / sealed+open), `count_level` picker; min/reorder inputs relabel to the count unit per mode.
- **Item detail**: on-hand rendered at the count level ("4 cases" / "5 reams" / "3 sealed + 1 open") instead of the old hardcoded "units"; the pack chain shown; **count/reconcile enters at the level** (opt-in `at_level`); **open/finish-pack** buttons for open-closed items (the `pack_container` action).
- `packaging.ts` client helpers, api.ts methods, and types for the new fields/endpoints.

## Safety
- **each-mode is opt-out-proof**: an each-mode item sends neither `at_level` nor a count and is read in base units, exactly as before — stated in the code and regression-tested.

## Verified
node24 lint clean (0 errors); the packaging suite — `packaging.test.ts` + `PackagingChainEditor` + item form/detail packaging tests — **69 tests pass** (1362 test lines total).

Bead: op-lkxl. Phase 4 (ScanTTY parity) is next.