### PR TITLE
PO header: edit UI + live payment-schedule summary (op-uc0o)

### DIFF
--- a/frontend/src/__tests__/pages/PurchaseOrderHeaderTerms.test.tsx
+++ b/frontend/src/__tests__/pages/PurchaseOrderHeaderTerms.test.tsx
@@ -1,0 +1,397 @@
+/**
+ * Purchase-order header terms in the web UI (op-uc0o, consuming op-bwo9).
+ *
+ * Detail page: the order date is editable — an order is often entered after it
+ * was placed — alongside priority and the payment/freight terms, and the
+ * payment those terms imply is read back from the API.
+ *
+ * Create form: the same four fields are set before the order exists, and the
+ * payment schedule is mirrored client-side so it tracks the cart as lines are
+ * added rather than waiting for a round trip.
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import PurchaseOrderFormPage from '../../pages/PurchaseOrderFormPage';
+import PurchaseOrderPage from '../../pages/PurchaseOrderPage';
+import * as api from '../../services/api';
+
+vi.mock('../../services/api');
+
+vi.mock('../../utils/dialogs', () => ({
+  showError: jest.fn(),
+  showSuccess: jest.fn(),
+  confirmAction: jest.fn(),
+  promptInput: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useNavigate: () => mockNavigate,
+}));
+
+// ───────────────────────────────────────────────────────────────────────────
+// Create form — header terms and the live payment schedule
+// ───────────────────────────────────────────────────────────────────────────
+const mockItem: api.ReorderDataItem = {
+  item_supplier_id: 1,
+  item_id: 'item-1',
+  item_name: 'Test Item',
+  item_sku: 'TEST-001',
+  current_stock: 5,
+  minimum_stock: 10,
+  // 10 × $2.50 = $25.00 in the cart the moment the supplier is picked.
+  suggested_quantity: 10,
+  reorder_quantity: 20,
+  unit_cost: '2.50',
+  package_cost: '2.50',
+  quantity_per_package: 1,
+  lead_time_days: 7,
+  supplier_sku: 'SUP-001',
+  supplier_url: 'https://example.com/item',
+  is_primary: true,
+  line_total: '25.00',
+};
+
+const mockSupplier = {
+  id: 1,
+  name: 'Acme Supplies',
+  supplier_type: 'online',
+  website: '',
+  total_items: 1,
+  items: [mockItem],
+  assets: [],
+  estimated_total: '25.00',
+  avg_lead_time: 5,
+};
+
+const liveSchedule = () => screen.getByTestId('live-payment-schedule').textContent;
+
+const renderFormWithSupplier = async () => {
+  render(
+    <MemoryRouter>
+      <PurchaseOrderFormPage />
+    </MemoryRouter>
+  );
+  await waitFor(() => {
+    expect(screen.getByText('Acme Supplies')).toBeInTheDocument();
+  });
+  fireEvent.click(screen.getByText('Acme Supplies').closest('button')!);
+  await screen.findByText('Test Item');
+};
+
+describe('PurchaseOrderFormPage — header terms', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem('token', 'test-token');
+    (api.purchaseOrderAPI.getReorderData as jest.Mock).mockResolvedValue({
+      data: { suppliers: [mockSupplier] },
+    });
+    (api.supplierAgreementAPI.listBySupplier as jest.Mock).mockResolvedValue({
+      data: { results: [] },
+    });
+    (api.workOrderAPI.listWorkOrders as jest.Mock).mockResolvedValue({ data: { results: [] } });
+    (api.sigAPI.listMySIGs as jest.Mock).mockResolvedValue({ data: { results: [] } });
+    (api.purchaseOrderAPI.createOrder as jest.Mock).mockResolvedValue({
+      data: { id: 'po-42', po_number: 'PO-2026-0042' },
+    });
+  });
+
+  test('a new order reads as a draft with no payment due until terms are set', async () => {
+    await renderFormWithSupplier();
+
+    expect(screen.getByTestId('live-status')).toHaveTextContent('Draft');
+    expect(liveSchedule()).toBe('$25.00 — no due date (No payment terms set)');
+  });
+
+  test('net terms fall due that many days after the order date', async () => {
+    await renderFormWithSupplier();
+
+    fireEvent.change(screen.getByLabelText('Date Ordered'), {
+      target: { value: '2026-04-01' },
+    });
+    fireEvent.change(screen.getByLabelText('Payment Terms'), { target: { value: 'net_30' } });
+
+    expect(liveSchedule()).toBe('$25.00 — due May 1, 2026 (Net 30 from order date)');
+  });
+
+  test('the payment tracks the cart as line quantities change', async () => {
+    await renderFormWithSupplier();
+
+    fireEvent.change(screen.getByLabelText('Date Ordered'), {
+      target: { value: '2026-04-01' },
+    });
+    fireEvent.change(screen.getByLabelText('Payment Terms'), { target: { value: 'net_15' } });
+    expect(liveSchedule()).toBe('$25.00 — due Apr 16, 2026 (Net 15 from order date)');
+
+    // Doubling the line doubles the payment — same due date, no round trip.
+    fireEvent.change(screen.getByLabelText('Quantity for Test Item'), {
+      target: { value: '20' },
+    });
+    expect(liveSchedule()).toBe('$50.00 — due Apr 16, 2026 (Net 15 from order date)');
+  });
+
+  test('delivery-anchored terms wait for a promised date', async () => {
+    await renderFormWithSupplier();
+
+    fireEvent.change(screen.getByLabelText('Payment Terms'), { target: { value: 'cod' } });
+    expect(liveSchedule()).toBe('$25.00 — no due date (On delivery)');
+
+    fireEvent.change(screen.getByLabelText('Date Promised (expected delivery)'), {
+      target: { value: '2026-04-20' },
+    });
+    expect(liveSchedule()).toBe('$25.00 — due Apr 20, 2026 (On delivery)');
+  });
+
+  test('sends the header terms with the created order', async () => {
+    await renderFormWithSupplier();
+
+    fireEvent.change(screen.getByLabelText('Date Ordered'), {
+      target: { value: '2026-04-01' },
+    });
+    fireEvent.change(screen.getByLabelText('Priority'), { target: { value: 'urgent' } });
+    fireEvent.change(screen.getByLabelText('Payment Terms'), { target: { value: 'net_30' } });
+    fireEvent.change(screen.getByLabelText('Freight Terms'), { target: { value: 'fob_origin' } });
+    fireEvent.click(screen.getByRole('button', { name: /create purchase order/i }));
+
+    await waitFor(() => {
+      expect(api.purchaseOrderAPI.createOrder).toHaveBeenCalled();
+    });
+    expect((api.purchaseOrderAPI.createOrder as jest.Mock).mock.calls[0][0]).toMatchObject({
+      // A day picked in the UI is a day the server keeps: midday UTC survives
+      // the datetime round trip in either direction.
+      order_date: '2026-04-01T12:00:00Z',
+      priority: 'urgent',
+      payment_terms: 'net_30',
+      freight_terms: 'fob_origin',
+    });
+  });
+
+  test('an order placed now keeps the server’s own date and no agreed terms', async () => {
+    await renderFormWithSupplier();
+
+    fireEvent.click(screen.getByRole('button', { name: /create purchase order/i }));
+
+    await waitFor(() => {
+      expect(api.purchaseOrderAPI.createOrder).toHaveBeenCalled();
+    });
+    const payload = (api.purchaseOrderAPI.createOrder as jest.Mock).mock.calls[0][0];
+    expect(payload).not.toHaveProperty('order_date');
+    expect(payload).not.toHaveProperty('payment_terms');
+    expect(payload).not.toHaveProperty('freight_terms');
+    expect(payload.priority).toBe('normal');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Detail page — displaying and editing the header
+// ───────────────────────────────────────────────────────────────────────────
+const line = () => ({
+  id: 'line-1',
+  item_type: 'inventory_item',
+  description: null,
+  item_details: { id: 'item-1', name: 'Test Item', sku: 'TEST-001' },
+  asset_details: null,
+  quantity_ordered: 4,
+  quantity_received: 0,
+  quantity_pending: 4,
+  is_fully_received: false,
+  unit_cost_ordered: '25.00',
+  unit_cost_actual: null,
+  estimated_cost: '100.00',
+  actual_cost: null,
+  expected_shipment_date: null,
+  notes: '',
+  is_voided: false,
+  voided_at: null,
+  void_reason: '',
+  work_order: null,
+  work_order_details: null,
+  owning_group: null,
+  owning_group_details: null,
+});
+
+const baseOrder = {
+  id: 'po-1',
+  po_number: 'PO-2026-0001',
+  supplier_details: 'Acme Supplies',
+  supplier_ordering_adapter: null,
+  supplier_agreement: null,
+  supplier_agreement_details: null,
+  work_order: null,
+  work_order_details: null,
+  owning_group: null,
+  owning_group_details: null,
+  status: 'sent',
+  status_label: 'Sent',
+  // Midnight UTC — west of UTC this renders as the previous day unless the
+  // page reads it as the business date the backend derives payments from.
+  order_date: '2026-04-01T00:00:00Z',
+  priority: 'high',
+  payment_terms: 'net_30',
+  freight_terms: 'fob_destination',
+  payment_schedule: {
+    due_date: '2026-05-01',
+    amount: '100.00',
+    basis: 'Net 30 from order date',
+  },
+  expected_delivery_date: '2026-04-20',
+  supplier_order_number: 'SUP-9',
+  sales_order_number: 'SO-7',
+  estimated_total: '100.00',
+  voided_at: null,
+  voided_by_username: null,
+  void_reason: '',
+  items: [line()],
+  attachments: [],
+};
+
+const renderDetail = () =>
+  render(
+    <MantineProvider>
+      <MemoryRouter initialEntries={['/purchase-orders/po-1']}>
+        <Routes>
+          <Route path="/purchase-orders/:orderId" element={<PurchaseOrderPage />} />
+        </Routes>
+      </MemoryRouter>
+    </MantineProvider>
+  );
+
+const infoValue = (label: string) =>
+  screen.getByText(label).closest('.info-item')!.querySelector('.info-value')!.textContent;
+
+describe('PurchaseOrderPage — header terms', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem('token', 'test-token');
+    (api.purchaseOrderAPI.getOrder as jest.Mock).mockResolvedValue({ data: baseOrder });
+    (api.purchaseOrderAPI.updateOrder as jest.Mock).mockResolvedValue({ data: baseOrder });
+    (api.workOrderAPI.listWorkOrders as jest.Mock).mockResolvedValue({ data: { results: [] } });
+    (api.sigAPI.listMySIGs as jest.Mock).mockResolvedValue({ data: { results: [] } });
+  });
+
+  test('shows the terms and the payment they imply', async () => {
+    renderDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Priority:')).toBeInTheDocument();
+    });
+    expect(infoValue('Date Ordered:')).toBe('Apr 1, 2026');
+    expect(infoValue('Date Promised:')).toBe('Apr 20, 2026');
+    expect(infoValue('Priority:')).toBe('High');
+    expect(infoValue('Payment Terms:')).toBe('Net 30');
+    expect(infoValue('Freight:')).toBe('FOB Destination');
+    expect(infoValue('Payment schedule:')).toBe(
+      '$100.00 — due May 1, 2026 (Net 30 from order date)'
+    );
+  });
+
+  test('reads an order with no terms agreed as an em dash, not a blank', async () => {
+    (api.purchaseOrderAPI.getOrder as jest.Mock).mockResolvedValue({
+      data: {
+        ...baseOrder,
+        priority: 'normal',
+        payment_terms: '',
+        freight_terms: '',
+        payment_schedule: {
+          due_date: null,
+          amount: '100.00',
+          basis: 'No payment terms set',
+        },
+      },
+    });
+
+    renderDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Priority:')).toBeInTheDocument();
+    });
+    expect(infoValue('Payment Terms:')).toBe('—');
+    expect(infoValue('Freight:')).toBe('—');
+    expect(infoValue('Payment schedule:')).toBe(
+      '$100.00 — no due date (No payment terms set)'
+    );
+  });
+
+  test('the editor opens on the order’s current terms', async () => {
+    renderDetail();
+
+    fireEvent.click(await screen.findByRole('button', { name: /edit details/i }));
+
+    expect((screen.getByLabelText('Date Ordered') as HTMLInputElement).value).toBe('2026-04-01');
+    expect((screen.getByLabelText('Priority') as HTMLSelectElement).value).toBe('high');
+    expect((screen.getByLabelText('Payment Terms') as HTMLSelectElement).value).toBe('net_30');
+    expect((screen.getByLabelText('Freight Terms') as HTMLSelectElement).value).toBe(
+      'fob_destination'
+    );
+    const promised = screen.getByLabelText('Date Promised (expected delivery)');
+    expect((promised as HTMLInputElement).value).toBe('2026-04-20');
+  });
+
+  test('saves a backdated order date and the three terms', async () => {
+    renderDetail();
+
+    fireEvent.click(await screen.findByRole('button', { name: /edit details/i }));
+    fireEvent.change(screen.getByLabelText('Date Ordered'), { target: { value: '2026-03-20' } });
+    fireEvent.change(screen.getByLabelText('Priority'), { target: { value: 'urgent' } });
+    fireEvent.change(screen.getByLabelText('Payment Terms'), { target: { value: 'net_60' } });
+    fireEvent.change(screen.getByLabelText('Freight Terms'), { target: { value: 'collect' } });
+    fireEvent.click(screen.getByRole('button', { name: /save details/i }));
+
+    await waitFor(() => {
+      expect(api.purchaseOrderAPI.updateOrder).toHaveBeenCalled();
+    });
+    const [orderId, payload] = (api.purchaseOrderAPI.updateOrder as jest.Mock).mock.calls[0];
+    expect(orderId).toBe('po-1');
+    expect(payload).toMatchObject({
+      order_date: '2026-03-20T12:00:00Z',
+      priority: 'urgent',
+      payment_terms: 'net_60',
+      freight_terms: 'collect',
+    });
+  });
+
+  test('clearing a term sends the blank rather than dropping the key', async () => {
+    renderDetail();
+
+    fireEvent.click(await screen.findByRole('button', { name: /edit details/i }));
+    fireEvent.change(screen.getByLabelText('Payment Terms'), { target: { value: '' } });
+    fireEvent.change(screen.getByLabelText('Freight Terms'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: /save details/i }));
+
+    await waitFor(() => {
+      expect(api.purchaseOrderAPI.updateOrder).toHaveBeenCalled();
+    });
+    expect((api.purchaseOrderAPI.updateOrder as jest.Mock).mock.calls[0][1]).toMatchObject({
+      payment_terms: '',
+      freight_terms: '',
+    });
+  });
+
+  test('offers every priority the backend accepts', async () => {
+    renderDetail();
+
+    fireEvent.click(await screen.findByRole('button', { name: /edit details/i }));
+    const picker = screen.getByLabelText('Priority');
+    expect(within(picker).getAllByRole('option').map((o) => o.textContent)).toEqual([
+      'Low',
+      'Normal',
+      'High',
+      'Urgent',
+    ]);
+  });
+
+  test('a signed-out viewer sees the terms but gets no editor', async () => {
+    localStorage.clear();
+
+    renderDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Priority:')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /edit details/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/utils/purchaseOrderTerms.test.ts
+++ b/frontend/src/__tests__/utils/purchaseOrderTerms.test.ts
@@ -1,0 +1,128 @@
+/**
+ * The client-side twin of `PurchaseOrder.payment_schedule` (op-bwo9/op-uc0o).
+ *
+ * Every case here mirrors one branch of the backend rule, so the create form's
+ * live summary and the API agree about the payment an order implies.
+ */
+import {
+  derivePaymentSchedule,
+  freightTermsLabel,
+  paymentScheduleSummary,
+  paymentTermsLabel,
+  PO_PAYMENT_TERMS_OPTIONS,
+  priorityLabel,
+} from '../../utils/purchaseOrderTerms';
+
+const schedule = (overrides: Partial<Parameters<typeof derivePaymentSchedule>[0]> = {}) =>
+  derivePaymentSchedule({
+    orderDate: '2026-04-01',
+    expectedDeliveryDate: '',
+    paymentTerms: '',
+    amount: 100,
+    ...overrides,
+  });
+
+describe('utils/purchaseOrderTerms — derivePaymentSchedule', () => {
+  it.each([
+    ['net_15', '2026-04-16', 'Net 15 from order date'],
+    ['net_30', '2026-05-01', 'Net 30 from order date'],
+    ['net_60', '2026-05-31', 'Net 60 from order date'],
+  ] as const)('%s falls due that many days after the order date', (terms, due, basis) => {
+    expect(schedule({ paymentTerms: terms })).toEqual({
+      due_date: due,
+      amount: '100.00',
+      basis,
+    });
+  });
+
+  it('prepaid falls due on the order date itself', () => {
+    expect(schedule({ paymentTerms: 'prepaid' })).toMatchObject({
+      due_date: '2026-04-01',
+      basis: 'Prepaid',
+    });
+  });
+
+  it.each(['due_on_receipt', 'cod'] as const)(
+    '%s falls due on the promised delivery date',
+    (terms) => {
+      expect(
+        schedule({ paymentTerms: terms, expectedDeliveryDate: '2026-04-20' })
+      ).toMatchObject({ due_date: '2026-04-20', basis: 'On delivery' });
+    }
+  );
+
+  it('stays on delivery — with no date — when nothing has been promised yet', () => {
+    expect(schedule({ paymentTerms: 'cod' })).toMatchObject({
+      due_date: null,
+      basis: 'On delivery',
+    });
+  });
+
+  it('has no due date at all until terms are agreed', () => {
+    expect(schedule()).toEqual({
+      due_date: null,
+      amount: '100.00',
+      basis: 'No payment terms set',
+    });
+  });
+
+  it('carries the running total as the amount, to the cent', () => {
+    expect(schedule({ amount: 62.5 }).amount).toBe('62.50');
+    expect(schedule({ amount: 0 }).amount).toBe('0.00');
+    // An empty cart of unpriced lines must not render "NaN".
+    expect(schedule({ amount: Number.NaN }).amount).toBe('0.00');
+  });
+
+  it('crosses a month boundary by calendar day, not by 30-day arithmetic', () => {
+    expect(schedule({ orderDate: '2026-01-31', paymentTerms: 'net_30' }).due_date).toBe(
+      '2026-03-02'
+    );
+  });
+
+  it('offers every payment term the backend accepts', () => {
+    expect(PO_PAYMENT_TERMS_OPTIONS.map((option) => option.value)).toEqual([
+      'due_on_receipt',
+      'net_15',
+      'net_30',
+      'net_60',
+      'cod',
+      'prepaid',
+    ]);
+  });
+});
+
+describe('utils/purchaseOrderTerms — labels', () => {
+  it('labels a stored choice', () => {
+    expect(priorityLabel('urgent')).toBe('Urgent');
+    expect(paymentTermsLabel('net_30')).toBe('Net 30');
+    expect(freightTermsLabel('fob_origin')).toBe('FOB Origin');
+  });
+
+  it('reads a blank or unknown term as an em dash', () => {
+    expect(paymentTermsLabel('')).toBe('—');
+    expect(freightTermsLabel(null)).toBe('—');
+    expect(priorityLabel('made_up')).toBe('—');
+  });
+});
+
+describe('utils/purchaseOrderTerms — paymentScheduleSummary', () => {
+  it('reads amount, due date and basis in one line', () => {
+    expect(
+      paymentScheduleSummary({
+        due_date: '2026-05-01',
+        amount: '100.00',
+        basis: 'Net 30 from order date',
+      })
+    ).toBe('$100.00 — due May 1, 2026 (Net 30 from order date)');
+  });
+
+  it('says so plainly when nothing anchors the payment', () => {
+    expect(
+      paymentScheduleSummary({ due_date: null, amount: '0.00', basis: 'No payment terms set' })
+    ).toBe('$0.00 — no due date (No payment terms set)');
+  });
+
+  it('falls back to an em dash when the order carries no schedule', () => {
+    expect(paymentScheduleSummary(null)).toBe('—');
+  });
+});

