### PR TITLE
chore(deps): patch brace-expansion for CVE-2026-13149 (op-egcf)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4533,14 +4533,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5577,7 +5579,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.15",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5846,7 +5850,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Clears **3 of the 4 open high-severity Dependabot alerts** — #149, #150, #151 are all the same advisory, [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) / CVE-2026-13149 (DoS via exponential-time expansion of consecutive non-expanding `{}` groups). They appear three times only because three major lines of `brace-expansion` are present in the frontend lockfile.

## Changes — `frontend/package-lock.json` only

| lockfile path | before | after | advisory's first patched |
|---|---|---|---|
| `node_modules/brace-expansion` | 5.0.6 | **5.0.9** | 5.0.7 |
| `node_modules/eslint-plugin-react/node_modules/brace-expansion` | 1.1.15 | **1.1.18** | 1.1.16 |
| `node_modules/filelist/node_modules/brace-expansion` | 2.1.1 | **2.1.4** | 2.1.2 |

Each lands at or above the patched version. All three are **transitive** and **dev-scope** (build/lint tooling, never shipped to the browser), so this is lockfile-only — no `package.json` change.

Produced with a targeted `npm update brace-expansion` rather than a blanket `npm audit fix`, so the diff touches only brace-expansion entries (plus their `resolved`/`integrity` hashes). Verified: 10 insertions, 4 deletions, one file.

### One thing worth noting
brace-expansion 5.0.9 narrows its `engines` from `"18 || 20 || >=22"` to `"20 || >=22"`. CI pins `node-version: "24"` in all three frontend jobs and the local toolchain is Node 24, so nothing is affected.

## Verification

All run on Node 24 against a lockfile-accurate tree:

- `npm run lint` — 0 errors (26 pre-existing warnings, unchanged)
- `npm run test:fast` equivalent (`vitest run --testTimeout=15000`) — **178 files / 1498 tests, all passing**
- `npm run build` — green

<details>
<summary>Why the raised timeout, and one local-env trap worth recording</summary>

The first full run came back with 15 red files. Two separate causes, neither related to this diff:

1. This box was at load average ~32 (other agents), which triggers the known 5s-timeout flake class — files pass in isolation.
2. More interesting: the shared checkout's `frontend/node_modules` had **drifted** from its own committed lockfile (`jsdom@29.1.1` installed, though the lockfile has specified jsdom 30 since #977). Any npm write reconciles the tree to the lockfile — which is why a 3-line lockfile edit reported "changed 29 packages" — but it does **not** re-run `patch-package`. That left `patches/jsdom+30.0.0.patch` unapplied, and unpatched jsdom 30 throws `TypeError: object null is not iterable` from `getComputedStyle()` on Mantine's `calc(var(...))` CSS: 54 occurrences across those 15 files.

After `npx patch-package`, the full suite is 1498/1498 green. Nothing here is a product change — flagging it because anyone running the frontend suite locally in that checkout is testing against the wrong jsdom.
</details>

## Out of scope
Alert #155 (react-router) is a separate advisory requiring a breaking major bump — its own bead.

Bead: op-egcf

🤖 Generated with [Claude Code](https://claude.com/claude-code)