### PR TITLE
Resilience: degraded-service banner + inline control gating (op-lpes)

### DIFF
--- a/frontend/src/__tests__/components/ServiceStatusBanner.test.tsx
+++ b/frontend/src/__tests__/components/ServiceStatusBanner.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * ServiceStatusBanner tests.
+ *
+ * Covers what the banner promises members: it stays out of the way when
+ * everything works, names the services that don't, never leaks the internal
+ * error detail, and a dismissal doesn't swallow the *next* outage.
+ */
+import { MantineProvider } from '@mantine/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ServiceStatusBanner from '../../components/ServiceStatusBanner';
+import { ServiceKey, ServiceStatus } from '../../types';
+
+const mockUseServiceStatus = vi.fn();
+vi.mock('../../hooks/useServiceStatus', () => ({
+  useServiceStatus: () => mockUseServiceStatus(),
+}));
+
+const LAST_ERROR = 'HTTPError 401 from postmark: invalid server token abc123';
+
+const service = (overrides: Partial<ServiceStatus> = {}): ServiceStatus => ({
+  key: 'email',
+  label: 'Email delivery',
+  description: 'Sending notifications, reorder alerts, and receipts',
+  state: 'open',
+  healthy: false,
+  since: '2026-08-04T12:00:00Z',
+  last_error: LAST_ERROR,
+  degraded_count: 1,
+  total_count: 1,
+  ...overrides,
+});
+
+const setStatus = (services: ServiceStatus[]) => {
+  mockUseServiceStatus.mockReturnValue({
+    status: { degraded: services.some((s) => !s.healthy), checked_at: '', services },
+    degraded: services.some((s) => !s.healthy),
+    services,
+    getService: (key: ServiceKey) => services.find((s) => s.key === key) ?? null,
+    isDegraded: (key: ServiceKey) =>
+      services.some((s) => s.key === key && s.state !== 'closed'),
+    refresh: vi.fn(),
+  });
+};
+
+const renderBanner = () =>
+  render(
+    <MantineProvider>
+      <ServiceStatusBanner />
+    </MantineProvider>,
+  );
+
+describe('ServiceStatusBanner', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    mockUseServiceStatus.mockReset();
+  });
+
+  it('renders nothing while every service is healthy', () => {
+    setStatus([service({ state: 'closed', healthy: true, last_error: null })]);
+    renderBanner();
+
+    expect(screen.queryByTestId('service-status-banner')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the status is unknown', () => {
+    setStatus([]);
+    renderBanner();
+
+    expect(screen.queryByTestId('service-status-banner')).not.toBeInTheDocument();
+  });
+
+  it('names the degraded service in plain language', () => {
+    setStatus([service()]);
+    renderBanner();
+
+    expect(screen.getByTestId('service-status-banner')).toBeInTheDocument();
+    expect(screen.getByText('Email delivery is temporarily unavailable')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Sending notifications, reorder alerts, and receipts/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/We're retrying automatically/)).toBeInTheDocument();
+  });
+
+  it('never renders last_error — it can carry internal detail', () => {
+    setStatus([service()]);
+    const { container } = renderBanner();
+
+    expect(container.textContent).not.toContain(LAST_ERROR);
+    expect(container.textContent).not.toContain('postmark');
+  });
+
+  it('lists every affected label when more than one service is down', () => {
+    setStatus([
+      service(),
+      service({
+        key: 'device_control',
+        label: 'Device control',
+        description: 'Turning equipment on and off remotely',
+      }),
+      service({
+        key: 'whmcs',
+        label: 'Maker Box billing',
+        description: 'Maker Box subscription and billing lookups',
+        state: 'closed',
+        healthy: true,
+        last_error: null,
+      }),
+    ]);
+    renderBanner();
+
+    expect(screen.getByText('Some services are temporarily unavailable')).toBeInTheDocument();
+    expect(screen.getByTestId('service-status-line-email')).toBeInTheDocument();
+    expect(screen.getByTestId('service-status-line-device_control')).toBeInTheDocument();
+    // Healthy services stay off the banner entirely.
+    expect(screen.queryByTestId('service-status-line-whmcs')).not.toBeInTheDocument();
+  });
+
+  it('reports counts for an aggregated family rather than declaring it all down', () => {
+    setStatus([
+      service({
+        key: 'webhooks',
+        label: 'Webhook delivery',
+        description: 'Notifying connected external systems',
+        degraded_count: 3,
+        total_count: 12,
+      }),
+    ]);
+    renderBanner();
+
+    expect(
+      screen.getByText('Webhook delivery degraded (3 of 12 endpoints)'),
+    ).toBeInTheDocument();
+  });
+
+  it('hides on dismiss and stays hidden for the same outage', () => {
+    setStatus([service()]);
+    const { unmount } = renderBanner();
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss service status/i }));
+    expect(screen.queryByTestId('service-status-banner')).not.toBeInTheDocument();
+
+    // Dismissal is per-session, so a remount (route change) keeps it hidden.
+    unmount();
+    renderBanner();
+    expect(screen.queryByTestId('service-status-banner')).not.toBeInTheDocument();
+  });
+
+  it('comes back when a different service goes degraded after a dismissal', () => {
+    setStatus([service()]);
+    const { unmount } = renderBanner();
+    fireEvent.click(screen.getByRole('button', { name: /dismiss service status/i }));
+    unmount();
+
+    setStatus([
+      service(),
+      service({
+        key: 'device_control',
+        label: 'Device control',
+        description: 'Turning equipment on and off remotely',
+      }),
+    ]);
+    renderBanner();
+
+    expect(screen.getByTestId('service-status-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('service-status-line-device_control')).toBeInTheDocument();
+  });
+
+  it('comes back when a dismissed service recovers and breaks again', () => {
+    setStatus([service()]);
+    const { unmount: unmountFirst } = renderBanner();
+    fireEvent.click(screen.getByRole('button', { name: /dismiss service status/i }));
+    unmountFirst();
+
+    // Recovered: the dismissal for this key is dropped…
+    setStatus([service({ state: 'closed', healthy: true, last_error: null })]);
+    const { unmount: unmountSecond } = renderBanner();
+    expect(screen.queryByTestId('service-status-banner')).not.toBeInTheDocument();
+    unmountSecond();
+
+    // …so the next outage of the same service is announced again.
+    setStatus([service()]);
+    renderBanner();
+    expect(screen.getByTestId('service-status-banner')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/ServiceUnavailableNotice.test.tsx
+++ b/frontend/src/__tests__/components/ServiceUnavailableNotice.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Inline service-gating tests.
+ *
+ * Two halves: the shared notice itself (does it appear only on real evidence
+ * of an outage?) and a real gated surface end-to-end through the provider —
+ * DeviceControlsCard, whose five buttons all publish over MQTT.
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DeviceControlsCard from '../../components/DeviceControlsCard';
+import ServiceUnavailableNotice, {
+  DEVICE_CONTROL_UNAVAILABLE,
+} from '../../components/ServiceUnavailableNotice';
+import { ServiceStatusProvider } from '../../contexts/ServiceStatusContext';
+import { ServiceStatus, ServiceStatusState } from '../../types';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual<typeof import('../../services/api')>(
+    '../../services/api',
+  );
+  return {
+    ...actual,
+    resilienceAPI: { getStatus: vi.fn() },
+    forgekeyAPI: {
+      recentCommands: vi.fn(),
+      blink: vi.fn(),
+      restart: vi.fn(),
+      capturePhoto: vi.fn(),
+      ping: vi.fn(),
+      identify: vi.fn(),
+    },
+  };
+});
+
+const { forgekeyAPI, resilienceAPI } = await import('../../services/api');
+const getStatus = resilienceAPI.getStatus as unknown as ReturnType<typeof vi.fn>;
+const recentCommands = forgekeyAPI.recentCommands as unknown as ReturnType<typeof vi.fn>;
+
+const deviceControl = (state: ServiceStatusState): ServiceStatus => ({
+  key: 'device_control',
+  label: 'Device control',
+  description: 'Turning equipment on and off remotely',
+  state,
+  healthy: state === 'closed',
+  since: '2026-08-04T12:00:00Z',
+  last_error: state === 'closed' ? null : 'broker unreachable at mqtt-internal:8883',
+  degraded_count: state === 'closed' ? 0 : 1,
+  total_count: 1,
+});
+
+const seedStatus = (services: ServiceStatus[]) => {
+  getStatus.mockResolvedValue({
+    data: {
+      degraded: services.some((s) => !s.healthy),
+      checked_at: '2026-08-04T12:00:00Z',
+      services,
+    },
+  });
+};
+
+const device = {
+  id: 'dev-1',
+  mac_address: 'AA:BB:CC:DD:EE:FF',
+  name: 'Sewing counter',
+  is_online: true,
+  last_seen: '2026-08-04T11:00:00Z',
+} as never;
+
+const renderInProvider = (node: React.ReactElement) =>
+  render(
+    <MantineProvider>
+      <ServiceStatusProvider>{node}</ServiceStatusProvider>
+    </MantineProvider>,
+  );
+
+const CONTROL_KEYS = ['blink', 'restart', 'capture', 'ping', 'identify'];
+
+describe('ServiceUnavailableNotice', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem('token', 'jwt');
+    getStatus.mockReset();
+    recentCommands.mockReset();
+    recentCommands.mockResolvedValue({ data: { results: [] } });
+  });
+
+  it('says nothing while the service is healthy', async () => {
+    seedStatus([deviceControl('closed')]);
+
+    renderInProvider(
+      <ServiceUnavailableNotice service="device_control" message={DEVICE_CONTROL_UNAVAILABLE} />,
+    );
+
+    await waitFor(() => expect(getStatus).toHaveBeenCalled());
+    expect(screen.queryByTestId('service-unavailable-device_control')).not.toBeInTheDocument();
+  });
+
+  it('says nothing when the status endpoint itself fails', async () => {
+    getStatus.mockRejectedValue(new Error('503'));
+
+    renderInProvider(
+      <ServiceUnavailableNotice service="device_control" message={DEVICE_CONTROL_UNAVAILABLE} />,
+    );
+
+    await waitFor(() => expect(getStatus).toHaveBeenCalled());
+    expect(screen.queryByTestId('service-unavailable-device_control')).not.toBeInTheDocument();
+  });
+
+  it('explains the outage where the control is', async () => {
+    seedStatus([deviceControl('open')]);
+
+    renderInProvider(
+      <ServiceUnavailableNotice service="device_control" message={DEVICE_CONTROL_UNAVAILABLE} />,
+    );
+
+    expect(
+      await screen.findByText('Device control unavailable (MQTT broker unreachable)'),
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to the service label when the caller supplies no message', async () => {
+    seedStatus([deviceControl('half_open')]);
+
+    renderInProvider(<ServiceUnavailableNotice service="device_control" />);
+
+    expect(await screen.findByText(/Device control is temporarily unavailable/)).toBeInTheDocument();
+  });
+
+  it('never shows the raw last_error', async () => {
+    seedStatus([deviceControl('open')]);
+
+    const { container } = renderInProvider(
+      <ServiceUnavailableNotice service="device_control" message={DEVICE_CONTROL_UNAVAILABLE} />,
+    );
+
+    await screen.findByTestId('service-unavailable-device_control');
+    expect(container.textContent).not.toContain('mqtt-internal');
+  });
+});
+
+describe('DeviceControlsCard service gating', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem('token', 'jwt');
+    getStatus.mockReset();
+    recentCommands.mockReset();
+    recentCommands.mockResolvedValue({ data: { results: [] } });
+  });
+
+  it('disables every command while the MQTT breaker is open', async () => {
+    seedStatus([deviceControl('open')]);
+
+    renderInProvider(<DeviceControlsCard device={device} />);
+
+    await screen.findByTestId('device-controls-service-notice');
+    CONTROL_KEYS.forEach((key) => {
+      expect(screen.getByTestId(`control-btn-${key}`)).toBeDisabled();
+    });
+  });
+
+  it('leaves every command usable while device control is healthy', async () => {
+    seedStatus([deviceControl('closed')]);
+
+    renderInProvider(<DeviceControlsCard device={device} />);
+
+    await waitFor(() => expect(getStatus).toHaveBeenCalled());
+    CONTROL_KEYS.forEach((key) => {
+      expect(screen.getByTestId(`control-btn-${key}`)).toBeEnabled();
+    });
+    expect(screen.queryByTestId('device-controls-service-notice')).not.toBeInTheDocument();
+  });
+
+  it('leaves every command usable when the status is unknown', async () => {
+    getStatus.mockRejectedValue(new Error('network'));
+
+    renderInProvider(<DeviceControlsCard device={device} />);
+
+    await waitFor(() => expect(getStatus).toHaveBeenCalled());
+    CONTROL_KEYS.forEach((key) => {
+      expect(screen.getByTestId(`control-btn-${key}`)).toBeEnabled();
+    });
+  });
+
+  it('does not gate a signed-out session on a status it never fetched', async () => {
+    localStorage.removeItem('token');
+    seedStatus([deviceControl('open')]);
+
+    renderInProvider(<DeviceControlsCard device={device} />);
+
+    await waitFor(() => expect(recentCommands).toHaveBeenCalled());
+    expect(getStatus).not.toHaveBeenCalled();
+    CONTROL_KEYS.forEach((key) => {
+      expect(screen.getByTestId(`control-btn-${key}`)).toBeEnabled();
+    });
+  });
+});