--- a/frontend/src/pages/PurchaseOrderFormPage.tsx
+++ b/frontend/src/pages/PurchaseOrderFormPage.tsx
@@ -10,6 +10,9 @@ import {
   CreatePurchaseOrderItem,
   inventoryAPI,
   purchaseOrderAPI,
+  PurchaseOrderFreightTerms,
+  PurchaseOrderPaymentTerms,
+  PurchaseOrderPriority,
   ReorderDataAsset,
   ReorderDataItem,
   ReorderDataSupplier,
@@ -21,7 +24,15 @@ import {
 import { SIG, SupplierAgreement, WorkOrder } from '../types';
 import '../styles/PurchaseOrderFormPage.css';
 import { workOrderOptionLabel } from '../utils/associations';
+import { utcYmd, ymdToUtcDateTime } from '../utils/dates';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
+import {
+  derivePaymentSchedule,
+  paymentScheduleSummary,
+  PO_FREIGHT_TERMS_OPTIONS,
+  PO_PAYMENT_TERMS_OPTIONS,
+  PO_PRIORITY_OPTIONS,
+} from '../utils/purchaseOrderTerms';
 
 interface SelectedItem extends ReorderDataItem {
   selected: boolean;
@@ -68,6 +79,14 @@ const PurchaseOrderFormPage: React.FC = () => {
   const [selectedSupplierId, setSelectedSupplierId] = useState<number | null>(null);
   const [expectedDeliveryDate, setExpectedDeliveryDate] = useState('');
   const [notes, setNotes] = useState('');
+
+  // Header terms (op-bwo9). `orderDate` is left blank on purpose: an order
+  // placed now takes the server's own timestamp, and a value is only sent when
+  // the operator backdates an order entered after the fact.
+  const [orderDate, setOrderDate] = useState('');
+  const [priority, setPriority] = useState<PurchaseOrderPriority>('normal');
+  const [paymentTerms, setPaymentTerms] = useState<PurchaseOrderPaymentTerms | ''>('');
+  const [freightTerms, setFreightTerms] = useState<PurchaseOrderFreightTerms | ''>('');
 
   // Optional purchase/pricing agreement this order is placed under (op-yoos).
   // Loaded per supplier — only that supplier's active agreements are offered.
@@ -525,6 +544,18 @@ const PurchaseOrderFormPage: React.FC = () => {
   const freeformItemCount = freeformItems.filter((item) => item.description && item.unit_cost).length;
   const totalLineItems = selectedItemCount + selectedAssetCount + freeformItemCount;
 
+  // The payment this cart implies, recomputed on every render from the running
+  // total and the chosen terms (op-uc0o). The order does not exist yet, so
+  // there is no server `payment_schedule` to read — this mirrors the same rule
+  // the API will apply the moment it is created. A blank order date means
+  // "now", which is the day the server would stamp.
+  const livePaymentSchedule = derivePaymentSchedule({
+    orderDate: orderDate || utcYmd(new Date()),
+    expectedDeliveryDate,
+    paymentTerms,
+    amount: grandTotal,
+  });
+
   // Validate form
   const canSubmit =
     selectedSupplierId &&
@@ -605,6 +636,14 @@ const PurchaseOrderFormPage: React.FC = () => {
         ...(selectedWorkOrderId && { work_order: selectedWorkOrderId }),
         ...(selectedCommitteeId && { owning_group: selectedCommitteeId }),
         ...(expectedDeliveryDate && { expected_delivery_date: expectedDeliveryDate }),
+        // Header terms (op-bwo9). `order_date` is a datetime, so a backdate
+        // goes out as midday UTC — the day picked is the day the server
+        // derives the payment schedule from. Left off entirely when blank so
+        // an order placed now keeps the server's own timestamp.
+        ...(orderDate && { order_date: ymdToUtcDateTime(orderDate) }),
+        priority,
+        ...(paymentTerms && { payment_terms: paymentTerms }),
+        ...(freightTerms && { freight_terms: freightTerms }),
         ...(notes && { notes }),
       };
 
@@ -1180,14 +1219,75 @@ const PurchaseOrderFormPage: React.FC = () => {
             <section className="form-section details-section">
               <h2>5. Order Details</h2>
               <div className="details-grid">
+                {/* Header terms (op-bwo9). Blank "Date Ordered" means the order
+                    is being placed now; fill it in to backdate one entered
+                    after the fact. */}
                 <div className="form-field">
-                  <label htmlFor="expected-delivery">Expected Delivery Date</label>
+                  <label htmlFor="order-date">Date Ordered</label>
+                  <input
+                    id="order-date"
+                    type="date"
+                    value={orderDate}
+                    onChange={(e) => setOrderDate(e.target.value)}
+                  />
+                  <span className="field-help-text">Leave blank for today.</span>
+                </div>
+                <div className="form-field">
+                  <label htmlFor="expected-delivery">Date Promised (expected delivery)</label>
                   <input
                     id="expected-delivery"
                     type="date"
                     value={expectedDeliveryDate}
                     onChange={(e) => setExpectedDeliveryDate(e.target.value)}
                   />
+                </div>
+                <div className="form-field">
+                  <label htmlFor="order-priority">Priority</label>
+                  <select
+                    id="order-priority"
+                    value={priority}
+                    onChange={(e) => setPriority(e.target.value as PurchaseOrderPriority)}
+                  >
+                    {PO_PRIORITY_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="form-field">
+                  <label htmlFor="order-payment-terms">Payment Terms</label>
+                  <select
+                    id="order-payment-terms"
+                    value={paymentTerms}
+                    onChange={(e) =>
+                      setPaymentTerms(e.target.value as PurchaseOrderPaymentTerms | '')
+                    }
+                  >
+                    <option value="">Not agreed</option>
+                    {PO_PAYMENT_TERMS_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="form-field">
+                  <label htmlFor="order-freight-terms">Freight Terms</label>
+                  <select
+                    id="order-freight-terms"
+                    value={freightTerms}
+                    onChange={(e) =>
+                      setFreightTerms(e.target.value as PurchaseOrderFreightTerms | '')
+                    }
+                  >
+                    <option value="">Not agreed</option>
+                    {PO_FREIGHT_TERMS_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
                 </div>
                 <div className="form-field notes-field">
                   <label htmlFor="notes">Notes</label>
@@ -1264,6 +1364,19 @@ const PurchaseOrderFormPage: React.FC = () => {
                 <div className="summary-row summary-total">
                   <span>Grand Total ({totalLineItems} line items)</span>
                   <span>{formatCurrency(grandTotal)}</span>
+                </div>
+                {/* What the order will look like the moment it is created
+                    (op-uc0o): every new order starts as a draft, and the
+                    payment follows the terms above and the running total. */}
+                <div className="summary-row">
+                  <span>Status</span>
+                  <span data-testid="live-status">Draft</span>
+                </div>
+                <div className="summary-row">
+                  <span>Payment schedule</span>
+                  <span data-testid="live-payment-schedule">
+                    {paymentScheduleSummary(livePaymentSchedule)}
+                  </span>
                 </div>
               </div>
             </section>

--- a/frontend/src/pages/PurchaseOrderPage.tsx
+++ b/frontend/src/pages/PurchaseOrderPage.tsx
@@ -16,6 +16,10 @@ import {
   OrderingAdapter,
   OrderPadExport,
   purchaseOrderAPI,
+  PurchaseOrderFreightTerms,
+  PurchaseOrderPaymentSchedule,
+  PurchaseOrderPaymentTerms,
+  PurchaseOrderPriority,
   serializedComponentsAPI,
   SerializedTrackingMode,
   sigAPI,
@@ -29,9 +33,18 @@ import {
   WorkOrderIdentity,
   workOrderOptionLabel,
 } from '../utils/associations';
-import { formatDateOnly, formatYmd } from '../utils/dates';
+import { formatDateOnly, formatYmd, utcYmd, ymdToUtcDateTime } from '../utils/dates';
 import { confirmAction, promptInput, showError, showSuccess } from '../utils/dialogs';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
+import {
+  freightTermsLabel,
+  paymentScheduleSummary,
+  paymentTermsLabel,
+  PO_FREIGHT_TERMS_OPTIONS,
+  PO_PAYMENT_TERMS_OPTIONS,
+  PO_PRIORITY_OPTIONS,
+  priorityLabel,
+} from '../utils/purchaseOrderTerms';
 import { parseSerialNumbers } from '../utils/serializedComponents';
 
 interface PurchaseOrderItem {
@@ -101,7 +114,15 @@ interface PurchaseOrder {
   owning_group_details: OwningGroupIdentity | null;
   status: string;
   status_label: string;
+  // Header terms (op-bwo9), all editable here. `order_date` is a datetime that
+  // carries a business *day* — the server derives `payment_schedule` from its
+  // UTC date — so it is read and written as a day (see `utcYmd`).
   order_date: string;
+  priority: PurchaseOrderPriority;
+  payment_terms: PurchaseOrderPaymentTerms | '';
+  freight_terms: PurchaseOrderFreightTerms | '';
+  // Derived, read-only: the single payment these terms imply.
+  payment_schedule: PurchaseOrderPaymentSchedule | null;
   expected_delivery_date: string | null;
   supplier_order_number: string;
   sales_order_number: string;
@@ -258,6 +279,16 @@ const PurchaseOrderPage: React.FC = () => {
   const [metadataSupplierOrderNumber, setMetadataSupplierOrderNumber] = useState('');
   const [metadataSalesOrderNumber, setMetadataSalesOrderNumber] = useState('');
   const [metadataExpectedDelivery, setMetadataExpectedDelivery] = useState('');
+  // Header terms (op-bwo9), edited alongside the rest of the order details.
+  // `metadataOrderDate` is a 'YYYY-MM-DD' day; empty terms mean "not agreed".
+  const [metadataOrderDate, setMetadataOrderDate] = useState('');
+  const [metadataPriority, setMetadataPriority] = useState<PurchaseOrderPriority>('normal');
+  const [metadataPaymentTerms, setMetadataPaymentTerms] = useState<PurchaseOrderPaymentTerms | ''>(
+    '',
+  );
+  const [metadataFreightTerms, setMetadataFreightTerms] = useState<PurchaseOrderFreightTerms | ''>(
+    '',
+  );
   // Order-level associations (op-shb9), edited alongside the other order
   // metadata. Empty string means "no association" in both pickers.
   const [metadataWorkOrder, setMetadataWorkOrder] = useState('');
@@ -793,6 +824,10 @@ const PurchaseOrderPage: React.FC = () => {
     setMetadataSupplierOrderNumber(order.supplier_order_number || '');
     setMetadataSalesOrderNumber(order.sales_order_number || '');
     setMetadataExpectedDelivery(order.expected_delivery_date || '');
+    setMetadataOrderDate(utcYmd(order.order_date));
+    setMetadataPriority(order.priority || 'normal');
+    setMetadataPaymentTerms(order.payment_terms || '');
+    setMetadataFreightTerms(order.freight_terms || '');
     setMetadataWorkOrder(order.work_order || '');
     setMetadataCommittee(order.owning_group ? String(order.owning_group) : '');
     setEditingMetadata(true);
@@ -803,6 +838,10 @@ const PurchaseOrderPage: React.FC = () => {
     setMetadataSupplierOrderNumber('');
     setMetadataSalesOrderNumber('');
     setMetadataExpectedDelivery('');
+    setMetadataOrderDate('');
+    setMetadataPriority('normal');
+    setMetadataPaymentTerms('');
+    setMetadataFreightTerms('');
     setMetadataWorkOrder('');
     setMetadataCommittee('');
   };
@@ -814,6 +853,15 @@ const PurchaseOrderPage: React.FC = () => {
         supplier_order_number: metadataSupplierOrderNumber,
         sales_order_number: metadataSalesOrderNumber,
         expected_delivery_date: metadataExpectedDelivery || null,
+        // Header terms (op-bwo9). The order date is edited as a day but the
+        // field is a datetime, so send midday UTC — the day the operator
+        // picked is the day the payment schedule is derived from. A cleared
+        // date would leave the order without one, so it is only sent when set.
+        ...(metadataOrderDate && { order_date: ymdToUtcDateTime(metadataOrderDate) }),
+        priority: metadataPriority,
+        // '' is a real value for both terms fields: "not agreed yet".
+        payment_terms: metadataPaymentTerms,
+        freight_terms: metadataFreightTerms,
         // Empty picker means "no association" — send null to clear it.
         work_order: metadataWorkOrder || null,
         owning_group: metadataCommittee ? Number(metadataCommittee) : null,
@@ -1288,12 +1336,26 @@ const PurchaseOrderPage: React.FC = () => {
 
       <div className="po-info">
         <div className="info-item">
-          <span className="info-label">Order Date:</span>
-          <span className="info-value">{formatDate(order.order_date)}</span>
+          <span className="info-label">Date Ordered:</span>
+          {/* The business day, not the viewer's local rendering of the stored
+              instant — it is the day `payment_schedule` is derived from. */}
+          <span className="info-value">{formatDate(utcYmd(order.order_date))}</span>
         </div>
         <div className="info-item">
-          <span className="info-label">Expected Delivery:</span>
+          <span className="info-label">Date Promised:</span>
           <span className="info-value">{formatDate(order.expected_delivery_date)}</span>
+        </div>
+        <div className="info-item">
+          <span className="info-label">Priority:</span>
+          <span className="info-value">{priorityLabel(order.priority)}</span>
+        </div>
+        <div className="info-item">
+          <span className="info-label">Payment Terms:</span>
+          <span className="info-value">{paymentTermsLabel(order.payment_terms)}</span>
+        </div>
+        <div className="info-item">
+          <span className="info-label">Freight:</span>
+          <span className="info-value">{freightTermsLabel(order.freight_terms)}</span>
         </div>
         <div className="info-item">
           <span className="info-label">Supplier Order #:</span>
@@ -1318,6 +1380,12 @@ const PurchaseOrderPage: React.FC = () => {
         <div className="info-item">
           <span className="info-label">Estimated Total:</span>
           <span className="info-value">{formatCurrency(order.estimated_total)}</span>
+        </div>
+        {/* Derived from the terms above (op-bwo9) — never stored, so voiding a
+            line moves it. Read-only: change the terms to change the payment. */}
+        <div className="info-item">
+          <span className="info-label">Payment schedule:</span>
+          <span className="info-value">{paymentScheduleSummary(order.payment_schedule)}</span>
         </div>
       </div>
 
@@ -1359,14 +1427,76 @@ const PurchaseOrderPage: React.FC = () => {
                   maxLength={128}
                 />
               </label>
+              {/* Header terms (op-bwo9). `order_date` is editable because an
+                  order is often entered after it was placed. */}
+              <label htmlFor="metadata-order-date">
+                Date Ordered
+                <input
+                  id="metadata-order-date"
+                  type="date"
+                  value={metadataOrderDate}
+                  onChange={(e) => setMetadataOrderDate(e.target.value)}
+                />
+              </label>
               <label htmlFor="metadata-expected-delivery">
-                Expected Delivery Date
+                Date Promised (expected delivery)
                 <input
                   id="metadata-expected-delivery"
                   type="date"
                   value={metadataExpectedDelivery}
                   onChange={(e) => setMetadataExpectedDelivery(e.target.value)}
                 />
+              </label>
+              <label htmlFor="metadata-priority">
+                Priority
+                <select
+                  id="metadata-priority"
+                  value={metadataPriority}
+                  onChange={(e) => setMetadataPriority(e.target.value as PurchaseOrderPriority)}
+                  disabled={saving}
+                >
+                  {PO_PRIORITY_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label htmlFor="metadata-payment-terms">
+                Payment Terms
+                <select
+                  id="metadata-payment-terms"
+                  value={metadataPaymentTerms}
+                  onChange={(e) =>
+                    setMetadataPaymentTerms(e.target.value as PurchaseOrderPaymentTerms | '')
+                  }
+                  disabled={saving}
+                >
+                  <option value="">Not agreed</option>
+                  {PO_PAYMENT_TERMS_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label htmlFor="metadata-freight-terms">
+                Freight Terms
+                <select
+                  id="metadata-freight-terms"
+                  value={metadataFreightTerms}
+                  onChange={(e) =>
+                    setMetadataFreightTerms(e.target.value as PurchaseOrderFreightTerms | '')
+                  }
+                  disabled={saving}
+                >
+                  <option value="">Not agreed</option>
+                  {PO_FREIGHT_TERMS_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
               </label>
               {/* Order-level associations (op-shb9). Attribution only — they
                   change no cost and bill no committee. */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1851,7 +1851,59 @@ export interface CreatePurchaseOrderItem {
   owning_group_id?: number;
 }
 
-export interface CreatePurchaseOrderData {
+/**
+ * Purchase-order header terms (op-bwo9). `priority` always carries a value —
+ * the model defaults it to `normal` — while both terms fields are blank until
+ * they are agreed with the supplier.
+ */
+export type PurchaseOrderPriority = 'low' | 'normal' | 'high' | 'urgent';
+
+export type PurchaseOrderPaymentTerms =
+  | 'due_on_receipt'
+  | 'net_15'
+  | 'net_30'
+  | 'net_60'
+  | 'cod'
+  | 'prepaid';
+
+export type PurchaseOrderFreightTerms =
+  | 'fob_origin'
+  | 'fob_destination'
+  | 'prepaid'
+  | 'collect'
+  | 'third_party';
+
+/**
+ * The single payment an order implies, derived server-side from its
+ * `payment_terms`, `order_date` and `expected_delivery_date` (op-bwo9).
+ * Read-only: recomputed on every read, never stored, so voiding a line moves
+ * `amount` with it.
+ *
+ * `due_date` is a bare 'YYYY-MM-DD', null where the terms have nothing to
+ * anchor to (none agreed, or delivery-anchored terms with no expected
+ * delivery). `amount` is the order's live estimated total as a 2dp string,
+ * matching `estimated_total` next to it.
+ */
+export interface PurchaseOrderPaymentSchedule {
+  due_date: string | null;
+  amount: string;
+  basis: string;
+}
+
+/**
+ * The four header fields a purchase order carries beyond its supplier and
+ * lines (op-bwo9). Shared by create and update: `order_date` is a *datetime*
+ * on the wire even though it is edited as a day — see `ymdToUtcDateTime`.
+ */
+export interface PurchaseOrderHeaderTerms {
+  order_date?: string;
+  priority?: PurchaseOrderPriority;
+  // '' clears the field back to "not agreed yet".
+  payment_terms?: PurchaseOrderPaymentTerms | '';
+  freight_terms?: PurchaseOrderFreightTerms | '';
+}
+
+export interface CreatePurchaseOrderData extends PurchaseOrderHeaderTerms {
   supplier: number;
   // Optional purchase/pricing agreement this order is placed under (op-yoos).
   // Must belong to `supplier` — the backend rejects a mismatch.
@@ -1864,6 +1916,20 @@ export interface CreatePurchaseOrderData {
   expected_delivery_date?: string;
   notes?: string;
   items: CreatePurchaseOrderItem[];
+}
+
+/**
+ * Fields the PO detail page can PATCH onto the order header. Omitting a key
+ * leaves it alone; `null` clears an association or the expected delivery date.
+ */
+export interface PurchaseOrderUpdate extends PurchaseOrderHeaderTerms {
+  supplier_order_number?: string;
+  sales_order_number?: string;
+  expected_delivery_date?: string | null;
+  notes?: string;
+  // Order-level associations (op-shb9). `null` clears one.
+  work_order?: string | null;
+  owning_group?: number | null;
 }
 
 /**
@@ -1960,18 +2026,8 @@ export const purchaseOrderAPI = {
       receipt_notes?: string;
     },
   ) => api.post<any>(`/reorders/purchase-orders/${orderId}/receive/`, data),
-  updateOrder: (
-    orderId: string,
-    data: {
-      supplier_order_number?: string;
-      sales_order_number?: string;
-      expected_delivery_date?: string | null;
-      notes?: string;
-      // Order-level associations (op-shb9). `null` clears one.
-      work_order?: string | null;
-      owning_group?: number | null;
-    },
-  ) => api.patch<any>(`/reorders/purchase-orders/${orderId}/`, data),
+  updateOrder: (orderId: string, data: PurchaseOrderUpdate) =>
+    api.patch<any>(`/reorders/purchase-orders/${orderId}/`, data),
   uploadAttachment: (orderId: string, file: File, description?: string) => {
     const formData = new FormData();
     formData.append('file', file);

--- a/frontend/src/styles/PurchaseOrderFormPage.css
+++ b/frontend/src/styles/PurchaseOrderFormPage.css
@@ -427,7 +427,7 @@
 /* Order Details */
 .details-grid {
   display: grid;
-  grid-template-columns: 200px 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
   gap: 1.5rem;
 }
 
@@ -468,6 +468,11 @@
 
 .notes-field {
   grid-column: 1 / -1;
+}
+
+.field-help-text {
+  font-size: 0.75rem;
+  color: var(--text-secondary, #64748b);
 }
 
 /* Associations (op-shb9) — work order / committee this order is placed for. */

--- a/frontend/src/styles/PurchaseOrderPage.css
+++ b/frontend/src/styles/PurchaseOrderPage.css
@@ -70,7 +70,8 @@
 
 .po-info {
   display: flex;
-  gap: 2rem;
+  flex-wrap: wrap;
+  gap: 1rem 2rem;
   margin-bottom: 2rem;
   padding: 1rem;
   background-color: #f8fafc;
@@ -581,5 +582,50 @@
   color: #94a3b8;
   font-size: 0.875rem;
   font-style: italic;
+}
+
+/* Order-details editor — reference numbers, header terms (op-bwo9) and the
+   order-level associations, all edited together. */
+.po-metadata-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.po-metadata-edit {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+  background-color: #f8fafc;
+  border-radius: 0.5rem;
+}
+
+.po-metadata-edit label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #64748b;
+}
+
+.po-metadata-edit input,
+.po-metadata-edit select {
+  padding: 0.5rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  color: #1e293b;
+  background-color: #ffffff;
+  font-family: inherit;
+}
+
+.po-metadata-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 0.5rem;
 }
 

--- a/frontend/src/utils/dates.ts
+++ b/frontend/src/utils/dates.ts
@@ -37,6 +37,44 @@ export function formatYmd(date: Date | null | undefined): string {
   return `${y}-${m}-${d}`;
 }
 
+/**
+ * Add whole days to a 'YYYY-MM-DD' string, staying in local Y/M/D space so
+ * DST transitions can't shift the answer. Returns '' for invalid input.
+ */
+export function addDaysToYmd(value: string | null | undefined, days: number): string {
+  const date = parseYmd(value);
+  if (!date) return '';
+  date.setDate(date.getDate() + days);
+  return formatYmd(date);
+}
+
+/**
+ * The calendar day a value falls on **in UTC**, as 'YYYY-MM-DD'.
+ *
+ * Some Django `DateTimeField`s carry a business *date* rather than a moment —
+ * `PurchaseOrder.order_date` is one: the server derives the payment schedule
+ * from `order_date.date()`, and `TIME_ZONE` is UTC. Editing such a field as a
+ * date means editing the day the server reasons about, not the day the
+ * viewer's timezone happens to render. A bare 'YYYY-MM-DD' passes through.
+ */
+export function utcYmd(value: string | Date | null | undefined): string {
+  if (!value) return '';
+  if (typeof value === 'string' && YMD_RE.test(value)) return value;
+  const date = typeof value === 'string' ? new Date(value) : value;
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * The ISO datetime to send for a date-only edit of a UTC business-date field
+ * (see `utcYmd`). Midday UTC, so the day survives both directions: the server
+ * stores exactly the day picked, and every timezone from UTC-11 to UTC+11
+ * renders it back as that same day.
+ */
+export function ymdToUtcDateTime(value: string): string {
+  return `${value}T12:00:00Z`;
+}
+
 const DEFAULT_DISPLAY_OPTS: Intl.DateTimeFormatOptions = {
   year: 'numeric',
   month: 'short',

--- a/frontend/src/utils/purchaseOrderTerms.ts
+++ b/frontend/src/utils/purchaseOrderTerms.ts
@@ -1,0 +1,147 @@
+/**
+ * Purchase-order header terms and the payment they imply (op-bwo9 / op-uc0o).
+ *
+ * Shared by the PO create form and the PO detail page so a term reads the same
+ * in both, and so the create form can show the payment a cart implies *before*
+ * the order exists: `derivePaymentSchedule` is the client-side twin of
+ * `PurchaseOrder.payment_schedule`.
+ *
+ * The backend stays the authority. Once the order is saved the detail page
+ * renders the API's `payment_schedule` verbatim — this mirror only covers the
+ * gap where there is nothing to ask the server about yet.
+ */
+import {
+  PurchaseOrderFreightTerms,
+  PurchaseOrderPaymentSchedule,
+  PurchaseOrderPaymentTerms,
+  PurchaseOrderPriority,
+} from '../services/api';
+import { addDaysToYmd, formatDateOnly } from './dates';
+
+export interface TermsOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+export const PO_PRIORITY_LABELS: Record<PurchaseOrderPriority, string> = {
+  low: 'Low',
+  normal: 'Normal',
+  high: 'High',
+  urgent: 'Urgent',
+};
+
+export const PO_PAYMENT_TERMS_LABELS: Record<PurchaseOrderPaymentTerms, string> = {
+  due_on_receipt: 'Due on receipt',
+  net_15: 'Net 15',
+  net_30: 'Net 30',
+  net_60: 'Net 60',
+  cod: 'COD',
+  prepaid: 'Prepaid',
+};
+
+export const PO_FREIGHT_TERMS_LABELS: Record<PurchaseOrderFreightTerms, string> = {
+  fob_origin: 'FOB Origin',
+  fob_destination: 'FOB Destination',
+  prepaid: 'Prepaid',
+  collect: 'Collect',
+  third_party: 'Third-party',
+};
+
+const toOptions = <T extends string>(labels: Record<T, string>): TermsOption<T>[] =>
+  (Object.keys(labels) as T[]).map((value) => ({ value, label: labels[value] }));
+
+export const PO_PRIORITY_OPTIONS = toOptions(PO_PRIORITY_LABELS);
+export const PO_PAYMENT_TERMS_OPTIONS = toOptions(PO_PAYMENT_TERMS_LABELS);
+export const PO_FREIGHT_TERMS_OPTIONS = toOptions(PO_FREIGHT_TERMS_LABELS);
+
+const labelFor = (
+  labels: Record<string, string>,
+  value: string | null | undefined,
+  fallback = '—',
+): string => (value && labels[value]) || fallback;
+
+/** Display label for a stored choice; an em dash when blank or unrecognised. */
+export const priorityLabel = (value: string | null | undefined): string =>
+  labelFor(PO_PRIORITY_LABELS, value);
+
+export const paymentTermsLabel = (value: string | null | undefined): string =>
+  labelFor(PO_PAYMENT_TERMS_LABELS, value);
+
+export const freightTermsLabel = (value: string | null | undefined): string =>
+  labelFor(PO_FREIGHT_TERMS_LABELS, value);
+
+/** Days-until-due for the "net N" terms — mirrors `PurchaseOrder.NET_PAYMENT_DAYS`. */
+const NET_PAYMENT_DAYS: Partial<Record<PurchaseOrderPaymentTerms, number>> = {
+  net_15: 15,
+  net_30: 30,
+  net_60: 60,
+};
+
+export interface PaymentScheduleInput {
+  /** Business date the order was placed, 'YYYY-MM-DD'. */
+  orderDate: string;
+  /** Promised delivery date, 'YYYY-MM-DD' or '' when none is set. */
+  expectedDeliveryDate: string;
+  paymentTerms: PurchaseOrderPaymentTerms | '';
+  /** Running total the payment covers. */
+  amount: number;
+}
+
+/**
+ * The payment a cart implies, in the API's `payment_schedule` shape.
+ *
+ * Same rule as the server: net terms fall due that many days after the order
+ * date, prepaid on the order date itself, and receipt-anchored terms on the
+ * promised delivery — which is null (and stays "On delivery") until one is
+ * given. No terms agreed means no due date at all.
+ */
+export function derivePaymentSchedule({
+  orderDate,
+  expectedDeliveryDate,
+  paymentTerms,
+  amount,
+}: PaymentScheduleInput): PurchaseOrderPaymentSchedule {
+  const netDays = paymentTerms ? NET_PAYMENT_DAYS[paymentTerms] : undefined;
+
+  let dueDate: string | null;
+  let basis: string;
+
+  if (netDays !== undefined) {
+    dueDate = addDaysToYmd(orderDate, netDays) || null;
+    basis = `${PO_PAYMENT_TERMS_LABELS[paymentTerms as PurchaseOrderPaymentTerms]} from order date`;
+  } else if (paymentTerms === 'prepaid') {
+    dueDate = orderDate || null;
+    basis = 'Prepaid';
+  } else if (paymentTerms === 'due_on_receipt' || paymentTerms === 'cod') {
+    dueDate = expectedDeliveryDate || null;
+    basis = 'On delivery';
+  } else {
+    dueDate = null;
+    basis = 'No payment terms set';
+  }
+
+  return {
+    due_date: dueDate,
+    amount: Number.isFinite(amount) ? amount.toFixed(2) : '0.00',
+    basis,
+  };
+}
+
+const CURRENCY_FORMAT = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+/**
+ * One-line reading of a payment schedule: how much, when it falls due, and on
+ * what basis — e.g. "$100.00 — due Apr 30, 2026 (Net 30 from order date)".
+ */
+export function paymentScheduleSummary(
+  schedule: PurchaseOrderPaymentSchedule | null | undefined,
+): string {
+  if (!schedule) return '—';
+  const amount = parseFloat(schedule.amount);
+  const money = Number.isNaN(amount) ? '—' : CURRENCY_FORMAT.format(amount);
+  const due = schedule.due_date ? `due ${formatDateOnly(schedule.due_date)}` : 'no due date';
+  return `${money} — ${due} (${schedule.basis})`;
+}


### PR DESCRIPTION
## What

Web UI for the editable PO header + a live payment-schedule summary — consumes the op-bwo9 backend (merged as #985). Sibling to the ScanTTY PR (uid0/scantty#125).

### PO detail page (`PurchaseOrderPage.tsx`)
- The header-edit modal now edits **Date ordered**, **Priority**, **Payment terms**, and **Freight terms** alongside the existing supplier/sales order numbers and delivery date — saved in one PATCH.
- Displays the new fields, plus the derived **payment schedule** (`amount — due <date> (basis)`) read straight from the API's `payment_schedule` — no client math once the order exists.

### PO create form (`PurchaseOrderFormPage.tsx`)
- New header inputs (order date / priority / payment terms / freight terms) included in the POST body.
- A **live Status + payment-schedule summary that recomputes as line items are added** — before the order exists there's no server `payment_schedule` to read, so `derivePaymentSchedule` mirrors the backend rule exactly (net→order date +N, prepaid→order date, due-on-receipt/COD→promised delivery, blank→none).

### Plumbing
- `api.ts`: `PurchaseOrderPriority`/`PaymentTerms`/`FreightTerms` unions (backend tokens verbatim), `PurchaseOrderPaymentSchedule`, and a shared `PurchaseOrderHeaderTerms` extended by both create and the new named `PurchaseOrderUpdate` interface (`''` clears a term).
- `dates.ts`: `ymdToUtcDateTime` sends the order date as **midday UTC** so the day the server reasons about survives timezone rendering in both directions; `addDaysToYmd` stays in local Y/M/D space so DST can't shift a net-term due date.

## Verification
- node24: `npm run lint` — **0 errors** (only pre-existing warnings, none in changed files); `npm run test:fast` (`TZ=America/Chicago`) — **1434 tests / 170 files pass**, including new `PurchaseOrderHeaderTerms.test.tsx` and `purchaseOrderTerms.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
