### PR TITLE
Storage slots: printable 3x5 Avery cards (QR + AprilTag + code) (op-uw2q)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -2580,6 +2580,12 @@ views:
         - AllowAny
   project_storage.views.StorageSlotViewSet:
     actions:
+      card_preview:
+        permission_classes:
+        - IsStorageAdminOrStaff
+      cards:
+        permission_classes:
+        - IsStorageAdminOrStaff
       create:
         permission_classes:
         - IsStorageAdminOrStaff

--- a/backend/project_storage/serializers.py
+++ b/backend/project_storage/serializers.py
@@ -230,3 +230,48 @@ class GenerateRackSerializer(serializers.Serializer):
                 f"Each level may appear at most once: {', '.join(duplicates)} repeated."
             )
         return value
+
+
+class SlotCardBatchSerializer(serializers.Serializer):
+    """Which slots to print cards for: an explicit list, or a whole rack.
+
+    Two selection modes because the two real jobs are different. Racking a
+    new aisle prints every slot of a rack in code order (the sheets come off
+    the printer in the order they get stuck on the uprights); replacing a
+    handful of scuffed cards prints exactly those slots, in the order the
+    caller listed them. Mixing the two would only make "what did I just
+    print?" ambiguous, so exactly one mode is required.
+    """
+
+    slot_ids = serializers.ListField(
+        child=serializers.IntegerField(min_value=1),
+        required=False,
+        allow_empty=False,
+        # 300 cards = 100 sheets. Past that the request is a rack print that
+        # should say so, and the renderer would be holding a lot of PNGs.
+        max_length=300,
+    )
+    rack = serializers.IntegerField(min_value=1, required=False)
+    level = serializers.RegexField(
+        StorageSlot.LEVEL_PATTERN,
+        required=False,
+        error_messages={"invalid": "Level must be a single letter (A-Z)."},
+    )
+    # A rack print covers the slots in service. Retired slots keep their
+    # marker (see StorageSlot.is_active) and can still be reprinted on
+    # purpose, but they shouldn't ride along with a rack's sheets.
+    include_inactive = serializers.BooleanField(required=False, default=False)
+
+    def validate_level(self, value: str) -> str:
+        return (value or "").upper()
+
+    def validate(self, attrs: dict) -> dict:
+        has_ids = bool(attrs.get("slot_ids"))
+        has_rack = attrs.get("rack") is not None
+        if has_ids and has_rack:
+            raise serializers.ValidationError("Provide either slot_ids or a rack filter, not both.")
+        if not has_ids and not has_rack:
+            raise serializers.ValidationError("Provide slot_ids or a rack to print.")
+        if attrs.get("level") and not has_rack:
+            raise serializers.ValidationError({"level": "level narrows a rack — send rack too."})
+        return attrs

