### PR TITLE
chore: baseline django-upgrade 4.2 rewrites with regression tests (op-3bl)

### DIFF
--- a/.criteria/django-upgrade-baseline.md
+++ b/.criteria/django-upgrade-baseline.md
@@ -1,0 +1,47 @@
+# Django Upgrade Baseline
+
+## Context
+The django-upgrade pre-commit hook currently rewrites the same four legacy Django idioms whenever agents run it, leaving unrelated worktrees dirty. This chore establishes a dedicated baseline for those deterministic rewrites so later work does not repeatedly rediscover them.
+
+## Scope
+- In: The django-upgrade rewrites in `backend/membership/views.py`, `backend/notifications/device_login.py`, `backend/preventive_maintenance/admin.py`, and `backend/project_storage/admin.py`; preserving the existing client IP, user-agent, and Django admin column-label behavior; targeted verification for the touched backend apps.
+- Out: Popping or applying any git stash; editing any path outside the four implementation files; changing models, migrations, tests, frontend code, settings, permissions, or business behavior; making unrelated main-branch pre-commit failures green; using `pre-commit run --all-files` as the acceptance gate for this chore.
+
+## Criteria
+
+### AC-1: Implementation diff is limited
+- **Given** the criteria commit is the starting point for implementation
+- **When** maintainers inspect the implementation diff after that commit
+- **Then** the only changed non-criteria paths are `backend/membership/views.py`, `backend/notifications/device_login.py`, `backend/preventive_maintenance/admin.py`, and `backend/project_storage/admin.py`
+
+### AC-2: Django upgrade hook is clean
+- **Given** the four django-upgrade rewrites have been committed on the chore branch
+- **When** `pre-commit run django-upgrade --all-files` is executed
+- **Then** the command exits successfully and a following `git status --short` shows no uncommitted django-upgrade rewrites
+
+### AC-3: Invite redemption keeps forwarded IP behavior
+- **Given** an anonymous invite redemption request includes `X-Forwarded-For: 203.0.113.10, 198.51.100.2`
+- **When** the invite code is redeemed successfully
+- **Then** the redeemed invite records `redeemed_ip` as `203.0.113.10`
+
+### AC-4: Device login keeps request header behavior
+- **Given** a staff user's new-device login request includes `X-Forwarded-For` and `User-Agent` HTTP headers
+- **When** device login tracking records the known-device row and notification metadata
+- **Then** the recorded IP is the first forwarded IP value and the recorded user agent matches the incoming user-agent header
+
+### AC-5: Admin display labels are preserved
+- **Given** Django admin loads the preventive maintenance and project storage model admins
+- **When** the list display metadata is inspected for the changed display callables
+- **Then** preventive maintenance still labels `_status` as `Status` and `_days_since` as `Last service`, and project storage still labels `status_display` as `Status`
+
+### AC-6: Targeted backend tests pass
+- **Given** the branch contains only the scoped django-upgrade implementation changes
+- **When** `cd backend && pytest membership notifications preventive_maintenance project_storage` is executed
+- **Then** the targeted backend tests for the four touched apps pass
+
+## Verification Commands
+- `pre-commit run django-upgrade --all-files`
+- `cd backend && pytest membership notifications preventive_maintenance project_storage`
+- `cd backend && python manage.py makemigrations --check`
+- `cd backend && python manage.py check_permission_matrix`
+- `cd frontend && npm test`

--- a/.criteria/django-upgrade-baseline.md
+++ b/.criteria/django-upgrade-baseline.md
@@ -1,18 +1,18 @@
 # Django Upgrade Baseline
 
 ## Context
-The django-upgrade pre-commit hook currently rewrites the same four legacy Django idioms whenever agents run it, leaving unrelated worktrees dirty. This chore establishes a dedicated baseline for those deterministic rewrites so later work does not repeatedly rediscover them.
+The django-upgrade pre-commit hook currently rewrites the same four legacy Django idioms whenever agents run it, leaving unrelated worktrees dirty. This chore establishes a dedicated baseline for those deterministic rewrites so later work does not repeatedly rediscover them. The baseline must prove the rewritten request-header and admin-display behavior with focused regression tests, not just diff inspection.
 
 ## Scope
