### PR TITLE
fix: guard ForgeKey id query filters against unparseable values (op-7487)

### DIFF
--- a/backend/forgekey/tests/test_asset_access_filtering.py
+++ b/backend/forgekey/tests/test_asset_access_filtering.py
@@ -5,18 +5,25 @@ Added for #7b so the asset detail page can fetch just the records for the
 asset it's showing via ``?asset=<id>`` (plus ``?is_active=`` for the
 authorization/lockout lists). op-rmic extends the same convention to
 ``/asset-devices/`` for the "Bound devices" section.
+
+``TestInvalidIdFilters`` (op-7487) covers the whole id-filter family across
+these viewsets, including the ``?location=`` / ``?user=`` / ``?actor=`` and
+indicator/access-log siblings that share the same ``_filter_by_id`` guard.
 """
 
 import pytest
 from rest_framework.test import APIClient
 
-from forgekey.models import AssetDevice
+from forgekey.audit import record_event
+from forgekey.models import AssetDevice, ForgeKeyAuditEvent
 from forgekey.tests.factories import (
     AssetAuthorizationFactory,
     AssetDeviceFactory,
     DeviceLockoutFactory,
     ESP32DeviceFactory,
+    IndicatorBindingFactory,
     OperationalModeFactory,
+    RoomOperationalModeFactory,
 )
 from inventory.tests.factories import AssetFactory
 
@@ -169,3 +176,112 @@ class TestAssetDeviceFilter:
         detached = client.delete(f"/api/forgekey/asset-devices/{created.data['id']}/")
         assert detached.status_code == 204
         assert not AssetDevice.objects.filter(asset=asset, device=device).exists()
+
+
+# Every ``?<param>=<id>`` filter across the ForgeKey access viewsets, as
+# (endpoint path, query param). The pks behind them are split between UUIDs
+# (asset, device) and integers (location, user, actor), which raise different
+# exceptions out of ``filter()`` — the guard has to cover both.
+ID_FILTERS = [
+    ("asset-devices", "asset"),
+    ("asset-devices", "device"),
+    ("operational-modes", "asset"),
+    ("room-operational-modes", "location"),
+    ("indicator-bindings", "asset"),
+    ("indicator-bindings", "device"),
+    ("indicator-bindings", "location"),
+    ("authorizations", "asset"),
+    ("authorizations", "user"),
+    ("access-log", "asset"),
+    ("access-log", "actor"),
+    ("access-log", "device"),
+    ("lockouts", "asset"),
+]
+
+
+@pytest.fixture
+def one_row_per_endpoint():
+    """Seed one real row behind every endpoint in ``ID_FILTERS``.
+
+    The rows matter: they are what distinguishes "the bad id narrowed to
+    nothing" from "the bad id was silently dropped and you got the whole
+    table back".
+    """
+    AssetDeviceFactory()
+    OperationalModeFactory()
+    RoomOperationalModeFactory()
+    IndicatorBindingFactory()
+    AssetAuthorizationFactory(asset=AssetFactory())
+    DeviceLockoutFactory()
+    record_event(action=ForgeKeyAuditEvent.ACTION_ACCESS_GRANTED, asset=AssetFactory())
+
+
+class TestInvalidIdFilters:
+    """op-7487: a garbage id in a filter param is a caller mistake, not a 500.
+
+    Before the ``_filter_by_id`` guard these reached the field's own coercion
+    inside ``filter()``: the integer pks (``location``, ``user``, ``actor``)
+    raised ``ValueError`` and surfaced as an unhandled 500, while the UUID pks
+    raised Django's ``ValidationError`` and were translated to a 400 by
+    ``standardized_exception_handler``. Same mistake, two different answers,
+    neither of them the empty page the caller should get.
+    """
+
+    @pytest.mark.parametrize("endpoint,param", ID_FILTERS)
+    def test_unparseable_id_returns_empty_page(self, client, one_row_per_endpoint, endpoint, param):
+        """Parametrized over every call site: a missed one shows up here."""
+        resp = client.get(f"/api/forgekey/{endpoint}/?{param}=abc")
+
+        assert resp.status_code == 200, resp.content
+        assert _results(resp) == []
+
+    @pytest.mark.parametrize(
+        "endpoint,param",
+        [("asset-devices", "asset"), ("authorizations", "user")],
+        ids=["uuid-pk", "int-pk"],
+    )
+    def test_digit_leading_garbage_id_returns_empty_page(
+        self, client, one_row_per_endpoint, endpoint, param
+    ):
+        """A truncated/typo'd id that starts numeric is the realistic mistake,
+        and it is invalid for a UUID pk and an integer pk alike."""
+        resp = client.get(f"/api/forgekey/{endpoint}/?{param}=12x34")
+
+        assert resp.status_code == 200, resp.content
+        assert _results(resp) == []
+
+    @pytest.mark.parametrize(
+        "endpoint,param",
+        [("asset-devices", "asset"), ("authorizations", "user")],
+        ids=["uuid-pk", "int-pk"],
+    )
+    def test_blank_id_is_not_a_filter(self, client, one_row_per_endpoint, endpoint, param):
+        """An empty ``?asset=`` is an absent filter, not an invalid one — it
+        must keep returning the unfiltered list rather than narrowing to none."""
+        resp = client.get(f"/api/forgekey/{endpoint}/?{param}=")
+
+        assert resp.status_code == 200, resp.content
+        assert len(_results(resp)) == 1
+
+    def test_valid_id_still_filters(self, client, one_row_per_endpoint):
+        """The guard must not swallow working filters: a real id still narrows."""
+        asset = AssetFactory()
+        AssetDeviceFactory(asset=asset)
+
+        resp = client.get(f"/api/forgekey/asset-devices/?asset={asset.id}")
+
+        assert resp.status_code == 200, resp.content
+        results = _results(resp)
+        assert len(results) == 1
+        assert str(results[0]["asset"]) == str(asset.id)
+
+    def test_bad_id_narrows_a_combined_filter(self, client):
+        """A bad id in one param must not be ignored just because another
+        param in the same ``get_queryset`` is valid."""
+        asset = AssetFactory()
+        AssetAuthorizationFactory(asset=asset, is_active=True)
+
+        resp = client.get("/api/forgekey/authorizations/?user=abc&is_active=true")
+
+        assert resp.status_code == 200, resp.content
+        assert _results(resp) == []

--- a/backend/forgekey/views.py
+++ b/backend/forgekey/views.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from django.db.models import F
 from django.http import FileResponse, HttpResponse, StreamingHttpResponse
@@ -1644,6 +1645,27 @@ def _parse_since_window(raw: str):
     return parsed
 
 
+def _filter_by_id(queryset, field, raw):
+    """Apply ``<field>=<raw>`` to *queryset*, narrowing to none() on a bad id.
+
+    An id off the query string is caller-controlled text, and handing it
+    straight to ``filter()`` lets the target field's own coercion raise:
+    ``ValueError`` for the integer pks (``location``, ``user``, ``actor``) and
+    ``ValidationError`` for the UUID ones (``asset``, ``device``). Only the
+    latter is translated by ``standardized_exception_handler``, so today the
+    same caller mistake answers 400 on some of these endpoints and 500 on
+    others. A present-but-unparseable id matches no rows, so answer with an
+    empty page everywhere instead. An absent or blank param is not a filter at
+    all and leaves the queryset untouched.
+    """
+    if not raw:
+        return queryset
+    try:
+        return queryset.filter(**{field: raw})
+    except (TypeError, ValueError, DjangoValidationError):
+        return queryset.none()
+
+
 class AssetDeviceViewSet(viewsets.ModelViewSet):
     """API endpoint for asset-device relationships."""
 
@@ -1657,12 +1679,8 @@ class AssetDeviceViewSet(viewsets.ModelViewSet):
         instead of paging the whole fleet's assignments."""
         qs = super().get_queryset()
         params = self.request.query_params