--- a/backend/project_storage/services/slot_cards.py
+++ b/backend/project_storage/services/slot_cards.py
@@ -1,0 +1,321 @@
+"""3×5 Avery cards for the project-storage racking.
+
+Same stock as the inventory index cards — Avery 5388, three 5"×3" cards per
+US-Letter sheet — so a warden prints a rack's worth of slot cards on the
+sheets already in the supply cabinet. Each card carries three ways to
+identify one physical slot:
+
+* the eye-readable **code** (``1A1``) in the largest type that fits, because
+  the fastest lookup on a rack aisle is still a human reading a label;
+* a **QR** that opens the project-storage kiosk pre-filled with this slot, so
+  a member reserving space scans the shelf instead of typing its code; and
+* an **AprilTag** — the fiducial a "where is this item?" camera sweep reads.
+  Slot markers come from the dedicated :data:`SLOT_TAG_FAMILY` pool
+  (tag36h10), never the recycling tag36h11 pool that stints draw from, so a
+  detected marker is unambiguous about *what kind* of thing it labels.
+
+The renderer subclasses :class:`~index_cards.services.IndexCardRenderer` for
+the sheet skeleton only: the 5388 constants (card size, margins, gap) and the
+``_render_to_canvas``/``_draw_page``/``_chunk`` page loop, all of which are
+pure geometry and know nothing about what a card holds. Everything below
+``_draw_card`` in that class is ``InventoryItem``-coupled, so this one
+overrides ``_draw_card`` outright rather than forcing a slot through the item
+helpers.
+"""
+
+from __future__ import annotations
+
+import base64
+from io import BytesIO
+from typing import Sequence
+from urllib.parse import quote
+
+import qrcode
+from reportlab.lib import colors
+from reportlab.lib.units import inch
+from reportlab.lib.utils import ImageReader
+from reportlab.pdfgen import canvas
+
+from fiducials.services.allocator import get_active_tag_id
+from fiducials.services.apriltag_render import build_apriltag_image
+from index_cards.services import IndexCardRenderer
+
+from ..models import StorageSlot
+from .storage_slots import SLOT_TAG_FAMILY
+
+# Kiosk route the card's QR opens (frontend ``/project-storage/kiosk``). The
+# ``slot`` query param is the canonical code — the same identifier the API
+# looks slots up by — so the kiosk can resolve it without knowing our PKs.
+KIOSK_PATH = "/project-storage/kiosk"
+SLOT_QUERY_PARAM = "slot"
+
+# Rendered marker resolution. The tag is drawn at ~1.15" on paper; 300 px
+# keeps it well above the detector's px-per-module floor at every print DPI
+# and matches the label service's "render big, let the PDF scale down" rule.
+TAG_TARGET_PX = 300
+
+
+class StorageSlotCardRenderer(IndexCardRenderer):
+    """Render :class:`~project_storage.models.StorageSlot` cards on Avery 5388.
+
+    Inherits the sheet layout from :class:`IndexCardRenderer` (see the module
+    docstring) and replaces the card face. The parent's ``blank_cards`` flag
+    is meaningless here — a slot card is always code + QR + marker.
+    """
+
+    # Both markers are square and share a right-hand column. 1.15" leaves a
+    # readable QR and a detectable tag while keeping the code column wide.
+    MARKER_SIZE = 1.15 * inch
+    # Gap between the text column and the marker column.
+    COLUMN_GAP = 0.15 * inch
+    # Space reserved under each marker for its caption line.
+    CAPTION_HEIGHT = 0.14 * inch
+    CAPTION_FONT_SIZE = 6.5
+
+    # Code type: start big, shrink until it fits its band. 84pt fits a
+    # 3-character code across the column; long codes (``12Z40``) step down.
+    CODE_FONT = "Helvetica-Bold"
+    CODE_MAX_FONT_SIZE = 84
+    CODE_MIN_FONT_SIZE = 22
+
+    DETAIL_FONT = "Helvetica"
+    DETAIL_FONT_SIZE = 9
+    DETAIL_LEADING = 11
+
+    _INK = colors.HexColor("#111827")
+    _MUTED = colors.HexColor("#6B7280")
+
+    # ------------------------------------------------------------------
+    # Payload + marker sources
+    # ------------------------------------------------------------------
+
+    def build_slot_url(self, slot: StorageSlot) -> str:
+        """The URL the card's QR encodes: the kiosk, pre-filled with ``slot``."""
+        return (
+            f"{self.base_url.rstrip('/')}{KIOSK_PATH}"
+            f"?{SLOT_QUERY_PARAM}={quote(slot.code or '')}"
+        )
+
+    @staticmethod
+    def tag_id_for(slot: StorageSlot) -> int | None:
+        """The slot's permanent marker ID, or None when it has none.
+
+        Prefers the ``active_april_tag_id`` annotation the viewset adds (one
+        query for the whole sheet instead of one per card); falls back to a
+        direct lookup for objects handed in from elsewhere. Same precedence
+        as ``StorageSlotSerializer.get_april_tag_id`` so the printed card and
+        the API payload can never disagree.
+        """
+        if hasattr(slot, "active_april_tag_id"):
+            return slot.active_april_tag_id
+        return get_active_tag_id(slot)
+
+    def build_qr_buffer(self, slot: StorageSlot) -> BytesIO:
+        """PNG bytes of the slot's QR, ready for :class:`ImageReader`."""
+        qr = qrcode.QRCode(
+            version=2,
+            error_correction=qrcode.constants.ERROR_CORRECT_M,
+            box_size=10,
+            border=2,
+        )
+        qr.add_data(self.build_slot_url(slot))
+        qr.make(fit=True)
+        image = qr.make_image(fill_color="black", back_color="white").convert("RGB")
+        buffer = BytesIO()
+        image.save(buffer, format="PNG")
+        buffer.seek(0)
+        return buffer
+
+    def build_tag_buffer(self, tag_id: int) -> BytesIO:
+        """PNG bytes of the AprilTag for ``tag_id`` in the slot family."""
+        buffer = BytesIO()
+        build_apriltag_image(tag_id, TAG_TARGET_PX, family=SLOT_TAG_FAMILY).save(
+            buffer, format="PNG"
+        )
+        buffer.seek(0)
+        return buffer
+
+    # ------------------------------------------------------------------
+    # Card face
+    # ------------------------------------------------------------------
+
+    def _draw_card(  # type: ignore[override]
+        self,
+        pdf_canvas: canvas.Canvas,
+        slot: StorageSlot,
+        origin_x: float,
+        origin_y: float,
+    ) -> None:
+        """Draw one slot card. ``origin`` is the card's bottom-left corner."""
+        marker_x = origin_x + self.CARD_WIDTH - self.CARD_PADDING - self.MARKER_SIZE
+        text_x = origin_x + self.CARD_PADDING
+        text_width = marker_x - self.COLUMN_GAP - text_x
+
+        self._draw_text_column(pdf_canvas, slot, text_x, origin_y, text_width)
+        self._draw_qr(pdf_canvas, slot, marker_x, origin_y)
+        self._draw_tag(pdf_canvas, slot, marker_x, origin_y)
+
+    def _draw_text_column(
+        self,
+        pdf_canvas: canvas.Canvas,
+        slot: StorageSlot,
+        x: float,
+        origin_y: float,
+        width: float,
+    ) -> None:
+        top = origin_y + self.CARD_HEIGHT - self.CARD_PADDING
+
+        pdf_canvas.setFillColor(self._MUTED)
+        pdf_canvas.setFont("Helvetica-Bold", 9)
+        pdf_canvas.drawString(x, top - 9, "PROJECT STORAGE")
+
+        # Detail lines stack up from the card's bottom padding, so the code
+        # band is whatever height is left over. Kept in the muted ink so the
+        # code stays the thing you see from down the aisle.
+        detail_y = origin_y + self.CARD_PADDING
+        pdf_canvas.setFillColor(self._MUTED)
+        pdf_canvas.setFont(self.DETAIL_FONT, self.DETAIL_FONT_SIZE)
+        for line in reversed(self._detail_lines(slot)):
+            pdf_canvas.drawString(x, detail_y, line)
+            detail_y += self.DETAIL_LEADING
+
+        band_bottom = detail_y + 2
+        band_top = top - 16
+        self._draw_code(pdf_canvas, slot, x, width, band_bottom, band_top)
+
+    def _draw_code(
+        self,
+        pdf_canvas: canvas.Canvas,
+        slot: StorageSlot,
+        x: float,
+        width: float,
+        band_bottom: float,
+        band_top: float,
+    ) -> None:
+        """Draw the location code as large as its band allows."""
+        code = slot.code or StorageSlot.compose_code(slot.rack, slot.level, slot.position)
+        band_height = max(band_top - band_bottom, 0)
+
+        size = self.CODE_MAX_FONT_SIZE
+        while size > self.CODE_MIN_FONT_SIZE:
+            fits_width = pdf_canvas.stringWidth(code, self.CODE_FONT, size) <= width
+            # Cap height is ~0.72 em for Helvetica; that (not the full em) is
+            # what a digits-and-capitals string actually occupies.
+            if fits_width and size * 0.72 <= band_height:
+                break
+            size -= 2
+
+        cap_height = size * 0.72
+        baseline = band_bottom + max(band_height - cap_height, 0) / 2
+        pdf_canvas.setFillColor(self._INK)
+        pdf_canvas.setFont(self.CODE_FONT, size)
+        pdf_canvas.drawCentredString(x + width / 2, baseline, code)
+
+    def _detail_lines(self, slot: StorageSlot) -> list[str]:
+        """The small print under the code — everything a warden needs on the aisle."""
+        lines = [f"Rack {slot.rack} - Level {slot.level} - Position {slot.position}"]
+        if slot.requires_pallet_jack:
+            lines.append("Pallet jack required")
+        if slot.owning_group_id:
+            lines.append(f"Reserved for {slot.owning_group.name}")
+        if not slot.is_active:
+            lines.append("Not in service")
+        return lines
+
+    def _draw_qr(
+        self,
+        pdf_canvas: canvas.Canvas,
+        slot: StorageSlot,
+        x: float,
+        origin_y: float,
+    ) -> None:
+        y = origin_y + self.CARD_HEIGHT - self.CARD_PADDING - self.MARKER_SIZE
+        pdf_canvas.drawImage(
+            ImageReader(self.build_qr_buffer(slot)),
+            x,
+            y,
+            width=self.MARKER_SIZE,
+            height=self.MARKER_SIZE,
+            preserveAspectRatio=True,
+        )
+        self._draw_caption(pdf_canvas, "Scan to reserve", x, y)
+
+    def _draw_tag(
+        self,
+        pdf_canvas: canvas.Canvas,
+        slot: StorageSlot,
+        x: float,
+        origin_y: float,
+    ) -> None:
+        """Draw the slot's location marker, or say so when it has none.
+
+        A slot created while the tag family was exhausted is still perfectly
+        printable — it just has no fiducial yet. Printing a placeholder note
+        instead of some other slot's marker keeps the CV path honest; re-running
+        the rack generator heals the slot and the reprint gets a real tag.
+        """
+        y = origin_y + self.CARD_PADDING + self.CAPTION_HEIGHT
+        tag_id = self.tag_id_for(slot)
+        if tag_id is None:
+            self._draw_caption(pdf_canvas, "no location tag", x, y)
+            return
+
+        pdf_canvas.drawImage(
+            ImageReader(self.build_tag_buffer(tag_id)),
+            x,
+            y,
+            width=self.MARKER_SIZE,
+            height=self.MARKER_SIZE,
+            preserveAspectRatio=True,
+        )
+        self._draw_caption(pdf_canvas, f"{SLOT_TAG_FAMILY} #{tag_id}", x, y)
+
+    def _draw_caption(
+        self,
+        pdf_canvas: canvas.Canvas,
+        text: str,
+        marker_x: float,
+        marker_y: float,
+    ) -> None:
+        """Centre a caption line in the space reserved under a marker."""
+        pdf_canvas.setFillColor(self._MUTED)
+        pdf_canvas.setFont("Helvetica", self.CAPTION_FONT_SIZE)
+        pdf_canvas.drawCentredString(
+            marker_x + self.MARKER_SIZE / 2,
+            marker_y - self.CAPTION_HEIGHT + 3,
+            text,
+        )
+
+
+# ----------------------------------------------------------------------
+# Module-level entry points — what the API layer calls
+# ----------------------------------------------------------------------
+
+
+def render_slot_cards(slots: Sequence[StorageSlot], *, base_url: str | None = None) -> bytes:
+    """Render ``slots`` to a multi-page 5388 PDF (3 cards per page)."""
+    if not slots:
+        raise ValueError("At least one storage slot is required to render cards.")
+    return StorageSlotCardRenderer(base_url=base_url).render_to_bytes(slots)
+
+
+def build_slot_card_preview(
+    slot: StorageSlot,
+    renderer: StorageSlotCardRenderer | None = None,
+) -> dict:
+    """Single-slot preview payload — mirrors ``index_cards.build_preview_payload``.
+
+    Also returns the kiosk URL and marker ID the card carries so a preview
+    surface can show what was encoded without decoding the PDF.
+    """
+    renderer = renderer or StorageSlotCardRenderer()
+    pdf_bytes = renderer.render_to_bytes([slot])
+    return {
+        "slot_id": slot.pk,
+        "code": slot.code,
+        "filename": f"storage_slot_{slot.code}_card.pdf",
+        "content_type": "application/pdf",
+        "preview": base64.b64encode(pdf_bytes).decode("ascii"),
+        "kiosk_url": renderer.build_slot_url(slot),
+        "april_tag_id": renderer.tag_id_for(slot),
+    }

