### PR TITLE
Storage slots: web overview status board + C/L/E staff assign UI (op-ytkb)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -97,6 +97,7 @@ import PurchasingReportPage from './pages/PurchasingReportPage';
 import ScanPage from './pages/ScanPage';
 import SIGDashboard from './pages/SIGDashboard';
 import SiteSettingsPage from './pages/SiteSettingsPage';
+import StorageOverviewPage from './pages/StorageOverviewPage';
 import StorageSlotsPage from './pages/StorageSlotsPage';
 import StorageVisionCapturePage from './pages/StorageVisionCapturePage';
 import StorageVisionReviewPage from './pages/StorageVisionReviewPage';
@@ -373,6 +374,7 @@ function AppContent() {
           {/* Static segment outranks the :stintId route below — react-router
               scores literal segments above dynamic ones regardless of order. */}
           <Route path="/facilities/project-storage/slots" element={<WorkspaceLayout><StorageSlotsPage /></WorkspaceLayout>} />
+          <Route path="/facilities/project-storage/overview" element={<WorkspaceLayout><StorageOverviewPage /></WorkspaceLayout>} />
           <Route path="/facilities/project-storage/:stintId" element={<WorkspaceLayout><FacilitiesProjectStoragePage /></WorkspaceLayout>} />
           <Route path="/facilities/project-storage" element={<WorkspaceLayout><FacilitiesProjectStoragePage /></WorkspaceLayout>} />
 

--- a/frontend/src/__tests__/pages/ProjectStorageKioskPage.slot.test.tsx
+++ b/frontend/src/__tests__/pages/ProjectStorageKioskPage.slot.test.tsx
@@ -78,6 +78,8 @@ const buildSlot = (overrides: Partial<StorageSlot> = {}): StorageSlot => ({
   notes: '',
   april_tag_id: 101,
   current_stint: null,
+  current_assignment: null,
+  occupancy_type: null,
   is_occupied: false,
   created_at: '2026-07-01T00:00:00Z',
   updated_at: '2026-07-01T00:00:00Z',

--- a/frontend/src/__tests__/pages/StorageOverviewPage.test.tsx
+++ b/frontend/src/__tests__/pages/StorageOverviewPage.test.tsx
@@ -1,0 +1,508 @@
+/**
+ * Tests for the storage overview — the rack board.
+ *
+ * The two things this screen has to get right: every tile paints the
+ * letter and colour the server sent (a wrong colour here means somebody
+ * walks past an expired project), and the staff intake for C/L/E posts
+ * what the assign endpoint expects.
+ */
+import { MantineProvider } from '@mantine/core';
+import { ModalsProvider } from '@mantine/modals';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import StorageOverviewPage from '../../pages/StorageOverviewPage';
+import {
+  sigAPI,
+  storageAssignmentsAPI,
+  storageOverviewAPI,
+  storageSlotsAPI,
+} from '../../services/api';
+import {
+  StorageOverview,
+  StorageOverviewCell,
+  StorageOverviewRack,
+  StorageSlot,
+} from '../../types';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual('../../services/api');
+  return {
+    ...actual,
+    storageOverviewAPI: { get: vi.fn() },
+    storageAssignmentsAPI: { list: vi.fn(), assign: vi.fn(), release: vi.fn() },
+    storageSlotsAPI: { get: vi.fn() },
+    sigAPI: { listMySIGs: vi.fn() },
+  };
+});
+
+const mockOverview = storageOverviewAPI as jest.Mocked<typeof storageOverviewAPI>;
+const mockAssignments = storageAssignmentsAPI as jest.Mocked<typeof storageAssignmentsAPI>;
+const mockSlots = storageSlotsAPI as jest.Mocked<typeof storageSlotsAPI>;
+const mockSigs = sigAPI as jest.Mocked<typeof sigAPI>;
+
+const ok = <T,>(data: T) =>
+  ({
+    data,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {} as never,
+  }) as never;
+
+const cell = (overrides: Partial<StorageOverviewCell> = {}): StorageOverviewCell => ({
+  code: '1A1',
+  slot_id: 1,
+  position: 1,
+  type: null,
+  status: 'empty',
+  color: null,
+  occupant: '',
+  is_active: true,
+  ...overrides,
+});
+
+const rack = (overrides: Partial<StorageOverviewRack> = {}): StorageOverviewRack => ({
+  rack: 1,
+  levels: ['B', 'A'],
+  max_position: 2,
+  rows: [
+    { level: 'B', cells: [cell({ code: '1B1', slot_id: 3 }), cell({ code: '1B2', slot_id: 4, position: 2 })] },
+    { level: 'A', cells: [cell({ code: '1A1' }), cell({ code: '1A2', slot_id: 2, position: 2 })] },
+  ],
+  ...overrides,
+});
+
+const overview = (racks: StorageOverviewRack[] = [rack()]): StorageOverview => ({
+  racks,
+  generated_at: '2026-08-01T12:00:00Z',
+});
+
+const buildSlot = (overrides: Partial<StorageSlot> = {}): StorageSlot => ({
+  id: 1,
+  code: '1A1',
+  rack: 1,
+  level: 'A',
+  position: 1,
+  requires_pallet_jack: false,
+  is_active: true,
+  owning_group: null,
+  owning_group_name: '',
+  notes: '',
+  april_tag_id: 101,
+  current_stint: null,
+  current_assignment: null,
+  occupancy_type: null,
+  is_occupied: false,
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+  ...overrides,
+});
+
+// env="test" disables Mantine's transitions — without it the Modal content
+// never lands in the DOM. ModalsProvider is what confirmAction opens into.
+const renderPage = () =>
+  render(
+    <MantineProvider env="test">
+      <ModalsProvider>
+        <MemoryRouter>
+          <StorageOverviewPage />
+        </MemoryRouter>
+      </ModalsProvider>
+    </MantineProvider>,
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockOverview.get.mockResolvedValue(ok(overview()));
+  mockSlots.get.mockResolvedValue(ok(buildSlot()));
+  mockSigs.listMySIGs.mockResolvedValue(ok({ results: [] }));
+});
+
+describe('StorageOverviewPage — the grid', () => {
+  it('paints the letter and colour the server sent, per cell', async () => {
+    mockOverview.get.mockResolvedValue(
+      ok(
+        overview([
+          rack({
+            rows: [
+              {
+                level: 'B',
+                cells: [
+                  cell({
+                    code: '1B1',
+                    slot_id: 3,
+                    type: 'P',
+                    status: 'expired',
+                    color: 'red',
+                    occupant: 'Alice Aardvark',
+                  }),
+                  cell({
+                    code: '1B2',
+                    slot_id: 4,
+                    position: 2,
+                    type: 'P',
+                    status: 'expiring_soon',
+                    color: 'yellow',
+                    occupant: 'Bob Badger',
+                  }),
+                ],
+              },
+              {
+                level: 'A',
+                cells: [
+                  cell({
+                    code: '1A1',
+                    type: 'C',
+                    status: 'occupied',
+                    occupant: 'Welding',
+                  }),
+                  cell({ code: '1A2', slot_id: 2, position: 2 }),
+                ],
+              },
+            ],
+          }),
+        ]),
+      ),
+    );
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId('cell-1B1')).toBeInTheDocument());
+
+    // Expired project — red, and the letter says whose kind of storage it is.
+    const expired = screen.getByTestId('cell-1B1');
+    expect(expired).toHaveTextContent('P');
+    expect(expired).toHaveAttribute('data-tone', 'red');
+    expect(expired).toHaveStyle({ background: 'var(--mantine-color-red-6)' });
+
+    // Expiring soon — yellow.
+    const expiring = screen.getByTestId('cell-1B2');
+    expect(expiring).toHaveAttribute('data-tone', 'yellow');
+    expect(expiring).toHaveStyle({ background: 'var(--mantine-color-yellow-4)' });
+
+    // A committee holding is C and plainly occupied: colouring a slot that
+    // has been theirs for two years would drown out the red one above.
+    const committee = screen.getByTestId('cell-1A1');
+    expect(committee).toHaveTextContent('C');
+    expect(committee).toHaveAttribute('data-tone', 'occupied');
+
+    // Empty stays blank.
+    const empty = screen.getByTestId('cell-1A2');
+    expect(empty).toHaveTextContent('');
+    expect(empty).toHaveAttribute('data-tone', 'empty');
+
+    // Counts: one committee + two projects in use, one free, two coloured.
+    expect(screen.getByTestId('count-attention')).toHaveTextContent('2 need attention');
+    expect(screen.getByTestId('count-occupied')).toHaveTextContent('3 in use');
+    expect(screen.getByTestId('count-free')).toHaveTextContent('1 free');
+  });
+
+  it('lays levels out high-first and leaves a hole where the racking has none', async () => {
+    mockOverview.get.mockResolvedValue(
+      ok(
+        overview([
+          rack({
+            levels: ['C', 'A'],
+            max_position: 3,
+            rows: [
+              {
+                level: 'C',
+                // Dense and 1-indexed: position 2 is a hole in the racking.
+                cells: [cell({ code: '1C1', slot_id: 5 }), null, cell({ code: '1C3', slot_id: 6, position: 3 })],
+              },
+              {
+                level: 'A',
+                cells: [
+                  cell({ code: '1A1' }),
+                  cell({ code: '1A2', slot_id: 2, position: 2 }),
+                  cell({ code: '1A3', slot_id: 7, position: 3 }),
+                ],
+              },
+            ],
+          }),
+        ]),
+      ),
+    );
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId('cell-1C1')).toBeInTheDocument());
+
+    // The hole is a spacer, not a tappable slot.
+    expect(screen.getByTestId('cell-gap-1C2')).toBeInTheDocument();
+    expect(screen.queryByTestId('cell-1C2')).not.toBeInTheDocument();
+
+    // High shelf first — the grid reads the way the steel does.
+    const grid = screen.getByTestId('rack-grid-1');
+    const levels = within(grid)
+      .getAllByTestId(/^level-label-/)
+      .map((node) => node.textContent);
+    expect(levels).toEqual(['C', 'A']);
+  });
+
+  it('narrows to one rack through the endpoint, keeping the other racks selectable', async () => {
+    mockOverview.get.mockResolvedValue(ok(overview([rack(), rack({ rack: 2 })])));
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId('rack-grid-2')).toBeInTheDocument());
+    expect(mockOverview.get).toHaveBeenLastCalledWith(undefined);
+
+    mockOverview.get.mockResolvedValue(ok(overview([rack({ rack: 2 })])));
+    const selector = screen.getByTestId('rack-filter');
+    fireEvent.click(within(selector).getByText('Rack 2'));
+
+    await waitFor(() => expect(mockOverview.get).toHaveBeenLastCalledWith({ rack: 2 }));
+    await waitFor(() => expect(screen.queryByTestId('rack-grid-1')).not.toBeInTheDocument());
+    // Rack 1 is still offered even though the narrowed payload never mentions it.
+    expect(within(selector).getByText('Rack 1')).toBeInTheDocument();
+  });
+
+  it('surfaces a rejected load instead of an empty board', async () => {
+    mockOverview.get.mockRejectedValue({
+      response: { status: 403, data: { detail: 'Storage admin or staff only.' } },
+    });
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('overview-error')).toHaveTextContent('Storage admin or staff only.'),
+    );
+  });
+});
+
+describe('StorageOverviewPage — C/L/E staff assignment', () => {
+  it('assigns a free slot to a committee', async () => {
+    mockSigs.listMySIGs.mockResolvedValue(
+      ok({ results: [{ id: 3, name: 'Welding', member_count: 0, asset_count: 0, inventory_count: 0, admins: [], is_user_admin: false }] }),
+    );
+    mockAssignments.assign.mockResolvedValue(ok({ id: 11 }));
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId('cell-1A1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('cell-1A1'));
+
+    // The tile says what to paint; the slot fetch says what can be done with it.
+    await waitFor(() => expect(screen.getByTestId('slot-assign-form')).toBeInTheDocument());
+    expect(mockSlots.get).toHaveBeenCalledWith('1A1');
+
+    fireEvent.click(await screen.findByPlaceholderText('Pick a committee'));
+    fireEvent.click(await screen.findByRole('option', { name: 'Welding' }));
+    fireEvent.change(screen.getByTestId('assign-notes'), {
+      target: { value: 'Fixture cart lives here' },
+    });
+    fireEvent.click(screen.getByTestId('assign-submit'));
+
+    await waitFor(() =>
+      expect(mockAssignments.assign).toHaveBeenCalledWith({
+        slot: '1A1',
+        storage_type: 'committee',
+        owning_group: 3,
+        occupant_label: '',
+        notes: 'Fixture cart lives here',
+      }),
+    );
+    // The board reloads so the new C tile is on it.
+    await waitFor(() => expect(mockOverview.get).toHaveBeenCalledTimes(2));
+  });
+
+  it('assigns logistics/class by free-text occupant, with no committee picker', async () => {
+    mockAssignments.assign.mockResolvedValue(ok({ id: 12 }));
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId('cell-1A1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('cell-1A1'));
+    await waitFor(() => expect(screen.getByTestId('slot-assign-form')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('E · Class'));
+    expect(screen.queryByTestId('assign-group')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('assign-label'), {
+      target: { value: "Ana's CNC class" },
+    });
+    fireEvent.click(screen.getByTestId('assign-submit'));
+
+    await waitFor(() =>
+      expect(mockAssignments.assign).toHaveBeenCalledWith({
+        slot: '1A1',
+        storage_type: 'class',
+        owning_group: null,
+        occupant_label: "Ana's CNC class",
+        notes: '',
+      }),
+    );
+  });
+
+  it('will not submit a committee assignment that names no committee', async () => {
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId('cell-1A1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('cell-1A1'));
+    await waitFor(() => expect(screen.getByTestId('slot-assign-form')).toBeInTheDocument());
+
+    // Same rule the server enforces: a committee holding with neither the
+    // group nor a label is just a blocked slot.
+    expect(screen.getByTestId('assign-submit')).toBeDisabled();
+    fireEvent.change(screen.getByTestId('assign-label'), { target: { value: 'Metal shop crew' } });
+    expect(screen.getByTestId('assign-submit')).not.toBeDisabled();
+  });
+
+  it('shows the conflict when the slot was taken between the load and the click', async () => {
+    mockAssignments.assign.mockRejectedValue({
+      response: {
+        status: 409,
+        data: { detail: 'Slot 1A1 is already held by Alice Aardvark.', code: 'slot_occupied' },
+      },
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId('cell-1A1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('cell-1A1'));
+    await waitFor(() => expect(screen.getByTestId('slot-assign-form')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('assign-label'), { target: { value: 'Welding' } });
+    fireEvent.click(screen.getByTestId('assign-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('slot-detail-error')).toHaveTextContent(
+        'Slot 1A1 is already held by Alice Aardvark.',
+      ),
+    );
+  });
+
+  it('releases a held slot by the assignment id the slot carries', async () => {
+    mockOverview.get.mockResolvedValue(
+      ok(
+        overview([
+          rack({
+            levels: ['A'],
+            max_position: 1,
+            rows: [
+              {
+                level: 'A',
+                cells: [cell({ code: '1A1', type: 'C', status: 'occupied', occupant: 'Welding' })],
+              },
+            ],
+          }),
+        ]),
+      ),
+    );
+    mockSlots.get.mockResolvedValue(
+      ok(
+        buildSlot({
+          is_occupied: true,
+          occupancy_type: 'C',
+          current_assignment: {
+            id: 42,
+            storage_type: 'committee',
+            type_letter: 'C',
+            occupant_display: 'Welding',
+            assigned_at: '2026-05-02T00:00:00Z',
+          },
+        }),
+      ),
+    );
+    mockAssignments.release.mockResolvedValue(ok({ id: 42 }));
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId('cell-1A1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('cell-1A1'));
+
+    await waitFor(() => expect(screen.getByTestId('slot-detail-assignment')).toBeInTheDocument());
+    // No assign form over an occupied slot.
+    expect(screen.queryByTestId('slot-assign-form')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('slot-release'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Release' }));
+
+    await waitFor(() => expect(mockAssignments.release).toHaveBeenCalledWith(42));
+    await waitFor(() => expect(mockOverview.get).toHaveBeenCalledTimes(2));
+  });
+
+  it('links a project tile to the stint rather than offering to assign it', async () => {
+    mockOverview.get.mockResolvedValue(
+      ok(
+        overview([
+          rack({
+            levels: ['A'],
+            max_position: 1,
+            rows: [
+              {
+                level: 'A',
+                cells: [
+                  cell({
+                    code: '1A1',
+                    type: 'P',
+                    status: 'expired',
+                    color: 'red',
+                    occupant: 'Alice Aardvark',
+                  }),
+                ],
+              },
+            ],
+          }),
+        ]),
+      ),
+    );
+    mockSlots.get.mockResolvedValue(
+      ok(
+        buildSlot({
+          is_occupied: true,
+          occupancy_type: 'P',
+          current_stint: {
+            id: 7,
+            stint_id: 'PS-AB23CDFG',
+            username: 'alice',
+            display_name: 'Alice Aardvark',
+            project_title: 'Big Sculpture',
+            started_at: '2026-06-01T00:00:00Z',
+            expires_at: '2026-07-01T00:00:00Z',
+            status: 'expired',
+          },
+        }),
+      ),
+    );
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId('cell-1A1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('cell-1A1'));
+
+    await waitFor(() => expect(screen.getByTestId('slot-detail-stint')).toBeInTheDocument());
+    expect(screen.getByTestId('slot-detail-stint-link')).toHaveAttribute(
+      'href',
+      '/facilities/project-storage/PS-AB23CDFG',
+    );
+    expect(screen.getByTestId('slot-detail-status')).toHaveTextContent('Expired');
+    expect(screen.queryByTestId('slot-assign-form')).not.toBeInTheDocument();
+  });
+
+  it('sends a retired slot back to the console instead of assigning it', async () => {
+    mockOverview.get.mockResolvedValue(
+      ok(
+        overview([
+          rack({
+            levels: ['A'],
+            max_position: 1,
+            rows: [{ level: 'A', cells: [cell({ code: '1A1', is_active: false })] }],
+          }),
+        ]),
+      ),
+    );
+    mockSlots.get.mockResolvedValue(ok(buildSlot({ is_active: false })));
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId('cell-1A1')).toBeInTheDocument());
+    expect(screen.getByTestId('cell-1A1')).toHaveAttribute('data-tone', 'retired');
+
+    fireEvent.click(screen.getByTestId('cell-1A1'));
+    await waitFor(() => expect(screen.getByTestId('slot-detail-retired')).toBeInTheDocument());
+    expect(screen.queryByTestId('slot-assign-form')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/StorageSlotsPage.test.tsx
+++ b/frontend/src/__tests__/pages/StorageSlotsPage.test.tsx
@@ -45,6 +45,8 @@ const buildSlot = (overrides: Partial<StorageSlot> = {}): StorageSlot => ({
   notes: '',
   april_tag_id: 101,
   current_stint: null,
+  current_assignment: null,
+  occupancy_type: null,
   is_occupied: false,
   created_at: '2026-07-01T00:00:00Z',
   updated_at: '2026-07-01T00:00:00Z',

--- a/frontend/src/pages/FacilitiesOverviewPage.tsx
+++ b/frontend/src/pages/FacilitiesOverviewPage.tsx
@@ -10,6 +10,7 @@ import {
   IconDeviceTv,
   IconGauge,
   IconKey,
+  IconLayoutGrid,
   IconLock,
   IconPackage,
   IconRocket,
@@ -142,6 +143,14 @@ const FacilitiesOverviewPage: React.FC = () => (
       icon={<IconPackage size={22} stroke={1.8} />}
       eyebrow="Members"
       testId="facilities-overview-card-/facilities/project-storage"
+    />
+    <CapabilityCard
+      to="/facilities/project-storage/overview"
+      title="Storage overview"
+      description="The rack board — every slot at a glance, with the late projects coloured."
+      icon={<IconLayoutGrid size={22} stroke={1.8} />}
+      eyebrow="Members"
+      testId="facilities-overview-card-/facilities/project-storage/overview"
     />
   </WorkspaceLanding>
 );

--- a/frontend/src/pages/FacilitiesProjectStorageListPage.tsx
+++ b/frontend/src/pages/FacilitiesProjectStorageListPage.tsx
@@ -131,6 +131,9 @@ const FacilitiesProjectStorageListPage: React.FC = () => {
           'Pick a row to open the warden actions (notice, purgatory, remove).',
         action: (
           <Group gap="sm">
+            <Button component={Link} to="/facilities/project-storage/overview" variant="light">
+              Rack overview
+            </Button>
             <Button component={Link} to="/facilities/project-storage/slots" variant="light">
               Storage slots
             </Button>

--- a/frontend/src/pages/StorageOverviewPage.tsx
+++ b/frontend/src/pages/StorageOverviewPage.tsx
@@ -1,0 +1,773 @@
+/**
+ * Storage overview — the rack board you pull up on a phone while standing
+ * in the aisle.
+ *
+ * One tile per slot, laid out the way the steel is: a row per level with
+ * the high shelves first (Z overhead, A at your feet) and a column per
+ * position. The letter says what kind of storage holds it — P for a
+ * member's project, C/L/E for a committee, logistics, or class holding —
+ * and the colour says whether something is wrong.
+ *
+ * Only Project storage is ever coloured, and the server decides: yellow
+ * when a stint is expiring soon, red once it has expired (that one needs
+ * to move to purgatory). A committee slot has been the committee's for two
+ * years and will be tomorrow, so painting it would drown out the one late
+ * member project this screen exists to surface. A healthy rack is a wall of
+ * plain tiles and the exceptions jump out.
+ *
+ * Tapping a tile opens the slot: who is in it, and the staff intake for the
+ * non-Project types — assign a free slot to a committee / logistics / class,
+ * or release one that is held. Those three are *not* self-service; a member
+ * claims their own slot at the kiosk, and staff hand out everything else.
+ *
+ * Permissions: the overview and the assign/release actions are all
+ * IsStorageAdminOrStaff, so the storage warden runs this without being
+ * platform-wide staff. Like the sibling slots console there is no
+ * client-side role gate — the backend is the gate, and hiding the actions
+ * from a group-only warden would take the screen away from the person who
+ * uses it most.
+ */
+import {
+  Alert,
+  Anchor,
+  Badge,
+  Box,
+  Button,
+  Group,
+  Loader,
+  Modal,
+  Paper,
+  SegmentedControl,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+  Tooltip,
+} from '@mantine/core';
+import { IconAlertCircle, IconRefresh } from '@tabler/icons-react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import WorkspacePage from '../components/landing/WorkspacePage';
+import {
+  sigAPI,
+  storageAssignmentsAPI,
+  storageOverviewAPI,
+  storageSlotsAPI,
+} from '../services/api';
+import {
+  SIG,
+  StorageAssignmentType,
+  StorageOverview,
+  StorageOverviewCell,
+  StorageOverviewRack,
+  StorageSlot,
+  StorageTypeLetter,
+} from '../types';
+import { confirmAction, showError, showSuccess } from '../utils/dialogs';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
+
+/** What each letter means, for the legend and the slot detail. */
+const TYPE_LABELS: Record<StorageTypeLetter, string> = {
+  P: 'Project',
+  C: 'Committee',
+  L: 'Logistics',
+  E: 'Class',
+};
+
+const ASSIGNABLE_TYPES: { value: StorageAssignmentType; label: string; letter: string }[] = [
+  { value: 'committee', label: 'Committee', letter: 'C' },
+  { value: 'logistics', label: 'Logistics', letter: 'L' },
+  { value: 'class', label: 'Class', letter: 'E' },
+];
+
+/**
+ * Tile colours. The server sends `yellow`/`red`; everything else is either
+ * plainly occupied or blank, and the difference between those two is what
+ * the whole screen is read for, so they stay visually quiet.
+ */
+const CELL_BACKGROUND: Record<string, string> = {
+  yellow: 'var(--mantine-color-yellow-4)',
+  red: 'var(--mantine-color-red-6)',
+  occupied: 'var(--mantine-color-gray-3)',
+  empty: 'transparent',
+  retired: 'var(--mantine-color-gray-5)',
+};
+
+const CELL_FOREGROUND: Record<string, string> = {
+  yellow: 'var(--mantine-color-black)',
+  red: 'var(--mantine-color-white)',
+  occupied: 'var(--mantine-color-black)',
+  empty: 'var(--mantine-color-gray-6)',
+  retired: 'var(--mantine-color-gray-7)',
+};
+
+/** Which colour bucket a cell paints in — the one place that decides. */
+const cellTone = (cell: StorageOverviewCell): string => {
+  if (cell.color) return cell.color;
+  if (cell.type) return 'occupied';
+  // An empty slot that is out of service is not the same as a free one:
+  // handing it out would send a member to a shelf that isn't there any more.
+  return cell.is_active ? 'empty' : 'retired';
+};
+
+const statusLabel = (cell: StorageOverviewCell): string => {
+  if (cell.status === 'empty') return cell.is_active ? 'Free' : 'Out of service';
+  if (cell.status === 'occupied') return 'Occupied';
+  // Stint statuses arrive snake_cased: expiring_soon → "Expiring soon".
+  const spaced = cell.status.replace(/_/g, ' ');
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+};
+
+// ---------------------------------------------------------------------------
+// Grid
+// ---------------------------------------------------------------------------
+
+interface RackGridProps {
+  rack: StorageOverviewRack;
+  onPick: (cell: StorageOverviewCell) => void;
+}
+
+const RackGrid: React.FC<RackGridProps> = ({ rack, onPick }) => {
+  const positions = useMemo(
+    () => Array.from({ length: rack.max_position }, (_, i) => i + 1),
+    [rack.max_position],
+  );
+
+  // A fixed track per position so every level lines up even where the
+  // racking has holes — the payload is dense and 1-indexed precisely so
+  // this doesn't have to re-derive which columns exist.
+  const gridStyle: React.CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: `2rem repeat(${rack.max_position}, minmax(2rem, 1fr))`,
+    gap: 4,
+    minWidth: rack.max_position * 40 + 32,
+  };
+
+  return (
+    <Paper withBorder p="sm" data-testid={`rack-grid-${rack.rack}`}>
+      <Group justify="space-between" mb="xs">
+        <Text fw={700}>Rack {rack.rack}</Text>
+        <Text size="xs" c="dimmed">
+          {rack.levels.length} levels · {rack.max_position} positions
+        </Text>
+      </Group>
+
+      {/* Wide racks scroll sideways rather than squeezing the tiles below
+          thumb size on a phone. */}
+      <Box style={{ overflowX: 'auto' }}>
+        <Box style={gridStyle}>
+          <Box />
+          {positions.map((position) => (
+            <Text key={`head-${position}`} size="xs" c="dimmed" ta="center">
+              {position}
+            </Text>
+          ))}
+
+          {rack.rows.map((row) => (
+            <React.Fragment key={`${rack.rack}-${row.level}`}>
+              <Text size="sm" fw={600} ta="center" data-testid={`level-label-${rack.rack}${row.level}`}>
+                {row.level}
+              </Text>
+              {row.cells.map((cell, index) =>
+                cell === null ? (
+                  // A hole in the racking. Not a slot, so not tappable —
+                  // and visibly not the same thing as a free slot.
+                  <Box
+                    key={`${rack.rack}-${row.level}-gap-${index + 1}`}
+                    data-testid={`cell-gap-${rack.rack}${row.level}${index + 1}`}
+                    style={{ minHeight: 34 }}
+                  />
+                ) : (
+                  <Tooltip
+                    key={cell.code}
+                    label={`${cell.code} — ${statusLabel(cell)}${
+                      cell.occupant ? ` · ${cell.occupant}` : ''
+                    }`}
+                    withArrow
+                  >
+                    <Box
+                      component="button"
+                      type="button"
+                      onClick={() => onPick(cell)}
+                      data-testid={`cell-${cell.code}`}
+                      data-tone={cellTone(cell)}
+                      data-type={cell.type ?? ''}
+                      aria-label={`Slot ${cell.code} — ${statusLabel(cell)}${
+                        cell.occupant ? `, ${cell.occupant}` : ''
+                      }`}
+                      style={{
+                        minHeight: 34,
+                        cursor: 'pointer',
+                        borderRadius: 4,
+                        border: '1px solid var(--mantine-color-gray-4)',
+                        borderStyle: cell.is_active ? 'solid' : 'dashed',
+                        background: CELL_BACKGROUND[cellTone(cell)],
+                        color: CELL_FOREGROUND[cellTone(cell)],
+                        fontWeight: 700,
+                        fontFamily: 'monospace',
+                        fontSize: 14,
+                      }}
+                    >
+                      {cell.type ?? ''}
+                    </Box>
+                  </Tooltip>
+                ),
+              )}
+            </React.Fragment>
+          ))}
+        </Box>
+      </Box>
+    </Paper>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Legend
+// ---------------------------------------------------------------------------
+
+const swatch = (background: string, border = 'var(--mantine-color-gray-4)') => (
+  <Box
+    style={{
+      width: 16,
+      height: 16,
+      borderRadius: 3,
+      border: `1px solid ${border}`,
+      background,
+    }}
+  />
+);
+
+const Legend: React.FC = () => (
+  <Paper withBorder p="sm" data-testid="overview-legend">
+    <Group gap="lg" wrap="wrap">
+      <Group gap={6}>
+        <Text size="sm" fw={600}>
+          P
+        </Text>
+        <Text size="sm" c="dimmed">
+          Project
+        </Text>
+      </Group>
+      <Group gap={6}>
+        <Text size="sm" fw={600}>
+          C
+        </Text>
+        <Text size="sm" c="dimmed">
+          Committee
+        </Text>
+      </Group>
+      <Group gap={6}>
+        <Text size="sm" fw={600}>
+          L
+        </Text>
+        <Text size="sm" c="dimmed">
+          Logistics
+        </Text>
+      </Group>
+      <Group gap={6}>
+        <Text size="sm" fw={600}>
+          E
+        </Text>
+        <Text size="sm" c="dimmed">
+          Class
+        </Text>
+      </Group>
+      <Group gap={6}>
+        {swatch(CELL_BACKGROUND.yellow)}
+        <Text size="sm" c="dimmed">
+          Expiring soon
+        </Text>
+      </Group>
+      <Group gap={6}>
+        {swatch(CELL_BACKGROUND.red)}
+        <Text size="sm" c="dimmed">
+          Expired — move to purgatory
+        </Text>
+      </Group>
+      <Group gap={6}>
+        {swatch(CELL_BACKGROUND.occupied)}
+        <Text size="sm" c="dimmed">
+          In use
+        </Text>
+      </Group>
+      <Group gap={6}>
+        {swatch(CELL_BACKGROUND.empty)}
+        <Text size="sm" c="dimmed">
+          Free
+        </Text>
+      </Group>
+      <Group gap={6}>
+        {swatch(CELL_BACKGROUND.retired)}
+        <Text size="sm" c="dimmed">
+          Out of service
+        </Text>
+      </Group>
+    </Group>
+  </Paper>
+);
+
+// ---------------------------------------------------------------------------
+// Slot detail + the C/L/E staff intake
+// ---------------------------------------------------------------------------
+
+interface SlotDetailModalProps {
+  cell: StorageOverviewCell | null;
+  onClose: () => void;
+  onChanged: () => void;
+}
+
+const SlotDetailModal: React.FC<SlotDetailModalProps> = ({ cell, onClose, onChanged }) => {
+  const [slot, setSlot] = useState<StorageSlot | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const [storageType, setStorageType] = useState<StorageAssignmentType>('committee');
+  const [owningGroup, setOwningGroup] = useState<string | null>(null);
+  const [occupantLabel, setOccupantLabel] = useState('');
+  const [notes, setNotes] = useState('');
+  const [sigs, setSigs] = useState<SIG[]>([]);
+
+  // The grid cell carries what to paint; the slot itself carries what to do
+  // with it — the stint's permalink and the assignment id release needs.
+  useEffect(() => {
+    if (!cell) {
+      setSlot(null);
+      setError(null);
+      return;
+    }
+    setStorageType('committee');
+    setOwningGroup(null);
+    setOccupantLabel('');
+    setNotes('');
+    setLoading(true);
+    setError(null);
+    let cancelled = false;
+    storageSlotsAPI
+      .get(cell.code)
+      .then((res) => {
+        if (!cancelled) setSlot(res?.data ?? null);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(extractErrorMessage(err, `Could not load slot ${cell.code}.`));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [cell]);
+
+  const assignment = slot?.current_assignment ?? null;
+  const stint = slot?.current_stint ?? null;
+  const canAssign = slot !== null && !slot.is_occupied && slot.is_active;
+
+  // Committees are auth groups, which is what the SIG endpoint lists. Only
+  // fetched once a free slot is open — most taps land on an occupied tile,
+  // and that one never shows the picker.
+  useEffect(() => {
+    if (!canAssign) return;
+    let cancelled = false;
+    sigAPI
+      .listMySIGs()
+      .then((res) => {
+        if (!cancelled) setSigs(res?.data?.results ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setSigs([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [canAssign]);
+
+  // Mirrors the server rule: a committee holding that names neither the
+  // group nor a label is just a blocked slot, and the grid would have
+  // nothing to show for it.
+  const assignValid =
+    storageType !== 'committee' || owningGroup !== null || occupantLabel.trim() !== '';
+
+  const submitAssign = async () => {
+    if (!cell || !assignValid) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await storageAssignmentsAPI.assign({
+        slot: cell.code,
+        storage_type: storageType,
+        owning_group: storageType === 'committee' && owningGroup ? Number(owningGroup) : null,
+        occupant_label: occupantLabel.trim(),
+        notes: notes.trim(),
+      });
+      showSuccess(`Slot ${cell.code} assigned.`);
+      onChanged();
+      onClose();
+    } catch (err) {
+      // 409 when something already holds it — the backend's message names
+      // which kind and what to do about it.
+      setError(extractErrorMessage(err, `Could not assign slot ${cell.code}.`));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const submitRelease = () => {
+    if (!assignment || !cell) return;
+    confirmAction(
+      `Release slot ${cell.code}`,
+      `Hand ${cell.code} back from ${assignment.occupant_display}? The slot becomes free to ` +
+        'give out again, and the record of who had it is kept.',
+      async () => {
+        setSubmitting(true);
+        try {
+          await storageAssignmentsAPI.release(assignment.id);
+          showSuccess(`Slot ${cell.code} released.`);
+          onChanged();
+          onClose();
+        } catch (err) {
+          showError(extractErrorMessage(err, `Could not release slot ${cell.code}.`));
+        } finally {
+          setSubmitting(false);
+        }
+      },
+      { labels: { confirm: 'Release', cancel: 'Cancel' }, color: 'red' },
+    );
+  };
+
+  return (
+    <Modal
+      opened={cell !== null}
+      onClose={onClose}
+      title={cell ? `Slot ${cell.code}` : 'Slot'}
+      centered
+      data-testid="slot-detail-modal"
+    >
+      <Stack gap="md">
+        {error && (
+          <Alert color="red" variant="light" icon={<IconAlertCircle size={18} />} data-testid="slot-detail-error">
+            {error}
+          </Alert>
+        )}
+
+        {loading && (
+          <Group justify="center" p="md">
+            <Loader size="sm" />
+          </Group>
+        )}
+
+        {cell && (
+          <Group gap="sm" wrap="wrap">
+            <Badge variant="light" data-testid="slot-detail-status">
+              {statusLabel(cell)}
+            </Badge>
+            {cell.type && (
+              <Badge variant="light" color="blue" data-testid="slot-detail-type">
+                {TYPE_LABELS[cell.type]}
+              </Badge>
+            )}
+            {slot?.requires_pallet_jack && (
+              <Badge variant="light" color="grape">
+                Pallet jack
+              </Badge>
+            )}
+            {slot && !slot.is_active && (
+              <Badge variant="filled" color="gray">
+                Retired
+              </Badge>
+            )}
+          </Group>
+        )}
+
+        {stint && (
+          <Stack gap={2} data-testid="slot-detail-stint">
+            <Text size="sm">{stint.display_name || stint.username}</Text>
+            {stint.project_title && (
+              <Text size="sm" c="dimmed">
+                {stint.project_title}
+              </Text>
+            )}
+            <Anchor
+              component={Link}
+              to={`/facilities/project-storage/${encodeURIComponent(stint.stint_id)}`}
+              size="sm"
+              data-testid="slot-detail-stint-link"
+            >
+              Open the stint ({stint.stint_id})
+            </Anchor>
+          </Stack>
+        )}
+
+        {assignment && (
+          <Stack gap="xs" data-testid="slot-detail-assignment">
+            <Text size="sm">
+              {assignment.occupant_display} — {TYPE_LABELS[assignment.type_letter]}
+            </Text>
+            <Text size="xs" c="dimmed">
+              Held since {new Date(assignment.assigned_at).toLocaleDateString()}
+            </Text>
+            <Group>
+              <Button
+                color="red"
+                variant="light"
+                disabled={submitting}
+                onClick={submitRelease}
+                data-testid="slot-release"
+              >
+                Release slot
+              </Button>
+            </Group>
+          </Stack>
+        )}
+
+        {slot && slot.is_occupied && !stint && !assignment && (
+          <Text size="sm" c="dimmed">
+            {cell?.occupant}
+          </Text>
+        )}
+
+        {slot && !slot.is_occupied && !slot.is_active && (
+          <Text size="sm" c="dimmed" data-testid="slot-detail-retired">
+            This slot is out of service. Return it on the{' '}
+            <Anchor component={Link} to="/facilities/project-storage/slots" size="sm">
+              slots console
+            </Anchor>{' '}
+            before assigning it.
+          </Text>
+        )}
+
+        {canAssign && (
+          <Stack gap="sm" data-testid="slot-assign-form">
+            <Text size="sm" fw={600}>
+              Assign this slot
+            </Text>
+            <Text size="xs" c="dimmed">
+              Committee, logistics and class storage are handed out by staff — members claim
+              their own slot at the kiosk.
+            </Text>
+
+            <SegmentedControl
+              value={storageType}
+              onChange={(value) => setStorageType(value as StorageAssignmentType)}
+              data={ASSIGNABLE_TYPES.map((type) => ({
+                value: type.value,
+                label: `${type.letter} · ${type.label}`,
+              }))}
+              data-testid="assign-type"
+            />
+
+            {storageType === 'committee' && (
+              <Select
+                label="Committee"
+                placeholder="Pick a committee"
+                data={sigs.map((sig) => ({ value: String(sig.id), label: sig.name }))}
+                value={owningGroup}
+                onChange={setOwningGroup}
+                searchable
+                clearable
+                nothingFoundMessage="No committees"
+                data-testid="assign-group"
+              />
+            )}
+
+            <TextInput
+              label={storageType === 'committee' ? 'Occupant label (optional)' : 'Occupant'}
+              description={
+                storageType === 'committee'
+                  ? 'Only needed when the committee is not in the list.'
+                  : 'Who this is for — a crew, an instructor, a class.'
+              }
+              value={occupantLabel}
+              onChange={(event) => setOccupantLabel(event.currentTarget.value)}
+              data-testid="assign-label"
+            />
+
+            <Textarea
+              label="Notes"
+              value={notes}
+              onChange={(event) => setNotes(event.currentTarget.value)}
+              autosize
+              minRows={2}
+              data-testid="assign-notes"
+            />
+
+            <Group justify="flex-end">
+              <Button variant="default" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button
+                onClick={submitAssign}
+                disabled={!assignValid || submitting}
+                data-testid="assign-submit"
+              >
+                Assign slot
+              </Button>
+            </Group>
+          </Stack>
+        )}
+      </Stack>
+    </Modal>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+const StorageOverviewPage: React.FC = () => {
+  const [overview, setOverview] = useState<StorageOverview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [rackFilter, setRackFilter] = useState<string>('all');
+  // Remembered across loads: narrowing to one rack means the response no
+  // longer mentions the others, and the selector must not lose them.
+  const [knownRacks, setKnownRacks] = useState<number[]>([]);
+  const [picked, setPicked] = useState<StorageOverviewCell | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await storageOverviewAPI.get(
+        rackFilter === 'all' ? undefined : { rack: Number(rackFilter) },
+      );
+      const data = res?.data ?? null;
+      setOverview(data);
+      const racks = data?.racks?.map((rack) => rack.rack) ?? [];
+      setKnownRacks((current) => [...new Set([...current, ...racks])].sort((a, b) => a - b));
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Failed to load the storage overview.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [rackFilter]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Memoised so the counts below don't recompute on every render just
+  // because the fallback [] is a fresh array each time.
+  const racks = useMemo(() => overview?.racks ?? [], [overview]);
+
+  // The counts worth having on a phone: how many tiles are shouting, and
+  // how much room is left.
+  const totals = useMemo(() => {
+    let attention = 0;
+    let occupied = 0;
+    let free = 0;
+    racks.forEach((rack) =>
+      rack.rows.forEach((row) =>
+        row.cells.forEach((cell) => {
+          if (!cell) return;
+          if (cell.color) attention += 1;
+          if (cell.type) occupied += 1;
+          else if (cell.is_active) free += 1;
+        }),
+      ),
+    );
+    return { attention, occupied, free };
+  }, [racks]);
+
+  return (
+    <WorkspacePage
+      testId="storage-overview-page"
+      hero={{
+        eyebrow: 'Facilities',
+        title: 'Storage overview',
+        description:
+          'Every rack at a glance — P for a member project, C/L/E for committee, logistics ' +
+          'and class storage. Coloured tiles are the ones to go fix: yellow is expiring, red ' +
+          'has expired and needs to move to purgatory. Tap a tile to open the slot.',
+        action: (
+          <Group gap="sm">
+            <Button component={Link} to="/facilities/project-storage/slots" variant="light">
+              Storage slots
+            </Button>
+            <Button component={Link} to="/facilities/project-storage/queue" variant="light">
+              Storage queue
+            </Button>
+          </Group>
+        ),
+      }}
+    >
+      <Stack gap="md">
+        <Paper p="md" withBorder>
+          <Group justify="space-between" wrap="wrap" gap="sm">
+            <Group gap="sm" wrap="wrap">
+              <SegmentedControl
+                value={rackFilter}
+                onChange={setRackFilter}
+                data={[
+                  { label: 'All racks', value: 'all' },
+                  ...knownRacks.map((rack) => ({ label: `Rack ${rack}`, value: String(rack) })),
+                ]}
+                data-testid="rack-filter"
+              />
+              <Button
+                variant="light"
+                leftSection={<IconRefresh size={16} />}
+                onClick={load}
+                data-testid="refresh-overview"
+              >
+                Refresh
+              </Button>
+            </Group>
+
+            <Group gap="sm" wrap="wrap">
+              <Badge color={totals.attention > 0 ? 'red' : 'gray'} variant="light" data-testid="count-attention">
+                {totals.attention} need attention
+              </Badge>
+              <Badge variant="light" data-testid="count-occupied">
+                {totals.occupied} in use
+              </Badge>
+              <Badge color="teal" variant="light" data-testid="count-free">
+                {totals.free} free
+              </Badge>
+            </Group>
+          </Group>
+        </Paper>
+
+        <Legend />
+
+        {error && (
+          <Alert color="red" variant="light" data-testid="overview-error">
+            {error}
+          </Alert>
+        )}
+
+        {loading ? (
+          <Group justify="center" p="xl">
+            <Loader />
+          </Group>
+        ) : racks.length === 0 ? (
+          <Paper p="xl" withBorder>
+            <Text c="dimmed" ta="center" data-testid="overview-empty">
+              No racking to show yet. Lay out a rack on the{' '}
+              <Anchor component={Link} to="/facilities/project-storage/slots">
+                slots console
+              </Anchor>
+              .
+            </Text>
+          </Paper>
+        ) : (
+          // Stacked vertically: on a phone one rack fills the screen, and
+          // scrolling past the healthy ones is how you find the coloured tile.
+          racks.map((rack) => <RackGrid key={rack.rack} rack={rack} onPick={setPicked} />)
+        )}
+
+        {overview?.generated_at && (
+          <Text size="xs" c="dimmed" data-testid="overview-generated">
+            Generated {new Date(overview.generated_at).toLocaleString()}
+          </Text>
+        )}
+      </Stack>
+
+      <SlotDetailModal cell={picked} onClose={() => setPicked(null)} onChanged={load} />
+    </WorkspacePage>
+  );
+};
+
+export default StorageOverviewPage;

--- a/frontend/src/pages/StorageSlotsPage.tsx
+++ b/frontend/src/pages/StorageSlotsPage.tsx
@@ -729,9 +729,14 @@ const StorageSlotsPage: React.FC = () => {
           'in each one, and print the cards that send a member to the kiosk with the slot ' +
           'already chosen.',
         action: (
-          <Button component={Link} to="/facilities/project-storage/queue" variant="light">
-            Storage queue
-          </Button>
+          <Group gap="sm">
+            <Button component={Link} to="/facilities/project-storage/overview" variant="light">
+              Rack overview
+            </Button>
+            <Button component={Link} to="/facilities/project-storage/queue" variant="light">
+              Storage queue
+            </Button>
+          </Group>
         ),
       }}
     >

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,7 +2,7 @@
  * API service for communicating with the Django backend
  */
 import axios from 'axios';
-import { ActiveMaintenanceRow, Asset, AssetCostRecoveryReport, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, GenerateRackRequest, GenerateRackResult, InventoryItem, InventoryItemMetrics, ItemCountMode, ItemOnHandDisplay, ItemPurchaseHistory, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LogUsageRequest, LogUsageResponse, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, MaintenanceTool, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, StockHistory, StorageSlot, StorageSlotCardPreview, Supplier, SupplierAgreement, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderAdHocMaterialInput, WorkOrderLotoCompletion, WorkOrderMaterialUsage, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
+import { ActiveMaintenanceRow, Asset, AssetCostRecoveryReport, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, AssignSlotRequest, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, GenerateRackRequest, GenerateRackResult, InventoryItem, InventoryItemMetrics, ItemCountMode, ItemOnHandDisplay, ItemPurchaseHistory, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LogUsageRequest, LogUsageResponse, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, MaintenanceTool, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, StockHistory, StorageAssignment, StorageAssignmentType, StorageOverview, StorageSlot, StorageSlotCardPreview, Supplier, SupplierAgreement, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderAdHocMaterialInput, WorkOrderLotoCompletion, WorkOrderMaterialUsage, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
 
 /**
  * Resolves the API base URL based on environment.
@@ -4896,6 +4896,49 @@ export const storageSlotsAPI = {
     api.post('/project-storage/slots/cards/', data, {
       responseType: 'blob',
     }),
+};
+
+// The glanceable rack board: one payload shaped like the racking rather
+// than like the tables behind it. Staff / storage-admin only — it names
+// every member with something on the shelves.
+export const storageOverviewAPI = {
+  // `rack` narrows to one rack server-side, which is what a phone wants
+  // once the shop has more racks than fit on a screen.
+  get: (params?: { rack?: number }) =>
+    api.get<StorageOverview>('/project-storage/overview/', { params }),
+};
+
+// Committee / logistics / class holdings — the staff-assigned half of slot
+// occupancy. No expiry, no purgatory: the lifecycle is assign → release,
+// and both ends are staff-gated (IsStorageAdminOrStaff).
+export const storageAssignmentsAPI = {
+  // ?active=true is the console read ("who holds what right now?"); the
+  // unfiltered list is every holding the racking has ever had. Booleans go
+  // over the wire as strings — the filters are hand-rolled query params.
+  list: (params?: {
+    active?: 'true' | 'false';
+    storage_type?: StorageAssignmentType;
+    rack?: number;
+    slot_code?: string;
+    page?: number;
+  }) =>
+    api.get<{
+      count: number;
+      next: string | null;
+      previous: string | null;
+      results: StorageAssignment[];
+    }>('/project-storage/assignments/', { params }),
+
+  // 409 when anything already holds the slot: `slot_occupied` for a
+  // member's live stint (the warden can clear that themselves) vs
+  // `slot_assigned` for another holding (staff has to hand it back).
+  assign: (data: AssignSlotRequest) =>
+    api.post<StorageAssignment>('/project-storage/assignments/assign/', data),
+
+  // Frees the slot by stamping released_at, not by deleting: the record of
+  // the two years the welding SIG held it survives.
+  release: (id: number) =>
+    api.post<StorageAssignment>(`/project-storage/assignments/${id}/release/`),
 };
 
 // Universal scanner dispatcher — resolves any barcode/QR payload to an

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2139,7 +2139,13 @@ export interface StorageSlot {
   notes: string;
   /** Permanent tag36h10 marker printed on the card; null if the pool ran dry. */
   april_tag_id: number | null;
+  /** A member's live project stint (type P), if one holds the slot. */
   current_stint: StorageSlotOccupant | null;
+  /** A live committee/logistics/class holding (C/L/E), if one does instead. */
+  current_assignment: StorageSlotAssignmentSummary | null;
+  /** Letter of whichever occupancy is live — P/C/L/E, null when free. */
+  occupancy_type: StorageTypeLetter | null;
+  /** True for either kind of occupant: neither slot is free to hand out. */
   is_occupied: boolean;
   created_at: string;
   updated_at: string;
@@ -2184,4 +2190,117 @@ export interface StorageSlotCardPreview {
   preview: string;
   kiosk_url: string;
   april_tag_id: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Storage assignments (the C/L/E half of occupancy) + the overview grid
+// ---------------------------------------------------------------------------
+
+/**
+ * The letter a slot paints in the overview: P for a member's project stint,
+ * C/L/E for the three staff-assigned kinds. "E" is class because C is
+ * already committee's — the grid has one character per cell to work with.
+ */
+export type StorageTypeLetter = 'P' | 'C' | 'L' | 'E';
+
+/** The three non-Project storage kinds. Staff-assigned, long-term. */
+export type StorageAssignmentType = 'committee' | 'logistics' | 'class';
+
+/**
+ * The live C/L/E holding of a slot, as StorageSlotSerializer nests it —
+ * enough to say who has the slot and to release it, without the audit and
+ * notes fields the full assignment carries.
+ */
+export interface StorageSlotAssignmentSummary {
+  id: number;
+  storage_type: StorageAssignmentType;
+  type_letter: StorageTypeLetter;
+  occupant_display: string;
+  assigned_at: string;
+}
+
+/**
+ * One committee/logistics/class holding, full shape.
+ *
+ * Unlike a member's stint this has no clock: no expiry, no violation
+ * notice, no purgatory. It runs until staff release it, and
+ * `released_at` (null while live) is what "active" means.
+ */
+export interface StorageAssignment {
+  id: number;
+  slot: number;
+  slot_code: string;
+  storage_type: StorageAssignmentType;
+  storage_type_display: string;
+  type_letter: StorageTypeLetter;
+  /** The committee (an auth.Group / SIG), for committee assignments. */
+  owning_group: number | null;
+  owning_group_name: string;
+  /** Free-text occupant, for logistics/class. */
+  occupant_label: string;
+  /** Group name if there is one, else the label — who to show in the grid. */
+  occupant_display: string;
+  assigned_by: number | null;
+  assigned_by_name: string;
+  assigned_at: string;
+  released_at: string | null;
+  is_active: boolean;
+  notes: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Payload for POST /project-storage/assignments/assign/. */
+export interface AssignSlotRequest {
+  /** Slot pk or code — "1A1" and 12 are both accepted. */
+  slot: string;
+  storage_type: StorageAssignmentType;
+  owning_group?: number | null;
+  occupant_label?: string;
+  notes?: string;
+}
+
+/**
+ * One cell of the overview grid.
+ *
+ * `color` is set by the server and **only ever for type P** — a committee
+ * slot has been the committee's for two years and will be tomorrow, so
+ * painting it would drown out the one late member project the screen
+ * exists to surface.
+ */
+export interface StorageOverviewCell {
+  code: string;
+  slot_id: number;
+  position: number;
+  /** null for an empty slot. */
+  type: StorageTypeLetter | null;
+  /** A stint's own status for P; 'occupied' for C/L/E; 'empty' otherwise. */
+  status: ProjectStorageStatus | 'occupied' | 'empty';
+  color: 'yellow' | 'red' | null;
+  occupant: string;
+  /** The slot's in-service flag — a retired slot is empty but not available. */
+  is_active: boolean;
+}
+
+export interface StorageOverviewRow {
+  level: string;
+  /**
+   * Dense and 1-indexed: entry *i* is position *i + 1*, and a hole in the
+   * racking is null, so every row of a rack lines up without the renderer
+   * re-deriving which columns exist.
+   */
+  cells: (StorageOverviewCell | null)[];
+}
+
+export interface StorageOverviewRack {
+  rack: number;
+  /** Descending — high shelf first, ground level last, like the steel. */
+  levels: string[];
+  max_position: number;
+  rows: StorageOverviewRow[];
+}
+
+export interface StorageOverview {
+  racks: StorageOverviewRack[];
+  generated_at: string;
 }


### PR DESCRIPTION
## What

The **web storage overview** — the rack status board you pull up on a phone — plus the staff assign/release UI for the non-Project types. Renders the `status_overview` endpoint (#994). Final web PR of the storage-slots epic.

### `StorageOverviewPage`
- One tile per slot, **laid out the way the steel is**: a row per level, high levels first (Z overhead → A at your feet), positions across, holes left blank.
- **Only Project storage is colored, and the server decides** — the page paints the `yellow`/`red` the endpoint sends (yellow = expiring soon, red = expired+), so it can't drift from the backend. A healthy rack is a wall of plain tiles and the one late member project is the thing that jumps out. Committee/Logistics/Class read as plain "occupied"; empty vs. out-of-service are distinguished.
- Type letters `P`/`C`/`L`/`E`, per-cell occupant, rack selector, and accessible text-on-tile contrast in both themes.

### Assign / release (staff-gated)
Assign a free slot to a **Committee** (owning group) / **Logistics** / **Class** (occupant label), and release it — the staff-assigned half of occupancy (`storageAssignmentsAPI` → `/assignments/assign/` + release).

### Plumbing
`storageOverviewAPI` (`/project-storage/overview/`) and `storageAssignmentsAPI`; `StorageOverview` / `StorageOverviewCell` / `StorageAssignment` / `AssignSlotRequest` types.

## Verification
- node24 `npm run lint` — **0 errors** (only pre-existing warnings).
- New + touched tests **25/25 pass** (`StorageOverviewPage.test.tsx` (508 ln), `StorageSlotsPage`, `ProjectStorageKioskPage.slot`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