--- a/frontend/src/__tests__/contexts/ServiceStatusContext.test.tsx
+++ b/frontend/src/__tests__/contexts/ServiceStatusContext.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * ServiceStatusContext tests.
+ *
+ * The contract this file defends is the conservative one: the status poll is
+ * only ever spent when it can pay off (signed in, tab visible), and nothing it
+ * fails to learn is ever allowed to gate a control.
+ */
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  SERVICE_STATUS_POLL_MS,
+  ServiceStatusProvider,
+} from '../../contexts/ServiceStatusContext';
+import { useServiceStatus } from '../../hooks/useServiceStatus';
+import { ResilienceStatus, ServiceStatus } from '../../types';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual<typeof import('../../services/api')>(
+    '../../services/api',
+  );
+  return {
+    ...actual,
+    resilienceAPI: { getStatus: vi.fn() },
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { resilienceAPI } = await import('../../services/api');
+const getStatus = resilienceAPI.getStatus as unknown as ReturnType<typeof vi.fn>;
+
+const service = (overrides: Partial<ServiceStatus> = {}): ServiceStatus => ({
+  key: 'device_control',
+  label: 'Device control',
+  description: 'Turning equipment on and off remotely',
+  state: 'open',
+  healthy: false,
+  since: '2026-08-04T12:00:00Z',
+  last_error: 'broker refused connection at mqtt-internal:8883',
+  degraded_count: 1,
+  total_count: 1,
+  ...overrides,
+});
+
+const snapshot = (services: ServiceStatus[]): { data: ResilienceStatus } => ({
+  data: {
+    degraded: services.some((s) => !s.healthy),
+    checked_at: '2026-08-04T12:00:00Z',
+    services,
+  },
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ServiceStatusProvider>{children}</ServiceStatusProvider>
+);
+
+describe('ServiceStatusProvider', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    getStatus.mockReset();
+    getStatus.mockResolvedValue(snapshot([]));
+  });
+
+  it('does not poll while unauthenticated', async () => {
+    renderHook(() => useServiceStatus(), { wrapper });
+
+    // Give any effect-scheduled fetch a chance to land before asserting.
+    await waitFor(() => expect(getStatus).not.toHaveBeenCalled());
+  });
+
+  it('polls once signed in and reports the degraded service', async () => {
+    localStorage.setItem('token', 'jwt');
+    getStatus.mockResolvedValue(snapshot([service()]));
+
+    const { result } = renderHook(() => useServiceStatus(), { wrapper });
+
+    await waitFor(() => expect(getStatus).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.degraded).toBe(true));
+    expect(result.current.isDegraded('device_control')).toBe(true);
+    expect(result.current.getService('device_control')?.label).toBe('Device control');
+  });
+
+  it('treats half_open as degraded — the dependency is still on trial', async () => {
+    localStorage.setItem('token', 'jwt');
+    getStatus.mockResolvedValue(
+      snapshot([service({ state: 'half_open', healthy: false })]),
+    );
+
+    const { result } = renderHook(() => useServiceStatus(), { wrapper });
+
+    await waitFor(() => expect(result.current.isDegraded('device_control')).toBe(true));
+  });
+
+  it('reports a closed service as healthy', async () => {
+    localStorage.setItem('token', 'jwt');
+    getStatus.mockResolvedValue(
+      snapshot([service({ state: 'closed', healthy: true, last_error: null })]),
+    );
+
+    const { result } = renderHook(() => useServiceStatus(), { wrapper });
+
+    await waitFor(() => expect(getStatus).toHaveBeenCalled());
+    await waitFor(() => expect(result.current.services).toHaveLength(1));
+    expect(result.current.isDegraded('device_control')).toBe(false);
+    expect(result.current.degraded).toBe(false);
+  });
+
+  it('treats a failed status fetch as healthy and surfaces no error', async () => {
+    localStorage.setItem('token', 'jwt');
+    getStatus.mockRejectedValue(new Error('500 Server Error'));
+
+    const { result } = renderHook(() => useServiceStatus(), { wrapper });
+
+    await waitFor(() => expect(getStatus).toHaveBeenCalled());
+    expect(result.current.degraded).toBe(false);
+    expect(result.current.isDegraded('device_control')).toBe(false);
+    expect(result.current.isDegraded('email')).toBe(false);
+    expect(result.current.status).toBeNull();
+  });
+
+  it('stops gating once a previously degraded fetch starts failing', async () => {
+    localStorage.setItem('token', 'jwt');
+    getStatus.mockResolvedValueOnce(snapshot([service()]));
+
+    const { result } = renderHook(() => useServiceStatus(), { wrapper });
+    await waitFor(() => expect(result.current.isDegraded('device_control')).toBe(true));
+
+    // A snapshot we can no longer refresh is not evidence of an outage.
+    getStatus.mockRejectedValue(new Error('network down'));
+    await result.current.refresh();
+
+    await waitFor(() => expect(result.current.isDegraded('device_control')).toBe(false));
+  });
+
+  it('skips the request while the tab is hidden', async () => {
+    localStorage.setItem('token', 'jwt');
+    const visibility = vi
+      .spyOn(document, 'visibilityState', 'get')
+      .mockReturnValue('hidden');
+
+    renderHook(() => useServiceStatus(), { wrapper });
+
+    await waitFor(() => expect(getStatus).not.toHaveBeenCalled());
+
+    // …and catches up as soon as the tab comes back.
+    visibility.mockReturnValue('visible');
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(getStatus).toHaveBeenCalledTimes(1));
+
+    visibility.mockRestore();
+  });
+
+  it('starts polling when a sign-in happens mid-session', async () => {
+    const { result } = renderHook(() => useServiceStatus(), { wrapper });
+    await waitFor(() => expect(getStatus).not.toHaveBeenCalled());
+
+    localStorage.setItem('token', 'jwt');
+    getStatus.mockResolvedValue(snapshot([service({ key: 'email', label: 'Email delivery' })]));
+    window.dispatchEvent(new Event('authChange'));
+
+    await waitFor(() => expect(result.current.isDegraded('email')).toBe(true));
+  });
+
+  it('clears the snapshot on sign-out', async () => {
+    localStorage.setItem('token', 'jwt');
+    getStatus.mockResolvedValue(snapshot([service()]));
+
+    const { result } = renderHook(() => useServiceStatus(), { wrapper });
+    await waitFor(() => expect(result.current.degraded).toBe(true));
+
+    localStorage.removeItem('token');
+    window.dispatchEvent(new Event('authChange'));
+
+    await waitFor(() => expect(result.current.status).toBeNull());
+    expect(result.current.isDegraded('device_control')).toBe(false);
+  });
+
+  it('gates nothing when consumed outside the provider', () => {
+    const Probe: React.FC = () => {
+      const { isDegraded, degraded } = useServiceStatus();
+      return (
+        <span data-testid="probe">
+          {String(degraded)}:{String(isDegraded('device_control'))}
+        </span>
+      );
+    };
+
+    render(<Probe />);
+
+    expect(screen.getByTestId('probe')).toHaveTextContent('false:false');
+    expect(getStatus).not.toHaveBeenCalled();
+  });
+
+  it('polls on a one-minute cycle', () => {
+    expect(SERVICE_STATUS_POLL_MS).toBe(60_000);
+  });
+});

