### PR TITLE
Resilience: service-status registry + public status API (op-kyfi)

### DIFF
--- a/backend/config/api_permission_matrix.yaml
+++ b/backend/config/api_permission_matrix.yaml
@@ -2810,6 +2810,9 @@ views:
       update:
         permission_classes:
         - IsAuthenticated
+  resilience.views.ResilienceStatusView:
+    permission_classes:
+    - IsAuthenticated
   scanner.views.dispatch_scan:
     permission_classes:
     - AllowAny

--- a/backend/config/tests/test_permission_matrix.py
+++ b/backend/config/tests/test_permission_matrix.py
@@ -68,6 +68,7 @@ def test_permission_matrix_covers_documented_apps():
         "membership.views",
         "notifications.views",
         "reorder_queue.views",
+        "resilience.views",
         "screens.views",
         "search.views",
         "vendors.views",

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -79,6 +79,9 @@ urlpatterns = [
     path("api/storage-vision/", include("storage_vision.urls")),
     path("api/interlocks/", include("interlocks.urls")),
     path("api/accounting/", include("accounting.urls")),
+    # Circuit-breaker health as a user-facing status board, so the web app
+    # and ScanTTY can say which capability is down instead of failing silently.
+    path("api/resilience/", include("resilience.urls")),
     # Flower proxy (superuser only)
     path("flower/", include("config.flower_urls")),
 ]

--- a/backend/resilience/circuit.py
+++ b/backend/resilience/circuit.py
@@ -47,6 +47,18 @@ class BaseStorage:
     def state(self, name: str) -> str:
         raise NotImplementedError
 
+    def states(self, prefix: str = "") -> dict[str, str]:
+        """Every breaker name known to this storage that starts with
+        ``prefix``, mapped to its current state.
+
+        Only breakers that have actually recorded state are listed — a
+        breaker that has never transitioned has nothing stored and is
+        (correctly) treated as an unknown, healthy member. Used by
+        :mod:`resilience.services` to aggregate dynamic breaker families
+        such as ``webhook:<id>``.
+        """
+        raise NotImplementedError
+
     def trip_open(self, name: str) -> None:
         raise NotImplementedError
 
@@ -78,6 +90,12 @@ class InMemoryStorage(BaseStorage):
     def state(self, name: str) -> str:
         with self._lock:
             return self._row(name)["state"]
+
+    def states(self, prefix: str = "") -> dict[str, str]:
+        with self._lock:
+            return {
+                name: row["state"] for name, row in self._rows.items() if name.startswith(prefix)
+            }
 
     def trip_open(self, name: str) -> None:
         with self._lock:
@@ -113,12 +131,28 @@ class RedisStorage(BaseStorage):
     """Fleet-shared state in Redis. Minor races during a transition are
     acceptable for a circuit breaker (worst case: a few extra trial calls)."""
 
+    #: Characters SCAN's MATCH pattern treats as glob syntax.
+    _GLOB_META = "\\*?[]"
+
     def __init__(self, client, prefix: str = "cb:") -> None:
         self._r = client
         self._p = prefix
 
     def _k(self, name: str, field: str) -> str:
         return f"{self._p}{name}:{field}"
+
+    def _name_from_key(self, key: str) -> str:
+        """``cb:webhook:12:state`` -> ``webhook:12``. Empty when the key is
+        not a state key (breaker names may themselves contain colons, so we
+        strip the fixed prefix/suffix rather than splitting)."""
+        if not key.startswith(self._p) or not key.endswith(":state"):
+            return ""
+        return key[len(self._p) : -len(":state")]
+
+    @classmethod
+    def _escape_glob(cls, value: str) -> str:
+        """Escape Redis glob metacharacters so a literal prefix stays literal."""
+        return "".join(f"\\{ch}" if ch in cls._GLOB_META else ch for ch in value)
 
     @staticmethod
     def _decode(value):
@@ -134,6 +168,27 @@ class RedisStorage(BaseStorage):
         except Exception:  # noqa: BLE001 — Redis down must not break callers
             logger.debug("Circuit '%s': redis state read failed", name, exc_info=True)
             return STATE_CLOSED
+
+    def states(self, prefix: str = "") -> dict[str, str]:
+        # SCAN, never KEYS: prod Redis is shared and KEYS blocks the server
+        # for the whole keyspace. Same degrade-gracefully contract as the
+        # rest of this class — a Redis outage yields {} (every member reads
+        # as healthy) instead of raising into the caller.
+        try:
+            pattern = f"{self._p}{self._escape_glob(prefix)}*:state"
+            keys = [self._decode(key) for key in self._r.scan_iter(match=pattern, count=200)]
+            if not keys:
+                return {}
+            values = self._r.mget(keys)
+            found: dict[str, str] = {}
+            for key, value in zip(keys, values):
+                name = self._name_from_key(key)
+                if name:
+                    found[name] = self._decode(value) or STATE_CLOSED
+            return found
+        except Exception:  # noqa: BLE001
+            logger.debug("Circuit scan for prefix '%s' failed", prefix, exc_info=True)
+            return {}
 
     def trip_open(self, name: str) -> None:
         try:

--- a/backend/resilience/serializers.py
+++ b/backend/resilience/serializers.py
@@ -1,0 +1,46 @@
+"""Response serializers for the public service-status endpoint.
+
+Read-only: these render the plain dicts built by
+:mod:`resilience.services`. They exist so drf-spectacular publishes the
+exact response shape the frontend (PR3) and ScanTTY (PR4) consume, and so
+timestamps serialize in DRF's canonical ``...Z`` form.
+"""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+
+class ServiceStatusSerializer(serializers.Serializer):
+    """One user-facing capability and whether it currently works."""
+
+    key = serializers.CharField(help_text="Stable machine key, e.g. 'device_control'.")
+    label = serializers.CharField(help_text="User-facing service name.")
+    description = serializers.CharField(help_text="What the user loses while degraded.")
+    state = serializers.ChoiceField(
+        choices=["closed", "half_open", "open"],
+        help_text="Aggregate breaker state: closed (working), half_open (on trial), open (down).",
+    )
+    healthy = serializers.BooleanField(help_text="True when state is 'closed'.")
+    since = serializers.DateTimeField(
+        allow_null=True,
+        help_text="When the service entered its current state; null if it never transitioned.",
+    )
+    last_error = serializers.CharField(
+        allow_null=True,
+        help_text="Error detail recorded on that transition; null when there is none.",
+    )
+    degraded_count = serializers.IntegerField(
+        help_text="Member breakers currently open or half-open."
+    )
+    total_count = serializers.IntegerField(
+        help_text="Member breakers with known state (1 for single-breaker services)."
+    )
+
+
+class ResilienceStatusSerializer(serializers.Serializer):
+    """Payload of ``GET /api/resilience/status/``."""
+
+    degraded = serializers.BooleanField(help_text="True when any service is not healthy.")
+    checked_at = serializers.DateTimeField(help_text="When this snapshot was taken.")
+    services = ServiceStatusSerializer(many=True)