--- a/backend/project_storage/tests/test_slot_cards.py
+++ b/backend/project_storage/tests/test_slot_cards.py
@@ -1,0 +1,401 @@
+"""Avery 5388 cards for the racking: renderer, batch print, and QR prefill.
+
+Every assertion here reads the *rendered artifact* rather than the renderer's
+intentions — the images are pulled back out of the PDF and decoded, so a card
+that prints an unreadable QR or somebody else's marker fails the test. Both
+decoders (``cv2.QRCodeDetector``, ``cv2.aruco``) come from the same
+opencv-headless the scan side uses, which is what makes the round trip
+meaningful: what these tests decode is what a scanner will decode.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+
+import cv2
+import numpy as np
+import pytest
+from PIL import Image
+from pypdf import PdfReader
+from rest_framework.test import APIClient
+
+from fiducials.models import FAMILY_TAG36H11
+from fiducials.services.allocator import active_tag_id_subquery
+from fiducials.services.apriltag_render import decode_apriltag_ids
+from project_storage.models import StorageSlot
+from project_storage.services.slot_cards import (
+    StorageSlotCardRenderer,
+    build_slot_card_preview,
+    render_slot_cards,
+)
+from project_storage.services.storage_slots import (
+    SLOT_TAG_FAMILY,
+    LevelSpec,
+    ensure_slot_tag,
+    generate_rack_slots,
+)
+from project_storage.tests.factories import StorageSlotFactory
+
+pytestmark = pytest.mark.django_db
+
+SLOTS_URL = "/api/project-storage/slots/"
+FRONTEND = "https://make.example.org"
+
+
+@pytest.fixture(autouse=True)
+def _frontend_url(settings):
+    """Pin the QR host so payload assertions don't depend on local config."""
+    settings.FRONTEND_URL = FRONTEND
+    return FRONTEND
+
+
+@pytest.fixture
+def staff_client():
+    User = get_user_model()
+    user = User.objects.create_user(username="warden", password="x", is_staff=True)
+    api = APIClient()
+    api.force_authenticate(user=user)
+    return api
+
+
+# ---------------------------------------------------------------------------
+# Reading the artifact back
+# ---------------------------------------------------------------------------
+
+
+def _pages(pdf_bytes: bytes):
+    return PdfReader(io.BytesIO(pdf_bytes)).pages
+
+
+def _images(pdf_bytes: bytes) -> list[Image.Image]:
+    """Every image the PDF embeds — one QR and (usually) one marker per card."""
+    return [embedded.image for page in _pages(pdf_bytes) for embedded in page.images]
+
+
+# cv2's detector is sensitive at the QR's stored resolution — some payloads
+# decode only once the modules are a few pixels bigger, even though the same
+# image reads fine upscaled (and prints at ~320 dpi / 0.9 mm modules, well
+# inside phone-scanner range). Upscale before detecting so the test measures
+# the payload, not the detector's floor.
+_QR_DECODE_SCALE = 3
+
+
+def _decode_qr(image: Image.Image) -> str:
+    gray = image.convert("L")
+    gray = gray.resize(
+        (gray.width * _QR_DECODE_SCALE, gray.height * _QR_DECODE_SCALE),
+        Image.Resampling.NEAREST,
+    )
+    payload, _points, _straight = cv2.QRCodeDetector().detectAndDecode(np.array(gray))
+    return payload
+
+
+def _qr_payloads(pdf_bytes: bytes) -> list[str]:
+    return [payload for payload in (_decode_qr(img) for img in _images(pdf_bytes)) if payload]
+
+
+def _tag_ids(pdf_bytes: bytes, family: str = SLOT_TAG_FAMILY) -> list[int]:
+    ids: list[int] = []
+    for image in _images(pdf_bytes):
+        ids.extend(decode_apriltag_ids(image, family=family))
+    return ids
+
+
+def _text(pdf_bytes: bytes) -> str:
+    return "\n".join(page.extract_text() or "" for page in _pages(pdf_bytes))
+
+
+def _codes_in_print_order(pdf_bytes: bytes, codes: list[str]) -> list[str]:
+    """The requested codes, ordered as they appear in the rendered text."""
+    text = _text(pdf_bytes)
+    return sorted((code for code in codes if code in text), key=text.index)
+
+
+def _kiosk_url(code: str) -> str:
+    return f"{FRONTEND}/project-storage/kiosk?slot={code}"
+
+
+# ---------------------------------------------------------------------------
+# Renderer
+# ---------------------------------------------------------------------------
+
+
+class TestSlotCardSheet:
+    @pytest.mark.parametrize("count,expected_pages", [(1, 1), (3, 1), (4, 2), (7, 3)])
+    def test_three_cards_per_sheet(self, count, expected_pages):
+        """Avery 5388 is 3-up: N slots fill ceil(N/3) sheets."""
+        slots = _annotated(generate_rack_slots(rack=1, levels=[LevelSpec("A", count)]).created)
+
+        pdf_bytes = render_slot_cards(slots)
+
+        assert pdf_bytes[:5] == b"%PDF-"
+        assert len(_pages(pdf_bytes)) == expected_pages
+
+    def test_cards_print_in_the_order_given(self):
+        slots = _annotated(generate_rack_slots(rack=1, levels=[LevelSpec("A", 4)]).created)
+        wanted = ["1A3", "1A1", "1A4", "1A2"]
+        ordered = sorted(slots, key=lambda slot: wanted.index(slot.code))
+
+        pdf_bytes = render_slot_cards(ordered)
+
+        assert _codes_in_print_order(pdf_bytes, wanted) == wanted
+
+    def test_empty_selection_is_rejected(self):
+        with pytest.raises(ValueError):
+            render_slot_cards([])
+
+
+class TestSlotCardFace:
+    def test_code_and_shelf_details_are_printed(self):
+        slot = StorageSlotFactory(rack=12, level="Z", position=40, requires_pallet_jack=True)
+        slot.owning_group = Group.objects.create(name="Metal SIG")
+        slot.save()
+        ensure_slot_tag(slot)
+
+        text = _text(render_slot_cards([slot]))
+
+        assert "12Z40" in text
+        assert "Rack 12 - Level Z - Position 40" in text
+        assert "Pallet jack required" in text
+        assert "Reserved for Metal SIG" in text
+
+    def test_qr_encodes_the_kiosk_prefilled_with_this_slot(self):
+        slot = StorageSlotFactory(rack=2, level="B", position=3)
+        ensure_slot_tag(slot)
+
+        payloads = _qr_payloads(render_slot_cards([slot]))
+
+        assert payloads == [_kiosk_url("2B3")]
+
+    def test_every_card_carries_its_own_prefill_url(self):
+        slots = _annotated(generate_rack_slots(rack=1, levels=[LevelSpec("A", 3)]).created)
+
+        payloads = _qr_payloads(render_slot_cards(slots))
+
+        assert sorted(payloads) == [_kiosk_url(code) for code in ("1A1", "1A2", "1A3")]
+
+    def test_apriltag_is_the_slots_allocated_id(self):
+        slot = StorageSlotFactory(rack=3, level="C", position=1)
+        tag_id = ensure_slot_tag(slot).tag_id
+
+        assert _tag_ids(render_slot_cards([slot])) == [tag_id]
+
+    def test_markers_come_from_the_location_family_not_the_recycling_pool(self):
+        """A card's marker has to decode in tag36h10 — the permanent-location
+        family — so a rack scan can never be read as a stint's 36h11 tag."""
+        slot = StorageSlotFactory()
+        ensure_slot_tag(slot)
+
+        pdf_bytes = render_slot_cards([slot])
+
+        assert _tag_ids(pdf_bytes, family=SLOT_TAG_FAMILY)
+        assert _tag_ids(pdf_bytes, family=FAMILY_TAG36H11) == []
+
+    def test_each_slot_gets_its_own_marker(self):
+        slots = _annotated(generate_rack_slots(rack=1, levels=[LevelSpec("A", 3)]).created)
+        expected = [StorageSlotCardRenderer.tag_id_for(slot) for slot in slots]
+
+        assert sorted(_tag_ids(render_slot_cards(slots))) == sorted(expected)
+
+    def test_untagged_slot_still_prints_a_usable_card(self):
+        """A slot created while the family was exhausted has no fiducial. The
+        card still prints — code and QR — and says the marker is missing
+        rather than borrowing another slot's."""
+        slot = StorageSlotFactory(rack=9, level="A", position=1)
+        assert StorageSlotCardRenderer.tag_id_for(slot) is None
+
+        pdf_bytes = render_slot_cards([slot])
+
+        assert _tag_ids(pdf_bytes) == []
+        assert _qr_payloads(pdf_bytes) == [_kiosk_url("9A1")]
+        assert "no location tag" in _text(pdf_bytes)
+
+    def test_rendering_an_annotated_sheet_costs_no_extra_queries(self, django_assert_num_queries):
+        """The sheet is prepared by one query, the way the viewset builds it —
+        no marker lookup or group read per card."""
+        sig = Group.objects.create(name="Woodshop SIG")
+        generate_rack_slots(rack=5, levels=[LevelSpec("A", 3)], owning_group=sig)
+        slots = list(
+            StorageSlot.objects.filter(rack=5)
+            .select_related("owning_group")
+            .annotate(active_april_tag_id=active_tag_id_subquery(StorageSlot))
+        )
+
+        with django_assert_num_queries(0):
+            render_slot_cards(slots)
+
+
+class TestSlotCardPreviewPayload:
+    def test_preview_is_a_single_card_pdf_plus_what_it_encoded(self):
+        slot = StorageSlotFactory(rack=1, level="A", position=1)
+        tag_id = ensure_slot_tag(slot).tag_id
+
+        payload = build_slot_card_preview(slot)
+
+        assert payload["code"] == "1A1"
+        assert payload["content_type"] == "application/pdf"
+        assert payload["filename"] == "storage_slot_1A1_card.pdf"
+        assert payload["kiosk_url"] == _kiosk_url("1A1")
+        assert payload["april_tag_id"] == tag_id
+        pdf_bytes = base64.b64decode(payload["preview"])
+        assert len(_pages(pdf_bytes)) == 1
+        assert _qr_payloads(pdf_bytes) == [_kiosk_url("1A1")]
+
+
+# ---------------------------------------------------------------------------
+# API
+# ---------------------------------------------------------------------------
+
+
+class TestSlotCardApiPermissions:
+    def test_anonymous_cannot_preview(self):
+        StorageSlotFactory(rack=1, level="A", position=1)
+        assert APIClient().get(f"{SLOTS_URL}1A1/card-preview/").status_code in (401, 403)
+
+    def test_anonymous_cannot_batch_print(self):
+        slot = StorageSlotFactory(rack=1, level="A", position=1)
+        resp = APIClient().post(f"{SLOTS_URL}cards/", {"slot_ids": [slot.pk]}, format="json")
+        assert resp.status_code in (401, 403)
+
+    def test_plain_authenticated_user_is_rejected(self):
+        StorageSlotFactory(rack=1, level="A", position=1)
+        api = APIClient()
+        api.force_authenticate(
+            user=get_user_model().objects.create_user(username="member", password="x")
+        )
+        assert api.get(f"{SLOTS_URL}1A1/card-preview/").status_code == 403
+
+
+class TestSlotCardPreviewEndpoint:
+    def test_preview_returns_the_encoded_card(self, staff_client):
+        slot = StorageSlotFactory(rack=1, level="A", position=1)
+        tag_id = ensure_slot_tag(slot).tag_id
+
+        resp = staff_client.get(f"{SLOTS_URL}1A1/card-preview/")
+
+        assert resp.status_code == 200, resp.data
+        assert resp.data["code"] == "1A1"
+        assert resp.data["april_tag_id"] == tag_id
+        assert resp.data["kiosk_url"] == _kiosk_url("1A1")
+        pdf_bytes = base64.b64decode(resp.data["preview"])
+        assert _qr_payloads(pdf_bytes) == [_kiosk_url("1A1")]
+        assert _tag_ids(pdf_bytes) == [tag_id]
+
+    def test_unknown_code_is_a_404(self, staff_client):
+        assert staff_client.get(f"{SLOTS_URL}9Z9/card-preview/").status_code == 404
+
+
+class TestSlotCardBatchEndpoint:
+    def test_selected_slots_render_in_the_requested_order(self, staff_client):
+        slots = {
+            slot.code: slot
+            for slot in generate_rack_slots(rack=1, levels=[LevelSpec("A", 3)]).created
+        }
+        wanted = ["1A3", "1A1"]
+
+        resp = staff_client.post(
+            f"{SLOTS_URL}cards/",
+            {"slot_ids": [slots[code].pk for code in wanted]},
+            format="json",
+        )
+
+        assert resp.status_code == 200, resp.content
+        assert resp["Content-Type"] == "application/pdf"
+        assert "attachment" in resp["Content-Disposition"]
+        assert _codes_in_print_order(resp.content, ["1A1", "1A2", "1A3"]) == wanted
+
+    def test_a_rack_prints_as_sheets_in_code_order(self, staff_client):
+        generate_rack_slots(rack=1, levels=[LevelSpec("A", 3), LevelSpec("B", 1)])
+        generate_rack_slots(rack=2, levels=[LevelSpec("A", 1)])
+
+        resp = staff_client.post(f"{SLOTS_URL}cards/", {"rack": 1}, format="json")
+
+        assert resp.status_code == 200, resp.content
+        assert len(_pages(resp.content)) == 2
+        assert _codes_in_print_order(resp.content, ["1A1", "1A2", "1A3", "1B1", "2A1"]) == [
+            "1A1",
+            "1A2",
+            "1A3",
+            "1B1",
+        ]
+
+    def test_a_level_narrows_the_rack(self, staff_client):
+        generate_rack_slots(rack=1, levels=[LevelSpec("A", 2), LevelSpec("Y", 2)])
+
+        resp = staff_client.post(f"{SLOTS_URL}cards/", {"rack": 1, "level": "y"}, format="json")
+
+        assert resp.status_code == 200, resp.content
+        assert _codes_in_print_order(resp.content, ["1A1", "1A2", "1Y1", "1Y2"]) == ["1Y1", "1Y2"]
+
+    def test_retired_slots_stay_off_a_rack_print_unless_asked_for(self, staff_client):
+        generate_rack_slots(rack=1, levels=[LevelSpec("A", 2)])
+        StorageSlot.objects.filter(code="1A2").update(is_active=False)
+
+        default = staff_client.post(f"{SLOTS_URL}cards/", {"rack": 1}, format="json")
+        included = staff_client.post(
+            f"{SLOTS_URL}cards/", {"rack": 1, "include_inactive": True}, format="json"
+        )
+
+        assert _codes_in_print_order(default.content, ["1A1", "1A2"]) == ["1A1"]
+        assert _codes_in_print_order(included.content, ["1A1", "1A2"]) == ["1A1", "1A2"]
+        assert "Not in service" in _text(included.content)
+
+    def test_batch_qr_codes_are_per_slot(self, staff_client):
+        generate_rack_slots(rack=1, levels=[LevelSpec("A", 2)])
+
+        resp = staff_client.post(f"{SLOTS_URL}cards/", {"rack": 1}, format="json")
+
+        assert sorted(_qr_payloads(resp.content)) == [_kiosk_url("1A1"), _kiosk_url("1A2")]
+
+    def test_batch_markers_match_each_slots_allocation(self, staff_client):
+        created = generate_rack_slots(rack=7, levels=[LevelSpec("A", 3)]).created
+        expected = sorted(StorageSlotCardRenderer.tag_id_for(slot) for slot in created)
+
+        resp = staff_client.post(f"{SLOTS_URL}cards/", {"rack": 7}, format="json")
+
+        assert sorted(_tag_ids(resp.content)) == expected
+
+    def test_missing_slot_ids_are_reported_not_silently_dropped(self, staff_client):
+        slot = StorageSlotFactory(rack=1, level="A", position=1)
+
+        resp = staff_client.post(
+            f"{SLOTS_URL}cards/", {"slot_ids": [slot.pk, slot.pk + 999]}, format="json"
+        )
+
+        assert resp.status_code == 404
+        assert resp.data["missing_ids"] == [slot.pk + 999]
+
+    def test_a_rack_with_nothing_to_print_is_a_404(self, staff_client):
+        resp = staff_client.post(f"{SLOTS_URL}cards/", {"rack": 42}, format="json")
+        assert resp.status_code == 404
+        assert resp.data["code"] == "no_slots_matched"
+
+    def test_a_selection_is_required(self, staff_client):
+        assert staff_client.post(f"{SLOTS_URL}cards/", {}, format="json").status_code == 400
+
+    def test_ids_and_a_rack_together_are_rejected(self, staff_client):
+        slot = StorageSlotFactory(rack=1, level="A", position=1)
+        resp = staff_client.post(
+            f"{SLOTS_URL}cards/", {"slot_ids": [slot.pk], "rack": 1}, format="json"
+        )
+        assert resp.status_code == 400
+
+    def test_level_without_a_rack_is_rejected(self, staff_client):
+        resp = staff_client.post(f"{SLOTS_URL}cards/", {"level": "A"}, format="json")
+        assert resp.status_code == 400
+
+
+def _annotated(slots) -> list[StorageSlot]:
+    """Re-read ``slots`` the way the viewset does: markers annotated in one query."""
+    codes = [slot.code for slot in slots]
+    by_code = {
+        slot.code: slot
+        for slot in StorageSlot.objects.filter(code__in=codes)
+        .select_related("owning_group")
+        .annotate(active_april_tag_id=active_tag_id_subquery(StorageSlot))
+    }
+    return [by_code[code] for code in codes]