-        asset_id = params.get("asset")
-        device_id = params.get("device")
-        if asset_id:
-            qs = qs.filter(asset_id=asset_id)
-        if device_id:
-            qs = qs.filter(device_id=device_id)
+        qs = _filter_by_id(qs, "asset_id", params.get("asset"))
+        qs = _filter_by_id(qs, "device_id", params.get("device"))
         return qs
 
 
@@ -1677,10 +1695,7 @@ class OperationalModeViewSet(viewsets.ModelViewSet):
         """Allow ``?asset=<id>`` so the asset detail page can fetch just the
         single OperationalMode (if any) for the asset it's showing."""
         qs = super().get_queryset()
-        asset_id = self.request.query_params.get("asset")
-        if asset_id:
-            qs = qs.filter(asset_id=asset_id)
-        return qs
+        return _filter_by_id(qs, "asset_id", self.request.query_params.get("asset"))
 
     @action(detail=True, methods=["post"])
     def enable_classroom_mode(self, request, pk=None):
@@ -1736,10 +1751,7 @@ class RoomOperationalModeViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         """Allow ``?location=<id>`` so a room panel can fetch just its mode."""
         qs = super().get_queryset()
-        location_id = self.request.query_params.get("location")
-        if location_id:
-            qs = qs.filter(location_id=location_id)
-        return qs
+        return _filter_by_id(qs, "location_id", self.request.query_params.get("location"))
 
     def _actor(self):
         user = self.request.user
