### PR TITLE
chore: delete unreachable sqlite branch in conftest fixture (op-224)

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -134,28 +134,7 @@ def ensure_auth_user_groups_table(django_db_setup, django_db_blocker):
 
     with django_db_blocker.unblock():
         with connection.cursor() as cursor:
-            if connection.vendor == "sqlite":
-                cursor.execute(
-                    "SELECT name FROM sqlite_master WHERE type='table' "
-                    "AND name='auth_user_groups';"
-                )
-                table_exists = cursor.fetchone() is not None
-                if not table_exists:
-                    cursor.execute("""
-                        CREATE TABLE auth_user_groups (
-                            id INTEGER PRIMARY KEY AUTOINCREMENT,
-                            user_id INTEGER NOT NULL,
-                            group_id INTEGER NOT NULL,
-                            UNIQUE(user_id, group_id),
-                            FOREIGN KEY (user_id) REFERENCES auth_user(id),
-                            FOREIGN KEY (group_id) REFERENCES auth_group(id)
-                        );
-                        CREATE INDEX auth_user_groups_user_id_idx
-                            ON auth_user_groups(user_id);
-                        CREATE INDEX auth_user_groups_group_id_idx
-                            ON auth_user_groups(group_id);
-                        """)
-            elif connection.vendor == "postgresql":
+            if connection.vendor == "postgresql":
                 cursor.execute("""
                     SELECT EXISTS (
                         SELECT FROM information_schema.tables


### PR DESCRIPTION
`ensure_auth_user_groups_table` in `backend/conftest.py` branches on `connection.vendor`, with a sqlite arm that hand-creates `auth_user_groups`. **That arm can never run.**

`backend/accounting/checks.py:19-36` registers `check_postgres_required`, which returns a `checks.Error` (not a Warning) whenever the default vendor is sqlite. Django **halts** management commands on Error-level checks, so `manage.py` / pytest abort at the system-check stage — *before any conftest fixture runs*. There is no reachable path on which `connection.vendor == "sqlite"` inside this fixture.

Delete the sqlite arm and promote the `postgresql` arm to `if`. The Postgres body is unchanged — it is the only path that ever ran.

**1 file, +1/−22.** No behavior change.

Deliberately *not* done, per the bead: no sqlite fallback is added and `accounting.E001` is not weakened. The check is the reason this code is dead, and it should stay that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)