-- In: The django-upgrade rewrites in `backend/membership/views.py`, `backend/notifications/device_login.py`, `backend/preventive_maintenance/admin.py`, and `backend/project_storage/admin.py`; preserving the existing client IP, user-agent, and Django admin column-label behavior; targeted verification for the touched backend apps.
-- Out: Popping or applying any git stash; editing any path outside the four implementation files; changing models, migrations, tests, frontend code, settings, permissions, or business behavior; making unrelated main-branch pre-commit failures green; using `pre-commit run --all-files` as the acceptance gate for this chore.
+- In: The django-upgrade rewrites in `backend/membership/views.py`, `backend/notifications/device_login.py`, `backend/preventive_maintenance/admin.py`, and `backend/project_storage/admin.py`; focused backend tests that prove invite redemption forwarded IP behavior, device-login request-header behavior, and preserved admin display labels; targeted verification for the touched backend apps.
+- Out: Popping or applying any git stash; editing implementation paths outside the four django-upgrade files; changing models, migrations, frontend code, settings, permissions, or business behavior; broad or unrelated test rewrites; making unrelated main-branch pre-commit failures green; using `pre-commit run --all-files` or frontend tests as acceptance gates for this chore.
 
 ## Criteria
 
 ### AC-1: Implementation diff is limited
-- **Given** the criteria commit is the starting point for implementation
-- **When** maintainers inspect the implementation diff after that commit
-- **Then** the only changed non-criteria paths are `backend/membership/views.py`, `backend/notifications/device_login.py`, `backend/preventive_maintenance/admin.py`, and `backend/project_storage/admin.py`
+- **Given** maintainers inspect the completed branch diff against `main`
+- **When** they ignore the criteria file itself
+- **Then** changed non-criteria paths are limited to `backend/membership/views.py`, `backend/notifications/device_login.py`, `backend/preventive_maintenance/admin.py`, `backend/project_storage/admin.py`, `backend/membership/tests/test_invite_codes.py`, `backend/notifications/tests.py`, and focused admin metadata tests under `backend/preventive_maintenance/tests/` and `backend/project_storage/tests/`
 
 ### AC-2: Django upgrade hook is clean
 - **Given** the four django-upgrade rewrites have been committed on the chore branch
@@ -20,14 +20,14 @@ The django-upgrade pre-commit hook currently rewrites the same four legacy Djang
 - **Then** the command exits successfully and a following `git status --short` shows no uncommitted django-upgrade rewrites
 
 ### AC-3: Invite redemption keeps forwarded IP behavior
-- **Given** an anonymous invite redemption request includes `X-Forwarded-For: 203.0.113.10, 198.51.100.2`
+- **Given** an anonymous client posts to `reverse("invite-redeem")` with `HTTP_X_FORWARDED_FOR="203.0.113.10, 198.51.100.2"`
 - **When** the invite code is redeemed successfully
-- **Then** the redeemed invite records `redeemed_ip` as `203.0.113.10`
+- **Then** the saved `InviteCode` row records `redeemed_ip` as `203.0.113.10`
 
 ### AC-4: Device login keeps request header behavior
-- **Given** a staff user's new-device login request includes `X-Forwarded-For` and `User-Agent` HTTP headers
-- **When** device login tracking records the known-device row and notification metadata
-- **Then** the recorded IP is the first forwarded IP value and the recorded user agent matches the incoming user-agent header
+- **Given** a staff user's new-device login request includes `X-Forwarded-For: 203.0.113.10, 198.51.100.2` and `User-Agent: OpenMakerSuite Test Browser`
+- **When** device login tracking records the known-device row and account-security notification
+- **Then** the `KnownDevice` row stores `203.0.113.10` and `OpenMakerSuite Test Browser`, and the notification metadata contains the same `ip` and `ua` values
 
 ### AC-5: Admin display labels are preserved
 - **Given** Django admin loads the preventive maintenance and project storage model admins
@@ -35,8 +35,8 @@ The django-upgrade pre-commit hook currently rewrites the same four legacy Djang
 - **Then** preventive maintenance still labels `_status` as `Status` and `_days_since` as `Last service`, and project storage still labels `status_display` as `Status`
 
 ### AC-6: Targeted backend tests pass
-- **Given** the branch contains only the scoped django-upgrade implementation changes
-- **When** `cd backend && pytest membership notifications preventive_maintenance project_storage` is executed
+- **Given** the branch contains only the scoped django-upgrade implementation changes and focused regression tests
+- **When** `cd backend && pytest membership notifications preventive_maintenance project_storage` is executed in a PostgreSQL-backed environment
 - **Then** the targeted backend tests for the four touched apps pass
 
 ## Verification Commands