@@ -1770,15 +1782,9 @@ class IndicatorBindingViewSet(viewsets.ModelViewSet):
         """Filter by ``?device=`` / ``?asset=`` / ``?location=`` for detail pages."""
         qs = super().get_queryset()
         params = self.request.query_params
-        device_id = params.get("device")
-        asset_id = params.get("asset")
-        location_id = params.get("location")
-        if device_id:
-            qs = qs.filter(device_id=device_id)
-        if asset_id:
-            qs = qs.filter(asset_id=asset_id)
-        if location_id:
-            qs = qs.filter(location_id=location_id)
+        qs = _filter_by_id(qs, "device_id", params.get("device"))
+        qs = _filter_by_id(qs, "asset_id", params.get("asset"))
+        qs = _filter_by_id(qs, "location_id", params.get("location"))
         return qs
 
     def _actor(self):
@@ -1843,12 +1849,8 @@ class AssetAuthorizationViewSet(viewsets.ModelViewSet):
         ``?user=`` backs the per-member "assets I'm authorized for" view (op-tup);
         ``?is_active=`` narrows either to the currently-active grants."""
         qs = super().get_queryset()
-        asset_id = self.request.query_params.get("asset")
-        if asset_id:
-            qs = qs.filter(asset_id=asset_id)
-        user_id = self.request.query_params.get("user")
-        if user_id:
-            qs = qs.filter(user_id=user_id)
+        qs = _filter_by_id(qs, "asset_id", self.request.query_params.get("asset"))
+        qs = _filter_by_id(qs, "user_id", self.request.query_params.get("user"))
         is_active = self.request.query_params.get("is_active")
         if is_active is not None:
             qs = qs.filter(is_active=is_active.lower() in ("1", "true", "yes"))
@@ -2077,15 +2079,9 @@ class ForgeKeyAuditEventViewSet(viewsets.ReadOnlyModelViewSet):
         action_filter = params.get("action")
         if action_filter:
             qs = qs.filter(action=action_filter)
-        asset_id = params.get("asset")
-        if asset_id:
-            qs = qs.filter(asset_id=asset_id)
-        actor_id = params.get("actor")
-        if actor_id:
-            qs = qs.filter(actor_id=actor_id)
-        device_id = params.get("device")
-        if device_id:
-            qs = qs.filter(device_id=device_id)
+        qs = _filter_by_id(qs, "asset_id", params.get("asset"))
+        qs = _filter_by_id(qs, "actor_id", params.get("actor"))
+        qs = _filter_by_id(qs, "device_id", params.get("device"))
         return qs
 
 
@@ -2101,9 +2097,7 @@ class DeviceLockoutViewSet(viewsets.ModelViewSet):
         detail page can list just that asset's lockouts (typically the active
         ones)."""
         qs = super().get_queryset()