--- a/backend/project_storage/views.py
+++ b/backend/project_storage/views.py
@@ -32,11 +32,13 @@ from .permissions import IsStorageAdminOrStaff
 from .serializers import (
     GenerateRackSerializer,
     ProjectStorageStintSerializer,
+    SlotCardBatchSerializer,
     StartStintSerializer,
     StorageSlotSerializer,
 )
 from .services.email_service import send_violation_notice
 from .services.label_service import PrinterFamily, render_stint_label
+from .services.slot_cards import build_slot_card_preview, render_slot_cards
 from .services.storage_slots import LevelSpec, ensure_slot_tag, generate_rack_slots
 
 logger = logging.getLogger(__name__)
@@ -733,3 +735,100 @@ class StorageSlotViewSet(viewsets.ModelViewSet):
             payload,
             status=status.HTTP_201_CREATED if result.created else status.HTTP_200_OK,
         )
+
+    # ------------------------------------------------------------------
+    # Printable cards (Avery 5388, 3 per sheet)
+    # ------------------------------------------------------------------
+
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path="card-preview",
+        permission_classes=[IsStorageAdminOrStaff],
+    )
+    def card_preview(self, request, code: str):
+        """Base64 PDF of this one slot's card, for an on-screen preview.
+
+        Mirrors the index-card preview endpoint: a single-card PDF, encoded
+        so the caller can drop it straight into an ``<iframe>`` without a
+        second round trip. Also reports the kiosk URL and marker ID the card
+        carries so the preview surface can show what was encoded.
+        """
+        return Response(build_slot_card_preview(self.get_object()))
+
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="cards",
+        permission_classes=[IsStorageAdminOrStaff],
+    )
+    def cards(self, request):
+        """Batch-render slot cards as a multi-page 5388 PDF (3 cards/page).
+
+        Payload is either ``{"slot_ids": [...]}`` or a rack filter
+        (``{"rack": 1, "level": "A", "include_inactive": false}``) — see
+        :class:`SlotCardBatchSerializer`. Explicit IDs print in the order
+        they were given (reprinting a handful of cards keeps the caller's
+        order); a rack prints in code order, which is the order the sheets
+        get stuck on the uprights.
+
+        Returns the PDF itself rather than a stored file: these sheets are
+        printed once and thrown away, so persisting them would only grow
+        MEDIA_ROOT.
+        """
+        ser = SlotCardBatchSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+
+        # Base manager + the tag annotation: one query for the whole sheet
+        # instead of a marker lookup per card. Not get_queryset(), so a stray
+        # query string on the POST can't silently drop cards from the run.
+        base = StorageSlot.objects.select_related("owning_group").annotate(
+            active_april_tag_id=active_tag_id_subquery(StorageSlot)
+        )
+
+        slot_ids = ser.validated_data.get("slot_ids")
+        if slot_ids:
+            found = {slot.pk: slot for slot in base.filter(pk__in=slot_ids)}
+            missing = [slot_id for slot_id in slot_ids if slot_id not in found]
+            if missing:
+                return Response(
+                    {
+                        "detail": "Some requested storage slots were not found.",
+                        "missing_ids": missing,
+                    },
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            # De-duplicated, but otherwise exactly the order asked for.
+            slots = []
+            seen: set[int] = set()
+            for slot_id in slot_ids:
+                if slot_id in seen:
+                    continue
+                seen.add(slot_id)
+                slots.append(found[slot_id])
+            filename = "storage_slot_cards.pdf"
+        else:
+            rack = ser.validated_data["rack"]
+            level = ser.validated_data.get("level")
+            qs = base.filter(rack=rack).order_by("rack", "level", "position")
+            if level:
+                qs = qs.filter(level=level)
+            if not ser.validated_data.get("include_inactive"):
+                qs = qs.filter(is_active=True)
+            slots = list(qs)
+            if not slots:
+                return Response(
+                    {
+                        "detail": f"No storage slots match rack {rack}"
+                        + (f", level {level}" if level else "")
+                        + ".",
+                        "code": "no_slots_matched",
+                    },
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            filename = f"storage_slot_cards_rack{rack}{level or ''}.pdf"
+
+        pdf_bytes = render_slot_cards(slots)
+        response = HttpResponse(pdf_bytes, content_type="application/pdf")
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return response


### PR DESCRIPTION
## What

Printable **3×5 Avery 5388 cards** for storage slots — the same stock as the inventory index cards, 3 per US-Letter sheet. Part of the storage-slots epic (backend, builds on the merged `StorageSlot` model in #990). Each card carries three ways to identify one physical slot:

- the eye-readable **code** (`1A1`) in the largest type that fits its band;
- a **QR** that opens the project-storage kiosk pre-filled with this slot (`/project-storage/kiosk?slot=<code>`);
- an **AprilTag** from the dedicated `tag36h10` slot family (never the recycling `tag36h11` pool), so a detected marker is unambiguous about what kind of thing it labels.

### Renderer
`StorageSlotCardRenderer` subclasses `index_cards.services.IndexCardRenderer` for the 5388 sheet geometry (card size / margins / gap / page loop) only, and replaces the card face — the parent's `_draw_*` methods are `InventoryItem`-coupled. A slot whose tag family was exhausted at creation still prints a usable card with a `"no location tag"` note rather than borrowing another slot's marker (keeps the CV path honest; re-running the generator heals it and a reprint gets a real tag).

### Endpoints (staff-gated, `IsStorageAdminOrStaff`)
- `GET .../slots/{code}/card-preview/` — single-card base64 PDF + the kiosk URL and marker ID it encoded.
- `POST .../slots/cards/` — batch multi-page 5388 PDF. Selection is **either** `slot_ids` (explicit, printed in the order given, deduped, missing IDs reported as 404 not silently dropped) **or** a `rack` (+ optional `level`, in code order; retired slots excluded unless `include_inactive`). Capped at 300 cards; returned inline (ephemeral, not stored).

## Verification
- 28 tests in `test_slot_cards.py`: 3-per-sheet pagination, order preservation, QR encodes the per-slot prefill URL, AprilTag = the slot's allocated id from the location family, untagged slot still prints, N+1-free annotated sheet, permission gating (anon/plain-user rejected), unknown-code 404, rack/level filters, retired-slot exclusion, and every selection-validation edge — green on Postgres.
- `check_permission_matrix` clean (new `card_preview`/`cards` actions registered). Mayor-side: `py_compile` clean; rebased onto current `main` (past #989).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