@@ -44,4 +44,3 @@ The django-upgrade pre-commit hook currently rewrites the same four legacy Djang
 - `cd backend && pytest membership notifications preventive_maintenance project_storage`
 - `cd backend && python manage.py makemigrations --check`
 - `cd backend && python manage.py check_permission_matrix`
-- `cd frontend && npm test`

--- a/backend/membership/tests/test_invite_codes.py
+++ b/backend/membership/tests/test_invite_codes.py
@@ -176,6 +176,25 @@ class TestAnonymousRedeem:
         assert invite.redeemed_by_id == user.id
         assert invite.redeemed_at is not None
 
+    def test_forwarded_ip_is_recorded_from_first_hop(self, api_client):
+        """Behind nginx the redeemer's IP is the first X-Forwarded-For hop."""
+        invite = _open_invite()
+        response = api_client.post(
+            reverse("invite-redeem"),
+            data={
+                "code": invite.code,
+                "username": "forwarded",
+                "email": "forwarded@example.com",
+                "password": VALID_PASSWORD,
+            },
+            format="json",
+            HTTP_X_FORWARDED_FOR="203.0.113.10, 198.51.100.2",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        invite.refresh_from_db()
+        assert invite.redeemed is True
+        assert invite.redeemed_ip == "203.0.113.10"
+
     def test_invalid_code_rejected(self, api_client):
         response = api_client.post(
             reverse("invite-redeem"),

--- a/backend/membership/views.py
+++ b/backend/membership/views.py
@@ -436,7 +436,7 @@ from .serializers import (  # noqa: E402
 
 def _client_ip(request) -> str | None:
     """Best-effort client IP, honoring X-Forwarded-For when behind nginx."""
-    xff = request.META.get("HTTP_X_FORWARDED_FOR", "")
+    xff = request.headers.get("x-forwarded-for", "")
     if xff:
         return xff.split(",")[0].strip()
     return request.META.get("REMOTE_ADDR")

--- a/backend/notifications/device_login.py
+++ b/backend/notifications/device_login.py
@@ -54,7 +54,7 @@ def get_client_ip(request):
     ``REMOTE_ADDR``. Mirrors the extractor in ``inventory.views`` so the alert
     reports the same address operators see elsewhere.
     """
-    forwarded = request.META.get("HTTP_X_FORWARDED_FOR")
+    forwarded = request.headers.get("x-forwarded-for")
     if forwarded:
         return forwarded.split(",")[0].strip()
     return request.META.get("REMOTE_ADDR")
@@ -125,7 +125,7 @@ def track_device_login(request, user):
 
         token = _read_device_token(request)
         ip_address = get_client_ip(request)
-        user_agent = request.META.get("HTTP_USER_AGENT", "")
+        user_agent = request.headers.get("user-agent", "")
 
         if token:
             device = KnownDevice.objects.filter(user=user, device_token=token).first()

--- a/backend/notifications/tests.py
+++ b/backend/notifications/tests.py
@@ -4,8 +4,9 @@ Tests for notifications app.
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.urls import reverse
 
-from .models import Notification, NotificationPreference
+from .models import KnownDevice, Notification, NotificationPreference
 from .services import create_bulk_notifications, create_notification, notify_admins
 
 User = get_user_model()
@@ -473,3 +474,35 @@ class NotificationListEtagTest(TestCase):
         ours = self._list()
         theirs = other_client.get("/api/notifications/")
         self.assertNotEqual(ours["ETag"], theirs["ETag"])
+
+
+class DeviceLoginRequestHeaderTest(TestCase):
+    """Device tracking reads the client IP and UA off the request headers."""
+
+    def setUp(self):
+        self.staff = User.objects.create_user(
+            username="deviceheaders",
+            email="deviceheaders@example.com",
+            password="staff-secret-42",
+            is_staff=True,
+        )
+
+    def test_new_device_records_forwarded_ip_and_user_agent(self):
+        response = self.client.post(
+            reverse("login"),
+            {"username": "deviceheaders", "password": "staff-secret-42"},
+            headers={
+                "x-forwarded-for": "203.0.113.10, 198.51.100.2",
+                "user-agent": "OpenMakerSuite Test Browser",
+            },
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+        # Behind nginx the first X-Forwarded-For hop is the real client.
+        device = KnownDevice.objects.get(user=self.staff)
+        self.assertEqual(device.ip_address, "203.0.113.10")
+        self.assertEqual(device.user_agent, "OpenMakerSuite Test Browser")
+
+        note = Notification.objects.get(user=self.staff, title="New device sign-in")
+        self.assertEqual(note.metadata["ip"], "203.0.113.10")
+        self.assertEqual(note.metadata["ua"], "OpenMakerSuite Test Browser")

--- a/backend/preventive_maintenance/admin.py
+++ b/backend/preventive_maintenance/admin.py
@@ -25,16 +25,14 @@ class PMScheduleAdmin(admin.ModelAdmin):
     search_fields = ("task_name", "asset__name", "asset__asset_tag")
     inlines = [PMServiceLogInline]
 
+    @admin.display(description="Status")
     def _status(self, obj: PMSchedule) -> str:
         return obj.status()
 
-    _status.short_description = "Status"
-
+    @admin.display(description="Last service")
     def _days_since(self, obj: PMSchedule) -> str:
         d = obj.days_since_last()
         return "never" if d is None else f"{d}d"
-
-    _days_since.short_description = "Last service"
 
 
 @admin.register(PMServiceLog)

--- a/backend/preventive_maintenance/tests/test_admin_display.py
+++ b/backend/preventive_maintenance/tests/test_admin_display.py
@@ -1,0 +1,24 @@
+"""Admin column labels for the PM schedule display callables.
+
+The django-upgrade 4.2 rewrite swapped ``fn.short_description = "..."`` for
+``@admin.display(description="...")``; these lock the rendered labels in place.
+"""
+
+from django.contrib import admin
+from django.contrib.admin.utils import label_for_field
+
+from preventive_maintenance.admin import PMScheduleAdmin
+from preventive_maintenance.models import PMSchedule
+
+
+class TestPMScheduleAdminLabels:
+    def test_status_callable_is_labeled_status(self):
+        assert PMScheduleAdmin._status.short_description == "Status"
+
+    def test_days_since_callable_is_labeled_last_service(self):
+        assert PMScheduleAdmin._days_since.short_description == "Last service"
+
+    def test_changelist_renders_the_same_labels(self):
+        model_admin = PMScheduleAdmin(PMSchedule, admin.site)
+        assert label_for_field("_status", PMSchedule, model_admin=model_admin) == "Status"
+        assert label_for_field("_days_since", PMSchedule, model_admin=model_admin) == "Last service"

--- a/backend/project_storage/admin.py
+++ b/backend/project_storage/admin.py
@@ -51,10 +51,9 @@ class ProjectStorageStintAdmin(admin.ModelAdmin):
     def get_queryset(self, request):
         return super().get_queryset(request).select_related("slot")
 
+    @admin.display(description="Status")
     def status_display(self, obj: ProjectStorageStint) -> str:
         return obj.compute_status()
-
-    status_display.short_description = "Status"
 
 
 @admin.register(StorageSlot)

--- a/backend/project_storage/tests/test_admin_display.py
+++ b/backend/project_storage/tests/test_admin_display.py
@@ -1,0 +1,21 @@
+"""Admin column label for the project-storage stint status callable.
+
+The django-upgrade 4.2 rewrite swapped ``fn.short_description = "..."`` for
+``@admin.display(description="...")``; this locks the rendered label in place.
+"""
+
+from django.contrib import admin
+from django.contrib.admin.utils import label_for_field
+
+from project_storage.admin import ProjectStorageStintAdmin
+from project_storage.models import ProjectStorageStint
+
+
+class TestProjectStorageStintAdminLabels:
+    def test_status_display_callable_is_labeled_status(self):
+        assert ProjectStorageStintAdmin.status_display.short_description == "Status"
+
+    def test_changelist_renders_the_same_label(self):
+        model_admin = ProjectStorageStintAdmin(ProjectStorageStint, admin.site)
+        label = label_for_field("status_display", ProjectStorageStint, model_admin=model_admin)
+        assert label == "Status"


### PR DESCRIPTION
## Why

The `django-upgrade` pre-commit hook rewrites the same four legacy Django idioms
every time an agent runs it, which left unrelated worktrees dirty and forced each
new branch to rediscover (and then discard) the same diff. This chore lands those
deterministic rewrites once as a dedicated baseline, so they stop reappearing as
noise in unrelated work.

Because the rewrites touch request-header reads and admin column labels — two
things a green test suite would happily let you break silently — each rewrite is
locked in place by a focused regression test rather than by diff inspection alone.

The rewrites themselves are mechanical:

- `request.META.get("HTTP_X_FORWARDED_FOR")` → `request.headers.get("x-forwarded-for")`
- `request.META.get("HTTP_USER_AGENT", "")` → `request.headers.get("user-agent", "")`
- `fn.short_description = "..."` → `@admin.display(description="...")`

## Acceptance criteria

Criteria file: `.criteria/django-upgrade-baseline.md`

| AC | Code | Test |
| --- | --- | --- |
| **AC-1** — implementation diff is limited | The only non-criteria implementation paths changed are `backend/membership/views.py`, `backend/notifications/device_login.py`, `backend/preventive_maintenance/admin.py`, `backend/project_storage/admin.py` | Verified by `git diff main...HEAD --stat`: 9 files, 4 implementation + 4 test + the criteria file. No models, migrations, settings, permissions, or frontend. |
| **AC-2** — django-upgrade hook is clean | The four rewrites, committed in `b4488849` | `pre-commit run django-upgrade --all-files` → **Passed**, and `git status --short` is empty afterward (no re-rewrite). |
| **AC-3** — invite redemption keeps forwarded IP behavior | `membership/views.py::_client_ip` now reads `request.headers.get("x-forwarded-for")` | `membership/tests/test_invite_codes.py::TestAnonymousRedeem::test_forwarded_ip_is_recorded_from_first_hop` — posts to `invite-redeem` with `X-Forwarded-For: 203.0.113.10, 198.51.100.2` and asserts the saved `InviteCode.redeemed_ip == "203.0.113.10"` (first hop, not the proxy). |
| **AC-4** — device login keeps request header behavior | `notifications/device_login.py::get_client_ip` and `track_device_login` now read both values off `request.headers` | `notifications/tests.py::DeviceLoginRequestHeaderTest::test_new_device_records_forwarded_ip_and_user_agent` — asserts the `KnownDevice` row stores `203.0.113.10` / `OpenMakerSuite Test Browser`, **and** that the "New device sign-in" notification metadata carries the same `ip` and `ua`. |
| **AC-5** — admin display labels are preserved | `preventive_maintenance/admin.py` (`_status`, `_days_since`) and `project_storage/admin.py` (`status_display`) now use `@admin.display(description=...)` | `preventive_maintenance/tests/test_admin_display.py` and `project_storage/tests/test_admin_display.py` — each asserts both the `short_description` attribute *and* the label Django actually renders in the changelist via `admin.utils.label_for_field`, so the columns still read `Status` / `Last service` / `Status`. |
| **AC-6** — targeted backend tests pass | — | `pytest membership/tests notifications/tests.py preventive_maintenance/tests project_storage/tests` → **502 passed**. |

## Verification

Run locally against PostgreSQL (`DATABASE_URL=postgres://…@localhost:5432/postgres`):

| Command | Result |
| --- | --- |
| `pre-commit run django-upgrade --all-files` | Passed; tree clean afterward |
| `pytest membership/tests notifications/tests.py preventive_maintenance/tests project_storage/tests` | **502 passed**, 23 warnings, 92s |
| `python manage.py makemigrations --check --dry-run` | `No changes detected` |
| `python manage.py check_permission_matrix` | `OK — 928 endpoints match the matrix` |
| `pre-commit run --files <the 9 changed files>` | black / isort / ruff / django-upgrade / detect-private-key all Passed |

Two notes on the commands, both pre-existing conditions rather than branch regressions:

- **AC-6's literal command form.** `pytest membership …` cannot collect, because
  `backend/membership/tests.py` and `backend/membership/tests/` both exist and
  resolve to the same module name (`import file mismatch`). Both paths are present
  identically on `main` (`git ls-tree origin/main backend/membership/`), and
  neither is touched here, so this is repo debt, not a regression. The
  path-scoped form above covers exactly the same four apps and is what was run.
- **`bandit`** fails on any file set with `Unknown test found in profile: B106`
  — a bad entry in `backend/.bandit`, unrelated to these files.

## Out of scope

Deliberately not addressed, per the criteria's Out section:

- The repo-wide `pre-commit run --all-files` debt on `main` (isort/black across many
  files, ruff `E402` in `backend/conftest.py`, the `bandit` profile bug,
  typescript-check errors in `frontend/src/`). Making those green is not this
  chore's contract, and folding them in would bury the baseline diff.
- The `membership/tests.py` vs `membership/tests/` collection collision noted
  above — a real cleanup, but it belongs to its own change.
- Any behavior change. Every rewrite is intended to be exactly behavior-preserving;
  the tests exist to prove that, not to adjust it.
- No models, migrations, settings, permissions, or frontend code were touched.

Closes op-3bl.