-        asset_id = self.request.query_params.get("asset")
-        if asset_id:
-            qs = qs.filter(asset_id=asset_id)
+        qs = _filter_by_id(qs, "asset_id", self.request.query_params.get("asset"))
         is_active = self.request.query_params.get("is_active")
         if is_active is not None:
             qs = qs.filter(is_active=is_active.lower() in ("1", "true", "yes"))


### PR DESCRIPTION
A garbage id in a query filter is a caller mistake, not a server error. Today four
ForgeKey endpoints answer it with a **500**.

## The failure splits by pk TYPE, not uniformly

The worker probed all 13 filters against a live instance before changing anything,
and the bead's premise turned out to be only half right:

| pk type | fields | raised | surfaced as |
|---|---|---|---|
| **integer** | `location`, `user`, `actor` | `ValueError` | **unhandled 500** (4 endpoints) |
| **UUID** | `asset`, `device` | Django `ValidationError` | 400 (9 endpoints) |

The 400 is a *global accident* — `config.api_errors.standardized_exception_handler`
happens to translate `ValidationError` — not a per-endpoint contract. **A guard
catching only one exception type would have left half these endpoints broken.**

The 500s are on `/room-operational-modes/?location=`, `/indicator-bindings/?location=`,
`/authorizations/?user=` and `/access-log/?actor=`.

## Fix

One module-level `_filter_by_id(queryset, field, raw)` in `backend/forgekey/views.py`,
catching `(TypeError, ValueError, DjangoValidationError)` → `queryset.none()`. All 13
id filters across **7** viewsets route through it. A present-but-unparseable id matches
no rows, so every endpoint now answers an empty page. An absent or blank param is not a
filter at all and leaves the queryset untouched.

Mirrors existing prior art in `inventory/views.py` and `SupplierAgreementViewSet`.

> Note: the bead said **six** viewsets — there are **seven**. It missed
> `ForgeKeyAuditEventViewSet`, whose route is `/access-log/`, not `/audit-events/`.

## Checked, no fix needed

Out-of-range integer ids (beyond both int4 and int8) and negative ids **already**
return 200 / zero rows on Postgres, so they need no separate guard.

## Tests

`TestInvalidIdFilters` parametrizes the empty-page assertion over **every one of the 13
call sites**, so a missed conversion fails loudly instead of hiding behind a sibling's
passing test. Plus digit-leading garbage per pk type, a combined-param case, and two
deliberate over-correction guardrails (blank id still unfiltered, valid id still filters).

**16 of the 19 new tests fail against `origin/main`**; the 3 that pass are the guardrails.

## Verification

- Full backend suite on Postgres: **4673 passed / 4 skipped / 2 failed**. Both failures
  are the documented `reorder_queue` MEDIA_ROOT-pollution artifact in an unrelated app —
  confirmed by clearing the scoped untracked path and re-running: 11 passed.
- ForgeKey suite: **774 passed**.
- black / isort / flake8 / ruff clean; bandit unchanged from baseline (2 pre-existing
  B105 on untouched header constants).
- ⚠️ The aggregate `pre-commit run` timed out at 10min building hook envs, so each hook
  was run directly (all green). **Mayor independently re-ran black / isort / flake8 /
  bandit on both changed files — all clean.**
- Frontend suite not run: zero frontend files changed, and the repo's own husky pre-push
  hook scopes the frontend gate to frontend diffs and skips it.

Closes op-7487.