--- a/frontend/src/__tests__/pages/ForgeKeyDeviceDetailPageServiceGate.test.tsx
+++ b/frontend/src/__tests__/pages/ForgeKeyDeviceDetailPageServiceGate.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Device-control gating on the ForgeKey device detail page.
+ *
+ * Every control here ends in an MQTT publish, so when the device_control
+ * service is open the relay channels, the LED blink and the OTA send all go
+ * grey with a reason attached — and none of them do while it is closed.
+ */
+import { MantineProvider } from '@mantine/core';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ServiceStatusProvider } from '../../contexts/ServiceStatusContext';
+import ForgeKeyDeviceDetailPage from '../../pages/ForgeKeyDeviceDetailPage';
+import { ServiceStatusState } from '../../types';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual<typeof import('../../services/api')>(
+    '../../services/api',
+  );
+  return {
+    ...actual,
+    resilienceAPI: { getStatus: vi.fn() },
+    forgekeyAPI: {
+      getDevice: vi.fn(),
+      getOccupancy: vi.fn(),
+      getTemperature: vi.fn(),
+      recentCommands: vi.fn(),
+      listDeviceTypes: vi.fn(),
+      listIndicatorBindings: vi.fn(),
+      setRelayChannel: vi.fn(),
+      blink: vi.fn(),
+      firmwareUpdate: vi.fn(),
+    },
+  };
+});
+
+vi.mock('recharts', async () => ({
+  __esModule: true,
+  ResponsiveContainer: ({ children }: any) => <div data-testid="chart">{children}</div>,
+  LineChart: ({ children }: any) => <div>{children}</div>,
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+}));
+
+const { forgekeyAPI, resilienceAPI } = await import('../../services/api');
+const api = forgekeyAPI as unknown as Record<string, ReturnType<typeof vi.fn>>;
+const getStatus = resilienceAPI.getStatus as unknown as ReturnType<typeof vi.fn>;
+
+const seedDevice = () => {
+  api.getDevice.mockResolvedValue({
+    data: {
+      id: 'dev-1',
+      mac_address: 'AA:BB:CC:DD:EE:FF',
+      name: 'Laser interlock',
+      is_online: true,
+      last_seen: '2026-08-04T11:00:00Z',
+      capabilities: ['power_relay', 'status_led'],
+      capabilities_announced_at: '2026-08-04T10:00:00Z',
+      relay_channels: [{ channel: 1, on: true }],
+      indicator_state: {},
+    },
+  });
+  api.getOccupancy.mockResolvedValue({
+    data: { device: 'AA:BB:CC:DD:EE:FF', since: '', current_occupancy: 0, events: [] },
+  });
+  api.getTemperature.mockResolvedValue({
+    data: {
+      device: 'AA:BB:CC:DD:EE:FF',
+      since: '',
+      latest_temperature_c: null,
+      latest_humidity_percent: null,
+      readings: [],
+    },
+  });
+  api.recentCommands.mockResolvedValue({ data: { results: [] } });
+  api.listDeviceTypes.mockResolvedValue({ data: [] });
+  api.listIndicatorBindings.mockResolvedValue({ data: [] });
+};
+
+const seedStatus = (state: ServiceStatusState) => {
+  getStatus.mockResolvedValue({
+    data: {
+      degraded: state !== 'closed',
+      checked_at: '2026-08-04T12:00:00Z',
+      services: [
+        {
+          key: 'device_control',
+          label: 'Device control',
+          description: 'Turning equipment on and off remotely',
+          state,
+          healthy: state === 'closed',
+          since: '2026-08-04T12:00:00Z',
+          last_error: null,
+          degraded_count: state === 'closed' ? 0 : 1,
+          total_count: 1,
+        },
+      ],
+    },
+  });
+};
+
+const renderPage = () =>
+  render(
+    <MantineProvider>
+      <ServiceStatusProvider>
+        <MemoryRouter initialEntries={['/facilities/forgekey-devices/dev-1']}>
+          <Routes>
+            <Route
+              path="/facilities/forgekey-devices/:id"
+              element={<ForgeKeyDeviceDetailPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </ServiceStatusProvider>
+    </MantineProvider>,
+  );
+
+describe('ForgeKeyDeviceDetailPage device-control gating', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem('token', 'jwt');
+    localStorage.setItem('is_staff', 'true');
+    getStatus.mockReset();
+    Object.values(api).forEach((fn) => fn.mockReset());
+    seedDevice();
+  });
+
+  it('greys out the relay, blink and OTA controls with a reason when MQTT is down', async () => {
+    seedStatus('open');
+
+    renderPage();
+
+    expect(await screen.findByTestId('relay-device-control-notice')).toHaveTextContent(
+      'Device control unavailable (MQTT broker unreachable)',
+    );
+    expect(screen.getByTestId('relay-channel-1-enable')).toBeDisabled();
+    expect(screen.getByTestId('relay-channel-1-disable')).toBeDisabled();
+    expect(screen.getByTestId('relay-channel-2-enable')).toBeDisabled();
+    expect(screen.getByRole('button', { name: /blink led/i })).toBeDisabled();
+    expect(screen.getByTestId('ota-device-control-notice')).toBeInTheDocument();
+  });
+
+  it('leaves the controls alone while device control is healthy', async () => {
+    seedStatus('closed');
+
+    renderPage();
+
+    await waitFor(() => expect(getStatus).toHaveBeenCalled());
+    expect(await screen.findByTestId('relay-channel-1-enable')).toBeEnabled();
+    expect(screen.getByRole('button', { name: /blink led/i })).toBeEnabled();
+    expect(screen.queryByTestId('relay-device-control-notice')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ota-device-control-notice')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/DeviceControlsCard.tsx
+++ b/frontend/src/components/DeviceControlsCard.tsx
@@ -21,7 +21,11 @@ import {
   ForgeKeyDeviceCommand,
   forgekeyAPI,
 } from '../services/api';
+import { useServiceStatus } from '../hooks/useServiceStatus';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
+import ServiceUnavailableNotice, {
+  DEVICE_CONTROL_UNAVAILABLE,
+} from './ServiceUnavailableNotice';
 
 const ACK_TIMEOUT_MS = 10_000;
 const POLL_INTERVAL_MS = 2_000;
@@ -95,6 +99,10 @@ interface DeviceControlsCardProps {
 
 const DeviceControlsCard: React.FC<DeviceControlsCardProps> = ({ device }) => {
   const deviceId = device.id;
+  // All five commands publish over MQTT, so one open breaker takes the whole
+  // card out. The buttons grey out rather than promising an ack that can't come.
+  const { isDegraded } = useServiceStatus();
+  const deviceControlDown = isDegraded('device_control');
 
   const [inFlight, setInFlight] = useState<Record<string, InFlightState>>(() =>
     Object.fromEntries(COMMANDS.map((c) => [c.key, initialInFlight])),
@@ -277,10 +285,16 @@ const DeviceControlsCard: React.FC<DeviceControlsCardProps> = ({ device }) => {
               ackedRow={ackedRow ?? null}
               now={now}
               onClick={() => runCommand(def)}
+              disabled={deviceControlDown}
             />
           );
         })}
       </div>
+      <ServiceUnavailableNotice
+        service="device_control"
+        message={DEVICE_CONTROL_UNAVAILABLE}
+        testId="device-controls-service-notice"
+      />
 
       <RecentCommandsTable
         commands={history}
@@ -297,6 +311,8 @@ interface ControlButtonProps {
   ackedRow: ForgeKeyDeviceCommand | null;
   now: number;
   onClick: () => void;
+  /** True while the MQTT breaker is open — the command cannot be delivered. */
+  disabled?: boolean;
 }
 
 const ControlButton: React.FC<ControlButtonProps> = ({
@@ -305,6 +321,7 @@ const ControlButton: React.FC<ControlButtonProps> = ({
   ackedRow,
   now,
   onClick,
+  disabled = false,
 }) => {
   // Resolve the visible feedback for this button. The row may not be present
   // in the history yet on the very first poll, so fall back to a 'sent'
@@ -394,7 +411,7 @@ const ControlButton: React.FC<ControlButtonProps> = ({
     >
       <button
         type="button"
-        disabled={state.pending}
+        disabled={state.pending || disabled}
         onClick={onClick}
         data-testid={`control-btn-${def.key}`}
         style={{

--- a/frontend/src/components/IndicatorManagementCard.tsx
+++ b/frontend/src/components/IndicatorManagementCard.tsx
@@ -27,6 +27,10 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import DeviceSectionGate from './DeviceSectionGate';
 import IndicatorStatusLegend from './IndicatorStatusLegend';
 import IndicatorSwatch from './IndicatorSwatch';
+import ServiceUnavailableNotice, {
+  DEVICE_CONTROL_UNAVAILABLE,
+} from './ServiceUnavailableNotice';
+import { useServiceStatus } from '../hooks/useServiceStatus';
 import {
   ForgeKeyDevice,
   ForgeKeyDeviceType,
@@ -73,6 +77,8 @@ function titleCase(value: string): string {
 }
 
 export default function IndicatorManagementCard({ device, onChanged }: Props) {
+  const { isDegraded } = useServiceStatus();
+  const deviceControlDown = isDegraded('device_control');
   const [loading, setLoading] = useState(true);
   const [isIndicator, setIsIndicator] = useState(false);
   const [binding, setBinding] = useState<ForgeKeyIndicatorBinding | null>(null);
@@ -311,6 +317,7 @@ export default function IndicatorManagementCard({ device, onChanged }: Props) {
                 size="xs"
                 variant="light"
                 loading={busy === 'sync'}
+                disabled={deviceControlDown}
                 onClick={onSync}
                 data-testid="indicator-sync-btn"
               >
@@ -327,6 +334,13 @@ export default function IndicatorManagementCard({ device, onChanged }: Props) {
                 Unbind
               </Button>
             </Group>
+            {/* "Sync now" re-pushes the light state over MQTT; unbinding is a
+                database change and stays available. */}
+            <ServiceUnavailableNotice
+              service="device_control"
+              message={DEVICE_CONTROL_UNAVAILABLE}
+              testId="indicator-sync-device-control-notice"
+            />
           </div>
         ) : (
           <div data-testid="indicator-bind-form">
@@ -440,11 +454,19 @@ export default function IndicatorManagementCard({ device, onChanged }: Props) {
             mt="sm"
             variant="light"
             loading={busy === 'test'}
+            disabled={deviceControlDown}
             onClick={onTest}
             data-testid="indicator-test-btn"
           >
             Send test
           </Button>
+          {/* A test push is a device command over MQTT, so it goes with the
+              broker. */}
+          <ServiceUnavailableNotice
+            service="device_control"
+            message={DEVICE_CONTROL_UNAVAILABLE}
+            testId="indicator-device-control-notice"
+          />
           {testResult && (
             <Text size="xs" c="dimmed" mt="xs" data-testid="indicator-test-result">
               Sent {testResult.payload.pattern ?? ''} · command {testResult.command_id}

--- a/frontend/src/components/ServiceStatusBanner.tsx
+++ b/frontend/src/components/ServiceStatusBanner.tsx
@@ -1,0 +1,135 @@
+/**
+ * ServiceStatusBanner
+ *
+ * Global banner for external dependencies that are currently down, so a member
+ * finds out from the app rather than from a control that silently does nothing.
+ * Mounted once in WorkspaceLayout alongside the other banners; fed by the one
+ * shared poll in ServiceStatusContext.
+ *
+ * Copy rules:
+ *  - Plain language and reassuring. The reader cannot fix a dead MQTT broker;
+ *    they need to know what won't work and that we're retrying.
+ *  - `last_error` is NEVER rendered here. It can carry internal detail
+ *    (hostnames, provider responses) and this banner is shown to every member.
+ *  - Dismissible for the session, but the dismissal is scoped to the services
+ *    that were degraded when it was dismissed — if something *else* breaks
+ *    afterwards, the banner comes back.
+ */
+import { Alert, Text } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useServiceStatus } from '../hooks/useServiceStatus';
+import { ServiceStatus } from '../types';
+
+const DISMISSED_KEY = 'oms_service_status_dismissed';
+
+const readDismissed = (): string[] => {
+  try {
+    const raw = sessionStorage.getItem(DISMISSED_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    return Array.isArray(parsed) ? parsed.filter((k): k is string => typeof k === 'string') : [];
+  } catch {
+    // Unreadable/garbage store is best-effort: show the banner.
+    return [];
+  }
+};
+
+const writeDismissed = (keys: string[]): void => {
+  try {
+    sessionStorage.setItem(DISMISSED_KEY, JSON.stringify(keys));
+  } catch {
+    // Private mode / quota. The dismissal just won't survive a remount.
+  }
+};
+
+/**
+ * One-line summary of what is wrong with a service.
+ *
+ * A family of breakers (webhooks) reports counts, because "webhook delivery is
+ * down" overstates 3 bad endpoints out of 12. `total_count` is only ever > 1
+ * for such a family, which is why "endpoints" is safe wording here.
+ */
+export const serviceHeadline = (service: ServiceStatus): string =>
+  service.total_count > 1
+    ? `${service.label} degraded (${service.degraded_count} of ${service.total_count} endpoints)`
+    : `${service.label} is temporarily unavailable`;
+
+const ServiceStatusBanner: React.FC = () => {
+  const { services } = useServiceStatus();
+  const [dismissed, setDismissed] = useState<string[]>(readDismissed);
+
+  const affected = useMemo(() => services.filter((service) => !service.healthy), [services]);
+  const affectedKeys = useMemo<string[]>(
+    () => affected.map((service) => service.key),
+    [affected],
+  );
+  const affectedSignature = affectedKeys.join('|');
+
+  // Drop recovered services from the dismissal. Without this, dismissing an
+  // email outage would also swallow the *next* email outage this session.
+  useEffect(() => {
+    setDismissed((prev) => {
+      const next = prev.filter((key) => affectedKeys.includes(key));
+      if (next.length === prev.length) return prev;
+      writeDismissed(next);
+      return next;
+    });
+    // affectedKeys is rebuilt on every snapshot; key off its contents instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [affectedSignature]);
+
+  const handleDismiss = useCallback(() => {
+    setDismissed(affectedKeys);
+    writeDismissed(affectedKeys);
+  }, [affectedKeys]);
+
+  const visible = affected.some((service) => !dismissed.includes(service.key));
+  if (!visible) return null;
+
+  const single = affected.length === 1 ? affected[0] : null;
+
+  return (
+    <Alert
+      icon={<IconAlertTriangle size={16} aria-hidden="true" />}
+      title={single ? serviceHeadline(single) : 'Some services are temporarily unavailable'}
+      color="yellow"
+      variant="light"
+      radius="md"
+      // Self-spacing: the layout mounts this bare, so it must not leave a gap
+      // behind when it renders nothing.
+      m="md"
+      withCloseButton
+      closeButtonLabel="Dismiss service status"
+      onClose={handleDismiss}
+      role="status"
+      data-testid="service-status-banner"
+    >
+      {single ? (
+        <Text size="sm" data-testid={`service-status-line-${single.key}`}>
+          {single.description}.
+        </Text>
+      ) : (
+        <ul style={{ margin: 0, paddingLeft: '1.1rem' }}>
+          {affected.map((service) => (
+            <li key={service.key} data-testid={`service-status-line-${service.key}`}>
+              <Text size="sm" span fw={600}>
+                {serviceHeadline(service)}
+              </Text>
+              <Text size="sm" span>
+                {' '}
+                — {service.description.charAt(0).toLowerCase()}
+                {service.description.slice(1)}.
+              </Text>
+            </li>
+          ))}
+        </ul>
+      )}
+      <Text size="sm" mt={6} c="dimmed">
+        We&apos;re retrying automatically. Everything else keeps working.
+      </Text>
+    </Alert>
+  );
+};
+
+export default ServiceStatusBanner;

--- a/frontend/src/components/ServiceUnavailableNotice.tsx
+++ b/frontend/src/components/ServiceUnavailableNotice.tsx
@@ -1,0 +1,72 @@
+/**
+ * ServiceUnavailableNotice
+ *
+ * The one inline treatment for "this control depends on something that is
+ * currently down". Put it next to the control you disabled, so the reason is
+ * where the click would have been rather than only in the page-top banner.
+ *
+ *   const { isDegraded } = useServiceStatus();
+ *   const controlDown = isDegraded('device_control');
+ *   <button disabled={busy || controlDown}>Enable</button>
+ *   <ServiceUnavailableNotice
+ *     service="device_control"
+ *     message="Device control unavailable (MQTT broker unreachable)"
+ *   />
+ *
+ * Renders nothing unless the backend positively reports that service as
+ * open/half-open — an unknown or failed status fetch shows nothing and gates
+ * nothing (see ServiceStatusContext). Whether to *disable* stays with the call
+ * site: some controls (a webhook test against one endpoint of a partly
+ * degraded family) deserve the warning without losing the ability to try.
+ *
+ * `message` is author-supplied static copy. Never pass the API's `last_error`
+ * — it can carry internal detail and this renders in member-facing surfaces.
+ */
+import React from 'react';
+
+import { useServiceStatus } from '../hooks/useServiceStatus';
+import { ServiceKey } from '../types';
+
+/**
+ * Standard copy for the device-control gate. Shared because every ForgeKey
+ * surface (detail page, controls card, indicator card) ends in the same MQTT
+ * publish and should say the same thing when the broker is unreachable.
+ */
+export const DEVICE_CONTROL_UNAVAILABLE =
+  'Device control unavailable (MQTT broker unreachable)';
+
+interface ServiceUnavailableNoticeProps {
+  /** Which capability this control depends on. */
+  service: ServiceKey;
+  /** Plain-language reason. Defaults to the service's own label/description. */
+  message?: string;
+  testId?: string;
+}
+
+const ServiceUnavailableNotice: React.FC<ServiceUnavailableNoticeProps> = ({
+  service,
+  message,
+  testId,
+}) => {
+  const { isDegraded, getService } = useServiceStatus();
+
+  if (!isDegraded(service)) return null;
+
+  const row = getService(service);
+  const text =
+    message ??
+    `${row?.label ?? 'This service'} is temporarily unavailable — we'll keep retrying.`;
+
+  return (
+    <small
+      role="status"
+      data-testid={testId ?? `service-unavailable-${service}`}
+      style={{ color: '#a1670c', display: 'block' }}
+    >
+      <span aria-hidden="true">⚠ </span>
+      {text}
+    </small>
+  );
+};
+
+export default ServiceUnavailableNotice;

--- a/frontend/src/components/WorkspaceLayout.tsx
+++ b/frontend/src/components/WorkspaceLayout.tsx
@@ -16,6 +16,7 @@ import NotificationBadge from './NotificationBadge';
 import NotificationBanner from './NotificationBanner';
 import NotificationCenter from './NotificationCenter';
 import OfflineIndicator from './OfflineIndicator';
+import ServiceStatusBanner from './ServiceStatusBanner';
 import SessionExpiredBanner from './SessionExpiredBanner';
 import Sidebar from './Sidebar';
 
@@ -107,6 +108,7 @@ const WorkspaceLayout: React.FC<WorkspaceLayoutProps> = ({ children }) => {
     return (
       <div className="workspace-layout no-sidebar">
         {/* Banners */}
+        <ServiceStatusBanner />
         {notifications.banners.length > 0 && (
           <div style={{ padding: '16px' }}>
             {notifications.banners.map((banner) => (
@@ -172,6 +174,7 @@ const WorkspaceLayout: React.FC<WorkspaceLayoutProps> = ({ children }) => {
             </div>
           </div>
           {/* Banners */}
+          <ServiceStatusBanner />
           {notifications.banners.length > 0 && (
             <div style={{ padding: '16px 20px 0' }}>
               {notifications.banners.map((banner) => (

--- a/frontend/src/contexts/ServiceStatusContext.tsx
+++ b/frontend/src/contexts/ServiceStatusContext.tsx
@@ -1,0 +1,184 @@
+/**
+ * Service Status Context
+ *
+ * One poll of `GET /api/resilience/status/` per tab, shared by everything that
+ * needs to know whether an external dependency is down: the global banner
+ * (components/ServiceStatusBanner) and every control that is gated inline
+ * (components/ServiceUnavailableNotice).
+ *
+ * Three rules this file exists to enforce:
+ *
+ * 1. **Poll only when it can pay off.** The endpoint is IsAuthenticated, so a
+ *    signed-out visitor never requests it; a backgrounded tab doesn't either.
+ *    A wall display left open overnight should not spend a request a minute.
+ *
+ * 2. **A failed status fetch is not an outage.** If the status endpoint itself
+ *    is unreachable we fall back to "unknown", which shows nothing and gates
+ *    nothing. The monitoring must never become the thing that breaks the app.
+ *
+ * 3. **Unknown is healthy.** `isDegraded` is false unless the backend
+ *    positively reports the service as open/half-open. That is what makes it
+ *    safe to call from a component rendered outside this provider (a page test,
+ *    a public kiosk route) — the default context value below gates nothing.
+ *    This deliberately differs from NotificationContext, which throws when its
+ *    provider is missing: here, failing open is the whole point.
+ */
+import React, {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+import { isAuthenticated } from '../components/RequireAuth';
+import { resilienceAPI } from '../services/api';
+import { ResilienceStatus, ServiceKey, ServiceStatus } from '../types';
+
+/** How often the snapshot is refreshed while signed in with a visible tab. */
+export const SERVICE_STATUS_POLL_MS = 60_000;
+
+/** States that count as degraded. Half-open is on trial — calls may still fail. */
+const DEGRADED_STATES = ['open', 'half_open'];
+
+export interface ServiceStatusContextType {
+  /** Latest snapshot, or null while unknown (never fetched / failed / signed out). */
+  status: ResilienceStatus | null;
+  /** True only when the backend positively reports something degraded. */
+  degraded: boolean;
+  /** Every service the backend knows about; empty while unknown. */
+  services: ServiceStatus[];
+  /** The named service's row, or null when unknown. */
+  getService: (key: ServiceKey) => ServiceStatus | null;
+  /** True only when the named service is positively open/half-open. */
+  isDegraded: (key: ServiceKey) => boolean;
+  /** Fetch a fresh snapshot now (used after a control fails, and by tests). */
+  refresh: () => Promise<void>;
+}
+
+const UNKNOWN: ServiceStatusContextType = {
+  status: null,
+  degraded: false,
+  services: [],
+  getService: () => null,
+  isDegraded: () => false,
+  refresh: async () => {},
+};
+
+const ServiceStatusContext = createContext<ServiceStatusContextType>(UNKNOWN);
+
+/**
+ * Read the shared service status. Safe outside the provider: returns the
+ * unknown-but-healthy default rather than throwing, so no component can be
+ * broken merely by being rendered somewhere the provider isn't mounted.
+ */
+export const useServiceStatusContext = (): ServiceStatusContextType =>
+  useContext(ServiceStatusContext);
+
+interface ServiceStatusProviderProps {
+  children: ReactNode;
+}
+
+export const ServiceStatusProvider: React.FC<ServiceStatusProviderProps> = ({ children }) => {
+  const [status, setStatus] = useState<ResilienceStatus | null>(null);
+  const [authed, setAuthed] = useState<boolean>(() => isAuthenticated());
+
+  // Login and logout both flip polling on/off without a reload. `authChange` is
+  // the app's own signal (AuthSection dispatches it, Sidebar listens); `storage`
+  // covers a sign-out performed in another tab.
+  useEffect(() => {
+    const sync = () => setAuthed(isAuthenticated());
+    window.addEventListener('authChange', sync);
+    window.addEventListener('storage', sync);
+    return () => {
+      window.removeEventListener('authChange', sync);
+      window.removeEventListener('storage', sync);
+    };
+  }, []);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const response = await resilienceAPI.getStatus();
+      const data = response?.data;
+      // Defensive: a mocked/absent payload is "unknown", not a crash.
+      setStatus(data && Array.isArray(data.services) ? data : null);
+    } catch {
+      // Deliberately silent, and deliberately back to unknown: a status
+      // endpoint we cannot reach tells us nothing, and stale "degraded" would
+      // keep gating controls on evidence we no longer have.
+      setStatus(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!authed) {
+      setStatus(null);
+      return undefined;
+    }
+
+    let cancelled = false;
+    const poll = async () => {
+      // A backgrounded tab learns nothing it can show anyone; skip the request
+      // and catch up on the visibilitychange below.
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
+      if (cancelled) return;
+      await fetchStatus();
+    };
+
+    poll();
+    const interval = window.setInterval(poll, SERVICE_STATUS_POLL_MS);
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') poll();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+    // `fetchStatus` is stable (useCallback with no deps); `authed` is the real
+    // trigger — sign in starts the loop, sign out tears it down.
+  }, [authed, fetchStatus]);
+
+  const services = useMemo(() => status?.services ?? [], [status]);
+
+  const byKey = useMemo(() => {
+    const map = new Map<string, ServiceStatus>();
+    services.forEach((service) => map.set(service.key, service));
+    return map;
+  }, [services]);
+
+  const getService = useCallback(
+    (key: ServiceKey) => byKey.get(key) ?? null,
+    [byKey],
+  );
+
+  const isDegraded = useCallback(
+    (key: ServiceKey) => {
+      const service = byKey.get(key);
+      return Boolean(service) && DEGRADED_STATES.includes(service!.state);
+    },
+    [byKey],
+  );
+
+  const value = useMemo<ServiceStatusContextType>(
+    () => ({
+      status,
+      degraded: Boolean(status?.degraded),
+      services,
+      getService,
+      isDegraded,
+      refresh: fetchStatus,
+    }),
+    [status, services, getService, isDegraded, fetchStatus],
+  );
+
+  return (
+    <ServiceStatusContext.Provider value={value}>{children}</ServiceStatusContext.Provider>
+  );
+};
+
+export default ServiceStatusContext;

--- a/frontend/src/hooks/useServiceStatus.ts
+++ b/frontend/src/hooks/useServiceStatus.ts
@@ -1,0 +1,15 @@
+/**
+ * useServiceStatus Hook
+ * Convenience hook for reading which external services are currently degraded.
+ *
+ * Backed by one shared poll (contexts/ServiceStatusContext) — call it from as
+ * many components as you like without adding a request. Outside the provider
+ * it reports everything healthy, so it never gates a control on ignorance.
+ */
+import { useServiceStatusContext } from '../contexts/ServiceStatusContext';
+
+export const useServiceStatus = () => {
+  return useServiceStatusContext();
+};
+
+export default useServiceStatus;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { NotificationProvider } from './contexts/NotificationContext';
+import { ServiceStatusProvider } from './contexts/ServiceStatusContext';
 import { restoreSentryAuthFromStorage } from './services/sentryAuth';
 import './styles/index.css';
 
@@ -106,8 +107,12 @@ root.render(
     <MantineProvider>
       <ModalsProvider>
         <NotificationProvider>
-          <Notifications />
-          <App />
+          {/* One poll of the service-status endpoint for the whole tab; the
+              banner and every inline gate read from it. */}
+          <ServiceStatusProvider>
+            <Notifications />
+            <App />
+          </ServiceStatusProvider>
         </NotificationProvider>
       </ModalsProvider>
     </MantineProvider>

--- a/frontend/src/pages/FacilitiesProjectStoragePage.tsx
+++ b/frontend/src/pages/FacilitiesProjectStoragePage.tsx
@@ -42,8 +42,10 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import ProjectStorageLabelPreview from '../components/ProjectStorageLabelPreview';
 import QRScanner from '../components/QRScanner';
+import ServiceUnavailableNotice from '../components/ServiceUnavailableNotice';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import { useNotifications } from '../hooks/useNotifications';
+import { useServiceStatus } from '../hooks/useServiceStatus';
 import { projectStorageAPI } from '../services/api';
 import {
   ProjectStorageStatus,
@@ -83,6 +85,8 @@ const formatDate = (iso: string | null): string => {
 
 const FacilitiesProjectStoragePage: React.FC = () => {
   const notifications = useNotifications();
+  const { isDegraded } = useServiceStatus();
+  const emailDown = isDegraded('email');
   const navigate = useNavigate();
   // The :stintId param is optional — the page is mounted at both
   // /facilities/project-storage (lookup form) and
@@ -254,10 +258,14 @@ const FacilitiesProjectStoragePage: React.FC = () => {
   // -- which actions are available right now --------------------------
 
   const status: ProjectStorageStatus | null = stint?.status ?? null;
+  // The notice IS an email — the endpoint only stamps notice_sent_at once the
+  // message goes out — so with email down the button can only fail. Purgatory
+  // and removal are database-only and stay available.
   const canSendNotice =
-    status === 'expired' ||
-    status === 'expiring_soon' ||
-    status === 'purgatory_warned';
+    (status === 'expired' ||
+      status === 'expiring_soon' ||
+      status === 'purgatory_warned') &&
+    !emailDown;
   const canMoveToPurgatory =
     status === 'purgatory_warned' && stint?.notice_sent_at != null;
   const canMarkRemoved =
@@ -451,6 +459,13 @@ const FacilitiesProjectStoragePage: React.FC = () => {
                 Reprint claim ticket
               </Button>
             </Group>
+            {/* Directly under the action row rather than inside it — the Group
+                lays its children out as buttons in a line. */}
+            <ServiceUnavailableNotice
+              service="email"
+              message="Email delivery is temporarily unavailable — the violation notice can't be sent yet. We'll keep retrying."
+              testId="notice-email-unavailable"
+            />
 
             {/*
               Claim-label preview. Only mounted here (inside the loaded-stint

--- a/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
+++ b/frontend/src/pages/ForgeKeyDeviceDetailPage.tsx
@@ -14,7 +14,11 @@ import DeviceLifecycleCard from '../components/DeviceLifecycleCard';
 import DeviceSectionGate from '../components/DeviceSectionGate';
 import IndicatorManagementCard from '../components/IndicatorManagementCard';
 import IndicatorSwatch from '../components/IndicatorSwatch';
+import ServiceUnavailableNotice, {
+  DEVICE_CONTROL_UNAVAILABLE,
+} from '../components/ServiceUnavailableNotice';
 import WorkspacePage from '../components/landing/WorkspacePage';
+import { useServiceStatus } from '../hooks/useServiceStatus';
 import {
   ForgeKeyCommandResponse,
   ForgeKeyDevice,
@@ -42,6 +46,12 @@ const initialControl: ControlState = { pending: false, lastResult: null, lastErr
 const ForgeKeyDeviceDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  // Every control on this page ends in an MQTT publish — forgekey's
+  // device_commands service routes all of them through the "mqtt" circuit
+  // breaker — so when device_control is degraded none of them can reach the
+  // hardware, and a click would only buy a broker timeout.
+  const { isDegraded } = useServiceStatus();
+  const deviceControlDown = isDegraded('device_control');
   const isStaff = typeof window !== 'undefined' && localStorage.getItem('is_staff') === 'true';
   const isSuperuser =
     typeof window !== 'undefined' && localStorage.getItem('is_superuser') === 'true';
@@ -322,6 +332,7 @@ const ForgeKeyDeviceDetailPage: React.FC = () => {
               )
             }
             blinkState={controls.blink}
+            deviceControlDown={deviceControlDown}
           />
 
           <section aria-label="OTA firmware update">
@@ -343,7 +354,7 @@ const ForgeKeyDeviceDetailPage: React.FC = () => {
               <ControlButton
                 label="Send OTA"
                 state={controls.ota}
-                disabled={!otaInputs.version || !otaInputs.url}
+                disabled={!otaInputs.version || !otaInputs.url || deviceControlDown}
                 onClick={() =>
                   runCommand('ota', () =>
                     forgekeyAPI.firmwareUpdate(id, {
@@ -354,6 +365,11 @@ const ForgeKeyDeviceDetailPage: React.FC = () => {
                 }
               />
             </div>
+            <ServiceUnavailableNotice
+              service="device_control"
+              message={DEVICE_CONTROL_UNAVAILABLE}
+              testId="ota-device-control-notice"
+            />
           </section>
         </>
       ) : (
@@ -378,12 +394,15 @@ interface CapabilitiesSectionProps {
   device: ForgeKeyDevice;
   blinkState: ControlState;
   onBlink: () => void;
+  /** True when the "mqtt" breaker is open — no command can reach the device. */
+  deviceControlDown: boolean;
 }
 
 const CapabilitiesSection: React.FC<CapabilitiesSectionProps> = ({
   device,
   blinkState,
   onBlink,
+  deviceControlDown,
 }) => {
   const capabilities = device.capabilities || [];
   if (capabilities.length === 0) {
@@ -419,6 +438,7 @@ const CapabilitiesSection: React.FC<CapabilitiesSectionProps> = ({
               blinkState={blinkState}
               onBlink={onBlink}
               device={device}
+              deviceControlDown={deviceControlDown}
             />
           </li>
         ))}
@@ -432,6 +452,7 @@ interface CapabilityRowProps {
   device: ForgeKeyDevice;
   blinkState: ControlState;
   onBlink: () => void;
+  deviceControlDown: boolean;
 }
 
 const CapabilityRow: React.FC<CapabilityRowProps> = ({
@@ -439,6 +460,7 @@ const CapabilityRow: React.FC<CapabilityRowProps> = ({
   device,
   blinkState,
   onBlink,
+  deviceControlDown,
 }) => {
   const meta = KNOWN_CAPABILITIES[capability];
   const header = meta ? (
@@ -469,18 +491,29 @@ const CapabilityRow: React.FC<CapabilityRowProps> = ({
     body = <ButtonEventWidget device={device} />;
   } else if (capability === 'status_led') {
     body = (
-      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-        <IndicatorStateInline state={device.indicator_state} />
-        <button type="button" onClick={onBlink} disabled={blinkState.pending}>
-          {blinkState.pending ? 'Blinking…' : 'Blink LED'}
-        </button>
-        {blinkState.lastError && (
-          <small style={{ color: '#c0392b' }}>{blinkState.lastError}</small>
-        )}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <IndicatorStateInline state={device.indicator_state} />
+          <button
+            type="button"
+            onClick={onBlink}
+            disabled={blinkState.pending || deviceControlDown}
+          >
+            {blinkState.pending ? 'Blinking…' : 'Blink LED'}
+          </button>
+          {blinkState.lastError && (
+            <small style={{ color: '#c0392b' }}>{blinkState.lastError}</small>
+          )}
+        </div>
+        <ServiceUnavailableNotice
+          service="device_control"
+          message={DEVICE_CONTROL_UNAVAILABLE}
+          testId="blink-device-control-notice"
+        />
       </div>
     );
   } else if (capability === 'power_relay') {
-    body = <PowerRelayWidget device={device} />;
+    body = <PowerRelayWidget device={device} deviceControlDown={deviceControlDown} />;
   }
 
   return (
@@ -564,7 +597,10 @@ const RelayChannelState: React.FC<{ on: boolean | undefined }> = ({ on }) => {
 // Per-channel control of the 2-channel power relay (ga-40w). Each click emits a
 // signed `power_set` command for that channel; the current on/off is surfaced
 // from the live sub-state the firmware reports over its status message (op-2cr).
-const PowerRelayWidget: React.FC<{ device: ForgeKeyDevice }> = ({ device }) => {
+const PowerRelayWidget: React.FC<{
+  device: ForgeKeyDevice;
+  deviceControlDown: boolean;
+}> = ({ device, deviceControlDown }) => {
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -604,7 +640,7 @@ const PowerRelayWidget: React.FC<{ device: ForgeKeyDevice }> = ({ device }) => {
           <button
             type="button"
             onClick={() => send(ch, true)}
-            disabled={busy !== null}
+            disabled={busy !== null || deviceControlDown}
             data-testid={`relay-channel-${ch}-enable`}
           >
             {busy === `${ch}:true` ? 'Enabling…' : 'Enable'}
@@ -612,13 +648,18 @@ const PowerRelayWidget: React.FC<{ device: ForgeKeyDevice }> = ({ device }) => {
           <button
             type="button"
             onClick={() => send(ch, false)}
-            disabled={busy !== null}
+            disabled={busy !== null || deviceControlDown}
             data-testid={`relay-channel-${ch}-disable`}
           >
             {busy === `${ch}:false` ? 'Disabling…' : 'Disable'}
           </button>
         </div>
       ))}
+      <ServiceUnavailableNotice
+        service="device_control"
+        message={DEVICE_CONTROL_UNAVAILABLE}
+        testId="relay-device-control-notice"
+      />
       {error && (
         <small style={{ color: '#c0392b' }} data-testid="relay-channel-error">
           {error}

--- a/frontend/src/pages/MakerBoxPreConversionPage.tsx
+++ b/frontend/src/pages/MakerBoxPreConversionPage.tsx
@@ -15,6 +15,8 @@
  * refreshes their identity row rather than producing duplicates.
  */
 import React, { useCallback, useEffect, useState } from 'react';
+import ServiceUnavailableNotice from '../components/ServiceUnavailableNotice';
+import { useServiceStatus } from '../hooks/useServiceStatus';
 import {
   makerBoxesAPI,
   MakerBox,
@@ -30,6 +32,12 @@ const IDENTITY_SOURCE_LABEL: Record<string, string> = {
 };
 
 const MakerBoxPreConversionPage: React.FC = () => {
+  // The identity cascade layers WHMCS over Common API, and it consults WHMCS on
+  // *both* paths — so a degraded WHMCS breaks every lookup and the buttons go
+  // with it. A degraded Common API only breaks badge scans; typing a username
+  // still resolves, so that one warns without taking the control away.
+  const { isDegraded } = useServiceStatus();
+  const billingDown = isDegraded('whmcs');
   const [query, setQuery] = useState('');
   const [notes, setNotes] = useState('');
   const [preview, setPreview] = useState<MakerBoxLookupResult | null>(null);
@@ -173,7 +181,7 @@ const MakerBoxPreConversionPage: React.FC = () => {
         <div style={{ display: 'flex', gap: '0.5rem' }}>
           <button
             type="submit"
-            disabled={previewing || !query.trim()}
+            disabled={previewing || !query.trim() || billingDown}
             style={{ padding: '0.5rem 1rem' }}
           >
             {previewing ? 'Looking up…' : 'Look up'}
@@ -181,12 +189,22 @@ const MakerBoxPreConversionPage: React.FC = () => {
           <button
             type="button"
             onClick={handleAddToQueue}
-            disabled={adding || !previewIsFresh || !preview?.found}
+            disabled={adding || !previewIsFresh || !preview?.found || billingDown}
             style={{ padding: '0.5rem 1rem' }}
           >
             {adding ? 'Adding…' : 'Add to queue'}
           </button>
         </div>
+        <ServiceUnavailableNotice
+          service="whmcs"
+          message="Membership lookups are unavailable right now — identity can't be resolved. Try again shortly."
+          testId="preconvert-whmcs-notice"
+        />
+        <ServiceUnavailableNotice
+          service="common_api"
+          message="Badge lookups are unavailable right now — type the member's username instead."
+          testId="preconvert-common-api-notice"
+        />
       </form>
 
       {error && (

--- a/frontend/src/pages/MakerBoxScanPage.tsx
+++ b/frontend/src/pages/MakerBoxScanPage.tsx
@@ -8,6 +8,8 @@
  * a pickup notice.
  */
 import React, { useCallback, useState } from 'react';
+import ServiceUnavailableNotice from '../components/ServiceUnavailableNotice';
+import { useServiceStatus } from '../hooks/useServiceStatus';
 import { makerBoxesAPI, MakerBoxScanResult } from '../services/api';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
 
@@ -17,6 +19,12 @@ type FormState = {
 };
 
 const MakerBoxScanPage: React.FC = () => {
+  // The scan itself is a WHMCS membership lookup, and the pickup notice is an
+  // email sent inline (the endpoint 502s if the provider is down), so each
+  // control is gated on the dependency it actually needs.
+  const { isDegraded } = useServiceStatus();
+  const billingDown = isDegraded('whmcs');
+  const emailDown = isDegraded('email');
   const [form, setForm] = useState<FormState>({ binId: '', username: '' });
   const [result, setResult] = useState<MakerBoxScanResult | null>(null);
   const [boxId, setBoxId] = useState<number | null>(null);
@@ -128,13 +136,22 @@ const MakerBoxScanPage: React.FC = () => {
           />
         </label>
         <div style={{ display: 'flex', gap: '0.5rem' }}>
-          <button type="submit" disabled={submitting} style={{ padding: '0.5rem 1rem' }}>
+          <button
+            type="submit"
+            disabled={submitting || billingDown}
+            style={{ padding: '0.5rem 1rem' }}
+          >
             {submitting ? 'Checking…' : 'Scan'}
           </button>
           <button type="button" onClick={reset} style={{ padding: '0.5rem 1rem' }}>
             Reset
           </button>
         </div>
+        <ServiceUnavailableNotice
+          service="whmcs"
+          message="Membership lookups are unavailable right now — a scan can't confirm this member's status."
+          testId="scan-whmcs-notice"
+        />
       </form>
 
       {error && (
@@ -167,7 +184,7 @@ const MakerBoxScanPage: React.FC = () => {
             <button
               type="button"
               onClick={handleEmailPickup}
-              disabled={emailSending || !!emailSentTo}
+              disabled={emailSending || !!emailSentTo || emailDown}
               style={{
                 marginTop: '1rem',
                 padding: '0.5rem 1rem',
@@ -186,6 +203,17 @@ const MakerBoxScanPage: React.FC = () => {
             </button>
           )}
         </div>
+      )}
+
+      {/* Sits under the status card rather than inside it — the card's solid
+          red/green background would swallow the warning colour — and only
+          when the pickup button it explains is on screen. */}
+      {boxId !== null && (
+        <ServiceUnavailableNotice
+          service="email"
+          message="Email delivery is temporarily unavailable — we'll keep retrying, so send the pickup notice again shortly."
+          testId="pickup-email-notice"
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/WebhookDetailPage.tsx
+++ b/frontend/src/pages/WebhookDetailPage.tsx
@@ -20,6 +20,7 @@ import {
 import { IconEdit, IconExternalLink, IconTestPipe, IconTrash } from '@tabler/icons-react';
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import ServiceUnavailableNotice from '../components/ServiceUnavailableNotice';
 import WorkspacePage from '../components/landing/WorkspacePage';
 import { webhooksAPI } from '../services/api';
 import '../styles/WebhookDetailPage.css';
@@ -229,6 +230,17 @@ const WebhookDetailPage: React.FC = () => {
     >
       <div className="webhook-detail-page">
         <Stack gap="md">
+          {/*
+            Warn, but deliberately do NOT disable Test. The status endpoint
+            aggregates the whole webhook family — it cannot say whether *this*
+            endpoint's breaker is the open one, and re-testing an endpoint is
+            exactly what a staffer does during a delivery outage.
+          */}
+          <ServiceUnavailableNotice
+            service="webhooks"
+            message="Webhook delivery is degraded right now — a test may fail or be retried."
+            testId="webhook-delivery-notice"
+          />
           {/* Status Badges */}
           <Group>
           {webhook.is_active ? (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,7 +2,7 @@
  * API service for communicating with the Django backend
  */
 import axios from 'axios';
-import { ActiveMaintenanceRow, Asset, AssetCostRecoveryReport, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, AssignSlotRequest, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, GenerateRackRequest, GenerateRackResult, InventoryItem, InventoryItemMetrics, ItemCountMode, ItemOnHandDisplay, ItemPurchaseHistory, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LogUsageRequest, LogUsageResponse, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, MaintenanceTool, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, StockHistory, StorageAssignment, StorageAssignmentType, StorageOverview, StorageSlot, StorageSlotCardPreview, Supplier, SupplierAgreement, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderAdHocMaterialInput, WorkOrderLotoCompletion, WorkOrderMaterialUsage, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
+import { ActiveMaintenanceRow, Asset, AssetCostRecoveryReport, AssetDocument, AssetMeter, AssetMeterReading, AssetPart, AssetProblem, AssetProblemPhoto, AssetProblemsData, AssignSlotRequest, Breaker, Category, ChangePasswordRequest, Checklist, ChecklistCompletion, CheckMaterialStockResponse, CreateReorderRequest, DashboardWidget, DeliveriesData, Disposition, DonationItem, Fixture, FixtureRefillRequest, GenerateRackRequest, GenerateRackResult, InventoryItem, InventoryItemMetrics, ItemCountMode, ItemOnHandDisplay, ItemPurchaseHistory, ItemSupplier, KioskPayload, LightSwitch, Location, LocationProblem, LogUsageRequest, LogUsageResponse, LowStockData, MaintenanceItem, MaintenanceLog, MaintenanceMaterial, MaintenanceTask, MaintenanceTool, NetworkDrop, NetworkDropType, NotificationPreferences, Outlet, PendingReordersData, ProjectStorageStatus, ProjectStorageStint, QRScansData, RecentSearch, ReorderRequest, ResilienceStatus, Screen, ScreenContentBlock, ScreenStatusEntry, SearchResult, SIG, SIGMember, SiteSettings, StockHistory, StorageAssignment, StorageAssignmentType, StorageOverview, StorageSlot, StorageSlotCardPreview, Supplier, SupplierAgreement, SupplierDetail, SystemMessage, TaxReceipt, UsageLog, UserProfile, Webhook, WebhookTestResult, WorkOrder, WorkOrderAdHocMaterialInput, WorkOrderLotoCompletion, WorkOrderMaterialUsage, WorkOrderPhoto, WorkOrderTaskCompletion, WorkOrderUploadResult } from '../types';
 
 /**
  * Resolves the API base URL based on environment.
@@ -5440,6 +5440,18 @@ export const storageVisionAPI = {
       '/storage-vision/observations/bulk-approve/',
       reason ? { observation_ids, reason } : { observation_ids },
     ),
+};
+
+// ---------------------------------------------------------------------------
+// Service status (resilience)
+// ---------------------------------------------------------------------------
+
+// Which external dependencies are working right now, derived from the backend
+// circuit breakers. Always 200 for an authenticated caller — a degraded
+// dependency is reported in the body, never as an error status. Polled by
+// ServiceStatusProvider; see contexts/ServiceStatusContext.tsx.
+export const resilienceAPI = {
+  getStatus: () => api.get<ResilienceStatus>('/resilience/status/'),
 };
 
 export default api;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2304,3 +2304,53 @@ export interface StorageOverview {
   racks: StorageOverviewRack[];
   generated_at: string;
 }
+
+// ---------------------------------------------------------------------------
+// Service status — GET /api/resilience/status/ (backend: resilience/services.py)
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregate circuit-breaker state for one capability. `half_open` means the
+ * dependency is on trial after an outage — still degraded, calls may fail.
+ */
+export type ServiceStatusState = 'closed' | 'half_open' | 'open';
+
+/**
+ * Stable machine keys, mirroring the backend SERVICE_REGISTRY. Call sites
+ * switch on these to gate a control; a key the backend adds later is still
+ * reported in the banner by its label, it just gates nothing until a call
+ * site opts in.
+ */
+export type ServiceKey =
+  | 'device_control'
+  | 'webhooks'
+  | 'whmcs'
+  | 'common_api'
+  | 'email';
+
+export interface ServiceStatus {
+  key: ServiceKey;
+  /** User-facing service name, e.g. "Device control". */
+  label: string;
+  /** What the user loses while this is degraded. */
+  description: string;
+  state: ServiceStatusState;
+  healthy: boolean;
+  /** When the service entered its current state; null if it never transitioned. */
+  since: string | null;
+  /**
+   * Error detail from that transition. Internal detail — never render this in
+   * a member-facing surface; it exists for a staff status view only.
+   */
+  last_error: string | null;
+  /** Member breakers currently open or half-open (families like webhooks). */
+  degraded_count: number;
+  /** Member breakers with a known state; 1 for a single-breaker service. */
+  total_count: number;
+}
+
+export interface ResilienceStatus {
+  degraded: boolean;
+  checked_at: string;
+  services: ServiceStatus[];
+}


### PR DESCRIPTION
PR3 of 4 in the resilience series (PR1 #999 = status registry + API, PR2 #1000 = email breaker). This is the part Ian actually asked for: **show users which capability is unavailable instead of failing silently.**

## What

A `ServiceStatusContext` polls `GET /api/resilience/status/` every 60s, and only when the user is authenticated and the tab is visible. Two surfaces consume it:

- **`ServiceStatusBanner`** in `WorkspaceLayout`, alongside the existing notification/session/compliance banners. Lists affected service *labels* in plain language ("Email delivery is temporarily unavailable — we'll keep retrying"), uses counts for the aggregated webhook family, and is dismissible per-session but returns if a new service degrades.
- **`ServiceUnavailableNotice`**, one shared component rather than a per-page treatment, for inline gating at the controls themselves.

## Gated, and deliberately not gated

Gated: ForgeKey device power/relay controls and indicator management (`device_control` ← mqtt), Maker Box scan + pre-conversion flows (`whmcs` / `common_api` lookups), and project-storage actions that trigger email.

**Not gated — webhook Test.** The status endpoint aggregates the whole webhook family, so it can't say whether *this* endpoint's breaker is the open one; and re-testing an endpoint is exactly what a staffer does during a delivery outage. It warns instead of disabling. That reasoning is in a comment at the call site.

## Safety properties

Gating is conservative in the direction that matters: a control is disabled **only** when its service is genuinely `open`/`half_open`. A failed or unknown status fetch is treated as healthy and gates nothing — a monitoring outage must never take working controls away from users. `last_error` is never rendered in the banner (it can carry internal detail).

## Verification

- 744 lines of new tests across 4 files: banner hidden-when-healthy / shown-when-degraded / correct labels, hook treats fetch failure as healthy, gated control disabled when open and enabled when closed, no polling while unauthenticated.
- Mayor re-verified on the pushed commit with node24: `npm run lint` → **0 errors**; `npm run test:fast` → **177 files, 1490 tests, all passing**. The 26 lint warnings are pre-existing and untouched by this branch (confirmed against `main`).

Frontend-only; no API shape changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
