### PR TITLE
test: collect the 6 orphaned backend apps in CI testpaths (op-t7q4)

### DIFF
--- a/backend/accounting/tests/conftest.py
+++ b/backend/accounting/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Shared fixtures for the accounting suite.
+
+Every ledger test posts against the chart of accounts, which is seeded by a
+*data migration* (``0002_seed_chart_of_accounts``) rather than a fixture. Any
+``transaction=True`` test earlier in the session flushes it back out — a
+``TransactionTestCase`` teardown truncates every table and the ``post_migrate``
+that follows only restores contenttypes/permissions, not data-migration rows.
+
+Before op-t7q4 the only such test on main (``facilities/tests/test_migration.py``)
+was absent from ``pytest.ini`` ``testpaths``, so CI never ran it and the accounting
+suite was accidentally safe. Now that facilities is collected, this module makes
+the whole accounting suite order-proof instead.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _chart_of_accounts(db):
+    """Guarantee the chart exists before a ledger test posts against it.
+
+    Re-seeding is idempotent by design — it is the same call the migration and
+    the ``seed_chart_of_accounts`` management command make — and it rolls back
+    with the test, so this costs one no-op query per test.
+    """
+    from accounting.chart import seed_chart_of_accounts
+
+    seed_chart_of_accounts()

--- a/backend/inventory/tests/test_log_usage_charge.py
+++ b/backend/inventory/tests/test_log_usage_charge.py
@@ -28,6 +28,22 @@ pytestmark = pytest.mark.django_db
 User = get_user_model()
 
 
+@pytest.fixture(autouse=True)
+def _chart_of_accounts(db):
+    """Guarantee the chart exists before a ledger test posts against it.
+
+    The chart is seeded by a *data migration*, and any ``transaction=True`` test
+    earlier in the session flushes it back out (its ``TransactionTestCase``
+    teardown truncates every table and ``post_migrate`` only restores
+    contenttypes/permissions). Re-seeding is idempotent by design — it is the
+    same call the migration and the management command make — and it rolls back
+    with the test, so this costs one no-op query and makes the module order-proof.
+    """
+    from accounting.chart import seed_chart_of_accounts
+
+    seed_chart_of_accounts()
+
+
 def _staff_client():
     user = User.objects.create_user(username="charger", password="pw", is_staff=True)
     client = APIClient()

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -38,6 +38,8 @@ addopts =
 testpaths =
     accounting/tests
     analytics/tests
+    backups/tests
+    bms/tests
     checklists/tests
     climate/tests
     config/tests
@@ -46,6 +48,7 @@ testpaths =
     devices/tests
     donations/tests
     electrical_circuits/tests
+    facilities/tests
     fiducials/tests
     forgekey/tests
     index_cards/tests
@@ -63,6 +66,9 @@ testpaths =
     reorder_queue/tests
     resilience/tests
     scanner/tests
+    screens/tests
+    search/tests
+    storage_vision/tests
     vendors/tests
 markers =
     unit: Unit tests

--- a/backend/reorder_queue/tests/test_receiving_ledger.py
+++ b/backend/reorder_queue/tests/test_receiving_ledger.py
@@ -27,6 +27,22 @@ pytestmark = pytest.mark.django_db
 PO_RECEIPT = "PO_RECEIPT"
 
 
+@pytest.fixture(autouse=True)
+def _chart_of_accounts(db):
+    """Guarantee the chart exists before a ledger test posts against it.
+
+    The chart is seeded by a *data migration*, and any ``transaction=True`` test
+    earlier in the session flushes it back out (its ``TransactionTestCase``
+    teardown truncates every table and ``post_migrate`` only restores
+    contenttypes/permissions). Re-seeding is idempotent by design — it is the
+    same call the migration and the management command make — and it rolls back
+    with the test, so this costs one no-op query and makes the module order-proof.
+    """
+    from accounting.chart import seed_chart_of_accounts
+
+    seed_chart_of_accounts()
+
+
 def _committee_po(user, *, group=None, qty=10, unit_cost=None, stock=0):
     """A SENT PO with one inventory line whose item is owned by ``group``.
 

--- a/backend/screens/tests/test_api.py
+++ b/backend/screens/tests/test_api.py
@@ -133,6 +133,7 @@ class TestKioskPayloadEndpoint:
 
 
 @pytest.mark.integration
+@pytest.mark.django_db
 class TestHeartbeatEndpoint:
     def test_heartbeat_requires_token(self, api_client):
         screen = ScreenFactory()
@@ -151,6 +152,7 @@ class TestHeartbeatEndpoint:
 
 
 @pytest.mark.integration
+@pytest.mark.django_db
 class TestScreenCrudPermissions:
     def test_regular_user_cannot_list(self, regular_client):
         client, _ = regular_client
@@ -211,6 +213,7 @@ class TestScreenCrudPermissions:
 
 
 @pytest.mark.integration
+@pytest.mark.django_db
 class TestSystemMessageEndpoints:
     def test_non_staff_cannot_create(self, regular_client):
         client, _ = regular_client
@@ -233,6 +236,7 @@ class TestSystemMessageEndpoints:
 
 
 @pytest.mark.integration
+@pytest.mark.django_db
 class TestContentBlockEndpoints:
     def test_staff_can_create_block(self, staff_client):
         client, _ = staff_client

--- a/backend/screens/tests/test_models.py
+++ b/backend/screens/tests/test_models.py
@@ -16,6 +16,8 @@ from screens.tests.factories import (
     SystemMessageFactory,
 )
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.mark.unit
 class TestScreenModel:


### PR DESCRIPTION
`backups`, `bms`, `facilities`, `screens`, `search` and `storage_vision` all ship tests that `backend/pytest.ini` never listed in `testpaths`, so CI's `pytest -n auto` silently skipped them — **219 tests that could rot green forever**. This adds all six. Collection goes **4679 → 4898**.

## Two things had to be fixed before they were collectible

**1. Missing `django_db` markers.** `screens/tests/test_models.py` and four classes in `screens/tests/test_api.py` reach the DB through factories but carry no marker — 12 tests fail the moment they actually run. Nobody noticed because CI never ran them.

**2. A real cross-test pollution bug, previously masked.** `facilities/tests/test_migration.py` is `django_db(transaction=True)` — it drives `MigrationExecutor` to rewind the graph, so it genuinely needs that. But its `TransactionTestCase` teardown truncates every table, and the `post_migrate` that follows restores only contenttypes/permissions — **not data-migration rows**. That wipes the accounting chart of accounts for every test scheduled after it on the same xdist worker: **42 of 74 accounting tests red**.

Fixed with the mitigation this repo already uses in `inventory/tests/test_work_order_committee_charge.py` — an idempotent autouse re-seed fixture — applied to the accounting suite (via a new `conftest.py`) and to the two other unprotected ledger modules.

The flush exposure is **pre-existing, not introduced here**: `test_safety_profile` and `test_fixture_refill_actor` are already collected and already carry `transaction=True`, so this makes those victims order-proof too.

## Coverage deliberately left alone
The six apps stay out of the `--cov=` list, so the `--cov-fail-under=85` denominator is unchanged. Measured for a separate follow-up decision: they are 1323 statements / 116 missed (91.2% from their own tests), which would move the aggregate **91.60% → 91.58%**.

## Verification
`pytest -n auto` on PostgreSQL, fresh DBs: **4894 passed, 4 skipped, 0 failed**, total coverage **91.60%** (38m39s).

Purely additive — 6 files, +72 lines, no deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)