--- a/backend/resilience/services.py
+++ b/backend/resilience/services.py
@@ -1,0 +1,208 @@
+"""User-facing service-status registry over the circuit breakers.
+
+``resilience.circuit`` knows about *breakers* — machine names like ``mqtt``
+or ``webhook:12``. Members do not. This module maps breakers onto the
+capability a person actually loses when one trips ("Device control",
+"Turning equipment on and off remotely") so the web app and ScanTTY can say
+so out loud instead of failing silently.
+
+Two kinds of entry live in :data:`SERVICE_REGISTRY`:
+
+* a fixed ``breaker`` name — one breaker, one service;
+* a ``breaker_prefix`` for a dynamic family (``webhook:<id>``), which
+  aggregates every member breaker: the family reads degraded when *any*
+  member is open/half-open, and reports ``degraded_count`` /
+  ``total_count`` so the UI can say "3 of 12 endpoints degraded".
+
+Deliberately non-sensitive: labels and states only. Never breaker config,
+URLs, credentials, or endpoint hostnames — the status endpoint is readable
+by every authenticated member.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.conf import settings
+from django.db.models import Q
+from django.utils import timezone
+
+from .circuit import STATE_CLOSED, STATE_HALF_OPEN, STATE_OPEN, BaseStorage, default_storage
+
+#: States a member counts as "degraded" in. Half-open is degraded on
+#: purpose: the dependency is still on trial and calls may still fail.
+DEGRADED_STATES = (STATE_OPEN, STATE_HALF_OPEN)
+
+
+@dataclass(frozen=True)
+class ServiceDescriptor:
+    """One user-facing capability backed by one breaker or one breaker family."""
+
+    key: str
+    """Stable machine key for the frontend/ScanTTY to switch on."""
+
+    label: str
+    """User-facing name, e.g. "Device control"."""
+
+    description: str
+    """What the user loses while this is degraded."""
+
+    breaker: str = ""
+    """Exact breaker name. Mutually exclusive with ``breaker_prefix``."""
+
+    breaker_prefix: str = ""
+    """Prefix for a dynamic family, e.g. ``"webhook:"``."""
+
+    def __post_init__(self) -> None:
+        if bool(self.breaker) == bool(self.breaker_prefix):
+            raise ValueError(
+                f"ServiceDescriptor '{self.key}' must set exactly one of "
+                "breaker / breaker_prefix"
+            )
+
+
+SERVICE_REGISTRY: tuple[ServiceDescriptor, ...] = (
+    ServiceDescriptor(
+        key="device_control",
+        label="Device control",
+        description="Turning equipment on and off remotely",
+        breaker="mqtt",
+    ),
+    ServiceDescriptor(
+        key="webhooks",
+        label="Webhook delivery",
+        description="Notifying connected external systems",
+        breaker_prefix="webhook:",
+    ),
+    ServiceDescriptor(
+        key="whmcs",
+        label="Maker Box billing",
+        description="Maker Box subscription and billing lookups",
+        breaker="whmcs",
+    ),
+    ServiceDescriptor(
+        key="common_api",
+        label="Member directory",
+        description="Member lookups from the shared directory",
+        breaker="common_api",
+    ),
+    # Seam for PR2: once outbound mail routes through a breaker, add
+    #     ServiceDescriptor(key="email", label="Email delivery", ...,
+    #                       breaker="postmark")
+    # here. Nothing else changes — the status endpoint renders whatever this
+    # tuple contains.
+)
+
+
+def _breakers_enabled() -> bool:
+    return bool(getattr(settings, "CIRCUIT_BREAKERS_ENABLED", True))
+
+
+def _member_states(descriptor: ServiceDescriptor, storage: BaseStorage) -> dict[str, str]:
+    """Current state of every known member breaker for ``descriptor``."""
+    if descriptor.breaker_prefix:
+        return storage.states(descriptor.breaker_prefix)
+    return {descriptor.breaker: storage.state(descriptor.breaker)}
+
+
+def _aggregate_state(member_states: dict[str, str]) -> str:
+    """Worst state across the family: open beats half-open beats closed."""
+    values = set(member_states.values())
+    if STATE_OPEN in values:
+        return STATE_OPEN
+    if STATE_HALF_OPEN in values:
+        return STATE_HALF_OPEN
+    return STATE_CLOSED
+
+
+def _latest_transitions(pairs: set[tuple[str, str]]) -> dict[str, tuple]:
+    """Most recent ``CircuitBreakerEvent`` per breaker name, for the given
+    ``(name, to_state)`` pairs — one query for all names, never N+1.
+
+    ``order_by("name", "-created_at")`` rides the model's
+    ``(name, -created_at)`` index, so taking the first row per name is an
+    index scan rather than a sort.
+    """
+    if not pairs:
+        return {}
+
+    from .models import CircuitBreakerEvent
+
+    query = Q()
+    for name, state in sorted(pairs):
+        query |= Q(name=name, to_state=state)
+
+    latest: dict[str, tuple] = {}
+    rows = (
+        CircuitBreakerEvent.objects.filter(query)
+        .order_by("name", "-created_at")
+        .values_list("name", "created_at", "detail")
+    )
+    for name, created_at, detail in rows.iterator():
+        if name not in latest:
+            latest[name] = (created_at, detail or None)
+    return latest
+
+
+def _attribution_name(member_states: dict[str, str], state: str) -> str:
+    """Which member breaker explains the service's state — the first member
+    sitting in that state (deterministic by name so repeated calls agree)."""
+    matching = sorted(name for name, value in member_states.items() if value == state)
+    return matching[0] if matching else ""
+
+
+def service_statuses(storage: BaseStorage | None = None) -> list[dict]:
+    """Per-service status rows for every entry in :data:`SERVICE_REGISTRY`.
+
+    When ``CIRCUIT_BREAKERS_ENABLED`` is off, breaker state is not consulted
+    at all and every service reports closed/healthy — stale keys from a
+    previous run with the feature on must not surface as a fake outage.
+    """
+    enabled = _breakers_enabled()
+    storage = storage if storage is not None else default_storage()
+
+    resolved: list[tuple[ServiceDescriptor, dict[str, str], str, str]] = []
+    for descriptor in SERVICE_REGISTRY:
+        if not enabled:
+            # Families have no known members while disabled; a fixed breaker
+            # is still one service, reported closed. No attribution either:
+            # a transition recorded while the feature was on is not history
+            # for a state we are asserting rather than observing.
+            member_states = {descriptor.breaker: STATE_CLOSED} if descriptor.breaker else {}
+            resolved.append((descriptor, member_states, STATE_CLOSED, ""))
+            continue
+        member_states = _member_states(descriptor, storage)
+        state = _aggregate_state(member_states)
+        resolved.append((descriptor, member_states, state, _attribution_name(member_states, state)))
+
+    transitions = _latest_transitions({(name, state) for _, _, state, name in resolved if name})
+
+    rows: list[dict] = []
+    for descriptor, member_states, state, attributed_to in resolved:
+        since, last_error = transitions.get(attributed_to, (None, None))
+        rows.append(
+            {
+                "key": descriptor.key,
+                "label": descriptor.label,
+                "description": descriptor.description,
+                "state": state,
+                "healthy": state == STATE_CLOSED,
+                "since": since,
+                "last_error": last_error,
+                "degraded_count": sum(
+                    1 for value in member_states.values() if value in DEGRADED_STATES
+                ),
+                "total_count": len(member_states),
+            }
+        )
+    return rows
+
+
+def status_snapshot(storage: BaseStorage | None = None) -> dict:
+    """The full payload behind ``GET /api/resilience/status/``."""
+    services = service_statuses(storage)
+    return {
+        "degraded": any(not service["healthy"] for service in services),
+        "checked_at": timezone.now(),
+        "services": services,
+    }

--- a/backend/resilience/tests/test_circuit.py
+++ b/backend/resilience/tests/test_circuit.py
@@ -1,3 +1,5 @@
+import fnmatch
+
 import pytest
 
 from resilience.circuit import (
@@ -182,6 +184,12 @@ class _FakeRedis:
     def expire(self, key, seconds):
         return True
 
+    def mget(self, keys):
+        return [self.kv.get(key) for key in keys]
+
+    def scan_iter(self, match=None, count=None):
+        return iter(fnmatch.filter(list(self.kv), match) if match else list(self.kv))
+
 
 class _BrokenRedis:
     """Every operation raises — models a Redis outage."""
@@ -189,7 +197,7 @@ class _BrokenRedis:
     def _down(self, *args, **kwargs):
         raise RuntimeError("redis down")
 
-    get = set = delete = incr = expire = _down
+    get = set = delete = incr = expire = mget = scan_iter = _down
 
 
 class TestRedisStorage:
@@ -214,9 +222,65 @@ class TestRedisStorage:
         assert storage.state("x") == STATE_CLOSED
         assert storage.record_failure("x", 60) == 0
         assert storage.opened_at("x") == 0.0
+        assert storage.states("webhook:") == {}
         storage.trip_open("x")
         storage.to_half_open("x")
         storage.close("x")
+
+    def test_states_enumerates_a_prefix_family(self):
+        storage = RedisStorage(_FakeRedis())
+        storage.trip_open("webhook:1")
+        storage.to_half_open("webhook:2")
+        storage.close("webhook:3")
+        storage.trip_open("mqtt")
+
+        assert storage.states("webhook:") == {
+            "webhook:1": STATE_OPEN,
+            "webhook:2": STATE_HALF_OPEN,
+            "webhook:3": STATE_CLOSED,
+        }
+        # An empty prefix enumerates everything; unrelated breakers are not
+        # swept into a family.
+        assert storage.states()["mqtt"] == STATE_OPEN
+
+    def test_states_uses_scan_not_keys(self):
+        """Prod Redis is shared — KEYS would block the whole server."""
+        client = _FakeRedis()
+        client.keys = lambda *a, **kw: pytest.fail("RedisStorage must not call KEYS")
+        storage = RedisStorage(client)
+        storage.trip_open("webhook:1")
+        assert storage.states("webhook:") == {"webhook:1": STATE_OPEN}
+
+    def test_states_ignores_non_state_keys(self):
+        storage = RedisStorage(_FakeRedis())
+        # record_failure writes cb:webhook:9:failures; trip_open also writes
+        # cb:webhook:9:opened_at. Neither is a state key.
+        storage.record_failure("webhook:9", 60)
+        assert storage.states("webhook:") == {}
+        storage.trip_open("webhook:9")
+        assert storage.states("webhook:") == {"webhook:9": STATE_OPEN}
+
+    def test_escape_glob_keeps_a_literal_prefix_literal(self):
+        assert RedisStorage._escape_glob("webhook:") == "webhook:"
+        assert RedisStorage._escape_glob("odd*name[") == "odd\\*name\\["
+
+
+def test_in_memory_states_filters_by_prefix():
+    storage = InMemoryStorage()
+    storage.trip_open("webhook:1")
+    storage.close("webhook:2")
+    storage.trip_open("mqtt")
+
+    assert storage.states("webhook:") == {"webhook:1": STATE_OPEN, "webhook:2": STATE_CLOSED}
+    assert storage.states("mqtt") == {"mqtt": STATE_OPEN}
+    assert storage.states("nothing-here:") == {}
+
+
+def test_base_storage_states_is_abstract():
+    from resilience.circuit import BaseStorage
+
+    with pytest.raises(NotImplementedError):
+        BaseStorage().states("x")
 
 
 def test_breaker_trips_over_redis_storage():

--- a/backend/resilience/tests/test_services.py
+++ b/backend/resilience/tests/test_services.py
@@ -1,0 +1,176 @@
+"""Service-status registry: descriptor validity and family aggregation."""
+
+import pytest
+
+from resilience.circuit import STATE_CLOSED, STATE_HALF_OPEN, STATE_OPEN, InMemoryStorage
+from resilience.services import (
+    SERVICE_REGISTRY,
+    ServiceDescriptor,
+    service_statuses,
+    status_snapshot,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def breakers_on(settings):
+    """Settings disable breakers under pytest; the resilience suite opts back in."""
+    settings.CIRCUIT_BREAKERS_ENABLED = True
+    settings.CIRCUIT_BREAKER_USE_REDIS = False
+
+
+@pytest.fixture
+def storage():
+    return InMemoryStorage()
+
+
+def _by_key(rows) -> dict:
+    return {row["key"]: row for row in rows}
+
+
+class TestRegistry:
+    def test_registers_the_four_wired_breakers(self):
+        registry = {descriptor.key: descriptor for descriptor in SERVICE_REGISTRY}
+        assert set(registry) == {"device_control", "webhooks", "whmcs", "common_api"}
+        assert registry["device_control"].breaker == "mqtt"
+        assert registry["webhooks"].breaker_prefix == "webhook:"
+        assert registry["whmcs"].breaker == "whmcs"
+        assert registry["common_api"].breaker == "common_api"
+
+    def test_keys_and_labels_are_unique(self):
+        keys = [descriptor.key for descriptor in SERVICE_REGISTRY]
+        assert len(keys) == len(set(keys))
+        labels = [descriptor.label for descriptor in SERVICE_REGISTRY]
+        assert len(labels) == len(set(labels))
+
+    def test_descriptor_requires_exactly_one_of_breaker_or_prefix(self):
+        with pytest.raises(ValueError):
+            ServiceDescriptor(key="k", label="L", description="d")
+        with pytest.raises(ValueError):
+            ServiceDescriptor(key="k", label="L", description="d", breaker="a", breaker_prefix="a:")
+
+
+class TestSingleBreakerServices:
+    def test_untouched_breaker_reports_healthy(self, storage):
+        row = _by_key(service_statuses(storage))["device_control"]
+        assert row["state"] == STATE_CLOSED
+        assert row["healthy"] is True
+        assert row["since"] is None
+        assert row["last_error"] is None
+        assert row["degraded_count"] == 0
+        assert row["total_count"] == 1
+
+    def test_open_breaker_reports_degraded(self, storage):
+        storage.trip_open("mqtt")
+        row = _by_key(service_statuses(storage))["device_control"]
+        assert row["state"] == STATE_OPEN
+        assert row["healthy"] is False
+        assert row["degraded_count"] == 1
+        assert row["total_count"] == 1
+
+    def test_half_open_counts_as_degraded(self, storage):
+        storage.to_half_open("whmcs")
+        row = _by_key(service_statuses(storage))["whmcs"]
+        assert row["state"] == STATE_HALF_OPEN
+        assert row["healthy"] is False
+        assert row["degraded_count"] == 1
+
+    def test_one_degraded_service_does_not_degrade_the_others(self, storage):
+        storage.trip_open("common_api")
+        rows = _by_key(service_statuses(storage))
+        assert rows["common_api"]["healthy"] is False
+        assert rows["device_control"]["healthy"] is True
+        assert rows["whmcs"]["healthy"] is True
+
+
+class TestWebhookFamilyAggregation:
+    def test_aggregates_member_breakers(self, storage):
+        storage.trip_open("webhook:1")
+        storage.to_half_open("webhook:2")
+        storage.close("webhook:3")
+
+        row = _by_key(service_statuses(storage))["webhooks"]
+        # Worst member wins, so the family reads open.
+        assert row["state"] == STATE_OPEN
+        assert row["healthy"] is False
+        assert row["degraded_count"] == 2
+        assert row["total_count"] == 3
+
+    def test_family_is_half_open_when_no_member_is_open(self, storage):
+        storage.to_half_open("webhook:1")
+        storage.close("webhook:2")
+        row = _by_key(service_statuses(storage))["webhooks"]
+        assert row["state"] == STATE_HALF_OPEN
+        assert row["healthy"] is False
+        assert row["degraded_count"] == 1
+        assert row["total_count"] == 2
+
+    def test_all_members_closed_is_healthy(self, storage):
+        storage.close("webhook:1")
+        storage.close("webhook:2")
+        row = _by_key(service_statuses(storage))["webhooks"]
+        assert row["state"] == STATE_CLOSED
+        assert row["healthy"] is True
+        assert row["degraded_count"] == 0
+        assert row["total_count"] == 2
+
+    def test_no_known_members_is_healthy_with_zero_counts(self, storage):
+        row = _by_key(service_statuses(storage))["webhooks"]
+        assert row["healthy"] is True
+        assert row["degraded_count"] == 0
+        assert row["total_count"] == 0
+
+    def test_other_breakers_are_not_swept_into_the_family(self, storage):
+        storage.trip_open("mqtt")
+        storage.trip_open("whmcs")
+        row = _by_key(service_statuses(storage))["webhooks"]
+        assert row["healthy"] is True
+        assert row["total_count"] == 0
+
+
+class TestSnapshot:
+    def test_degraded_flag_reflects_any_unhealthy_service(self, storage):
+        assert status_snapshot(storage)["degraded"] is False
+        storage.trip_open("webhook:7")
+        assert status_snapshot(storage)["degraded"] is True
+
+    def test_snapshot_lists_every_registered_service(self, storage):
+        snapshot = status_snapshot(storage)
+        assert [row["key"] for row in snapshot["services"]] == [
+            descriptor.key for descriptor in SERVICE_REGISTRY
+        ]
+        assert snapshot["checked_at"] is not None
+
+    def test_payload_never_leaks_breaker_names_or_config(self, storage):
+        """Labels and states only — no breaker names, URLs, or hostnames."""
+        storage.trip_open("webhook:1")
+        row = _by_key(service_statuses(storage))["webhooks"]
+        assert set(row) == {
+            "key",
+            "label",
+            "description",
+            "state",
+            "healthy",
+            "since",
+            "last_error",
+            "degraded_count",
+            "total_count",
+        }
+        assert "webhook:1" not in str(row)
+
+
+class TestBreakersDisabled:
+    def test_reports_every_service_healthy(self, settings, storage):
+        storage.trip_open("mqtt")
+        storage.trip_open("webhook:1")
+        settings.CIRCUIT_BREAKERS_ENABLED = False
+
+        snapshot = status_snapshot(storage)
+        assert snapshot["degraded"] is False
+        for row in snapshot["services"]:
+            assert row["state"] == STATE_CLOSED
+            assert row["healthy"] is True
+            assert row["degraded_count"] == 0
+            assert row["since"] is None
+            assert row["last_error"] is None

--- a/backend/resilience/tests/test_status_api.py
+++ b/backend/resilience/tests/test_status_api.py
@@ -1,0 +1,254 @@
+"""``GET /api/resilience/status/`` — the user-facing status board."""
+
+from datetime import timedelta
+
+from django.urls import reverse
+from django.utils import timezone
+
+import pytest
+
+from resilience.circuit import (
+    STATE_CLOSED,
+    STATE_HALF_OPEN,
+    STATE_OPEN,
+    InMemoryStorage,
+    RedisStorage,
+    reset_storage,
+)
+from resilience.models import CircuitBreakerEvent
+from resilience.services import service_statuses
+from resilience.tests.test_circuit import _BrokenRedis
+
+pytestmark = pytest.mark.django_db
+
+STATUS_URL = "/api/resilience/status/"
+
+
+@pytest.fixture(autouse=True)
+def memory_storage(settings):
+    """Hermetic breaker state, breakers explicitly re-enabled (settings turn
+    them off under pytest)."""
+    settings.CIRCUIT_BREAKERS_ENABLED = True
+    settings.CIRCUIT_BREAKER_USE_REDIS = False
+    storage = InMemoryStorage()
+    reset_storage(storage)
+    yield storage
+    reset_storage(None)
+
+
+def _services(response) -> dict:
+    return {row["key"]: row for row in response.json()["services"]}
+
+
+def test_url_is_reversible():
+    assert reverse("resilience:status") == STATUS_URL
+
+
+class TestPermissions:
+    def test_anonymous_is_rejected(self, api_client):
+        response = api_client.get(STATUS_URL)
+        assert response.status_code == 401
+
+    def test_any_authenticated_member_may_read(self, authenticated_client):
+        client, _user = authenticated_client
+        # Deliberately not staff — ordinary members are the audience.
+        assert client.get(STATUS_URL).status_code == 200
+
+
+class TestHealthyPath:
+    def test_reports_every_service_healthy(self, authenticated_client):
+        client, _user = authenticated_client
+        response = client.get(STATUS_URL)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["degraded"] is False
+        assert body["checked_at"].endswith("Z")
+        assert set(_services(response)) == {
+            "device_control",
+            "webhooks",
+            "whmcs",
+            "common_api",
+        }
+        for row in body["services"]:
+            assert row["state"] == STATE_CLOSED
+            assert row["healthy"] is True
+            assert row["since"] is None
+            assert row["last_error"] is None
+
+    def test_row_shape_is_stable(self, authenticated_client):
+        """Frontend (PR3) and ScanTTY (PR4) both pin this contract."""
+        client, _user = authenticated_client
+        row = _services(client.get(STATUS_URL))["device_control"]
+        assert set(row) == {
+            "key",
+            "label",
+            "description",
+            "state",
+            "healthy",
+            "since",
+            "last_error",
+            "degraded_count",
+            "total_count",
+        }
+        assert row["label"] == "Device control"
+        assert row["description"] == "Turning equipment on and off remotely"
+
+
+class TestDegradedPath:
+    def test_open_breaker_surfaces_as_a_degraded_service(
+        self, authenticated_client, memory_storage
+    ):
+        memory_storage.trip_open("mqtt")
+        client, _user = authenticated_client
+        response = client.get(STATUS_URL)
+
+        assert response.status_code == 200
+        assert response.json()["degraded"] is True
+        row = _services(response)["device_control"]
+        assert row["state"] == STATE_OPEN
+        assert row["healthy"] is False
+        assert row["degraded_count"] == 1
+        assert row["total_count"] == 1
+
+    def test_webhook_family_reports_partial_degradation(self, authenticated_client, memory_storage):
+        memory_storage.trip_open("webhook:1")
+        memory_storage.to_half_open("webhook:2")
+        for endpoint_id in range(3, 13):
+            memory_storage.close(f"webhook:{endpoint_id}")
+
+        client, _user = authenticated_client
+        row = _services(client.get(STATUS_URL))["webhooks"]
+        # "2 of 12 endpoints degraded"
+        assert row["state"] == STATE_OPEN
+        assert row["degraded_count"] == 2
+        assert row["total_count"] == 12
+
+    def test_half_open_service_is_not_healthy(self, authenticated_client, memory_storage):
+        memory_storage.to_half_open("common_api")
+        client, _user = authenticated_client
+        row = _services(client.get(STATUS_URL))["common_api"]
+        assert row["state"] == STATE_HALF_OPEN
+        assert row["healthy"] is False
+
+
+class TestSinceAndLastError:
+    def test_sourced_from_the_latest_matching_event(self, authenticated_client, memory_storage):
+        memory_storage.trip_open("mqtt")
+        now = timezone.now()
+
+        stale = CircuitBreakerEvent.objects.create(
+            name="mqtt", from_state=STATE_CLOSED, to_state=STATE_OPEN, detail="older trip"
+        )
+        current = CircuitBreakerEvent.objects.create(
+            name="mqtt",
+            from_state=STATE_HALF_OPEN,
+            to_state=STATE_OPEN,
+            detail="MQTT broker did not PUBACK within 5s",
+        )
+        # auto_now_add can't be set on create; rewrite via UPDATE so the
+        # ordering under test is explicit rather than insertion-order luck.
+        CircuitBreakerEvent.objects.filter(pk=stale.pk).update(created_at=now - timedelta(hours=3))
+        CircuitBreakerEvent.objects.filter(pk=current.pk).update(
+            created_at=now - timedelta(minutes=8)
+        )
+
+        client, _user = authenticated_client
+        row = _services(client.get(STATUS_URL))["device_control"]
+        assert row["last_error"] == "MQTT broker did not PUBACK within 5s"
+        assert row["since"] == (now - timedelta(minutes=8)).isoformat().replace("+00:00", "Z")
+
+    def test_ignores_events_for_a_different_state(self, authenticated_client, memory_storage):
+        memory_storage.trip_open("mqtt")
+        CircuitBreakerEvent.objects.create(
+            name="mqtt", from_state=STATE_OPEN, to_state=STATE_CLOSED, detail="recovered"
+        )
+
+        client, _user = authenticated_client
+        row = _services(client.get(STATUS_URL))["device_control"]
+        assert row["state"] == STATE_OPEN
+        assert row["since"] is None
+        assert row["last_error"] is None
+
+    def test_ignores_events_for_a_different_breaker(self, authenticated_client, memory_storage):
+        memory_storage.trip_open("mqtt")
+        CircuitBreakerEvent.objects.create(
+            name="whmcs", from_state=STATE_CLOSED, to_state=STATE_OPEN, detail="not mine"
+        )
+
+        client, _user = authenticated_client
+        row = _services(client.get(STATUS_URL))["device_control"]
+        assert row["last_error"] is None
+
+    def test_family_attributes_to_a_degraded_member(self, authenticated_client, memory_storage):
+        memory_storage.close("webhook:1")
+        memory_storage.trip_open("webhook:2")
+        CircuitBreakerEvent.objects.create(
+            name="webhook:2",
+            from_state=STATE_CLOSED,
+            to_state=STATE_OPEN,
+            detail="endpoint refused the connection",
+        )
+
+        client, _user = authenticated_client
+        row = _services(client.get(STATUS_URL))["webhooks"]
+        assert row["last_error"] == "endpoint refused the connection"
+        assert row["since"] is not None
+
+    def test_blank_detail_serializes_as_null(self, authenticated_client, memory_storage):
+        memory_storage.trip_open("whmcs")
+        CircuitBreakerEvent.objects.create(
+            name="whmcs", from_state=STATE_CLOSED, to_state=STATE_OPEN, detail=""
+        )
+
+        client, _user = authenticated_client
+        row = _services(client.get(STATUS_URL))["whmcs"]
+        assert row["since"] is not None
+        assert row["last_error"] is None
+
+    def test_history_costs_one_query_for_all_services(
+        self, memory_storage, django_assert_num_queries
+    ):
+        """Ten degraded breakers across four services, one history query."""
+        for endpoint_id in range(1, 9):
+            memory_storage.trip_open(f"webhook:{endpoint_id}")
+            CircuitBreakerEvent.objects.create(
+                name=f"webhook:{endpoint_id}",
+                from_state=STATE_CLOSED,
+                to_state=STATE_OPEN,
+                detail="down",
+            )
+        memory_storage.trip_open("mqtt")
+        memory_storage.trip_open("whmcs")
+
+        with django_assert_num_queries(1):
+            assert len(service_statuses(memory_storage)) == 4
+
+
+class TestDegradesInsteadOfFailing:
+    def test_redis_outage_reports_healthy_rather_than_500(self, authenticated_client):
+        """A down breaker store must not take the status board down with it."""
+        reset_storage(RedisStorage(_BrokenRedis()))
+
+        client, _user = authenticated_client
+        response = client.get(STATUS_URL)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["degraded"] is False
+        assert all(row["healthy"] for row in body["services"])
+        assert _services(response)["webhooks"]["total_count"] == 0
+
+    def test_breakers_disabled_reports_everything_healthy(
+        self, authenticated_client, memory_storage, settings
+    ):
+        memory_storage.trip_open("mqtt")
+        memory_storage.trip_open("webhook:1")
+        settings.CIRCUIT_BREAKERS_ENABLED = False
+
+        client, _user = authenticated_client
+        response = client.get(STATUS_URL)
+
+        assert response.status_code == 200
+        assert response.json()["degraded"] is False
+        assert all(row["state"] == STATE_CLOSED for row in response.json()["services"])

--- a/backend/resilience/urls.py
+++ b/backend/resilience/urls.py
@@ -1,0 +1,11 @@
+"""URL routes for the resilience app."""
+
+from django.urls import path
+
+from .views import ResilienceStatusView
+
+app_name = "resilience"
+
+urlpatterns = [
+    path("status/", ResilienceStatusView.as_view(), name="status"),
+]

--- a/backend/resilience/views.py
+++ b/backend/resilience/views.py
@@ -1,0 +1,42 @@
+"""Public service-status endpoint.
+
+``GET /api/resilience/status/`` turns circuit-breaker state into something a
+member can read: which capabilities are working right now, and what they
+lose while one is down. The web app (PR3) uses it to raise a banner and gate
+affected controls; ScanTTY (PR4) mirrors it on the kiosk.
+
+Readable by any authenticated user — the whole point is that ordinary
+members see the degradation rather than hitting a silent failure. The
+payload carries labels and states only: never breaker config, URLs,
+credentials, or endpoint hostnames.
+"""
+
+from __future__ import annotations
+
+from drf_spectacular.utils import extend_schema
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .serializers import ResilienceStatusSerializer
+from .services import status_snapshot
+
+
+class ResilienceStatusView(APIView):
+    """``GET /api/resilience/status/`` — current health of external dependencies."""
+
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        operation_id="resilience_status_retrieve",
+        responses=ResilienceStatusSerializer,
+        summary="Current status of external service dependencies",
+        description=(
+            "Reports each user-facing capability backed by a circuit breaker "
+            "as healthy or degraded. Always returns 200 — a degraded "
+            "dependency (or an unreachable breaker store) is reported in the "
+            "body, never as an error status."
+        ),
+    )
+    def get(self, request):
+        return Response(ResilienceStatusSerializer(status_snapshot()).data)

--- a/docs/API_PERMISSION_MATRIX.md
+++ b/docs/API_PERMISSION_MATRIX.md
@@ -378,6 +378,18 @@ category spend, and a maintenance forecast.
 | GET | `analytics/pulse/` | staff-or-sig-admin **or** signed-URL token | `IsAnalyticsViewer` — returns the full aggregate JSON used by both the dashboard and the monthly email. Authenticated staff/SIG admins are allowed; anyone presenting a valid `?token=...` minted by `analytics/share/` is also allowed (board-member bypass). | 60-min django-redis cache keyed by `(start, end, bucket)`. Token verifies signature + embedded TTL; rotating `ANALYTICS_SHARE_SALT` invalidates all outstanding tokens. |
 | POST | `analytics/share/` | staff-or-sig-admin | `IsAnalyticsSharer` — mints a signed token (`{"ttl_days": 1..365}`, defaults to 30). Returns the token + ttl; the frontend composes the shareable URL. | Pure HMAC-signed token (no DB row); authoritative kill-switch is the salt setting. |
 
+## Resilience (`/api/resilience/`)
+
+Circuit-breaker health rendered as user-facing service status, so the web
+app and ScanTTY can tell a member which capability is unavailable instead
+of failing silently. The registry in `resilience/services.py` maps breaker
+names (`mqtt`, `whmcs`, `common_api`, and the dynamic `webhook:<id>`
+family) onto labelled capabilities.
+
+| Method | Path | Class | Purpose | Notes |
+| --- | --- | --- | --- | --- |
+| GET | `resilience/status/` | member | `IsAuthenticated` on `ResilienceStatusView` — every authenticated member may read it; seeing the degradation is the point. The payload is deliberately non-sensitive: labels, states, and counts only, **never** breaker config, URLs, credentials, or endpoint hostnames. | Always 200. A degraded dependency — or an unreachable breaker store — is reported in the body, never as an error status. When `CIRCUIT_BREAKERS_ENABLED` is off, every service reports healthy. |
+
 ## Flower (Celery monitoring)
 
 | Method | Path | Class | Notes |


### PR DESCRIPTION
PR 1 of 4 in the circuit-breaker surfacing series.

## Why
Circuit breakers already protect MQTT, webhooks (per endpoint), WHMCS and common_api — but nothing surfaced a trip to a person. The `resilience` app had no `views.py` and no `urls.py`, so when a breaker opened a member just saw things quietly not work. Prod Sentry shows the cost: MQTT connect failures (2074x) and Postmark 401s (still firing 08-02) are all currently *muted* rather than visible.

## What
- **`resilience/services.py`** — registry mapping breaker names onto the capability someone actually loses (`device_control` → "Device control" / "Turning equipment on and off remotely"; plus `webhooks`, `whmcs`, `common_api`). Dynamic families like `webhook:<id>` aggregate, reporting `degraded_count`/`total_count` so a UI can say "3 of 12 endpoints degraded". `email` is added by PR 2.
- **`states(prefix)`** on `BaseStorage`/`InMemoryStorage`/`RedisStorage` — enumerating breaker state wasn't previously possible. Redis uses **SCAN, never KEYS** (prod Redis is shared) and keeps the existing degrade-gracefully contract: a Redis outage returns `{}` rather than breaking callers or the status endpoint.
- **`GET /api/resilience/status/`** — per-service `state`/`healthy`/`since`/`last_error`, with `since` and `last_error` sourced from `CircuitBreakerEvent` in a single query. Reports everything healthy when `CIRCUIT_BREAKERS_ENABLED` is off.

## Security
`IsAuthenticated` — every member should be able to see degradation, that's the point. The payload is labels and states only: never breaker config, URLs, credentials, or endpoint hostnames.

## Verification
- `bandit -r resilience config -x tests,migrations -s B101,B105,B106,B308` — clean (exit 0)
- `ResilienceStatusView` registered in `api_permission_matrix.yaml` + `docs/API_PERMISSION_MATRIX.md` (the gate targeted pytest runs miss)
- **No migration** — `CircuitBreakerEvent` is unchanged
- New tests: `test_services.py` (176 lines), `test_status_api.py` (254), plus `test_circuit.py` additions covering registry aggregation, degraded/healthy responses, Redis-down, breakers-disabled, and auth

Backend only; no existing call path changes behavior. Next: `op-ivmc` (route Postmark/email through a breaker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)